### PR TITLE
feat: Add a `noReturn` to all ORM methods that return a list

### DIFF
--- a/examples/legacy/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/legacy/chat/chat_server/lib/src/generated/channel.dart
@@ -335,16 +335,22 @@ class ChannelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Channel>> insert(
     _i1.DatabaseSession session,
     List<Channel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Channel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -378,6 +384,10 @@ class ChannelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Channel>> upsert(
     _i1.DatabaseSession session,
     List<Channel> rows, {
@@ -385,6 +395,7 @@ class ChannelRepository {
     _i1.ColumnSelections<ChannelTable>? updateColumns,
     _i1.WhereExpressionBuilder<ChannelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Channel>(
       rows,
@@ -392,6 +403,7 @@ class ChannelRepository {
       updateColumns: updateColumns?.call(Channel.t),
       updateWhere: updateWhere?.call(Channel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -430,16 +442,22 @@ class ChannelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Channel>> update(
     _i1.DatabaseSession session,
     List<Channel> rows, {
     _i1.ColumnSelections<ChannelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Channel>(
       rows,
       columns: columns?.call(Channel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -476,6 +494,10 @@ class ChannelRepository {
 
   /// Updates all [Channel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Channel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ChannelUpdateTable> columnValues,
@@ -487,6 +509,7 @@ class ChannelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Channel>(
       columnValues: columnValues(Channel.t.updateTable),
@@ -498,6 +521,7 @@ class ChannelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -508,6 +532,10 @@ class ChannelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Channel>> delete(
     _i1.DatabaseSession session,
     List<Channel> rows, {
@@ -516,6 +544,7 @@ class ChannelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChannelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Channel>(
       rows,
@@ -524,6 +553,7 @@ class ChannelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -543,6 +573,10 @@ class ChannelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Channel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChannelTable> where,
@@ -551,6 +585,7 @@ class ChannelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChannelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Channel>(
       where: where(Channel.t),
@@ -559,6 +594,7 @@ class ChannelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
@@ -406,16 +406,22 @@ class AuthKeyRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AuthKey>> insert(
     _i1.DatabaseSession session,
     List<AuthKey> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<AuthKey>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -449,6 +455,10 @@ class AuthKeyRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AuthKey>> upsert(
     _i1.DatabaseSession session,
     List<AuthKey> rows, {
@@ -456,6 +466,7 @@ class AuthKeyRepository {
     _i1.ColumnSelections<AuthKeyTable>? updateColumns,
     _i1.WhereExpressionBuilder<AuthKeyTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<AuthKey>(
       rows,
@@ -463,6 +474,7 @@ class AuthKeyRepository {
       updateColumns: updateColumns?.call(AuthKey.t),
       updateWhere: updateWhere?.call(AuthKey.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -501,16 +513,22 @@ class AuthKeyRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AuthKey>> update(
     _i1.DatabaseSession session,
     List<AuthKey> rows, {
     _i1.ColumnSelections<AuthKeyTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<AuthKey>(
       rows,
       columns: columns?.call(AuthKey.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -547,6 +565,10 @@ class AuthKeyRepository {
 
   /// Updates all [AuthKey]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AuthKey>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<AuthKeyUpdateTable> columnValues,
@@ -558,6 +580,7 @@ class AuthKeyRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<AuthKey>(
       columnValues: columnValues(AuthKey.t.updateTable),
@@ -569,6 +592,7 @@ class AuthKeyRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -579,6 +603,10 @@ class AuthKeyRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AuthKey>> delete(
     _i1.DatabaseSession session,
     List<AuthKey> rows, {
@@ -587,6 +615,7 @@ class AuthKeyRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AuthKeyTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<AuthKey>(
       rows,
@@ -595,6 +624,7 @@ class AuthKeyRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -614,6 +644,10 @@ class AuthKeyRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AuthKey>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AuthKeyTable> where,
@@ -622,6 +656,7 @@ class AuthKeyRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AuthKeyTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<AuthKey>(
       where: where(AuthKey.t),
@@ -630,6 +665,7 @@ class AuthKeyRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -362,16 +362,22 @@ class EmailAuthRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAuth>> insert(
     _i1.DatabaseSession session,
     List<EmailAuth> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EmailAuth>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -405,6 +411,10 @@ class EmailAuthRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAuth>> upsert(
     _i1.DatabaseSession session,
     List<EmailAuth> rows, {
@@ -412,6 +422,7 @@ class EmailAuthRepository {
     _i1.ColumnSelections<EmailAuthTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmailAuthTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EmailAuth>(
       rows,
@@ -419,6 +430,7 @@ class EmailAuthRepository {
       updateColumns: updateColumns?.call(EmailAuth.t),
       updateWhere: updateWhere?.call(EmailAuth.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -457,16 +469,22 @@ class EmailAuthRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAuth>> update(
     _i1.DatabaseSession session,
     List<EmailAuth> rows, {
     _i1.ColumnSelections<EmailAuthTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EmailAuth>(
       rows,
       columns: columns?.call(EmailAuth.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -503,6 +521,10 @@ class EmailAuthRepository {
 
   /// Updates all [EmailAuth]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAuth>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmailAuthUpdateTable> columnValues,
@@ -514,6 +536,7 @@ class EmailAuthRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EmailAuth>(
       columnValues: columnValues(EmailAuth.t.updateTable),
@@ -525,6 +548,7 @@ class EmailAuthRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -535,6 +559,10 @@ class EmailAuthRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAuth>> delete(
     _i1.DatabaseSession session,
     List<EmailAuth> rows, {
@@ -543,6 +571,7 @@ class EmailAuthRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAuthTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EmailAuth>(
       rows,
@@ -551,6 +580,7 @@ class EmailAuthRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -570,6 +600,10 @@ class EmailAuthRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAuth>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmailAuthTable> where,
@@ -578,6 +612,7 @@ class EmailAuthRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAuthTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EmailAuth>(
       where: where(EmailAuth.t),
@@ -586,6 +621,7 @@ class EmailAuthRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -393,16 +393,22 @@ class EmailCreateAccountRequestRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailCreateAccountRequest>> insert(
     _i1.DatabaseSession session,
     List<EmailCreateAccountRequest> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EmailCreateAccountRequest>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -436,6 +442,10 @@ class EmailCreateAccountRequestRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailCreateAccountRequest>> upsert(
     _i1.DatabaseSession session,
     List<EmailCreateAccountRequest> rows, {
@@ -444,6 +454,7 @@ class EmailCreateAccountRequestRepository {
     _i1.ColumnSelections<EmailCreateAccountRequestTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmailCreateAccountRequestTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EmailCreateAccountRequest>(
       rows,
@@ -451,6 +462,7 @@ class EmailCreateAccountRequestRepository {
       updateColumns: updateColumns?.call(EmailCreateAccountRequest.t),
       updateWhere: updateWhere?.call(EmailCreateAccountRequest.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -490,16 +502,22 @@ class EmailCreateAccountRequestRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailCreateAccountRequest>> update(
     _i1.DatabaseSession session,
     List<EmailCreateAccountRequest> rows, {
     _i1.ColumnSelections<EmailCreateAccountRequestTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EmailCreateAccountRequest>(
       rows,
       columns: columns?.call(EmailCreateAccountRequest.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -537,6 +555,10 @@ class EmailCreateAccountRequestRepository {
 
   /// Updates all [EmailCreateAccountRequest]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailCreateAccountRequest>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmailCreateAccountRequestUpdateTable>
@@ -549,6 +571,7 @@ class EmailCreateAccountRequestRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EmailCreateAccountRequest>(
       columnValues: columnValues(EmailCreateAccountRequest.t.updateTable),
@@ -560,6 +583,7 @@ class EmailCreateAccountRequestRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -570,6 +594,10 @@ class EmailCreateAccountRequestRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailCreateAccountRequest>> delete(
     _i1.DatabaseSession session,
     List<EmailCreateAccountRequest> rows, {
@@ -578,6 +606,7 @@ class EmailCreateAccountRequestRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailCreateAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EmailCreateAccountRequest>(
       rows,
@@ -586,6 +615,7 @@ class EmailCreateAccountRequestRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -605,6 +635,10 @@ class EmailCreateAccountRequestRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailCreateAccountRequest>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmailCreateAccountRequestTable> where,
@@ -613,6 +647,7 @@ class EmailCreateAccountRequestRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailCreateAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EmailCreateAccountRequest>(
       where: where(EmailCreateAccountRequest.t),
@@ -621,6 +656,7 @@ class EmailCreateAccountRequestRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -364,16 +364,22 @@ class EmailFailedSignInRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailFailedSignIn>> insert(
     _i1.DatabaseSession session,
     List<EmailFailedSignIn> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EmailFailedSignIn>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -407,6 +413,10 @@ class EmailFailedSignInRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailFailedSignIn>> upsert(
     _i1.DatabaseSession session,
     List<EmailFailedSignIn> rows, {
@@ -414,6 +424,7 @@ class EmailFailedSignInRepository {
     _i1.ColumnSelections<EmailFailedSignInTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmailFailedSignInTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EmailFailedSignIn>(
       rows,
@@ -421,6 +432,7 @@ class EmailFailedSignInRepository {
       updateColumns: updateColumns?.call(EmailFailedSignIn.t),
       updateWhere: updateWhere?.call(EmailFailedSignIn.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -459,16 +471,22 @@ class EmailFailedSignInRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailFailedSignIn>> update(
     _i1.DatabaseSession session,
     List<EmailFailedSignIn> rows, {
     _i1.ColumnSelections<EmailFailedSignInTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EmailFailedSignIn>(
       rows,
       columns: columns?.call(EmailFailedSignIn.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -506,6 +524,10 @@ class EmailFailedSignInRepository {
 
   /// Updates all [EmailFailedSignIn]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailFailedSignIn>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmailFailedSignInUpdateTable>
@@ -518,6 +540,7 @@ class EmailFailedSignInRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EmailFailedSignIn>(
       columnValues: columnValues(EmailFailedSignIn.t.updateTable),
@@ -529,6 +552,7 @@ class EmailFailedSignInRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -539,6 +563,10 @@ class EmailFailedSignInRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailFailedSignIn>> delete(
     _i1.DatabaseSession session,
     List<EmailFailedSignIn> rows, {
@@ -547,6 +575,7 @@ class EmailFailedSignInRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailFailedSignInTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EmailFailedSignIn>(
       rows,
@@ -555,6 +584,7 @@ class EmailFailedSignInRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -574,6 +604,10 @@ class EmailFailedSignInRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailFailedSignIn>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmailFailedSignInTable> where,
@@ -582,6 +616,7 @@ class EmailFailedSignInRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailFailedSignInTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EmailFailedSignIn>(
       where: where(EmailFailedSignIn.t),
@@ -590,6 +625,7 @@ class EmailFailedSignInRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -366,16 +366,22 @@ class EmailResetRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailReset>> insert(
     _i1.DatabaseSession session,
     List<EmailReset> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EmailReset>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -409,6 +415,10 @@ class EmailResetRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailReset>> upsert(
     _i1.DatabaseSession session,
     List<EmailReset> rows, {
@@ -416,6 +426,7 @@ class EmailResetRepository {
     _i1.ColumnSelections<EmailResetTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmailResetTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EmailReset>(
       rows,
@@ -423,6 +434,7 @@ class EmailResetRepository {
       updateColumns: updateColumns?.call(EmailReset.t),
       updateWhere: updateWhere?.call(EmailReset.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -461,16 +473,22 @@ class EmailResetRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailReset>> update(
     _i1.DatabaseSession session,
     List<EmailReset> rows, {
     _i1.ColumnSelections<EmailResetTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EmailReset>(
       rows,
       columns: columns?.call(EmailReset.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -507,6 +525,10 @@ class EmailResetRepository {
 
   /// Updates all [EmailReset]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailReset>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmailResetUpdateTable> columnValues,
@@ -518,6 +540,7 @@ class EmailResetRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EmailReset>(
       columnValues: columnValues(EmailReset.t.updateTable),
@@ -529,6 +552,7 @@ class EmailResetRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -539,6 +563,10 @@ class EmailResetRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailReset>> delete(
     _i1.DatabaseSession session,
     List<EmailReset> rows, {
@@ -547,6 +575,7 @@ class EmailResetRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailResetTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EmailReset>(
       rows,
@@ -555,6 +584,7 @@ class EmailResetRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -574,6 +604,10 @@ class EmailResetRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailReset>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmailResetTable> where,
@@ -582,6 +616,7 @@ class EmailResetRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailResetTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EmailReset>(
       where: where(EmailReset.t),
@@ -590,6 +625,7 @@ class EmailResetRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -337,16 +337,22 @@ class GoogleRefreshTokenRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GoogleRefreshToken>> insert(
     _i1.DatabaseSession session,
     List<GoogleRefreshToken> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<GoogleRefreshToken>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -380,6 +386,10 @@ class GoogleRefreshTokenRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GoogleRefreshToken>> upsert(
     _i1.DatabaseSession session,
     List<GoogleRefreshToken> rows, {
@@ -387,6 +397,7 @@ class GoogleRefreshTokenRepository {
     _i1.ColumnSelections<GoogleRefreshTokenTable>? updateColumns,
     _i1.WhereExpressionBuilder<GoogleRefreshTokenTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<GoogleRefreshToken>(
       rows,
@@ -394,6 +405,7 @@ class GoogleRefreshTokenRepository {
       updateColumns: updateColumns?.call(GoogleRefreshToken.t),
       updateWhere: updateWhere?.call(GoogleRefreshToken.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -432,16 +444,22 @@ class GoogleRefreshTokenRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GoogleRefreshToken>> update(
     _i1.DatabaseSession session,
     List<GoogleRefreshToken> rows, {
     _i1.ColumnSelections<GoogleRefreshTokenTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<GoogleRefreshToken>(
       rows,
       columns: columns?.call(GoogleRefreshToken.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -479,6 +497,10 @@ class GoogleRefreshTokenRepository {
 
   /// Updates all [GoogleRefreshToken]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GoogleRefreshToken>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<GoogleRefreshTokenUpdateTable>
@@ -491,6 +513,7 @@ class GoogleRefreshTokenRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<GoogleRefreshToken>(
       columnValues: columnValues(GoogleRefreshToken.t.updateTable),
@@ -502,6 +525,7 @@ class GoogleRefreshTokenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +536,10 @@ class GoogleRefreshTokenRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GoogleRefreshToken>> delete(
     _i1.DatabaseSession session,
     List<GoogleRefreshToken> rows, {
@@ -520,6 +548,7 @@ class GoogleRefreshTokenRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleRefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<GoogleRefreshToken>(
       rows,
@@ -528,6 +557,7 @@ class GoogleRefreshTokenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -547,6 +577,10 @@ class GoogleRefreshTokenRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GoogleRefreshToken>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<GoogleRefreshTokenTable> where,
@@ -555,6 +589,7 @@ class GoogleRefreshTokenRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleRefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<GoogleRefreshToken>(
       where: where(GoogleRefreshToken.t),
@@ -563,6 +598,7 @@ class GoogleRefreshTokenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -362,16 +362,22 @@ class UserImageRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserImage>> insert(
     _i1.DatabaseSession session,
     List<UserImage> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UserImage>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -405,6 +411,10 @@ class UserImageRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserImage>> upsert(
     _i1.DatabaseSession session,
     List<UserImage> rows, {
@@ -412,6 +422,7 @@ class UserImageRepository {
     _i1.ColumnSelections<UserImageTable>? updateColumns,
     _i1.WhereExpressionBuilder<UserImageTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UserImage>(
       rows,
@@ -419,6 +430,7 @@ class UserImageRepository {
       updateColumns: updateColumns?.call(UserImage.t),
       updateWhere: updateWhere?.call(UserImage.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -457,16 +469,22 @@ class UserImageRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserImage>> update(
     _i1.DatabaseSession session,
     List<UserImage> rows, {
     _i1.ColumnSelections<UserImageTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UserImage>(
       rows,
       columns: columns?.call(UserImage.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -503,6 +521,10 @@ class UserImageRepository {
 
   /// Updates all [UserImage]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserImage>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UserImageUpdateTable> columnValues,
@@ -514,6 +536,7 @@ class UserImageRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UserImage>(
       columnValues: columnValues(UserImage.t.updateTable),
@@ -525,6 +548,7 @@ class UserImageRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -535,6 +559,10 @@ class UserImageRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserImage>> delete(
     _i1.DatabaseSession session,
     List<UserImage> rows, {
@@ -543,6 +571,7 @@ class UserImageRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserImageTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UserImage>(
       rows,
@@ -551,6 +580,7 @@ class UserImageRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -570,6 +600,10 @@ class UserImageRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserImage>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserImageTable> where,
@@ -578,6 +612,7 @@ class UserImageRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserImageTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UserImage>(
       where: where(UserImage.t),
@@ -586,6 +621,7 @@ class UserImageRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -504,16 +504,22 @@ class UserInfoRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserInfo>> insert(
     _i1.DatabaseSession session,
     List<UserInfo> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UserInfo>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -547,6 +553,10 @@ class UserInfoRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserInfo>> upsert(
     _i1.DatabaseSession session,
     List<UserInfo> rows, {
@@ -554,6 +564,7 @@ class UserInfoRepository {
     _i1.ColumnSelections<UserInfoTable>? updateColumns,
     _i1.WhereExpressionBuilder<UserInfoTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UserInfo>(
       rows,
@@ -561,6 +572,7 @@ class UserInfoRepository {
       updateColumns: updateColumns?.call(UserInfo.t),
       updateWhere: updateWhere?.call(UserInfo.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -599,16 +611,22 @@ class UserInfoRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserInfo>> update(
     _i1.DatabaseSession session,
     List<UserInfo> rows, {
     _i1.ColumnSelections<UserInfoTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UserInfo>(
       rows,
       columns: columns?.call(UserInfo.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -645,6 +663,10 @@ class UserInfoRepository {
 
   /// Updates all [UserInfo]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserInfo>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UserInfoUpdateTable> columnValues,
@@ -656,6 +678,7 @@ class UserInfoRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UserInfo>(
       columnValues: columnValues(UserInfo.t.updateTable),
@@ -667,6 +690,7 @@ class UserInfoRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -677,6 +701,10 @@ class UserInfoRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserInfo>> delete(
     _i1.DatabaseSession session,
     List<UserInfo> rows, {
@@ -685,6 +713,7 @@ class UserInfoRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserInfoTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UserInfo>(
       rows,
@@ -693,6 +722,7 @@ class UserInfoRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -712,6 +742,10 @@ class UserInfoRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserInfo>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserInfoTable> where,
@@ -720,6 +754,7 @@ class UserInfoRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserInfoTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UserInfo>(
       where: where(UserInfo.t),
@@ -728,6 +763,7 @@ class UserInfoRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -507,16 +507,22 @@ class ChatMessageRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChatMessage>> insert(
     _i1.DatabaseSession session,
     List<ChatMessage> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ChatMessage>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -550,6 +556,10 @@ class ChatMessageRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChatMessage>> upsert(
     _i1.DatabaseSession session,
     List<ChatMessage> rows, {
@@ -557,6 +567,7 @@ class ChatMessageRepository {
     _i1.ColumnSelections<ChatMessageTable>? updateColumns,
     _i1.WhereExpressionBuilder<ChatMessageTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ChatMessage>(
       rows,
@@ -564,6 +575,7 @@ class ChatMessageRepository {
       updateColumns: updateColumns?.call(ChatMessage.t),
       updateWhere: updateWhere?.call(ChatMessage.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -602,16 +614,22 @@ class ChatMessageRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChatMessage>> update(
     _i1.DatabaseSession session,
     List<ChatMessage> rows, {
     _i1.ColumnSelections<ChatMessageTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ChatMessage>(
       rows,
       columns: columns?.call(ChatMessage.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -648,6 +666,10 @@ class ChatMessageRepository {
 
   /// Updates all [ChatMessage]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChatMessage>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ChatMessageUpdateTable> columnValues,
@@ -659,6 +681,7 @@ class ChatMessageRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ChatMessage>(
       columnValues: columnValues(ChatMessage.t.updateTable),
@@ -670,6 +693,7 @@ class ChatMessageRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -680,6 +704,10 @@ class ChatMessageRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChatMessage>> delete(
     _i1.DatabaseSession session,
     List<ChatMessage> rows, {
@@ -688,6 +716,7 @@ class ChatMessageRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChatMessageTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ChatMessage>(
       rows,
@@ -696,6 +725,7 @@ class ChatMessageRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -715,6 +745,10 @@ class ChatMessageRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChatMessage>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChatMessageTable> where,
@@ -723,6 +757,7 @@ class ChatMessageRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChatMessageTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ChatMessage>(
       where: where(ChatMessage.t),
@@ -731,6 +766,7 @@ class ChatMessageRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -362,16 +362,22 @@ class ChatReadMessageRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChatReadMessage>> insert(
     _i1.DatabaseSession session,
     List<ChatReadMessage> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ChatReadMessage>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -405,6 +411,10 @@ class ChatReadMessageRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChatReadMessage>> upsert(
     _i1.DatabaseSession session,
     List<ChatReadMessage> rows, {
@@ -412,6 +422,7 @@ class ChatReadMessageRepository {
     _i1.ColumnSelections<ChatReadMessageTable>? updateColumns,
     _i1.WhereExpressionBuilder<ChatReadMessageTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ChatReadMessage>(
       rows,
@@ -419,6 +430,7 @@ class ChatReadMessageRepository {
       updateColumns: updateColumns?.call(ChatReadMessage.t),
       updateWhere: updateWhere?.call(ChatReadMessage.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -457,16 +469,22 @@ class ChatReadMessageRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChatReadMessage>> update(
     _i1.DatabaseSession session,
     List<ChatReadMessage> rows, {
     _i1.ColumnSelections<ChatReadMessageTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ChatReadMessage>(
       rows,
       columns: columns?.call(ChatReadMessage.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -504,6 +522,10 @@ class ChatReadMessageRepository {
 
   /// Updates all [ChatReadMessage]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChatReadMessage>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ChatReadMessageUpdateTable>
@@ -516,6 +538,7 @@ class ChatReadMessageRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ChatReadMessage>(
       columnValues: columnValues(ChatReadMessage.t.updateTable),
@@ -527,6 +550,7 @@ class ChatReadMessageRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -537,6 +561,10 @@ class ChatReadMessageRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChatReadMessage>> delete(
     _i1.DatabaseSession session,
     List<ChatReadMessage> rows, {
@@ -545,6 +573,7 @@ class ChatReadMessageRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChatReadMessageTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ChatReadMessage>(
       rows,
@@ -553,6 +582,7 @@ class ChatReadMessageRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -572,6 +602,10 @@ class ChatReadMessageRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChatReadMessage>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChatReadMessageTable> where,
@@ -580,6 +614,7 @@ class ChatReadMessageRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChatReadMessageTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ChatReadMessage>(
       where: where(ChatReadMessage.t),
@@ -588,6 +623,7 @@ class ChatReadMessageRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_email_password.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_email_password.dart
@@ -400,16 +400,22 @@ class LegacyEmailPasswordRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacyEmailPassword>> insert(
     _i1.DatabaseSession session,
     List<LegacyEmailPassword> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<LegacyEmailPassword>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -443,6 +449,10 @@ class LegacyEmailPasswordRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacyEmailPassword>> upsert(
     _i1.DatabaseSession session,
     List<LegacyEmailPassword> rows, {
@@ -450,6 +460,7 @@ class LegacyEmailPasswordRepository {
     _i1.ColumnSelections<LegacyEmailPasswordTable>? updateColumns,
     _i1.WhereExpressionBuilder<LegacyEmailPasswordTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<LegacyEmailPassword>(
       rows,
@@ -457,6 +468,7 @@ class LegacyEmailPasswordRepository {
       updateColumns: updateColumns?.call(LegacyEmailPassword.t),
       updateWhere: updateWhere?.call(LegacyEmailPassword.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -495,16 +507,22 @@ class LegacyEmailPasswordRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacyEmailPassword>> update(
     _i1.DatabaseSession session,
     List<LegacyEmailPassword> rows, {
     _i1.ColumnSelections<LegacyEmailPasswordTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<LegacyEmailPassword>(
       rows,
       columns: columns?.call(LegacyEmailPassword.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -542,6 +560,10 @@ class LegacyEmailPasswordRepository {
 
   /// Updates all [LegacyEmailPassword]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacyEmailPassword>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<LegacyEmailPasswordUpdateTable>
@@ -554,6 +576,7 @@ class LegacyEmailPasswordRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<LegacyEmailPassword>(
       columnValues: columnValues(LegacyEmailPassword.t.updateTable),
@@ -565,6 +588,7 @@ class LegacyEmailPasswordRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -575,6 +599,10 @@ class LegacyEmailPasswordRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacyEmailPassword>> delete(
     _i1.DatabaseSession session,
     List<LegacyEmailPassword> rows, {
@@ -583,6 +611,7 @@ class LegacyEmailPasswordRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyEmailPasswordTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<LegacyEmailPassword>(
       rows,
@@ -591,6 +620,7 @@ class LegacyEmailPasswordRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -610,6 +640,10 @@ class LegacyEmailPasswordRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacyEmailPassword>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<LegacyEmailPasswordTable> where,
@@ -618,6 +652,7 @@ class LegacyEmailPasswordRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyEmailPasswordTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<LegacyEmailPassword>(
       where: where(LegacyEmailPassword.t),
@@ -626,6 +661,7 @@ class LegacyEmailPasswordRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_external_user_identifier.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_external_user_identifier.dart
@@ -405,16 +405,22 @@ class LegacyExternalUserIdentifierRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacyExternalUserIdentifier>> insert(
     _i1.DatabaseSession session,
     List<LegacyExternalUserIdentifier> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<LegacyExternalUserIdentifier>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -448,6 +454,10 @@ class LegacyExternalUserIdentifierRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacyExternalUserIdentifier>> upsert(
     _i1.DatabaseSession session,
     List<LegacyExternalUserIdentifier> rows, {
@@ -456,6 +466,7 @@ class LegacyExternalUserIdentifierRepository {
     _i1.ColumnSelections<LegacyExternalUserIdentifierTable>? updateColumns,
     _i1.WhereExpressionBuilder<LegacyExternalUserIdentifierTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<LegacyExternalUserIdentifier>(
       rows,
@@ -463,6 +474,7 @@ class LegacyExternalUserIdentifierRepository {
       updateColumns: updateColumns?.call(LegacyExternalUserIdentifier.t),
       updateWhere: updateWhere?.call(LegacyExternalUserIdentifier.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -502,16 +514,22 @@ class LegacyExternalUserIdentifierRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacyExternalUserIdentifier>> update(
     _i1.DatabaseSession session,
     List<LegacyExternalUserIdentifier> rows, {
     _i1.ColumnSelections<LegacyExternalUserIdentifierTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<LegacyExternalUserIdentifier>(
       rows,
       columns: columns?.call(LegacyExternalUserIdentifier.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,6 +567,10 @@ class LegacyExternalUserIdentifierRepository {
 
   /// Updates all [LegacyExternalUserIdentifier]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacyExternalUserIdentifier>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<LegacyExternalUserIdentifierUpdateTable>
@@ -562,6 +584,7 @@ class LegacyExternalUserIdentifierRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<LegacyExternalUserIdentifier>(
       columnValues: columnValues(LegacyExternalUserIdentifier.t.updateTable),
@@ -573,6 +596,7 @@ class LegacyExternalUserIdentifierRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -583,6 +607,10 @@ class LegacyExternalUserIdentifierRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacyExternalUserIdentifier>> delete(
     _i1.DatabaseSession session,
     List<LegacyExternalUserIdentifier> rows, {
@@ -591,6 +619,7 @@ class LegacyExternalUserIdentifierRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyExternalUserIdentifierTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<LegacyExternalUserIdentifier>(
       rows,
@@ -599,6 +628,7 @@ class LegacyExternalUserIdentifierRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -618,6 +648,10 @@ class LegacyExternalUserIdentifierRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacyExternalUserIdentifier>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<LegacyExternalUserIdentifierTable>
@@ -627,6 +661,7 @@ class LegacyExternalUserIdentifierRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyExternalUserIdentifierTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<LegacyExternalUserIdentifier>(
       where: where(LegacyExternalUserIdentifier.t),
@@ -635,6 +670,7 @@ class LegacyExternalUserIdentifierRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_session.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_session.dart
@@ -448,16 +448,22 @@ class LegacySessionRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacySession>> insert(
     _i1.DatabaseSession session,
     List<LegacySession> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<LegacySession>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -491,6 +497,10 @@ class LegacySessionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacySession>> upsert(
     _i1.DatabaseSession session,
     List<LegacySession> rows, {
@@ -498,6 +508,7 @@ class LegacySessionRepository {
     _i1.ColumnSelections<LegacySessionTable>? updateColumns,
     _i1.WhereExpressionBuilder<LegacySessionTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<LegacySession>(
       rows,
@@ -505,6 +516,7 @@ class LegacySessionRepository {
       updateColumns: updateColumns?.call(LegacySession.t),
       updateWhere: updateWhere?.call(LegacySession.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -543,16 +555,22 @@ class LegacySessionRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacySession>> update(
     _i1.DatabaseSession session,
     List<LegacySession> rows, {
     _i1.ColumnSelections<LegacySessionTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<LegacySession>(
       rows,
       columns: columns?.call(LegacySession.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -589,6 +607,10 @@ class LegacySessionRepository {
 
   /// Updates all [LegacySession]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacySession>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<LegacySessionUpdateTable> columnValues,
@@ -600,6 +622,7 @@ class LegacySessionRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<LegacySession>(
       columnValues: columnValues(LegacySession.t.updateTable),
@@ -611,6 +634,7 @@ class LegacySessionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -621,6 +645,10 @@ class LegacySessionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacySession>> delete(
     _i1.DatabaseSession session,
     List<LegacySession> rows, {
@@ -629,6 +657,7 @@ class LegacySessionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LegacySessionTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<LegacySession>(
       rows,
@@ -637,6 +666,7 @@ class LegacySessionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -656,6 +686,10 @@ class LegacySessionRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LegacySession>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<LegacySessionTable> where,
@@ -664,6 +698,7 @@ class LegacySessionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LegacySessionTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<LegacySession>(
       where: where(LegacySession.t),
@@ -672,6 +707,7 @@ class LegacySessionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/auth_user/models/auth_user.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/auth_user/models/auth_user.dart
@@ -377,16 +377,22 @@ class AuthUserRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AuthUser>> insert(
     _i1.DatabaseSession session,
     List<AuthUser> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<AuthUser>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -420,6 +426,10 @@ class AuthUserRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AuthUser>> upsert(
     _i1.DatabaseSession session,
     List<AuthUser> rows, {
@@ -427,6 +437,7 @@ class AuthUserRepository {
     _i1.ColumnSelections<AuthUserTable>? updateColumns,
     _i1.WhereExpressionBuilder<AuthUserTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<AuthUser>(
       rows,
@@ -434,6 +445,7 @@ class AuthUserRepository {
       updateColumns: updateColumns?.call(AuthUser.t),
       updateWhere: updateWhere?.call(AuthUser.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -472,16 +484,22 @@ class AuthUserRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AuthUser>> update(
     _i1.DatabaseSession session,
     List<AuthUser> rows, {
     _i1.ColumnSelections<AuthUserTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<AuthUser>(
       rows,
       columns: columns?.call(AuthUser.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -518,6 +536,10 @@ class AuthUserRepository {
 
   /// Updates all [AuthUser]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AuthUser>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<AuthUserUpdateTable> columnValues,
@@ -529,6 +551,7 @@ class AuthUserRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<AuthUser>(
       columnValues: columnValues(AuthUser.t.updateTable),
@@ -540,6 +563,7 @@ class AuthUserRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -550,6 +574,10 @@ class AuthUserRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AuthUser>> delete(
     _i1.DatabaseSession session,
     List<AuthUser> rows, {
@@ -558,6 +586,7 @@ class AuthUserRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AuthUserTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<AuthUser>(
       rows,
@@ -566,6 +595,7 @@ class AuthUserRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -585,6 +615,10 @@ class AuthUserRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AuthUser>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AuthUserTable> where,
@@ -593,6 +627,7 @@ class AuthUserRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AuthUserTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<AuthUser>(
       where: where(AuthUser.t),
@@ -601,6 +636,7 @@ class AuthUserRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/jwt/models/refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/jwt/models/refresh_token.dart
@@ -613,16 +613,22 @@ class RefreshTokenRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RefreshToken>> insert(
     _i1.DatabaseSession session,
     List<RefreshToken> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<RefreshToken>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -656,6 +662,10 @@ class RefreshTokenRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RefreshToken>> upsert(
     _i1.DatabaseSession session,
     List<RefreshToken> rows, {
@@ -663,6 +673,7 @@ class RefreshTokenRepository {
     _i1.ColumnSelections<RefreshTokenTable>? updateColumns,
     _i1.WhereExpressionBuilder<RefreshTokenTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<RefreshToken>(
       rows,
@@ -670,6 +681,7 @@ class RefreshTokenRepository {
       updateColumns: updateColumns?.call(RefreshToken.t),
       updateWhere: updateWhere?.call(RefreshToken.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -708,16 +720,22 @@ class RefreshTokenRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RefreshToken>> update(
     _i1.DatabaseSession session,
     List<RefreshToken> rows, {
     _i1.ColumnSelections<RefreshTokenTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<RefreshToken>(
       rows,
       columns: columns?.call(RefreshToken.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -754,6 +772,10 @@ class RefreshTokenRepository {
 
   /// Updates all [RefreshToken]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RefreshToken>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<RefreshTokenUpdateTable> columnValues,
@@ -765,6 +787,7 @@ class RefreshTokenRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<RefreshToken>(
       columnValues: columnValues(RefreshToken.t.updateTable),
@@ -776,6 +799,7 @@ class RefreshTokenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -786,6 +810,10 @@ class RefreshTokenRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RefreshToken>> delete(
     _i1.DatabaseSession session,
     List<RefreshToken> rows, {
@@ -794,6 +822,7 @@ class RefreshTokenRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<RefreshToken>(
       rows,
@@ -802,6 +831,7 @@ class RefreshTokenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -821,6 +851,10 @@ class RefreshTokenRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RefreshToken>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RefreshTokenTable> where,
@@ -829,6 +863,7 @@ class RefreshTokenRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<RefreshToken>(
       where: where(RefreshToken.t),
@@ -837,6 +872,7 @@ class RefreshTokenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/profile/models/user_profile.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/profile/models/user_profile.dart
@@ -574,16 +574,22 @@ class UserProfileRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserProfile>> insert(
     _i1.DatabaseSession session,
     List<UserProfile> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UserProfile>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -617,6 +623,10 @@ class UserProfileRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserProfile>> upsert(
     _i1.DatabaseSession session,
     List<UserProfile> rows, {
@@ -624,6 +634,7 @@ class UserProfileRepository {
     _i1.ColumnSelections<UserProfileTable>? updateColumns,
     _i1.WhereExpressionBuilder<UserProfileTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UserProfile>(
       rows,
@@ -631,6 +642,7 @@ class UserProfileRepository {
       updateColumns: updateColumns?.call(UserProfile.t),
       updateWhere: updateWhere?.call(UserProfile.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -669,16 +681,22 @@ class UserProfileRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserProfile>> update(
     _i1.DatabaseSession session,
     List<UserProfile> rows, {
     _i1.ColumnSelections<UserProfileTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UserProfile>(
       rows,
       columns: columns?.call(UserProfile.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -715,6 +733,10 @@ class UserProfileRepository {
 
   /// Updates all [UserProfile]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserProfile>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UserProfileUpdateTable> columnValues,
@@ -726,6 +748,7 @@ class UserProfileRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UserProfile>(
       columnValues: columnValues(UserProfile.t.updateTable),
@@ -737,6 +760,7 @@ class UserProfileRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -747,6 +771,10 @@ class UserProfileRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserProfile>> delete(
     _i1.DatabaseSession session,
     List<UserProfile> rows, {
@@ -755,6 +783,7 @@ class UserProfileRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UserProfile>(
       rows,
@@ -763,6 +792,7 @@ class UserProfileRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -782,6 +812,10 @@ class UserProfileRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserProfile>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserProfileTable> where,
@@ -790,6 +824,7 @@ class UserProfileRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UserProfile>(
       where: where(UserProfile.t),
@@ -798,6 +833,7 @@ class UserProfileRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/profile/models/user_profile_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/profile/models/user_profile_image.dart
@@ -483,16 +483,22 @@ class UserProfileImageRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserProfileImage>> insert(
     _i1.DatabaseSession session,
     List<UserProfileImage> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UserProfileImage>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -526,6 +532,10 @@ class UserProfileImageRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserProfileImage>> upsert(
     _i1.DatabaseSession session,
     List<UserProfileImage> rows, {
@@ -533,6 +543,7 @@ class UserProfileImageRepository {
     _i1.ColumnSelections<UserProfileImageTable>? updateColumns,
     _i1.WhereExpressionBuilder<UserProfileImageTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UserProfileImage>(
       rows,
@@ -540,6 +551,7 @@ class UserProfileImageRepository {
       updateColumns: updateColumns?.call(UserProfileImage.t),
       updateWhere: updateWhere?.call(UserProfileImage.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -578,16 +590,22 @@ class UserProfileImageRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserProfileImage>> update(
     _i1.DatabaseSession session,
     List<UserProfileImage> rows, {
     _i1.ColumnSelections<UserProfileImageTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UserProfileImage>(
       rows,
       columns: columns?.call(UserProfileImage.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -625,6 +643,10 @@ class UserProfileImageRepository {
 
   /// Updates all [UserProfileImage]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserProfileImage>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UserProfileImageUpdateTable>
@@ -637,6 +659,7 @@ class UserProfileImageRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UserProfileImage>(
       columnValues: columnValues(UserProfileImage.t.updateTable),
@@ -648,6 +671,7 @@ class UserProfileImageRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -658,6 +682,10 @@ class UserProfileImageRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserProfileImage>> delete(
     _i1.DatabaseSession session,
     List<UserProfileImage> rows, {
@@ -666,6 +694,7 @@ class UserProfileImageRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileImageTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UserProfileImage>(
       rows,
@@ -674,6 +703,7 @@ class UserProfileImageRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -693,6 +723,10 @@ class UserProfileImageRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserProfileImage>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserProfileImageTable> where,
@@ -701,6 +735,7 @@ class UserProfileImageRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileImageTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UserProfileImage>(
       where: where(UserProfileImage.t),
@@ -709,6 +744,7 @@ class UserProfileImageRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/session/models/server_side_session.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/session/models/server_side_session.dart
@@ -628,16 +628,22 @@ class ServerSideSessionRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerSideSession>> insert(
     _i1.DatabaseSession session,
     List<ServerSideSession> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ServerSideSession>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -671,6 +677,10 @@ class ServerSideSessionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerSideSession>> upsert(
     _i1.DatabaseSession session,
     List<ServerSideSession> rows, {
@@ -678,6 +688,7 @@ class ServerSideSessionRepository {
     _i1.ColumnSelections<ServerSideSessionTable>? updateColumns,
     _i1.WhereExpressionBuilder<ServerSideSessionTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ServerSideSession>(
       rows,
@@ -685,6 +696,7 @@ class ServerSideSessionRepository {
       updateColumns: updateColumns?.call(ServerSideSession.t),
       updateWhere: updateWhere?.call(ServerSideSession.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -723,16 +735,22 @@ class ServerSideSessionRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerSideSession>> update(
     _i1.DatabaseSession session,
     List<ServerSideSession> rows, {
     _i1.ColumnSelections<ServerSideSessionTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ServerSideSession>(
       rows,
       columns: columns?.call(ServerSideSession.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -770,6 +788,10 @@ class ServerSideSessionRepository {
 
   /// Updates all [ServerSideSession]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerSideSession>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ServerSideSessionUpdateTable>
@@ -782,6 +804,7 @@ class ServerSideSessionRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ServerSideSession>(
       columnValues: columnValues(ServerSideSession.t.updateTable),
@@ -793,6 +816,7 @@ class ServerSideSessionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -803,6 +827,10 @@ class ServerSideSessionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerSideSession>> delete(
     _i1.DatabaseSession session,
     List<ServerSideSession> rows, {
@@ -811,6 +839,7 @@ class ServerSideSessionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServerSideSessionTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ServerSideSession>(
       rows,
@@ -819,6 +848,7 @@ class ServerSideSessionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -838,6 +868,10 @@ class ServerSideSessionRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerSideSession>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ServerSideSessionTable> where,
@@ -846,6 +880,7 @@ class ServerSideSessionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServerSideSessionTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ServerSideSession>(
       where: where(ServerSideSession.t),
@@ -854,6 +889,7 @@ class ServerSideSessionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/common/rate_limited_request_attempt/models/rate_limited_request_attempt.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/common/rate_limited_request_attempt/models/rate_limited_request_attempt.dart
@@ -467,16 +467,22 @@ class RateLimitedRequestAttemptRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RateLimitedRequestAttempt>> insert(
     _i1.DatabaseSession session,
     List<RateLimitedRequestAttempt> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<RateLimitedRequestAttempt>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -510,6 +516,10 @@ class RateLimitedRequestAttemptRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RateLimitedRequestAttempt>> upsert(
     _i1.DatabaseSession session,
     List<RateLimitedRequestAttempt> rows, {
@@ -518,6 +528,7 @@ class RateLimitedRequestAttemptRepository {
     _i1.ColumnSelections<RateLimitedRequestAttemptTable>? updateColumns,
     _i1.WhereExpressionBuilder<RateLimitedRequestAttemptTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<RateLimitedRequestAttempt>(
       rows,
@@ -525,6 +536,7 @@ class RateLimitedRequestAttemptRepository {
       updateColumns: updateColumns?.call(RateLimitedRequestAttempt.t),
       updateWhere: updateWhere?.call(RateLimitedRequestAttempt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,16 +576,22 @@ class RateLimitedRequestAttemptRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RateLimitedRequestAttempt>> update(
     _i1.DatabaseSession session,
     List<RateLimitedRequestAttempt> rows, {
     _i1.ColumnSelections<RateLimitedRequestAttemptTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<RateLimitedRequestAttempt>(
       rows,
       columns: columns?.call(RateLimitedRequestAttempt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -611,6 +629,10 @@ class RateLimitedRequestAttemptRepository {
 
   /// Updates all [RateLimitedRequestAttempt]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RateLimitedRequestAttempt>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<RateLimitedRequestAttemptUpdateTable>
@@ -623,6 +645,7 @@ class RateLimitedRequestAttemptRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<RateLimitedRequestAttempt>(
       columnValues: columnValues(RateLimitedRequestAttempt.t.updateTable),
@@ -634,6 +657,7 @@ class RateLimitedRequestAttemptRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -644,6 +668,10 @@ class RateLimitedRequestAttemptRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RateLimitedRequestAttempt>> delete(
     _i1.DatabaseSession session,
     List<RateLimitedRequestAttempt> rows, {
@@ -652,6 +680,7 @@ class RateLimitedRequestAttemptRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RateLimitedRequestAttemptTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<RateLimitedRequestAttempt>(
       rows,
@@ -660,6 +689,7 @@ class RateLimitedRequestAttemptRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -679,6 +709,10 @@ class RateLimitedRequestAttemptRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RateLimitedRequestAttempt>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RateLimitedRequestAttemptTable> where,
@@ -687,6 +721,7 @@ class RateLimitedRequestAttemptRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RateLimitedRequestAttemptTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<RateLimitedRequestAttempt>(
       where: where(RateLimitedRequestAttempt.t),
@@ -695,6 +730,7 @@ class RateLimitedRequestAttemptRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/common/secret_challenge/models/secret_challenge.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/common/secret_challenge/models/secret_challenge.dart
@@ -314,16 +314,22 @@ class SecretChallengeRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SecretChallenge>> insert(
     _i1.DatabaseSession session,
     List<SecretChallenge> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<SecretChallenge>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -357,6 +363,10 @@ class SecretChallengeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SecretChallenge>> upsert(
     _i1.DatabaseSession session,
     List<SecretChallenge> rows, {
@@ -364,6 +374,7 @@ class SecretChallengeRepository {
     _i1.ColumnSelections<SecretChallengeTable>? updateColumns,
     _i1.WhereExpressionBuilder<SecretChallengeTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<SecretChallenge>(
       rows,
@@ -371,6 +382,7 @@ class SecretChallengeRepository {
       updateColumns: updateColumns?.call(SecretChallenge.t),
       updateWhere: updateWhere?.call(SecretChallenge.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -409,16 +421,22 @@ class SecretChallengeRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SecretChallenge>> update(
     _i1.DatabaseSession session,
     List<SecretChallenge> rows, {
     _i1.ColumnSelections<SecretChallengeTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<SecretChallenge>(
       rows,
       columns: columns?.call(SecretChallenge.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -456,6 +474,10 @@ class SecretChallengeRepository {
 
   /// Updates all [SecretChallenge]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SecretChallenge>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<SecretChallengeUpdateTable>
@@ -468,6 +490,7 @@ class SecretChallengeRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<SecretChallenge>(
       columnValues: columnValues(SecretChallenge.t.updateTable),
@@ -479,6 +502,7 @@ class SecretChallengeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -489,6 +513,10 @@ class SecretChallengeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SecretChallenge>> delete(
     _i1.DatabaseSession session,
     List<SecretChallenge> rows, {
@@ -497,6 +525,7 @@ class SecretChallengeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SecretChallengeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<SecretChallenge>(
       rows,
@@ -505,6 +534,7 @@ class SecretChallengeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -524,6 +554,10 @@ class SecretChallengeRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SecretChallenge>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SecretChallengeTable> where,
@@ -532,6 +566,7 @@ class SecretChallengeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SecretChallengeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<SecretChallenge>(
       where: where(SecretChallenge.t),
@@ -540,6 +575,7 @@ class SecretChallengeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/anonymous/models/anonymous_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/anonymous/models/anonymous_account.dart
@@ -399,16 +399,22 @@ class AnonymousAccountRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AnonymousAccount>> insert(
     _i1.DatabaseSession session,
     List<AnonymousAccount> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<AnonymousAccount>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -442,6 +448,10 @@ class AnonymousAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AnonymousAccount>> upsert(
     _i1.DatabaseSession session,
     List<AnonymousAccount> rows, {
@@ -449,6 +459,7 @@ class AnonymousAccountRepository {
     _i1.ColumnSelections<AnonymousAccountTable>? updateColumns,
     _i1.WhereExpressionBuilder<AnonymousAccountTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<AnonymousAccount>(
       rows,
@@ -456,6 +467,7 @@ class AnonymousAccountRepository {
       updateColumns: updateColumns?.call(AnonymousAccount.t),
       updateWhere: updateWhere?.call(AnonymousAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -494,16 +506,22 @@ class AnonymousAccountRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AnonymousAccount>> update(
     _i1.DatabaseSession session,
     List<AnonymousAccount> rows, {
     _i1.ColumnSelections<AnonymousAccountTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<AnonymousAccount>(
       rows,
       columns: columns?.call(AnonymousAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -541,6 +559,10 @@ class AnonymousAccountRepository {
 
   /// Updates all [AnonymousAccount]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AnonymousAccount>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<AnonymousAccountUpdateTable>
@@ -553,6 +575,7 @@ class AnonymousAccountRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<AnonymousAccount>(
       columnValues: columnValues(AnonymousAccount.t.updateTable),
@@ -564,6 +587,7 @@ class AnonymousAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -574,6 +598,10 @@ class AnonymousAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AnonymousAccount>> delete(
     _i1.DatabaseSession session,
     List<AnonymousAccount> rows, {
@@ -582,6 +610,7 @@ class AnonymousAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AnonymousAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<AnonymousAccount>(
       rows,
@@ -590,6 +619,7 @@ class AnonymousAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -609,6 +639,10 @@ class AnonymousAccountRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AnonymousAccount>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AnonymousAccountTable> where,
@@ -617,6 +651,7 @@ class AnonymousAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AnonymousAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<AnonymousAccount>(
       where: where(AnonymousAccount.t),
@@ -625,6 +660,7 @@ class AnonymousAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/apple/models/apple_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/apple/models/apple_account.dart
@@ -681,16 +681,22 @@ class AppleAccountRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AppleAccount>> insert(
     _i1.DatabaseSession session,
     List<AppleAccount> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<AppleAccount>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -724,6 +730,10 @@ class AppleAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AppleAccount>> upsert(
     _i1.DatabaseSession session,
     List<AppleAccount> rows, {
@@ -731,6 +741,7 @@ class AppleAccountRepository {
     _i1.ColumnSelections<AppleAccountTable>? updateColumns,
     _i1.WhereExpressionBuilder<AppleAccountTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<AppleAccount>(
       rows,
@@ -738,6 +749,7 @@ class AppleAccountRepository {
       updateColumns: updateColumns?.call(AppleAccount.t),
       updateWhere: updateWhere?.call(AppleAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -776,16 +788,22 @@ class AppleAccountRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AppleAccount>> update(
     _i1.DatabaseSession session,
     List<AppleAccount> rows, {
     _i1.ColumnSelections<AppleAccountTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<AppleAccount>(
       rows,
       columns: columns?.call(AppleAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -822,6 +840,10 @@ class AppleAccountRepository {
 
   /// Updates all [AppleAccount]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AppleAccount>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<AppleAccountUpdateTable> columnValues,
@@ -833,6 +855,7 @@ class AppleAccountRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<AppleAccount>(
       columnValues: columnValues(AppleAccount.t.updateTable),
@@ -844,6 +867,7 @@ class AppleAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -854,6 +878,10 @@ class AppleAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AppleAccount>> delete(
     _i1.DatabaseSession session,
     List<AppleAccount> rows, {
@@ -862,6 +890,7 @@ class AppleAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AppleAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<AppleAccount>(
       rows,
@@ -870,6 +899,7 @@ class AppleAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -889,6 +919,10 @@ class AppleAccountRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AppleAccount>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AppleAccountTable> where,
@@ -897,6 +931,7 @@ class AppleAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AppleAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<AppleAccount>(
       where: where(AppleAccount.t),
@@ -905,6 +940,7 @@ class AppleAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account.dart
@@ -454,16 +454,22 @@ class EmailAccountRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccount>> insert(
     _i1.DatabaseSession session,
     List<EmailAccount> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EmailAccount>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -497,6 +503,10 @@ class EmailAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccount>> upsert(
     _i1.DatabaseSession session,
     List<EmailAccount> rows, {
@@ -504,6 +514,7 @@ class EmailAccountRepository {
     _i1.ColumnSelections<EmailAccountTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmailAccountTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EmailAccount>(
       rows,
@@ -511,6 +522,7 @@ class EmailAccountRepository {
       updateColumns: updateColumns?.call(EmailAccount.t),
       updateWhere: updateWhere?.call(EmailAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,16 +561,22 @@ class EmailAccountRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccount>> update(
     _i1.DatabaseSession session,
     List<EmailAccount> rows, {
     _i1.ColumnSelections<EmailAccountTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EmailAccount>(
       rows,
       columns: columns?.call(EmailAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -595,6 +613,10 @@ class EmailAccountRepository {
 
   /// Updates all [EmailAccount]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccount>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmailAccountUpdateTable> columnValues,
@@ -606,6 +628,7 @@ class EmailAccountRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EmailAccount>(
       columnValues: columnValues(EmailAccount.t.updateTable),
@@ -617,6 +640,7 @@ class EmailAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -627,6 +651,10 @@ class EmailAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccount>> delete(
     _i1.DatabaseSession session,
     List<EmailAccount> rows, {
@@ -635,6 +663,7 @@ class EmailAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EmailAccount>(
       rows,
@@ -643,6 +672,7 @@ class EmailAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -662,6 +692,10 @@ class EmailAccountRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccount>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmailAccountTable> where,
@@ -670,6 +704,7 @@ class EmailAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EmailAccount>(
       where: where(EmailAccount.t),
@@ -678,6 +713,7 @@ class EmailAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account_password_reset_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account_password_reset_request.dart
@@ -566,16 +566,22 @@ class EmailAccountPasswordResetRequestRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccountPasswordResetRequest>> insert(
     _i1.DatabaseSession session,
     List<EmailAccountPasswordResetRequest> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EmailAccountPasswordResetRequest>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -609,6 +615,10 @@ class EmailAccountPasswordResetRequestRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccountPasswordResetRequest>> upsert(
     _i1.DatabaseSession session,
     List<EmailAccountPasswordResetRequest> rows, {
@@ -618,6 +628,7 @@ class EmailAccountPasswordResetRequestRepository {
     _i1.WhereExpressionBuilder<EmailAccountPasswordResetRequestTable>?
     updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EmailAccountPasswordResetRequest>(
       rows,
@@ -625,6 +636,7 @@ class EmailAccountPasswordResetRequestRepository {
       updateColumns: updateColumns?.call(EmailAccountPasswordResetRequest.t),
       updateWhere: updateWhere?.call(EmailAccountPasswordResetRequest.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -665,16 +677,22 @@ class EmailAccountPasswordResetRequestRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccountPasswordResetRequest>> update(
     _i1.DatabaseSession session,
     List<EmailAccountPasswordResetRequest> rows, {
     _i1.ColumnSelections<EmailAccountPasswordResetRequestTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EmailAccountPasswordResetRequest>(
       rows,
       columns: columns?.call(EmailAccountPasswordResetRequest.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -716,6 +734,10 @@ class EmailAccountPasswordResetRequestRepository {
 
   /// Updates all [EmailAccountPasswordResetRequest]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccountPasswordResetRequest>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<
@@ -731,6 +753,7 @@ class EmailAccountPasswordResetRequestRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EmailAccountPasswordResetRequest>(
       columnValues: columnValues(
@@ -744,6 +767,7 @@ class EmailAccountPasswordResetRequestRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -754,6 +778,10 @@ class EmailAccountPasswordResetRequestRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccountPasswordResetRequest>> delete(
     _i1.DatabaseSession session,
     List<EmailAccountPasswordResetRequest> rows, {
@@ -762,6 +790,7 @@ class EmailAccountPasswordResetRequestRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountPasswordResetRequestTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EmailAccountPasswordResetRequest>(
       rows,
@@ -770,6 +799,7 @@ class EmailAccountPasswordResetRequestRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -789,6 +819,10 @@ class EmailAccountPasswordResetRequestRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccountPasswordResetRequest>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmailAccountPasswordResetRequestTable>
@@ -798,6 +832,7 @@ class EmailAccountPasswordResetRequestRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountPasswordResetRequestTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EmailAccountPasswordResetRequest>(
       where: where(EmailAccountPasswordResetRequest.t),
@@ -806,6 +841,7 @@ class EmailAccountPasswordResetRequestRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account_request.dart
@@ -517,16 +517,22 @@ class EmailAccountRequestRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccountRequest>> insert(
     _i1.DatabaseSession session,
     List<EmailAccountRequest> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EmailAccountRequest>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -560,6 +566,10 @@ class EmailAccountRequestRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccountRequest>> upsert(
     _i1.DatabaseSession session,
     List<EmailAccountRequest> rows, {
@@ -567,6 +577,7 @@ class EmailAccountRequestRepository {
     _i1.ColumnSelections<EmailAccountRequestTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmailAccountRequestTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EmailAccountRequest>(
       rows,
@@ -574,6 +585,7 @@ class EmailAccountRequestRepository {
       updateColumns: updateColumns?.call(EmailAccountRequest.t),
       updateWhere: updateWhere?.call(EmailAccountRequest.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -612,16 +624,22 @@ class EmailAccountRequestRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccountRequest>> update(
     _i1.DatabaseSession session,
     List<EmailAccountRequest> rows, {
     _i1.ColumnSelections<EmailAccountRequestTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EmailAccountRequest>(
       rows,
       columns: columns?.call(EmailAccountRequest.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -659,6 +677,10 @@ class EmailAccountRequestRepository {
 
   /// Updates all [EmailAccountRequest]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccountRequest>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmailAccountRequestUpdateTable>
@@ -671,6 +693,7 @@ class EmailAccountRequestRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EmailAccountRequest>(
       columnValues: columnValues(EmailAccountRequest.t.updateTable),
@@ -682,6 +705,7 @@ class EmailAccountRequestRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -692,6 +716,10 @@ class EmailAccountRequestRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccountRequest>> delete(
     _i1.DatabaseSession session,
     List<EmailAccountRequest> rows, {
@@ -700,6 +728,7 @@ class EmailAccountRequestRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EmailAccountRequest>(
       rows,
@@ -708,6 +737,7 @@ class EmailAccountRequestRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -727,6 +757,10 @@ class EmailAccountRequestRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmailAccountRequest>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmailAccountRequestTable> where,
@@ -735,6 +769,7 @@ class EmailAccountRequestRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EmailAccountRequest>(
       where: where(EmailAccountRequest.t),
@@ -743,6 +778,7 @@ class EmailAccountRequestRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/facebook/models/facebook_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/facebook/models/facebook_account.dart
@@ -540,16 +540,22 @@ class FacebookAccountRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FacebookAccount>> insert(
     _i1.DatabaseSession session,
     List<FacebookAccount> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<FacebookAccount>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -583,6 +589,10 @@ class FacebookAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FacebookAccount>> upsert(
     _i1.DatabaseSession session,
     List<FacebookAccount> rows, {
@@ -590,6 +600,7 @@ class FacebookAccountRepository {
     _i1.ColumnSelections<FacebookAccountTable>? updateColumns,
     _i1.WhereExpressionBuilder<FacebookAccountTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<FacebookAccount>(
       rows,
@@ -597,6 +608,7 @@ class FacebookAccountRepository {
       updateColumns: updateColumns?.call(FacebookAccount.t),
       updateWhere: updateWhere?.call(FacebookAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -635,16 +647,22 @@ class FacebookAccountRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FacebookAccount>> update(
     _i1.DatabaseSession session,
     List<FacebookAccount> rows, {
     _i1.ColumnSelections<FacebookAccountTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<FacebookAccount>(
       rows,
       columns: columns?.call(FacebookAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -682,6 +700,10 @@ class FacebookAccountRepository {
 
   /// Updates all [FacebookAccount]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FacebookAccount>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<FacebookAccountUpdateTable>
@@ -694,6 +716,7 @@ class FacebookAccountRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<FacebookAccount>(
       columnValues: columnValues(FacebookAccount.t.updateTable),
@@ -705,6 +728,7 @@ class FacebookAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -715,6 +739,10 @@ class FacebookAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FacebookAccount>> delete(
     _i1.DatabaseSession session,
     List<FacebookAccount> rows, {
@@ -723,6 +751,7 @@ class FacebookAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<FacebookAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<FacebookAccount>(
       rows,
@@ -731,6 +760,7 @@ class FacebookAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -750,6 +780,10 @@ class FacebookAccountRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FacebookAccount>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<FacebookAccountTable> where,
@@ -758,6 +792,7 @@ class FacebookAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<FacebookAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<FacebookAccount>(
       where: where(FacebookAccount.t),
@@ -766,6 +801,7 @@ class FacebookAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/firebase/models/firebase_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/firebase/models/firebase_account.dart
@@ -486,16 +486,22 @@ class FirebaseAccountRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FirebaseAccount>> insert(
     _i1.DatabaseSession session,
     List<FirebaseAccount> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<FirebaseAccount>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -529,6 +535,10 @@ class FirebaseAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FirebaseAccount>> upsert(
     _i1.DatabaseSession session,
     List<FirebaseAccount> rows, {
@@ -536,6 +546,7 @@ class FirebaseAccountRepository {
     _i1.ColumnSelections<FirebaseAccountTable>? updateColumns,
     _i1.WhereExpressionBuilder<FirebaseAccountTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<FirebaseAccount>(
       rows,
@@ -543,6 +554,7 @@ class FirebaseAccountRepository {
       updateColumns: updateColumns?.call(FirebaseAccount.t),
       updateWhere: updateWhere?.call(FirebaseAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -581,16 +593,22 @@ class FirebaseAccountRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FirebaseAccount>> update(
     _i1.DatabaseSession session,
     List<FirebaseAccount> rows, {
     _i1.ColumnSelections<FirebaseAccountTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<FirebaseAccount>(
       rows,
       columns: columns?.call(FirebaseAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -628,6 +646,10 @@ class FirebaseAccountRepository {
 
   /// Updates all [FirebaseAccount]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FirebaseAccount>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<FirebaseAccountUpdateTable>
@@ -640,6 +662,7 @@ class FirebaseAccountRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<FirebaseAccount>(
       columnValues: columnValues(FirebaseAccount.t.updateTable),
@@ -651,6 +674,7 @@ class FirebaseAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -661,6 +685,10 @@ class FirebaseAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FirebaseAccount>> delete(
     _i1.DatabaseSession session,
     List<FirebaseAccount> rows, {
@@ -669,6 +697,7 @@ class FirebaseAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<FirebaseAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<FirebaseAccount>(
       rows,
@@ -677,6 +706,7 @@ class FirebaseAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -696,6 +726,10 @@ class FirebaseAccountRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FirebaseAccount>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<FirebaseAccountTable> where,
@@ -704,6 +738,7 @@ class FirebaseAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<FirebaseAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<FirebaseAccount>(
       where: where(FirebaseAccount.t),
@@ -712,6 +747,7 @@ class FirebaseAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/github/models/github_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/github/models/github_account.dart
@@ -461,16 +461,22 @@ class GitHubAccountRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GitHubAccount>> insert(
     _i1.DatabaseSession session,
     List<GitHubAccount> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<GitHubAccount>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -504,6 +510,10 @@ class GitHubAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GitHubAccount>> upsert(
     _i1.DatabaseSession session,
     List<GitHubAccount> rows, {
@@ -511,6 +521,7 @@ class GitHubAccountRepository {
     _i1.ColumnSelections<GitHubAccountTable>? updateColumns,
     _i1.WhereExpressionBuilder<GitHubAccountTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<GitHubAccount>(
       rows,
@@ -518,6 +529,7 @@ class GitHubAccountRepository {
       updateColumns: updateColumns?.call(GitHubAccount.t),
       updateWhere: updateWhere?.call(GitHubAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -556,16 +568,22 @@ class GitHubAccountRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GitHubAccount>> update(
     _i1.DatabaseSession session,
     List<GitHubAccount> rows, {
     _i1.ColumnSelections<GitHubAccountTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<GitHubAccount>(
       rows,
       columns: columns?.call(GitHubAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -602,6 +620,10 @@ class GitHubAccountRepository {
 
   /// Updates all [GitHubAccount]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GitHubAccount>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<GitHubAccountUpdateTable> columnValues,
@@ -613,6 +635,7 @@ class GitHubAccountRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<GitHubAccount>(
       columnValues: columnValues(GitHubAccount.t.updateTable),
@@ -624,6 +647,7 @@ class GitHubAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -634,6 +658,10 @@ class GitHubAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GitHubAccount>> delete(
     _i1.DatabaseSession session,
     List<GitHubAccount> rows, {
@@ -642,6 +670,7 @@ class GitHubAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<GitHubAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<GitHubAccount>(
       rows,
@@ -650,6 +679,7 @@ class GitHubAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -669,6 +699,10 @@ class GitHubAccountRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GitHubAccount>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<GitHubAccountTable> where,
@@ -677,6 +711,7 @@ class GitHubAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<GitHubAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<GitHubAccount>(
       where: where(GitHubAccount.t),
@@ -685,6 +720,7 @@ class GitHubAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/google/models/google_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/google/models/google_account.dart
@@ -457,16 +457,22 @@ class GoogleAccountRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GoogleAccount>> insert(
     _i1.DatabaseSession session,
     List<GoogleAccount> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<GoogleAccount>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -500,6 +506,10 @@ class GoogleAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GoogleAccount>> upsert(
     _i1.DatabaseSession session,
     List<GoogleAccount> rows, {
@@ -507,6 +517,7 @@ class GoogleAccountRepository {
     _i1.ColumnSelections<GoogleAccountTable>? updateColumns,
     _i1.WhereExpressionBuilder<GoogleAccountTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<GoogleAccount>(
       rows,
@@ -514,6 +525,7 @@ class GoogleAccountRepository {
       updateColumns: updateColumns?.call(GoogleAccount.t),
       updateWhere: updateWhere?.call(GoogleAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -552,16 +564,22 @@ class GoogleAccountRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GoogleAccount>> update(
     _i1.DatabaseSession session,
     List<GoogleAccount> rows, {
     _i1.ColumnSelections<GoogleAccountTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<GoogleAccount>(
       rows,
       columns: columns?.call(GoogleAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -598,6 +616,10 @@ class GoogleAccountRepository {
 
   /// Updates all [GoogleAccount]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GoogleAccount>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<GoogleAccountUpdateTable> columnValues,
@@ -609,6 +631,7 @@ class GoogleAccountRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<GoogleAccount>(
       columnValues: columnValues(GoogleAccount.t.updateTable),
@@ -620,6 +643,7 @@ class GoogleAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -630,6 +654,10 @@ class GoogleAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GoogleAccount>> delete(
     _i1.DatabaseSession session,
     List<GoogleAccount> rows, {
@@ -638,6 +666,7 @@ class GoogleAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<GoogleAccount>(
       rows,
@@ -646,6 +675,7 @@ class GoogleAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -665,6 +695,10 @@ class GoogleAccountRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<GoogleAccount>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<GoogleAccountTable> where,
@@ -673,6 +707,7 @@ class GoogleAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<GoogleAccount>(
       where: where(GoogleAccount.t),
@@ -681,6 +716,7 @@ class GoogleAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/microsoft/models/microsoft_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/microsoft/models/microsoft_account.dart
@@ -462,16 +462,22 @@ class MicrosoftAccountRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MicrosoftAccount>> insert(
     _i1.DatabaseSession session,
     List<MicrosoftAccount> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<MicrosoftAccount>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -505,6 +511,10 @@ class MicrosoftAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MicrosoftAccount>> upsert(
     _i1.DatabaseSession session,
     List<MicrosoftAccount> rows, {
@@ -512,6 +522,7 @@ class MicrosoftAccountRepository {
     _i1.ColumnSelections<MicrosoftAccountTable>? updateColumns,
     _i1.WhereExpressionBuilder<MicrosoftAccountTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<MicrosoftAccount>(
       rows,
@@ -519,6 +530,7 @@ class MicrosoftAccountRepository {
       updateColumns: updateColumns?.call(MicrosoftAccount.t),
       updateWhere: updateWhere?.call(MicrosoftAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -557,16 +569,22 @@ class MicrosoftAccountRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MicrosoftAccount>> update(
     _i1.DatabaseSession session,
     List<MicrosoftAccount> rows, {
     _i1.ColumnSelections<MicrosoftAccountTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<MicrosoftAccount>(
       rows,
       columns: columns?.call(MicrosoftAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -604,6 +622,10 @@ class MicrosoftAccountRepository {
 
   /// Updates all [MicrosoftAccount]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MicrosoftAccount>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<MicrosoftAccountUpdateTable>
@@ -616,6 +638,7 @@ class MicrosoftAccountRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<MicrosoftAccount>(
       columnValues: columnValues(MicrosoftAccount.t.updateTable),
@@ -627,6 +650,7 @@ class MicrosoftAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -637,6 +661,10 @@ class MicrosoftAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MicrosoftAccount>> delete(
     _i1.DatabaseSession session,
     List<MicrosoftAccount> rows, {
@@ -645,6 +673,7 @@ class MicrosoftAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MicrosoftAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<MicrosoftAccount>(
       rows,
@@ -653,6 +682,7 @@ class MicrosoftAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -672,6 +702,10 @@ class MicrosoftAccountRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MicrosoftAccount>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MicrosoftAccountTable> where,
@@ -680,6 +714,7 @@ class MicrosoftAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MicrosoftAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<MicrosoftAccount>(
       where: where(MicrosoftAccount.t),
@@ -688,6 +723,7 @@ class MicrosoftAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/passkey/models/passkey_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/passkey/models/passkey_account.dart
@@ -535,16 +535,22 @@ class PasskeyAccountRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PasskeyAccount>> insert(
     _i1.DatabaseSession session,
     List<PasskeyAccount> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<PasskeyAccount>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -578,6 +584,10 @@ class PasskeyAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PasskeyAccount>> upsert(
     _i1.DatabaseSession session,
     List<PasskeyAccount> rows, {
@@ -585,6 +595,7 @@ class PasskeyAccountRepository {
     _i1.ColumnSelections<PasskeyAccountTable>? updateColumns,
     _i1.WhereExpressionBuilder<PasskeyAccountTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<PasskeyAccount>(
       rows,
@@ -592,6 +603,7 @@ class PasskeyAccountRepository {
       updateColumns: updateColumns?.call(PasskeyAccount.t),
       updateWhere: updateWhere?.call(PasskeyAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -630,16 +642,22 @@ class PasskeyAccountRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PasskeyAccount>> update(
     _i1.DatabaseSession session,
     List<PasskeyAccount> rows, {
     _i1.ColumnSelections<PasskeyAccountTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<PasskeyAccount>(
       rows,
       columns: columns?.call(PasskeyAccount.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -676,6 +694,10 @@ class PasskeyAccountRepository {
 
   /// Updates all [PasskeyAccount]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PasskeyAccount>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PasskeyAccountUpdateTable> columnValues,
@@ -687,6 +709,7 @@ class PasskeyAccountRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<PasskeyAccount>(
       columnValues: columnValues(PasskeyAccount.t.updateTable),
@@ -698,6 +721,7 @@ class PasskeyAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -708,6 +732,10 @@ class PasskeyAccountRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PasskeyAccount>> delete(
     _i1.DatabaseSession session,
     List<PasskeyAccount> rows, {
@@ -716,6 +744,7 @@ class PasskeyAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<PasskeyAccount>(
       rows,
@@ -724,6 +753,7 @@ class PasskeyAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -743,6 +773,10 @@ class PasskeyAccountRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PasskeyAccount>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PasskeyAccountTable> where,
@@ -751,6 +785,7 @@ class PasskeyAccountRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyAccountTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<PasskeyAccount>(
       where: where(PasskeyAccount.t),
@@ -759,6 +794,7 @@ class PasskeyAccountRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/passkey/models/passkey_challenge.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/passkey/models/passkey_challenge.dart
@@ -341,16 +341,22 @@ class PasskeyChallengeRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PasskeyChallenge>> insert(
     _i1.DatabaseSession session,
     List<PasskeyChallenge> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<PasskeyChallenge>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -384,6 +390,10 @@ class PasskeyChallengeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PasskeyChallenge>> upsert(
     _i1.DatabaseSession session,
     List<PasskeyChallenge> rows, {
@@ -391,6 +401,7 @@ class PasskeyChallengeRepository {
     _i1.ColumnSelections<PasskeyChallengeTable>? updateColumns,
     _i1.WhereExpressionBuilder<PasskeyChallengeTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<PasskeyChallenge>(
       rows,
@@ -398,6 +409,7 @@ class PasskeyChallengeRepository {
       updateColumns: updateColumns?.call(PasskeyChallenge.t),
       updateWhere: updateWhere?.call(PasskeyChallenge.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -436,16 +448,22 @@ class PasskeyChallengeRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PasskeyChallenge>> update(
     _i1.DatabaseSession session,
     List<PasskeyChallenge> rows, {
     _i1.ColumnSelections<PasskeyChallengeTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<PasskeyChallenge>(
       rows,
       columns: columns?.call(PasskeyChallenge.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -483,6 +501,10 @@ class PasskeyChallengeRepository {
 
   /// Updates all [PasskeyChallenge]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PasskeyChallenge>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PasskeyChallengeUpdateTable>
@@ -495,6 +517,7 @@ class PasskeyChallengeRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<PasskeyChallenge>(
       columnValues: columnValues(PasskeyChallenge.t.updateTable),
@@ -506,6 +529,7 @@ class PasskeyChallengeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -516,6 +540,10 @@ class PasskeyChallengeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PasskeyChallenge>> delete(
     _i1.DatabaseSession session,
     List<PasskeyChallenge> rows, {
@@ -524,6 +552,7 @@ class PasskeyChallengeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyChallengeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<PasskeyChallenge>(
       rows,
@@ -532,6 +561,7 @@ class PasskeyChallengeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -551,6 +581,10 @@ class PasskeyChallengeRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PasskeyChallenge>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PasskeyChallengeTable> where,
@@ -559,6 +593,7 @@ class PasskeyChallengeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyChallengeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<PasskeyChallenge>(
       where: where(PasskeyChallenge.t),
@@ -567,6 +602,7 @@ class PasskeyChallengeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/migrated_user.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/migrated_user.dart
@@ -440,16 +440,22 @@ class MigratedUserRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MigratedUser>> insert(
     _i1.DatabaseSession session,
     List<MigratedUser> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<MigratedUser>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -483,6 +489,10 @@ class MigratedUserRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MigratedUser>> upsert(
     _i1.DatabaseSession session,
     List<MigratedUser> rows, {
@@ -490,6 +500,7 @@ class MigratedUserRepository {
     _i1.ColumnSelections<MigratedUserTable>? updateColumns,
     _i1.WhereExpressionBuilder<MigratedUserTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<MigratedUser>(
       rows,
@@ -497,6 +508,7 @@ class MigratedUserRepository {
       updateColumns: updateColumns?.call(MigratedUser.t),
       updateWhere: updateWhere?.call(MigratedUser.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -535,16 +547,22 @@ class MigratedUserRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MigratedUser>> update(
     _i1.DatabaseSession session,
     List<MigratedUser> rows, {
     _i1.ColumnSelections<MigratedUserTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<MigratedUser>(
       rows,
       columns: columns?.call(MigratedUser.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -581,6 +599,10 @@ class MigratedUserRepository {
 
   /// Updates all [MigratedUser]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MigratedUser>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<MigratedUserUpdateTable> columnValues,
@@ -592,6 +614,7 @@ class MigratedUserRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<MigratedUser>(
       columnValues: columnValues(MigratedUser.t.updateTable),
@@ -603,6 +626,7 @@ class MigratedUserRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -613,6 +637,10 @@ class MigratedUserRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MigratedUser>> delete(
     _i1.DatabaseSession session,
     List<MigratedUser> rows, {
@@ -621,6 +649,7 @@ class MigratedUserRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MigratedUserTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<MigratedUser>(
       rows,
@@ -629,6 +658,7 @@ class MigratedUserRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -648,6 +678,10 @@ class MigratedUserRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MigratedUser>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MigratedUserTable> where,
@@ -656,6 +690,7 @@ class MigratedUserRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MigratedUserTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<MigratedUser>(
       where: where(MigratedUser.t),
@@ -664,6 +699,7 @@ class MigratedUserRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -451,16 +451,22 @@ class CloudStorageEntryRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CloudStorageEntry>> insert(
     _i1.DatabaseSession session,
     List<CloudStorageEntry> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CloudStorageEntry>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -494,6 +500,10 @@ class CloudStorageEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CloudStorageEntry>> upsert(
     _i1.DatabaseSession session,
     List<CloudStorageEntry> rows, {
@@ -501,6 +511,7 @@ class CloudStorageEntryRepository {
     _i1.ColumnSelections<CloudStorageEntryTable>? updateColumns,
     _i1.WhereExpressionBuilder<CloudStorageEntryTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CloudStorageEntry>(
       rows,
@@ -508,6 +519,7 @@ class CloudStorageEntryRepository {
       updateColumns: updateColumns?.call(CloudStorageEntry.t),
       updateWhere: updateWhere?.call(CloudStorageEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -546,16 +558,22 @@ class CloudStorageEntryRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CloudStorageEntry>> update(
     _i1.DatabaseSession session,
     List<CloudStorageEntry> rows, {
     _i1.ColumnSelections<CloudStorageEntryTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CloudStorageEntry>(
       rows,
       columns: columns?.call(CloudStorageEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -593,6 +611,10 @@ class CloudStorageEntryRepository {
 
   /// Updates all [CloudStorageEntry]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CloudStorageEntry>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CloudStorageEntryUpdateTable>
@@ -605,6 +627,7 @@ class CloudStorageEntryRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CloudStorageEntry>(
       columnValues: columnValues(CloudStorageEntry.t.updateTable),
@@ -616,6 +639,7 @@ class CloudStorageEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -626,6 +650,10 @@ class CloudStorageEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CloudStorageEntry>> delete(
     _i1.DatabaseSession session,
     List<CloudStorageEntry> rows, {
@@ -634,6 +662,7 @@ class CloudStorageEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CloudStorageEntry>(
       rows,
@@ -642,6 +671,7 @@ class CloudStorageEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -661,6 +691,10 @@ class CloudStorageEntryRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CloudStorageEntry>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CloudStorageEntryTable> where,
@@ -669,6 +703,7 @@ class CloudStorageEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CloudStorageEntry>(
       where: where(CloudStorageEntry.t),
@@ -677,6 +712,7 @@ class CloudStorageEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -394,16 +394,22 @@ class CloudStorageDirectUploadEntryRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CloudStorageDirectUploadEntry>> insert(
     _i1.DatabaseSession session,
     List<CloudStorageDirectUploadEntry> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CloudStorageDirectUploadEntry>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -437,6 +443,10 @@ class CloudStorageDirectUploadEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CloudStorageDirectUploadEntry>> upsert(
     _i1.DatabaseSession session,
     List<CloudStorageDirectUploadEntry> rows, {
@@ -445,6 +455,7 @@ class CloudStorageDirectUploadEntryRepository {
     _i1.ColumnSelections<CloudStorageDirectUploadEntryTable>? updateColumns,
     _i1.WhereExpressionBuilder<CloudStorageDirectUploadEntryTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CloudStorageDirectUploadEntry>(
       rows,
@@ -452,6 +463,7 @@ class CloudStorageDirectUploadEntryRepository {
       updateColumns: updateColumns?.call(CloudStorageDirectUploadEntry.t),
       updateWhere: updateWhere?.call(CloudStorageDirectUploadEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -491,16 +503,22 @@ class CloudStorageDirectUploadEntryRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CloudStorageDirectUploadEntry>> update(
     _i1.DatabaseSession session,
     List<CloudStorageDirectUploadEntry> rows, {
     _i1.ColumnSelections<CloudStorageDirectUploadEntryTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CloudStorageDirectUploadEntry>(
       rows,
       columns: columns?.call(CloudStorageDirectUploadEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -540,6 +558,10 @@ class CloudStorageDirectUploadEntryRepository {
 
   /// Updates all [CloudStorageDirectUploadEntry]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CloudStorageDirectUploadEntry>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<
@@ -555,6 +577,7 @@ class CloudStorageDirectUploadEntryRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CloudStorageDirectUploadEntry>(
       columnValues: columnValues(CloudStorageDirectUploadEntry.t.updateTable),
@@ -566,6 +589,7 @@ class CloudStorageDirectUploadEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -576,6 +600,10 @@ class CloudStorageDirectUploadEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CloudStorageDirectUploadEntry>> delete(
     _i1.DatabaseSession session,
     List<CloudStorageDirectUploadEntry> rows, {
@@ -584,6 +612,7 @@ class CloudStorageDirectUploadEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageDirectUploadEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CloudStorageDirectUploadEntry>(
       rows,
@@ -592,6 +621,7 @@ class CloudStorageDirectUploadEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -611,6 +641,10 @@ class CloudStorageDirectUploadEntryRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CloudStorageDirectUploadEntry>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CloudStorageDirectUploadEntryTable>
@@ -620,6 +654,7 @@ class CloudStorageDirectUploadEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageDirectUploadEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CloudStorageDirectUploadEntry>(
       where: where(CloudStorageDirectUploadEntry.t),
@@ -628,6 +663,7 @@ class CloudStorageDirectUploadEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database_migration_version.dart
@@ -362,16 +362,22 @@ class DatabaseMigrationVersionRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DatabaseMigrationVersion>> insert(
     _i2.DatabaseSession session,
     List<DatabaseMigrationVersion> rows, {
     _i2.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DatabaseMigrationVersion>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -405,6 +411,10 @@ class DatabaseMigrationVersionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DatabaseMigrationVersion>> upsert(
     _i2.DatabaseSession session,
     List<DatabaseMigrationVersion> rows, {
@@ -413,6 +423,7 @@ class DatabaseMigrationVersionRepository {
     _i2.ColumnSelections<DatabaseMigrationVersionTable>? updateColumns,
     _i2.WhereExpressionBuilder<DatabaseMigrationVersionTable>? updateWhere,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DatabaseMigrationVersion>(
       rows,
@@ -420,6 +431,7 @@ class DatabaseMigrationVersionRepository {
       updateColumns: updateColumns?.call(DatabaseMigrationVersion.t),
       updateWhere: updateWhere?.call(DatabaseMigrationVersion.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -459,16 +471,22 @@ class DatabaseMigrationVersionRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DatabaseMigrationVersion>> update(
     _i2.DatabaseSession session,
     List<DatabaseMigrationVersion> rows, {
     _i2.ColumnSelections<DatabaseMigrationVersionTable>? columns,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DatabaseMigrationVersion>(
       rows,
       columns: columns?.call(DatabaseMigrationVersion.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -506,6 +524,10 @@ class DatabaseMigrationVersionRepository {
 
   /// Updates all [DatabaseMigrationVersion]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DatabaseMigrationVersion>> updateWhere(
     _i2.DatabaseSession session, {
     required _i2.ColumnValueListBuilder<DatabaseMigrationVersionUpdateTable>
@@ -518,6 +540,7 @@ class DatabaseMigrationVersionRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DatabaseMigrationVersion>(
       columnValues: columnValues(DatabaseMigrationVersion.t.updateTable),
@@ -529,6 +552,7 @@ class DatabaseMigrationVersionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -539,6 +563,10 @@ class DatabaseMigrationVersionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DatabaseMigrationVersion>> delete(
     _i2.DatabaseSession session,
     List<DatabaseMigrationVersion> rows, {
@@ -547,6 +575,7 @@ class DatabaseMigrationVersionRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<DatabaseMigrationVersionTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DatabaseMigrationVersion>(
       rows,
@@ -555,6 +584,7 @@ class DatabaseMigrationVersionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -574,6 +604,10 @@ class DatabaseMigrationVersionRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DatabaseMigrationVersion>> deleteWhere(
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<DatabaseMigrationVersionTable> where,
@@ -582,6 +616,7 @@ class DatabaseMigrationVersionRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<DatabaseMigrationVersionTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DatabaseMigrationVersion>(
       where: where(DatabaseMigrationVersion.t),
@@ -590,6 +625,7 @@ class DatabaseMigrationVersionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/future_call_claim_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_claim_entry.dart
@@ -344,16 +344,22 @@ class FutureCallClaimEntryRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FutureCallClaimEntry>> insert(
     _i1.DatabaseSession session,
     List<FutureCallClaimEntry> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<FutureCallClaimEntry>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -387,6 +393,10 @@ class FutureCallClaimEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FutureCallClaimEntry>> upsert(
     _i1.DatabaseSession session,
     List<FutureCallClaimEntry> rows, {
@@ -394,6 +404,7 @@ class FutureCallClaimEntryRepository {
     _i1.ColumnSelections<FutureCallClaimEntryTable>? updateColumns,
     _i1.WhereExpressionBuilder<FutureCallClaimEntryTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<FutureCallClaimEntry>(
       rows,
@@ -401,6 +412,7 @@ class FutureCallClaimEntryRepository {
       updateColumns: updateColumns?.call(FutureCallClaimEntry.t),
       updateWhere: updateWhere?.call(FutureCallClaimEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -439,16 +451,22 @@ class FutureCallClaimEntryRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FutureCallClaimEntry>> update(
     _i1.DatabaseSession session,
     List<FutureCallClaimEntry> rows, {
     _i1.ColumnSelections<FutureCallClaimEntryTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<FutureCallClaimEntry>(
       rows,
       columns: columns?.call(FutureCallClaimEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,6 +504,10 @@ class FutureCallClaimEntryRepository {
 
   /// Updates all [FutureCallClaimEntry]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FutureCallClaimEntry>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<FutureCallClaimEntryUpdateTable>
@@ -498,6 +520,7 @@ class FutureCallClaimEntryRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<FutureCallClaimEntry>(
       columnValues: columnValues(FutureCallClaimEntry.t.updateTable),
@@ -509,6 +532,7 @@ class FutureCallClaimEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -519,6 +543,10 @@ class FutureCallClaimEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FutureCallClaimEntry>> delete(
     _i1.DatabaseSession session,
     List<FutureCallClaimEntry> rows, {
@@ -527,6 +555,7 @@ class FutureCallClaimEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallClaimEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<FutureCallClaimEntry>(
       rows,
@@ -535,6 +564,7 @@ class FutureCallClaimEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -554,6 +584,10 @@ class FutureCallClaimEntryRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FutureCallClaimEntry>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<FutureCallClaimEntryTable> where,
@@ -562,6 +596,7 @@ class FutureCallClaimEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallClaimEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<FutureCallClaimEntry>(
       where: where(FutureCallClaimEntry.t),
@@ -570,6 +605,7 @@ class FutureCallClaimEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -454,16 +454,22 @@ class FutureCallEntryRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FutureCallEntry>> insert(
     _i1.DatabaseSession session,
     List<FutureCallEntry> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<FutureCallEntry>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -497,6 +503,10 @@ class FutureCallEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FutureCallEntry>> upsert(
     _i1.DatabaseSession session,
     List<FutureCallEntry> rows, {
@@ -504,6 +514,7 @@ class FutureCallEntryRepository {
     _i1.ColumnSelections<FutureCallEntryTable>? updateColumns,
     _i1.WhereExpressionBuilder<FutureCallEntryTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<FutureCallEntry>(
       rows,
@@ -511,6 +522,7 @@ class FutureCallEntryRepository {
       updateColumns: updateColumns?.call(FutureCallEntry.t),
       updateWhere: updateWhere?.call(FutureCallEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,16 +561,22 @@ class FutureCallEntryRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FutureCallEntry>> update(
     _i1.DatabaseSession session,
     List<FutureCallEntry> rows, {
     _i1.ColumnSelections<FutureCallEntryTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<FutureCallEntry>(
       rows,
       columns: columns?.call(FutureCallEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -596,6 +614,10 @@ class FutureCallEntryRepository {
 
   /// Updates all [FutureCallEntry]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FutureCallEntry>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<FutureCallEntryUpdateTable>
@@ -608,6 +630,7 @@ class FutureCallEntryRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<FutureCallEntry>(
       columnValues: columnValues(FutureCallEntry.t.updateTable),
@@ -619,6 +642,7 @@ class FutureCallEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -629,6 +653,10 @@ class FutureCallEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FutureCallEntry>> delete(
     _i1.DatabaseSession session,
     List<FutureCallEntry> rows, {
@@ -637,6 +665,7 @@ class FutureCallEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<FutureCallEntry>(
       rows,
@@ -645,6 +674,7 @@ class FutureCallEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -664,6 +694,10 @@ class FutureCallEntryRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<FutureCallEntry>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<FutureCallEntryTable> where,
@@ -672,6 +706,7 @@ class FutureCallEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<FutureCallEntry>(
       where: where(FutureCallEntry.t),
@@ -680,6 +715,7 @@ class FutureCallEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -546,16 +546,22 @@ class LogEntryRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LogEntry>> insert(
     _i1.DatabaseSession session,
     List<LogEntry> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<LogEntry>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -589,6 +595,10 @@ class LogEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LogEntry>> upsert(
     _i1.DatabaseSession session,
     List<LogEntry> rows, {
@@ -596,6 +606,7 @@ class LogEntryRepository {
     _i1.ColumnSelections<LogEntryTable>? updateColumns,
     _i1.WhereExpressionBuilder<LogEntryTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<LogEntry>(
       rows,
@@ -603,6 +614,7 @@ class LogEntryRepository {
       updateColumns: updateColumns?.call(LogEntry.t),
       updateWhere: updateWhere?.call(LogEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -641,16 +653,22 @@ class LogEntryRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LogEntry>> update(
     _i1.DatabaseSession session,
     List<LogEntry> rows, {
     _i1.ColumnSelections<LogEntryTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<LogEntry>(
       rows,
       columns: columns?.call(LogEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -687,6 +705,10 @@ class LogEntryRepository {
 
   /// Updates all [LogEntry]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LogEntry>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<LogEntryUpdateTable> columnValues,
@@ -698,6 +720,7 @@ class LogEntryRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<LogEntry>(
       columnValues: columnValues(LogEntry.t.updateTable),
@@ -709,6 +732,7 @@ class LogEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -719,6 +743,10 @@ class LogEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LogEntry>> delete(
     _i1.DatabaseSession session,
     List<LogEntry> rows, {
@@ -727,6 +755,7 @@ class LogEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LogEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<LogEntry>(
       rows,
@@ -735,6 +764,7 @@ class LogEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -754,6 +784,10 @@ class LogEntryRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LogEntry>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<LogEntryTable> where,
@@ -762,6 +796,7 @@ class LogEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LogEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<LogEntry>(
       where: where(LogEntry.t),
@@ -770,6 +805,7 @@ class LogEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -548,16 +548,22 @@ class MessageLogEntryRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MessageLogEntry>> insert(
     _i1.DatabaseSession session,
     List<MessageLogEntry> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<MessageLogEntry>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +597,10 @@ class MessageLogEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MessageLogEntry>> upsert(
     _i1.DatabaseSession session,
     List<MessageLogEntry> rows, {
@@ -598,6 +608,7 @@ class MessageLogEntryRepository {
     _i1.ColumnSelections<MessageLogEntryTable>? updateColumns,
     _i1.WhereExpressionBuilder<MessageLogEntryTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<MessageLogEntry>(
       rows,
@@ -605,6 +616,7 @@ class MessageLogEntryRepository {
       updateColumns: updateColumns?.call(MessageLogEntry.t),
       updateWhere: updateWhere?.call(MessageLogEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -643,16 +655,22 @@ class MessageLogEntryRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MessageLogEntry>> update(
     _i1.DatabaseSession session,
     List<MessageLogEntry> rows, {
     _i1.ColumnSelections<MessageLogEntryTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<MessageLogEntry>(
       rows,
       columns: columns?.call(MessageLogEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -690,6 +708,10 @@ class MessageLogEntryRepository {
 
   /// Updates all [MessageLogEntry]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MessageLogEntry>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<MessageLogEntryUpdateTable>
@@ -702,6 +724,7 @@ class MessageLogEntryRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<MessageLogEntry>(
       columnValues: columnValues(MessageLogEntry.t.updateTable),
@@ -713,6 +736,7 @@ class MessageLogEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -723,6 +747,10 @@ class MessageLogEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MessageLogEntry>> delete(
     _i1.DatabaseSession session,
     List<MessageLogEntry> rows, {
@@ -731,6 +759,7 @@ class MessageLogEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MessageLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<MessageLogEntry>(
       rows,
@@ -739,6 +768,7 @@ class MessageLogEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -758,6 +788,10 @@ class MessageLogEntryRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MessageLogEntry>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MessageLogEntryTable> where,
@@ -766,6 +800,7 @@ class MessageLogEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MessageLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<MessageLogEntry>(
       where: where(MessageLogEntry.t),
@@ -774,6 +809,7 @@ class MessageLogEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -336,16 +336,22 @@ class MethodInfoRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MethodInfo>> insert(
     _i1.DatabaseSession session,
     List<MethodInfo> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<MethodInfo>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -379,6 +385,10 @@ class MethodInfoRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MethodInfo>> upsert(
     _i1.DatabaseSession session,
     List<MethodInfo> rows, {
@@ -386,6 +396,7 @@ class MethodInfoRepository {
     _i1.ColumnSelections<MethodInfoTable>? updateColumns,
     _i1.WhereExpressionBuilder<MethodInfoTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<MethodInfo>(
       rows,
@@ -393,6 +404,7 @@ class MethodInfoRepository {
       updateColumns: updateColumns?.call(MethodInfo.t),
       updateWhere: updateWhere?.call(MethodInfo.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -431,16 +443,22 @@ class MethodInfoRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MethodInfo>> update(
     _i1.DatabaseSession session,
     List<MethodInfo> rows, {
     _i1.ColumnSelections<MethodInfoTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<MethodInfo>(
       rows,
       columns: columns?.call(MethodInfo.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -477,6 +495,10 @@ class MethodInfoRepository {
 
   /// Updates all [MethodInfo]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MethodInfo>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<MethodInfoUpdateTable> columnValues,
@@ -488,6 +510,7 @@ class MethodInfoRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<MethodInfo>(
       columnValues: columnValues(MethodInfo.t.updateTable),
@@ -499,6 +522,7 @@ class MethodInfoRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -509,6 +533,10 @@ class MethodInfoRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MethodInfo>> delete(
     _i1.DatabaseSession session,
     List<MethodInfo> rows, {
@@ -517,6 +545,7 @@ class MethodInfoRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MethodInfoTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<MethodInfo>(
       rows,
@@ -525,6 +554,7 @@ class MethodInfoRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -544,6 +574,10 @@ class MethodInfoRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MethodInfo>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MethodInfoTable> where,
@@ -552,6 +586,7 @@ class MethodInfoRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MethodInfoTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<MethodInfo>(
       where: where(MethodInfo.t),
@@ -560,6 +595,7 @@ class MethodInfoRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -548,16 +548,22 @@ class QueryLogEntryRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<QueryLogEntry>> insert(
     _i1.DatabaseSession session,
     List<QueryLogEntry> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<QueryLogEntry>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +597,10 @@ class QueryLogEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<QueryLogEntry>> upsert(
     _i1.DatabaseSession session,
     List<QueryLogEntry> rows, {
@@ -598,6 +608,7 @@ class QueryLogEntryRepository {
     _i1.ColumnSelections<QueryLogEntryTable>? updateColumns,
     _i1.WhereExpressionBuilder<QueryLogEntryTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<QueryLogEntry>(
       rows,
@@ -605,6 +616,7 @@ class QueryLogEntryRepository {
       updateColumns: updateColumns?.call(QueryLogEntry.t),
       updateWhere: updateWhere?.call(QueryLogEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -643,16 +655,22 @@ class QueryLogEntryRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<QueryLogEntry>> update(
     _i1.DatabaseSession session,
     List<QueryLogEntry> rows, {
     _i1.ColumnSelections<QueryLogEntryTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<QueryLogEntry>(
       rows,
       columns: columns?.call(QueryLogEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -689,6 +707,10 @@ class QueryLogEntryRepository {
 
   /// Updates all [QueryLogEntry]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<QueryLogEntry>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<QueryLogEntryUpdateTable> columnValues,
@@ -700,6 +722,7 @@ class QueryLogEntryRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<QueryLogEntry>(
       columnValues: columnValues(QueryLogEntry.t.updateTable),
@@ -711,6 +734,7 @@ class QueryLogEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -721,6 +745,10 @@ class QueryLogEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<QueryLogEntry>> delete(
     _i1.DatabaseSession session,
     List<QueryLogEntry> rows, {
@@ -729,6 +757,7 @@ class QueryLogEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<QueryLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<QueryLogEntry>(
       rows,
@@ -737,6 +766,7 @@ class QueryLogEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -756,6 +786,10 @@ class QueryLogEntryRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<QueryLogEntry>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<QueryLogEntryTable> where,
@@ -764,6 +798,7 @@ class QueryLogEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<QueryLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<QueryLogEntry>(
       where: where(QueryLogEntry.t),
@@ -772,6 +807,7 @@ class QueryLogEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -312,16 +312,22 @@ class ReadWriteTestEntryRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ReadWriteTestEntry>> insert(
     _i1.DatabaseSession session,
     List<ReadWriteTestEntry> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ReadWriteTestEntry>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -355,6 +361,10 @@ class ReadWriteTestEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ReadWriteTestEntry>> upsert(
     _i1.DatabaseSession session,
     List<ReadWriteTestEntry> rows, {
@@ -362,6 +372,7 @@ class ReadWriteTestEntryRepository {
     _i1.ColumnSelections<ReadWriteTestEntryTable>? updateColumns,
     _i1.WhereExpressionBuilder<ReadWriteTestEntryTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ReadWriteTestEntry>(
       rows,
@@ -369,6 +380,7 @@ class ReadWriteTestEntryRepository {
       updateColumns: updateColumns?.call(ReadWriteTestEntry.t),
       updateWhere: updateWhere?.call(ReadWriteTestEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -407,16 +419,22 @@ class ReadWriteTestEntryRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ReadWriteTestEntry>> update(
     _i1.DatabaseSession session,
     List<ReadWriteTestEntry> rows, {
     _i1.ColumnSelections<ReadWriteTestEntryTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ReadWriteTestEntry>(
       rows,
       columns: columns?.call(ReadWriteTestEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -454,6 +472,10 @@ class ReadWriteTestEntryRepository {
 
   /// Updates all [ReadWriteTestEntry]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ReadWriteTestEntry>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ReadWriteTestEntryUpdateTable>
@@ -466,6 +488,7 @@ class ReadWriteTestEntryRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ReadWriteTestEntry>(
       columnValues: columnValues(ReadWriteTestEntry.t.updateTable),
@@ -477,6 +500,7 @@ class ReadWriteTestEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -487,6 +511,10 @@ class ReadWriteTestEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ReadWriteTestEntry>> delete(
     _i1.DatabaseSession session,
     List<ReadWriteTestEntry> rows, {
@@ -495,6 +523,7 @@ class ReadWriteTestEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ReadWriteTestEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ReadWriteTestEntry>(
       rows,
@@ -503,6 +532,7 @@ class ReadWriteTestEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -522,6 +552,10 @@ class ReadWriteTestEntryRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ReadWriteTestEntry>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ReadWriteTestEntryTable> where,
@@ -530,6 +564,7 @@ class ReadWriteTestEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ReadWriteTestEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ReadWriteTestEntry>(
       where: where(ReadWriteTestEntry.t),
@@ -538,6 +573,7 @@ class ReadWriteTestEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -411,16 +411,22 @@ class RuntimeSettingsRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RuntimeSettings>> insert(
     _i1.DatabaseSession session,
     List<RuntimeSettings> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<RuntimeSettings>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -454,6 +460,10 @@ class RuntimeSettingsRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RuntimeSettings>> upsert(
     _i1.DatabaseSession session,
     List<RuntimeSettings> rows, {
@@ -461,6 +471,7 @@ class RuntimeSettingsRepository {
     _i1.ColumnSelections<RuntimeSettingsTable>? updateColumns,
     _i1.WhereExpressionBuilder<RuntimeSettingsTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<RuntimeSettings>(
       rows,
@@ -468,6 +479,7 @@ class RuntimeSettingsRepository {
       updateColumns: updateColumns?.call(RuntimeSettings.t),
       updateWhere: updateWhere?.call(RuntimeSettings.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -506,16 +518,22 @@ class RuntimeSettingsRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RuntimeSettings>> update(
     _i1.DatabaseSession session,
     List<RuntimeSettings> rows, {
     _i1.ColumnSelections<RuntimeSettingsTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<RuntimeSettings>(
       rows,
       columns: columns?.call(RuntimeSettings.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -553,6 +571,10 @@ class RuntimeSettingsRepository {
 
   /// Updates all [RuntimeSettings]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RuntimeSettings>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<RuntimeSettingsUpdateTable>
@@ -565,6 +587,7 @@ class RuntimeSettingsRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<RuntimeSettings>(
       columnValues: columnValues(RuntimeSettings.t.updateTable),
@@ -576,6 +599,7 @@ class RuntimeSettingsRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -586,6 +610,10 @@ class RuntimeSettingsRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RuntimeSettings>> delete(
     _i1.DatabaseSession session,
     List<RuntimeSettings> rows, {
@@ -594,6 +622,7 @@ class RuntimeSettingsRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RuntimeSettingsTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<RuntimeSettings>(
       rows,
@@ -602,6 +631,7 @@ class RuntimeSettingsRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -621,6 +651,10 @@ class RuntimeSettingsRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RuntimeSettings>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RuntimeSettingsTable> where,
@@ -629,6 +663,7 @@ class RuntimeSettingsRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RuntimeSettingsTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<RuntimeSettings>(
       where: where(RuntimeSettings.t),
@@ -637,6 +672,7 @@ class RuntimeSettingsRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -450,16 +450,22 @@ class ServerHealthConnectionInfoRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerHealthConnectionInfo>> insert(
     _i1.DatabaseSession session,
     List<ServerHealthConnectionInfo> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ServerHealthConnectionInfo>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -493,6 +499,10 @@ class ServerHealthConnectionInfoRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerHealthConnectionInfo>> upsert(
     _i1.DatabaseSession session,
     List<ServerHealthConnectionInfo> rows, {
@@ -501,6 +511,7 @@ class ServerHealthConnectionInfoRepository {
     _i1.ColumnSelections<ServerHealthConnectionInfoTable>? updateColumns,
     _i1.WhereExpressionBuilder<ServerHealthConnectionInfoTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ServerHealthConnectionInfo>(
       rows,
@@ -508,6 +519,7 @@ class ServerHealthConnectionInfoRepository {
       updateColumns: updateColumns?.call(ServerHealthConnectionInfo.t),
       updateWhere: updateWhere?.call(ServerHealthConnectionInfo.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -547,16 +559,22 @@ class ServerHealthConnectionInfoRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerHealthConnectionInfo>> update(
     _i1.DatabaseSession session,
     List<ServerHealthConnectionInfo> rows, {
     _i1.ColumnSelections<ServerHealthConnectionInfoTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ServerHealthConnectionInfo>(
       rows,
       columns: columns?.call(ServerHealthConnectionInfo.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -594,6 +612,10 @@ class ServerHealthConnectionInfoRepository {
 
   /// Updates all [ServerHealthConnectionInfo]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerHealthConnectionInfo>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ServerHealthConnectionInfoUpdateTable>
@@ -606,6 +628,7 @@ class ServerHealthConnectionInfoRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ServerHealthConnectionInfo>(
       columnValues: columnValues(ServerHealthConnectionInfo.t.updateTable),
@@ -617,6 +640,7 @@ class ServerHealthConnectionInfoRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -627,6 +651,10 @@ class ServerHealthConnectionInfoRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerHealthConnectionInfo>> delete(
     _i1.DatabaseSession session,
     List<ServerHealthConnectionInfo> rows, {
@@ -635,6 +663,7 @@ class ServerHealthConnectionInfoRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthConnectionInfoTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ServerHealthConnectionInfo>(
       rows,
@@ -643,6 +672,7 @@ class ServerHealthConnectionInfoRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -662,6 +692,10 @@ class ServerHealthConnectionInfoRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerHealthConnectionInfo>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ServerHealthConnectionInfoTable> where,
@@ -670,6 +704,7 @@ class ServerHealthConnectionInfoRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthConnectionInfoTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ServerHealthConnectionInfo>(
       where: where(ServerHealthConnectionInfo.t),
@@ -678,6 +713,7 @@ class ServerHealthConnectionInfoRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -448,16 +448,22 @@ class ServerHealthMetricRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerHealthMetric>> insert(
     _i1.DatabaseSession session,
     List<ServerHealthMetric> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ServerHealthMetric>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -491,6 +497,10 @@ class ServerHealthMetricRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerHealthMetric>> upsert(
     _i1.DatabaseSession session,
     List<ServerHealthMetric> rows, {
@@ -498,6 +508,7 @@ class ServerHealthMetricRepository {
     _i1.ColumnSelections<ServerHealthMetricTable>? updateColumns,
     _i1.WhereExpressionBuilder<ServerHealthMetricTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ServerHealthMetric>(
       rows,
@@ -505,6 +516,7 @@ class ServerHealthMetricRepository {
       updateColumns: updateColumns?.call(ServerHealthMetric.t),
       updateWhere: updateWhere?.call(ServerHealthMetric.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -543,16 +555,22 @@ class ServerHealthMetricRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerHealthMetric>> update(
     _i1.DatabaseSession session,
     List<ServerHealthMetric> rows, {
     _i1.ColumnSelections<ServerHealthMetricTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ServerHealthMetric>(
       rows,
       columns: columns?.call(ServerHealthMetric.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -590,6 +608,10 @@ class ServerHealthMetricRepository {
 
   /// Updates all [ServerHealthMetric]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerHealthMetric>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ServerHealthMetricUpdateTable>
@@ -602,6 +624,7 @@ class ServerHealthMetricRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ServerHealthMetric>(
       columnValues: columnValues(ServerHealthMetric.t.updateTable),
@@ -613,6 +636,7 @@ class ServerHealthMetricRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -623,6 +647,10 @@ class ServerHealthMetricRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerHealthMetric>> delete(
     _i1.DatabaseSession session,
     List<ServerHealthMetric> rows, {
@@ -631,6 +659,7 @@ class ServerHealthMetricRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthMetricTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ServerHealthMetric>(
       rows,
@@ -639,6 +668,7 @@ class ServerHealthMetricRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -658,6 +688,10 @@ class ServerHealthMetricRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerHealthMetric>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ServerHealthMetricTable> where,
@@ -666,6 +700,7 @@ class ServerHealthMetricRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthMetricTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ServerHealthMetric>(
       where: where(ServerHealthMetric.t),
@@ -674,6 +709,7 @@ class ServerHealthMetricRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -894,16 +894,22 @@ class SessionLogEntryRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SessionLogEntry>> insert(
     _i1.DatabaseSession session,
     List<SessionLogEntry> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<SessionLogEntry>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -937,6 +943,10 @@ class SessionLogEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SessionLogEntry>> upsert(
     _i1.DatabaseSession session,
     List<SessionLogEntry> rows, {
@@ -944,6 +954,7 @@ class SessionLogEntryRepository {
     _i1.ColumnSelections<SessionLogEntryTable>? updateColumns,
     _i1.WhereExpressionBuilder<SessionLogEntryTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<SessionLogEntry>(
       rows,
@@ -951,6 +962,7 @@ class SessionLogEntryRepository {
       updateColumns: updateColumns?.call(SessionLogEntry.t),
       updateWhere: updateWhere?.call(SessionLogEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -989,16 +1001,22 @@ class SessionLogEntryRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SessionLogEntry>> update(
     _i1.DatabaseSession session,
     List<SessionLogEntry> rows, {
     _i1.ColumnSelections<SessionLogEntryTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<SessionLogEntry>(
       rows,
       columns: columns?.call(SessionLogEntry.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -1036,6 +1054,10 @@ class SessionLogEntryRepository {
 
   /// Updates all [SessionLogEntry]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SessionLogEntry>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<SessionLogEntryUpdateTable>
@@ -1048,6 +1070,7 @@ class SessionLogEntryRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<SessionLogEntry>(
       columnValues: columnValues(SessionLogEntry.t.updateTable),
@@ -1059,6 +1082,7 @@ class SessionLogEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -1069,6 +1093,10 @@ class SessionLogEntryRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SessionLogEntry>> delete(
     _i1.DatabaseSession session,
     List<SessionLogEntry> rows, {
@@ -1077,6 +1105,7 @@ class SessionLogEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SessionLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<SessionLogEntry>(
       rows,
@@ -1085,6 +1114,7 @@ class SessionLogEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -1104,6 +1134,10 @@ class SessionLogEntryRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SessionLogEntry>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SessionLogEntryTable> where,
@@ -1112,6 +1146,7 @@ class SessionLogEntryRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SessionLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<SessionLogEntry>(
       where: where(SessionLogEntry.t),
@@ -1120,6 +1155,7 @@ class SessionLogEntryRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod_database/lib/src/adapters/postgres/database_connection.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/database_connection.dart
@@ -156,6 +156,7 @@ class PostgresDatabaseConnection
     List<T> rows, {
     Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     if (rows.isEmpty) return [];
 
@@ -177,6 +178,7 @@ class PostgresDatabaseConnection
               [row],
               transaction: tx,
               ignoreConflicts: ignoreConflicts,
+              noReturn: noReturn,
             ).then((results) => results.firstOrNull),
         ].whereType<T>().toList(),
       );
@@ -188,6 +190,7 @@ class PostgresDatabaseConnection
       table: table,
       rows: rows,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     ).build();
 
     return (await _mappedResultsQuery(
@@ -228,6 +231,7 @@ class PostgresDatabaseConnection
     List<Column>? updateColumns,
     Expression? updateWhere,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     if (rows.isEmpty) return [];
 
@@ -246,6 +250,7 @@ class PostgresDatabaseConnection
               updateColumns: updateColumns,
               updateWhere: updateWhere,
               transaction: tx,
+              noReturn: noReturn,
             ),
         ],
         settings: const TransactionSettings(),
@@ -260,6 +265,7 @@ class PostgresDatabaseConnection
       conflictColumns: conflictColumns,
       updateColumns: updateColumns,
       updateWhere: updateWhere,
+      noReturn: noReturn,
     ).build();
 
     return (await _mappedResultsQuery(
@@ -310,6 +316,7 @@ class PostgresDatabaseConnection
     List<T> rows, {
     List<Column>? columns,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     if (rows.isEmpty) return [];
     if (rows.any((column) => column.id == null)) {
@@ -338,10 +345,13 @@ class PostgresDatabaseConnection
         .join(', ');
 
     const tableAlias = 't';
-    var returning = buildReturningClause(table, tableAlias: tableAlias);
 
     var query =
-        'UPDATE "${table.tableName}" AS $tableAlias SET $setColumns FROM (VALUES $values) AS data($columnNames) WHERE data.id = $tableAlias.id RETURNING $returning';
+        'UPDATE "${table.tableName}" AS $tableAlias SET $setColumns FROM (VALUES $values) AS data($columnNames) WHERE data.id = $tableAlias.id';
+    if (!noReturn) {
+      var returning = buildReturningClause(table, tableAlias: tableAlias);
+      query += ' RETURNING $returning';
+    }
 
     return (await _mappedResultsQuery(
           session,
@@ -429,6 +439,7 @@ class PostgresDatabaseConnection
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     var table = _getTableOrAssert<T>(session, operation: 'updateWhere');
 
@@ -463,26 +474,33 @@ class PostgresDatabaseConnection
 
       var idAlias = '${table.tableName}.${table.id.columnName}';
 
-      var orderByClause = switch (orders) {
-        != null when orders.isNotEmpty =>
-          ' ORDER BY '
-              '${orders.map((o) => o.toString().replaceAll('"${table.tableName}".', '')).join(', ')}',
-        _ => '',
-      };
+      if (noReturn) {
+        // No rows are returned, so the wrapping SELECT and its ordering are
+        // unnecessary: run the UPDATE directly against the selected ids.
+        updateQuery =
+            'WITH rows_to_update AS ($subquery) '
+            'UPDATE "${table.tableName}" SET $setClause '
+            'WHERE "${table.id.columnName}" IN (SELECT "$idAlias" FROM rows_to_update)';
+      } else {
+        var orderByClause = switch (orders) {
+          != null when orders.isNotEmpty =>
+            ' ORDER BY '
+                '${orders.map((o) => o.toString().replaceAll('"${table.tableName}".', '')).join(', ')}',
+          _ => '',
+        };
 
-      updateQuery =
-          'WITH rows_to_update AS ($subquery), '
-          'updated AS ('
-          'UPDATE "${table.tableName}" SET $setClause '
-          'WHERE "${table.id.columnName}" IN (SELECT "$idAlias" FROM rows_to_update) '
-          'RETURNING *'
-          ') '
-          'SELECT * FROM updated$orderByClause';
+        updateQuery =
+            'WITH rows_to_update AS ($subquery), '
+            'updated AS ('
+            'UPDATE "${table.tableName}" SET $setClause '
+            'WHERE "${table.id.columnName}" IN (SELECT "$idAlias" FROM rows_to_update) '
+            'RETURNING *'
+            ') '
+            'SELECT * FROM updated$orderByClause';
+      }
     } else {
-      updateQuery =
-          'UPDATE "${table.tableName}" SET $setClause'
-          ' WHERE $where'
-          ' RETURNING *';
+      updateQuery = 'UPDATE "${table.tableName}" SET $setClause WHERE $where';
+      if (!noReturn) updateQuery += ' RETURNING *';
     }
 
     var result = await _mappedResultsQuery(
@@ -503,6 +521,7 @@ class PostgresDatabaseConnection
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     if (rows.isEmpty) return [];
     if (rows.any((column) => column.id == null)) {
@@ -519,6 +538,7 @@ class PostgresDatabaseConnection
       // ignore: deprecated_member_use_from_same_package
       orderDescending: orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -552,13 +572,17 @@ class PostgresDatabaseConnection
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     var table = _getTableOrAssert<T>(session, operation: 'deleteWhere');
-    var orderByCols = _resolveOrderBy(orderByList, orderBy, orderDescending);
+    // Ordering applies to the returned deleted rows, not to which rows are
+    // deleted, so it is irrelevant when nothing is returned.
+    var orderByCols = noReturn
+        ? null
+        : _resolveOrderBy(orderByList, orderBy, orderDescending);
 
-    // Ordering applies to the returned deleted rows, not to which rows are deleted.
     var query = DeleteQueryBuilder(table: table)
-        .withReturn(Returning.all)
+        .withReturn(noReturn ? Returning.none : Returning.all)
         .withWhere(where)
         .withOrderBy(orderByCols)
         .build();

--- a/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
@@ -387,6 +387,7 @@ class InsertQueryBuilder {
   final List<Column>? _conflictColumns;
   final List<Column>? _updateColumns;
   final Expression? _updateWhere;
+  final bool _noReturn;
   late final List<TableRow> _rows;
 
   /// Creates a new [InsertQueryBuilder].
@@ -399,6 +400,9 @@ class InsertQueryBuilder {
   /// [ignoreConflicts] and [conflictColumns] are mutually exclusive.
   /// [updateColumns] and [updateWhere] only apply to upserts and require
   /// [conflictColumns].
+  ///
+  /// When [noReturn] is true the built query omits the `RETURNING` clause, so
+  /// the database does not send the affected rows back to the client.
   InsertQueryBuilder({
     required Table table,
     required List<TableRow> rows,
@@ -406,11 +410,13 @@ class InsertQueryBuilder {
     List<Column>? conflictColumns,
     List<Column>? updateColumns,
     Expression? updateWhere,
+    bool noReturn = false,
   }) : _table = table,
        _ignoreConflicts = ignoreConflicts,
        _conflictColumns = conflictColumns,
        _updateColumns = updateColumns,
-       _updateWhere = updateWhere {
+       _updateWhere = updateWhere,
+       _noReturn = noReturn {
     if (rows.isEmpty) {
       throw ArgumentError.value(
         rows,
@@ -536,12 +542,14 @@ class InsertQueryBuilder {
         })
         .join(', ');
 
-    var returning = buildReturningClause(_table);
     var onConflict = _buildOnConflictClause(selectedColumns);
+    var returning = _noReturn
+        ? ''
+        : ' RETURNING ${buildReturningClause(_table)}';
 
     return columnNames.isEmpty
-        ? 'INSERT INTO "${_table.tableName}" DEFAULT VALUES$onConflict RETURNING $returning'
-        : 'INSERT INTO "${_table.tableName}" ($columnNames) VALUES $values$onConflict RETURNING $returning';
+        ? 'INSERT INTO "${_table.tableName}" DEFAULT VALUES$onConflict$returning'
+        : 'INSERT INTO "${_table.tableName}" ($columnNames) VALUES $values$onConflict$returning';
   }
 
   String _buildOnConflictClause(Iterable<Column<dynamic>> selectedColumns) {
@@ -591,6 +599,16 @@ class InsertQueryBuilder {
     // Can not be empty because the constructor checks for empty rows.
     var insertQueries = [true, false].map(_build).nonNulls;
     if (insertQueries.length == 1) return insertQueries.single;
+
+    // Without a RETURNING clause the inserts produce no rows to union, so the
+    // id-null insert is run as a data-modifying CTE (which Postgres still
+    // executes even when its output is not referenced) and the id-not-null
+    // insert is run as the primary statement.
+    if (_noReturn) {
+      return '''
+WITH insertWithIdNull AS (${insertQueries.first})
+${insertQueries.last}''';
+    }
 
     return '''
 WITH

--- a/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
@@ -188,6 +188,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     List<T> rows, {
     Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     if (rows.isEmpty) return [];
     if (rows.length > 1) {
@@ -201,6 +202,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
               [row],
               transaction: tx,
               ignoreConflicts: ignoreConflicts,
+              noReturn: noReturn,
             ).then((results) => results.firstOrNull),
         ].whereType<T>().toList(),
       );
@@ -214,6 +216,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
           ignoreConflicts,
           withIdNull,
           transaction,
+          noReturn,
         ),
     ];
 
@@ -227,6 +230,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     bool ignoreConflicts,
     bool withIdNull,
     Transaction? transaction,
+    bool noReturn,
   ) async {
     var filteredRows = rows
         .where((r) => withIdNull ? r.id == null : r.id != null)
@@ -278,6 +282,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
             columns: p.columns,
             encodedValues: p.values,
             ignoreConflicts: ignoreConflicts,
+            noReturn: noReturn,
           ),
           transaction: transaction,
           table: table,
@@ -310,12 +315,16 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     List<Column>? updateColumns,
     Expression? updateWhere,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     if (rows.isEmpty) return [];
     if (rows.length > 1) {
       return DatabaseUtil.runInTransactionOrSavepoint(session.db, transaction, (
         tx,
       ) async {
+        // The per-row upserts always read back their rows (even when [noReturn]
+        // is set), because the returned ids are needed to detect duplicate
+        // conflict rows below.
         final results = [
           for (var row in rows)
             ...await upsert<T>(
@@ -341,7 +350,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
           );
         }
 
-        return results;
+        return noReturn ? <T>[] : results;
       });
     }
 
@@ -352,6 +361,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
       conflictColumns: conflictColumns,
       updateColumns: updateColumns,
       updateWhere: updateWhere,
+      noReturn: noReturn,
     ).build();
 
     var results = await _mappedResultsQuery(
@@ -403,6 +413,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     List<T> rows, {
     List<Column>? columns,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     if (rows.isEmpty) return [];
     if (rows.any((r) => r.id == null)) {
@@ -420,6 +431,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
               [row],
               columns: columns,
               transaction: tx,
+              noReturn: noReturn,
             ).then((r) => r.firstOrNull),
         ].whereType<T>().toList(),
       );
@@ -460,6 +472,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
             table: table,
             setClause: setParts.join(', '),
             idSqlValue: idValue,
+            noReturn: noReturn,
           ),
           transaction: transaction,
           table: table,
@@ -542,6 +555,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     var table = _getTableOrAssert<T>(session, operation: 'updateWhere');
 
@@ -604,6 +618,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
         table: table,
         setClause: _buildSetClause(columnValues),
         idListSql: idList,
+        noReturn: noReturn,
       ),
       transaction: transaction,
       table: table,
@@ -624,6 +639,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     if (rows.isEmpty) return [];
     if (rows.any((r) => r.id == null)) {
@@ -639,6 +655,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
       // ignore: deprecated_member_use_from_same_package
       orderDescending: orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -668,9 +685,14 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     var table = _getTableOrAssert<T>(session, operation: 'deleteWhere');
-    var orderByCols = _resolveOrderBy(orderByList, orderBy, orderDescending);
+    // Ordering applies to the returned deleted rows, so it is irrelevant when
+    // nothing is returned.
+    var orderByCols = noReturn
+        ? null
+        : _resolveOrderBy(orderByList, orderBy, orderDescending);
 
     // SQLite does not support DELETE ... USING. Use subquery to get ids first.
     var selectIdsQuery = SelectQueryBuilder(table: table)
@@ -712,6 +734,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
       selectIdsQuery,
       where,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -722,11 +745,12 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     Expression where, {
     List<Object>? orderedIds,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     var deleteQuery =
         'DELETE FROM "${table.tableName}" '
-        'WHERE "${table.id.columnName}" IN ($selectIdsQuery) '
-        'RETURNING *';
+        'WHERE "${table.id.columnName}" IN ($selectIdsQuery)'
+        '${noReturn ? '' : ' RETURNING *'}';
 
     var result = await _mappedResultsQuery(
       session,
@@ -1441,36 +1465,42 @@ String _buildSqlSingleRowInsert({
   required List<Column> columns,
   required List<String> encodedValues,
   bool ignoreConflicts = false,
+  bool noReturn = false,
 }) {
   final onConflict = ignoreConflicts ? ' ON CONFLICT DO NOTHING' : '';
+  final returning = noReturn ? '' : ' RETURNING *';
   if (columns.isEmpty) {
     return 'INSERT INTO "${table.tableName}" DEFAULT VALUES'
-        '$onConflict RETURNING *';
+        '$onConflict$returning';
   }
   final columnNames = columns.map((c) => '"${c.columnName}"').join(', ');
   final values = encodedValues.join(', ');
   return 'INSERT INTO "${table.tableName}" ($columnNames) VALUES ($values)'
-      '$onConflict RETURNING *';
+      '$onConflict$returning';
 }
 
 String _buildSqlUpdateWhereId({
   required Table table,
   required String setClause,
   required String idSqlValue,
+  bool noReturn = false,
 }) {
+  final returning = noReturn ? '' : ' RETURNING *';
   return 'UPDATE "${table.tableName}" SET $setClause '
-      'WHERE "${table.id.columnName}" = $idSqlValue '
-      'RETURNING *';
+      'WHERE "${table.id.columnName}" = $idSqlValue'
+      '$returning';
 }
 
 String _buildSqlUpdateWhereIdIn({
   required Table table,
   required String setClause,
   required String idListSql,
+  bool noReturn = false,
 }) {
+  final returning = noReturn ? '' : ' RETURNING *';
   return 'UPDATE "${table.tableName}" SET $setClause '
-      'WHERE "${table.id.columnName}" IN ($idListSql) '
-      'RETURNING *';
+      'WHERE "${table.id.columnName}" IN ($idListSql)'
+      '$returning';
 }
 
 Table _getTableOrAssert<T>(

--- a/packages/serverpod_database/lib/src/database.dart
+++ b/packages/serverpod_database/lib/src/database.dart
@@ -229,10 +229,15 @@ class Database {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<T>> update<T extends TableRow>(
     List<T> rows, {
     List<Column>? columns,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return _databaseConnection.update<T>(
       _session,
@@ -240,6 +245,7 @@ class Database {
       columns: columns,
       // ignore: invalid_use_of_visible_for_testing_member
       transaction: transaction ?? _session.transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -278,6 +284,10 @@ class Database {
 
   /// Updates all [TableRow]s matching the [where] expression with the specified column values.
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<T>> updateWhere<T extends TableRow>({
     required List<ColumnValue> columnValues,
     required Expression where,
@@ -288,6 +298,7 @@ class Database {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return _databaseConnection.updateWhere<T>(
       _session,
@@ -301,6 +312,7 @@ class Database {
       orderDescending: orderDescending,
       // ignore: invalid_use_of_visible_for_testing_member
       transaction: transaction ?? _session.transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -311,10 +323,15 @@ class Database {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<T>> insert<T extends TableRow>(
     List<T> rows, {
     Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return _databaseConnection.insert<T>(
       _session,
@@ -322,6 +339,7 @@ class Database {
       // ignore: invalid_use_of_visible_for_testing_member
       transaction: transaction ?? _session.transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -350,12 +368,17 @@ class Database {
   /// matching the given expression. Rows that conflict but don't match
   /// [updateWhere] are skipped and not returned, so the resulting list may be
   /// shorter than [rows].
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<T>> upsert<T extends TableRow>(
     List<T> rows, {
     required List<Column> conflictColumns,
     List<Column>? updateColumns,
     Expression? updateWhere,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return _databaseConnection.upsert<T>(
       _session,
@@ -365,6 +388,7 @@ class Database {
       updateWhere: updateWhere,
       // ignore: invalid_use_of_visible_for_testing_member
       transaction: transaction ?? _session.transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -402,6 +426,10 @@ class Database {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<T>> delete<T extends TableRow>(
     List<T> rows, {
     Column? orderBy,
@@ -409,6 +437,7 @@ class Database {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return _databaseConnection.delete<T>(
       _session,
@@ -419,6 +448,7 @@ class Database {
       orderDescending: orderDescending,
       // ignore: invalid_use_of_visible_for_testing_member
       transaction: transaction ?? _session.transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -439,6 +469,12 @@ class Database {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
+  /// Any [orderBy]/[orderByList] is ignored in that case since there are no
+  /// returned rows to order.
   Future<List<T>> deleteWhere<T extends TableRow>({
     required Expression where,
     Column? orderBy,
@@ -446,6 +482,7 @@ class Database {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return _databaseConnection.deleteWhere<T>(
       _session,
@@ -456,6 +493,7 @@ class Database {
       orderDescending: orderDescending,
       // ignore: invalid_use_of_visible_for_testing_member
       transaction: transaction ?? _session.transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/packages/serverpod_database/lib/src/interface/database_connection.dart
+++ b/packages/serverpod_database/lib/src/interface/database_connection.dart
@@ -83,6 +83,7 @@ abstract class DatabaseConnection<D extends DatabasePoolManager> {
     List<T> rows, {
     Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   });
 
   /// For most cases use the corresponding method in [Database] instead.
@@ -100,6 +101,7 @@ abstract class DatabaseConnection<D extends DatabasePoolManager> {
     List<Column>? updateColumns,
     Expression? updateWhere,
     Transaction? transaction,
+    bool noReturn = false,
   });
 
   /// For most cases use the corresponding method in [Database] instead.
@@ -118,6 +120,7 @@ abstract class DatabaseConnection<D extends DatabasePoolManager> {
     List<T> rows, {
     List<Column>? columns,
     Transaction? transaction,
+    bool noReturn = false,
   });
 
   /// For most cases use the corresponding method in [Database] instead.
@@ -161,6 +164,7 @@ abstract class DatabaseConnection<D extends DatabasePoolManager> {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   });
 
   /// For most cases use the corresponding method in [Database] instead.
@@ -172,6 +176,7 @@ abstract class DatabaseConnection<D extends DatabasePoolManager> {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   });
 
   /// For most cases use the corresponding method in [Database] instead.
@@ -190,6 +195,7 @@ abstract class DatabaseConnection<D extends DatabasePoolManager> {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   });
 
   /// For most cases use the corresponding method in [Database] instead.

--- a/packages/serverpod_database/test/database_query/insert_sql_query_test.dart
+++ b/packages/serverpod_database/test/database_query/insert_sql_query_test.dart
@@ -693,4 +693,76 @@ SELECT * FROM insertWithIdNotNull
       },
     );
   });
+
+  group('Given noReturn is true', () {
+    test(
+      'when building insert query then the RETURNING clause is omitted.',
+      () {
+        var query = InsertQueryBuilder(
+          table: PersonTable(),
+          rows: [PersonClass(name: 'Alex', age: 33)],
+          noReturn: true,
+        ).build();
+
+        expect(
+          query,
+          'INSERT INTO "person" ("name", "age") VALUES (\'Alex\', 33)',
+        );
+      },
+    );
+
+    test(
+      'when building insert query with default values then the RETURNING clause is omitted.',
+      () {
+        var query = InsertQueryBuilder(
+          table: Table<int?>(tableName: 'only_id'),
+          rows: [OnlyIdClass()],
+          noReturn: true,
+        ).build();
+
+        expect(query, 'INSERT INTO "only_id" DEFAULT VALUES');
+      },
+    );
+
+    test(
+      'when building upsert query then the RETURNING clause is omitted.',
+      () {
+        var table = PersonTable();
+        var query = InsertQueryBuilder(
+          table: table,
+          rows: [PersonClass(name: 'Alex', age: 33)],
+          conflictColumns: [table.name],
+          noReturn: true,
+        ).build();
+
+        expect(
+          query,
+          'INSERT INTO "person" ("name", "age") VALUES (\'Alex\', 33) '
+          'ON CONFLICT ("name") DO UPDATE SET "age" = EXCLUDED."age"',
+        );
+      },
+    );
+
+    test(
+      'when building insert query with mixed id rows then the id-null insert '
+      'runs as a data-modifying CTE without RETURNING or a wrapping SELECT.',
+      () {
+        var query = InsertQueryBuilder(
+          table: PersonTable(),
+          rows: [
+            PersonClass(id: 33, name: 'Alex', age: 33),
+            PersonClass(name: 'Isak', age: 33),
+          ],
+          noReturn: true,
+        ).build();
+
+        expect(
+          query,
+          '''
+WITH insertWithIdNull AS (INSERT INTO "person" ("name", "age") VALUES ('Isak', 33))
+INSERT INTO "person" ("id", "name", "age") VALUES (33, 'Alex', 33)''',
+        );
+      },
+    );
+  });
 }

--- a/packages/serverpod_test/lib/src/test_database_proxy.dart
+++ b/packages/serverpod_test/lib/src/test_database_proxy.dart
@@ -58,6 +58,7 @@ class TestDatabaseProxy implements Database {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   }) {
     return _rollbackSingleOperationIfDatabaseException(
       () => _db.delete<T>(
@@ -67,6 +68,7 @@ class TestDatabaseProxy implements Database {
         // ignore: deprecated_member_use
         orderDescending: orderDescending,
         transaction: transaction,
+        noReturn: noReturn,
       ),
       isPartOfUserTransaction: transaction != null,
     );
@@ -94,6 +96,7 @@ class TestDatabaseProxy implements Database {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   }) {
     return _rollbackSingleOperationIfDatabaseException(
       () => _db.deleteWhere<T>(
@@ -103,6 +106,7 @@ class TestDatabaseProxy implements Database {
         // ignore: deprecated_member_use
         orderDescending: orderDescending,
         transaction: transaction,
+        noReturn: noReturn,
       ),
       isPartOfUserTransaction: transaction != null,
     );
@@ -213,12 +217,14 @@ class TestDatabaseProxy implements Database {
     List<T> rows, {
     Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) {
     return _rollbackSingleOperationIfDatabaseException(
       () => _db.insert<T>(
         rows,
         transaction: transaction,
         ignoreConflicts: ignoreConflicts,
+        noReturn: noReturn,
       ),
       isPartOfUserTransaction: transaction != null,
     );
@@ -245,6 +251,7 @@ class TestDatabaseProxy implements Database {
     List<Column>? updateColumns,
     Expression? updateWhere,
     Transaction? transaction,
+    bool noReturn = false,
   }) {
     return _rollbackSingleOperationIfDatabaseException(
       () => _db.upsert<T>(
@@ -253,6 +260,7 @@ class TestDatabaseProxy implements Database {
         updateColumns: updateColumns,
         updateWhere: updateWhere,
         transaction: transaction,
+        noReturn: noReturn,
       ),
       isPartOfUserTransaction: transaction != null,
     );
@@ -407,12 +415,14 @@ class TestDatabaseProxy implements Database {
     List<T> rows, {
     List<Column>? columns,
     Transaction? transaction,
+    bool noReturn = false,
   }) {
     return _rollbackSingleOperationIfDatabaseException(
       () => _db.update<T>(
         rows,
         columns: columns,
         transaction: transaction,
+        noReturn: noReturn,
       ),
       isPartOfUserTransaction: transaction != null,
     );
@@ -463,6 +473,7 @@ class TestDatabaseProxy implements Database {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     Transaction? transaction,
+    bool noReturn = false,
   }) {
     return _rollbackSingleOperationIfDatabaseException(
       () => _db.updateWhere<T>(
@@ -475,6 +486,7 @@ class TestDatabaseProxy implements Database {
         // ignore: deprecated_member_use
         orderDescending: orderDescending,
         transaction: transaction,
+        noReturn: noReturn,
       ),
       isPartOfUserTransaction: transaction != null,
     );

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/challenge_tracker.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/challenge_tracker.dart
@@ -423,16 +423,22 @@ class ChallengeTrackerRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChallengeTracker>> insert(
     _i1.DatabaseSession session,
     List<ChallengeTracker> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ChallengeTracker>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -466,6 +472,10 @@ class ChallengeTrackerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChallengeTracker>> upsert(
     _i1.DatabaseSession session,
     List<ChallengeTracker> rows, {
@@ -473,6 +483,7 @@ class ChallengeTrackerRepository {
     _i1.ColumnSelections<ChallengeTrackerTable>? updateColumns,
     _i1.WhereExpressionBuilder<ChallengeTrackerTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ChallengeTracker>(
       rows,
@@ -480,6 +491,7 @@ class ChallengeTrackerRepository {
       updateColumns: updateColumns?.call(ChallengeTracker.t),
       updateWhere: updateWhere?.call(ChallengeTracker.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -518,16 +530,22 @@ class ChallengeTrackerRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChallengeTracker>> update(
     _i1.DatabaseSession session,
     List<ChallengeTracker> rows, {
     _i1.ColumnSelections<ChallengeTrackerTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ChallengeTracker>(
       rows,
       columns: columns?.call(ChallengeTracker.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -565,6 +583,10 @@ class ChallengeTrackerRepository {
 
   /// Updates all [ChallengeTracker]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChallengeTracker>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ChallengeTrackerUpdateTable>
@@ -577,6 +599,7 @@ class ChallengeTrackerRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ChallengeTracker>(
       columnValues: columnValues(ChallengeTracker.t.updateTable),
@@ -588,6 +611,7 @@ class ChallengeTrackerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -598,6 +622,10 @@ class ChallengeTrackerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChallengeTracker>> delete(
     _i1.DatabaseSession session,
     List<ChallengeTracker> rows, {
@@ -606,6 +634,7 @@ class ChallengeTrackerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChallengeTrackerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ChallengeTracker>(
       rows,
@@ -614,6 +643,7 @@ class ChallengeTrackerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -633,6 +663,10 @@ class ChallengeTrackerRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChallengeTracker>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChallengeTrackerTable> where,
@@ -641,6 +675,7 @@ class ChallengeTrackerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChallengeTrackerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ChallengeTracker>(
       where: where(ChallengeTracker.t),
@@ -649,6 +684,7 @@ class ChallengeTrackerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/session_metadata.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/session_metadata.dart
@@ -470,16 +470,22 @@ class SessionMetadataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SessionMetadata>> insert(
     _i1.DatabaseSession session,
     List<SessionMetadata> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<SessionMetadata>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -513,6 +519,10 @@ class SessionMetadataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SessionMetadata>> upsert(
     _i1.DatabaseSession session,
     List<SessionMetadata> rows, {
@@ -520,6 +530,7 @@ class SessionMetadataRepository {
     _i1.ColumnSelections<SessionMetadataTable>? updateColumns,
     _i1.WhereExpressionBuilder<SessionMetadataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<SessionMetadata>(
       rows,
@@ -527,6 +538,7 @@ class SessionMetadataRepository {
       updateColumns: updateColumns?.call(SessionMetadata.t),
       updateWhere: updateWhere?.call(SessionMetadata.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -565,16 +577,22 @@ class SessionMetadataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SessionMetadata>> update(
     _i1.DatabaseSession session,
     List<SessionMetadata> rows, {
     _i1.ColumnSelections<SessionMetadataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<SessionMetadata>(
       rows,
       columns: columns?.call(SessionMetadata.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -612,6 +630,10 @@ class SessionMetadataRepository {
 
   /// Updates all [SessionMetadata]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SessionMetadata>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<SessionMetadataUpdateTable>
@@ -624,6 +646,7 @@ class SessionMetadataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<SessionMetadata>(
       columnValues: columnValues(SessionMetadata.t.updateTable),
@@ -635,6 +658,7 @@ class SessionMetadataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -645,6 +669,10 @@ class SessionMetadataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SessionMetadata>> delete(
     _i1.DatabaseSession session,
     List<SessionMetadata> rows, {
@@ -653,6 +681,7 @@ class SessionMetadataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SessionMetadataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<SessionMetadata>(
       rows,
@@ -661,6 +690,7 @@ class SessionMetadataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -680,6 +710,10 @@ class SessionMetadataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SessionMetadata>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SessionMetadataTable> where,
@@ -688,6 +722,7 @@ class SessionMetadataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SessionMetadataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<SessionMetadata>(
       where: where(SessionMetadata.t),
@@ -696,6 +731,7 @@ class SessionMetadataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/token_metadata.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/token_metadata.dart
@@ -465,16 +465,22 @@ class TokenMetadataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TokenMetadata>> insert(
     _i1.DatabaseSession session,
     List<TokenMetadata> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<TokenMetadata>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -508,6 +514,10 @@ class TokenMetadataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TokenMetadata>> upsert(
     _i1.DatabaseSession session,
     List<TokenMetadata> rows, {
@@ -515,6 +525,7 @@ class TokenMetadataRepository {
     _i1.ColumnSelections<TokenMetadataTable>? updateColumns,
     _i1.WhereExpressionBuilder<TokenMetadataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<TokenMetadata>(
       rows,
@@ -522,6 +533,7 @@ class TokenMetadataRepository {
       updateColumns: updateColumns?.call(TokenMetadata.t),
       updateWhere: updateWhere?.call(TokenMetadata.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -560,16 +572,22 @@ class TokenMetadataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TokenMetadata>> update(
     _i1.DatabaseSession session,
     List<TokenMetadata> rows, {
     _i1.ColumnSelections<TokenMetadataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<TokenMetadata>(
       rows,
       columns: columns?.call(TokenMetadata.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -606,6 +624,10 @@ class TokenMetadataRepository {
 
   /// Updates all [TokenMetadata]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TokenMetadata>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TokenMetadataUpdateTable> columnValues,
@@ -617,6 +639,7 @@ class TokenMetadataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<TokenMetadata>(
       columnValues: columnValues(TokenMetadata.t.updateTable),
@@ -628,6 +651,7 @@ class TokenMetadataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -638,6 +662,10 @@ class TokenMetadataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TokenMetadata>> delete(
     _i1.DatabaseSession session,
     List<TokenMetadata> rows, {
@@ -646,6 +674,7 @@ class TokenMetadataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TokenMetadataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<TokenMetadata>(
       rows,
@@ -654,6 +683,7 @@ class TokenMetadataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -673,6 +703,10 @@ class TokenMetadataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TokenMetadata>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TokenMetadataTable> where,
@@ -681,6 +715,7 @@ class TokenMetadataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TokenMetadataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<TokenMetadata>(
       where: where(TokenMetadata.t),
@@ -689,6 +724,7 @@ class TokenMetadataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/user_data.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/user_data.dart
@@ -421,16 +421,22 @@ class UserDataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserData>> insert(
     _i1.DatabaseSession session,
     List<UserData> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UserData>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -464,6 +470,10 @@ class UserDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserData>> upsert(
     _i1.DatabaseSession session,
     List<UserData> rows, {
@@ -471,6 +481,7 @@ class UserDataRepository {
     _i1.ColumnSelections<UserDataTable>? updateColumns,
     _i1.WhereExpressionBuilder<UserDataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UserData>(
       rows,
@@ -478,6 +489,7 @@ class UserDataRepository {
       updateColumns: updateColumns?.call(UserData.t),
       updateWhere: updateWhere?.call(UserData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -516,16 +528,22 @@ class UserDataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserData>> update(
     _i1.DatabaseSession session,
     List<UserData> rows, {
     _i1.ColumnSelections<UserDataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UserData>(
       rows,
       columns: columns?.call(UserData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -562,6 +580,10 @@ class UserDataRepository {
 
   /// Updates all [UserData]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserData>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UserDataUpdateTable> columnValues,
@@ -573,6 +595,7 @@ class UserDataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UserData>(
       columnValues: columnValues(UserData.t.updateTable),
@@ -584,6 +607,7 @@ class UserDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -594,6 +618,10 @@ class UserDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserData>> delete(
     _i1.DatabaseSession session,
     List<UserData> rows, {
@@ -602,6 +630,7 @@ class UserDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UserData>(
       rows,
@@ -610,6 +639,7 @@ class UserDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -629,6 +659,10 @@ class UserDataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserData>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserDataTable> where,
@@ -637,6 +671,7 @@ class UserDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UserData>(
       where: where(UserData.t),
@@ -645,6 +680,7 @@ class UserDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/generated/greeting.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/generated/greeting.dart
@@ -364,16 +364,22 @@ class GreetingRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Greeting>> insert(
     _i1.DatabaseSession session,
     List<Greeting> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Greeting>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -407,6 +413,10 @@ class GreetingRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Greeting>> upsert(
     _i1.DatabaseSession session,
     List<Greeting> rows, {
@@ -414,6 +424,7 @@ class GreetingRepository {
     _i1.ColumnSelections<GreetingTable>? updateColumns,
     _i1.WhereExpressionBuilder<GreetingTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Greeting>(
       rows,
@@ -421,6 +432,7 @@ class GreetingRepository {
       updateColumns: updateColumns?.call(Greeting.t),
       updateWhere: updateWhere?.call(Greeting.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -459,16 +471,22 @@ class GreetingRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Greeting>> update(
     _i1.DatabaseSession session,
     List<Greeting> rows, {
     _i1.ColumnSelections<GreetingTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Greeting>(
       rows,
       columns: columns?.call(Greeting.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -505,6 +523,10 @@ class GreetingRepository {
 
   /// Updates all [Greeting]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Greeting>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<GreetingUpdateTable> columnValues,
@@ -516,6 +538,7 @@ class GreetingRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Greeting>(
       columnValues: columnValues(Greeting.t.updateTable),
@@ -527,6 +550,7 @@ class GreetingRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -537,6 +561,10 @@ class GreetingRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Greeting>> delete(
     _i1.DatabaseSession session,
     List<Greeting> rows, {
@@ -545,6 +573,7 @@ class GreetingRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<GreetingTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Greeting>(
       rows,
@@ -553,6 +582,7 @@ class GreetingRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -572,6 +602,10 @@ class GreetingRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Greeting>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<GreetingTable> where,
@@ -580,6 +614,7 @@ class GreetingRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<GreetingTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Greeting>(
       where: where(Greeting.t),
@@ -588,6 +623,7 @@ class GreetingRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/course.dart
@@ -397,16 +397,22 @@ class CourseUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CourseUuid>> insert(
     _i1.DatabaseSession session,
     List<CourseUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CourseUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -440,6 +446,10 @@ class CourseUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CourseUuid>> upsert(
     _i1.DatabaseSession session,
     List<CourseUuid> rows, {
@@ -447,6 +457,7 @@ class CourseUuidRepository {
     _i1.ColumnSelections<CourseUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<CourseUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CourseUuid>(
       rows,
@@ -454,6 +465,7 @@ class CourseUuidRepository {
       updateColumns: updateColumns?.call(CourseUuid.t),
       updateWhere: updateWhere?.call(CourseUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -492,16 +504,22 @@ class CourseUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CourseUuid>> update(
     _i1.DatabaseSession session,
     List<CourseUuid> rows, {
     _i1.ColumnSelections<CourseUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CourseUuid>(
       rows,
       columns: columns?.call(CourseUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -538,6 +556,10 @@ class CourseUuidRepository {
 
   /// Updates all [CourseUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CourseUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CourseUuidUpdateTable> columnValues,
@@ -549,6 +571,7 @@ class CourseUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CourseUuid>(
       columnValues: columnValues(CourseUuid.t.updateTable),
@@ -560,6 +583,7 @@ class CourseUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -570,6 +594,10 @@ class CourseUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CourseUuid>> delete(
     _i1.DatabaseSession session,
     List<CourseUuid> rows, {
@@ -578,6 +606,7 @@ class CourseUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CourseUuid>(
       rows,
@@ -586,6 +615,7 @@ class CourseUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -605,6 +635,10 @@ class CourseUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CourseUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CourseUuidTable> where,
@@ -613,6 +647,7 @@ class CourseUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CourseUuid>(
       where: where(CourseUuid.t),
@@ -621,6 +656,7 @@ class CourseUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/enrollment.dart
@@ -442,16 +442,22 @@ class EnrollmentIntRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnrollmentInt>> insert(
     _i1.DatabaseSession session,
     List<EnrollmentInt> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EnrollmentInt>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -485,6 +491,10 @@ class EnrollmentIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnrollmentInt>> upsert(
     _i1.DatabaseSession session,
     List<EnrollmentInt> rows, {
@@ -492,6 +502,7 @@ class EnrollmentIntRepository {
     _i1.ColumnSelections<EnrollmentIntTable>? updateColumns,
     _i1.WhereExpressionBuilder<EnrollmentIntTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EnrollmentInt>(
       rows,
@@ -499,6 +510,7 @@ class EnrollmentIntRepository {
       updateColumns: updateColumns?.call(EnrollmentInt.t),
       updateWhere: updateWhere?.call(EnrollmentInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -537,16 +549,22 @@ class EnrollmentIntRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnrollmentInt>> update(
     _i1.DatabaseSession session,
     List<EnrollmentInt> rows, {
     _i1.ColumnSelections<EnrollmentIntTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EnrollmentInt>(
       rows,
       columns: columns?.call(EnrollmentInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -583,6 +601,10 @@ class EnrollmentIntRepository {
 
   /// Updates all [EnrollmentInt]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnrollmentInt>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnrollmentIntUpdateTable> columnValues,
@@ -594,6 +616,7 @@ class EnrollmentIntRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EnrollmentInt>(
       columnValues: columnValues(EnrollmentInt.t.updateTable),
@@ -605,6 +628,7 @@ class EnrollmentIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -615,6 +639,10 @@ class EnrollmentIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnrollmentInt>> delete(
     _i1.DatabaseSession session,
     List<EnrollmentInt> rows, {
@@ -623,6 +651,7 @@ class EnrollmentIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EnrollmentInt>(
       rows,
@@ -631,6 +660,7 @@ class EnrollmentIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -650,6 +680,10 @@ class EnrollmentIntRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnrollmentInt>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnrollmentIntTable> where,
@@ -658,6 +692,7 @@ class EnrollmentIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EnrollmentInt>(
       where: where(EnrollmentInt.t),
@@ -666,6 +701,7 @@ class EnrollmentIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/student.dart
@@ -393,16 +393,22 @@ class StudentUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StudentUuid>> insert(
     _i1.DatabaseSession session,
     List<StudentUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<StudentUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -436,6 +442,10 @@ class StudentUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StudentUuid>> upsert(
     _i1.DatabaseSession session,
     List<StudentUuid> rows, {
@@ -443,6 +453,7 @@ class StudentUuidRepository {
     _i1.ColumnSelections<StudentUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<StudentUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<StudentUuid>(
       rows,
@@ -450,6 +461,7 @@ class StudentUuidRepository {
       updateColumns: updateColumns?.call(StudentUuid.t),
       updateWhere: updateWhere?.call(StudentUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -488,16 +500,22 @@ class StudentUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StudentUuid>> update(
     _i1.DatabaseSession session,
     List<StudentUuid> rows, {
     _i1.ColumnSelections<StudentUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<StudentUuid>(
       rows,
       columns: columns?.call(StudentUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -534,6 +552,10 @@ class StudentUuidRepository {
 
   /// Updates all [StudentUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StudentUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<StudentUuidUpdateTable> columnValues,
@@ -545,6 +567,7 @@ class StudentUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<StudentUuid>(
       columnValues: columnValues(StudentUuid.t.updateTable),
@@ -556,6 +579,7 @@ class StudentUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -566,6 +590,10 @@ class StudentUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StudentUuid>> delete(
     _i1.DatabaseSession session,
     List<StudentUuid> rows, {
@@ -574,6 +602,7 @@ class StudentUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<StudentUuid>(
       rows,
@@ -582,6 +611,7 @@ class StudentUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -601,6 +631,10 @@ class StudentUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StudentUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StudentUuidTable> where,
@@ -609,6 +643,7 @@ class StudentUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<StudentUuid>(
       where: where(StudentUuid.t),
@@ -617,6 +652,7 @@ class StudentUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/arena.dart
@@ -362,16 +362,22 @@ class ArenaUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ArenaUuid>> insert(
     _i1.DatabaseSession session,
     List<ArenaUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ArenaUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -405,6 +411,10 @@ class ArenaUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ArenaUuid>> upsert(
     _i1.DatabaseSession session,
     List<ArenaUuid> rows, {
@@ -412,6 +422,7 @@ class ArenaUuidRepository {
     _i1.ColumnSelections<ArenaUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<ArenaUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ArenaUuid>(
       rows,
@@ -419,6 +430,7 @@ class ArenaUuidRepository {
       updateColumns: updateColumns?.call(ArenaUuid.t),
       updateWhere: updateWhere?.call(ArenaUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -457,16 +469,22 @@ class ArenaUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ArenaUuid>> update(
     _i1.DatabaseSession session,
     List<ArenaUuid> rows, {
     _i1.ColumnSelections<ArenaUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ArenaUuid>(
       rows,
       columns: columns?.call(ArenaUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -503,6 +521,10 @@ class ArenaUuidRepository {
 
   /// Updates all [ArenaUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ArenaUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ArenaUuidUpdateTable> columnValues,
@@ -514,6 +536,7 @@ class ArenaUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ArenaUuid>(
       columnValues: columnValues(ArenaUuid.t.updateTable),
@@ -525,6 +548,7 @@ class ArenaUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -535,6 +559,10 @@ class ArenaUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ArenaUuid>> delete(
     _i1.DatabaseSession session,
     List<ArenaUuid> rows, {
@@ -543,6 +571,7 @@ class ArenaUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ArenaUuid>(
       rows,
@@ -551,6 +580,7 @@ class ArenaUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -570,6 +600,10 @@ class ArenaUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ArenaUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ArenaUuidTable> where,
@@ -578,6 +612,7 @@ class ArenaUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ArenaUuid>(
       where: where(ArenaUuid.t),
@@ -586,6 +621,7 @@ class ArenaUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
@@ -386,16 +386,22 @@ class PlayerUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PlayerUuid>> insert(
     _i1.DatabaseSession session,
     List<PlayerUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<PlayerUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -429,6 +435,10 @@ class PlayerUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PlayerUuid>> upsert(
     _i1.DatabaseSession session,
     List<PlayerUuid> rows, {
@@ -436,6 +446,7 @@ class PlayerUuidRepository {
     _i1.ColumnSelections<PlayerUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<PlayerUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<PlayerUuid>(
       rows,
@@ -443,6 +454,7 @@ class PlayerUuidRepository {
       updateColumns: updateColumns?.call(PlayerUuid.t),
       updateWhere: updateWhere?.call(PlayerUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,16 +493,22 @@ class PlayerUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PlayerUuid>> update(
     _i1.DatabaseSession session,
     List<PlayerUuid> rows, {
     _i1.ColumnSelections<PlayerUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<PlayerUuid>(
       rows,
       columns: columns?.call(PlayerUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -527,6 +545,10 @@ class PlayerUuidRepository {
 
   /// Updates all [PlayerUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PlayerUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PlayerUuidUpdateTable> columnValues,
@@ -538,6 +560,7 @@ class PlayerUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<PlayerUuid>(
       columnValues: columnValues(PlayerUuid.t.updateTable),
@@ -549,6 +572,7 @@ class PlayerUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -559,6 +583,10 @@ class PlayerUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PlayerUuid>> delete(
     _i1.DatabaseSession session,
     List<PlayerUuid> rows, {
@@ -567,6 +595,7 @@ class PlayerUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<PlayerUuid>(
       rows,
@@ -575,6 +604,7 @@ class PlayerUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -594,6 +624,10 @@ class PlayerUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PlayerUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PlayerUuidTable> where,
@@ -602,6 +636,7 @@ class PlayerUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<PlayerUuid>(
       where: where(PlayerUuid.t),
@@ -610,6 +645,7 @@ class PlayerUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/team.dart
@@ -468,16 +468,22 @@ class TeamIntRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TeamInt>> insert(
     _i1.DatabaseSession session,
     List<TeamInt> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<TeamInt>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -511,6 +517,10 @@ class TeamIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TeamInt>> upsert(
     _i1.DatabaseSession session,
     List<TeamInt> rows, {
@@ -518,6 +528,7 @@ class TeamIntRepository {
     _i1.ColumnSelections<TeamIntTable>? updateColumns,
     _i1.WhereExpressionBuilder<TeamIntTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<TeamInt>(
       rows,
@@ -525,6 +536,7 @@ class TeamIntRepository {
       updateColumns: updateColumns?.call(TeamInt.t),
       updateWhere: updateWhere?.call(TeamInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -563,16 +575,22 @@ class TeamIntRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TeamInt>> update(
     _i1.DatabaseSession session,
     List<TeamInt> rows, {
     _i1.ColumnSelections<TeamIntTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<TeamInt>(
       rows,
       columns: columns?.call(TeamInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -609,6 +627,10 @@ class TeamIntRepository {
 
   /// Updates all [TeamInt]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TeamInt>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TeamIntUpdateTable> columnValues,
@@ -620,6 +642,7 @@ class TeamIntRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<TeamInt>(
       columnValues: columnValues(TeamInt.t.updateTable),
@@ -631,6 +654,7 @@ class TeamIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -641,6 +665,10 @@ class TeamIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TeamInt>> delete(
     _i1.DatabaseSession session,
     List<TeamInt> rows, {
@@ -649,6 +677,7 @@ class TeamIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<TeamInt>(
       rows,
@@ -657,6 +686,7 @@ class TeamIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -676,6 +706,10 @@ class TeamIntRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TeamInt>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TeamIntTable> where,
@@ -684,6 +718,7 @@ class TeamIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<TeamInt>(
       where: where(TeamInt.t),
@@ -692,6 +727,7 @@ class TeamIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/comment.dart
@@ -387,16 +387,22 @@ class CommentIntRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CommentInt>> insert(
     _i1.DatabaseSession session,
     List<CommentInt> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CommentInt>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -430,6 +436,10 @@ class CommentIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CommentInt>> upsert(
     _i1.DatabaseSession session,
     List<CommentInt> rows, {
@@ -437,6 +447,7 @@ class CommentIntRepository {
     _i1.ColumnSelections<CommentIntTable>? updateColumns,
     _i1.WhereExpressionBuilder<CommentIntTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CommentInt>(
       rows,
@@ -444,6 +455,7 @@ class CommentIntRepository {
       updateColumns: updateColumns?.call(CommentInt.t),
       updateWhere: updateWhere?.call(CommentInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -482,16 +494,22 @@ class CommentIntRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CommentInt>> update(
     _i1.DatabaseSession session,
     List<CommentInt> rows, {
     _i1.ColumnSelections<CommentIntTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CommentInt>(
       rows,
       columns: columns?.call(CommentInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -528,6 +546,10 @@ class CommentIntRepository {
 
   /// Updates all [CommentInt]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CommentInt>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CommentIntUpdateTable> columnValues,
@@ -539,6 +561,7 @@ class CommentIntRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CommentInt>(
       columnValues: columnValues(CommentInt.t.updateTable),
@@ -550,6 +573,7 @@ class CommentIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -560,6 +584,10 @@ class CommentIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CommentInt>> delete(
     _i1.DatabaseSession session,
     List<CommentInt> rows, {
@@ -568,6 +596,7 @@ class CommentIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CommentInt>(
       rows,
@@ -576,6 +605,7 @@ class CommentIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -595,6 +625,10 @@ class CommentIntRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CommentInt>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CommentIntTable> where,
@@ -603,6 +637,7 @@ class CommentIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CommentInt>(
       where: where(CommentInt.t),
@@ -611,6 +646,7 @@ class CommentIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
@@ -391,16 +391,22 @@ class CustomerIntRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CustomerInt>> insert(
     _i1.DatabaseSession session,
     List<CustomerInt> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CustomerInt>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -434,6 +440,10 @@ class CustomerIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CustomerInt>> upsert(
     _i1.DatabaseSession session,
     List<CustomerInt> rows, {
@@ -441,6 +451,7 @@ class CustomerIntRepository {
     _i1.ColumnSelections<CustomerIntTable>? updateColumns,
     _i1.WhereExpressionBuilder<CustomerIntTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CustomerInt>(
       rows,
@@ -448,6 +459,7 @@ class CustomerIntRepository {
       updateColumns: updateColumns?.call(CustomerInt.t),
       updateWhere: updateWhere?.call(CustomerInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,16 +498,22 @@ class CustomerIntRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CustomerInt>> update(
     _i1.DatabaseSession session,
     List<CustomerInt> rows, {
     _i1.ColumnSelections<CustomerIntTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CustomerInt>(
       rows,
       columns: columns?.call(CustomerInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -532,6 +550,10 @@ class CustomerIntRepository {
 
   /// Updates all [CustomerInt]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CustomerInt>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CustomerIntUpdateTable> columnValues,
@@ -543,6 +565,7 @@ class CustomerIntRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CustomerInt>(
       columnValues: columnValues(CustomerInt.t.updateTable),
@@ -554,6 +577,7 @@ class CustomerIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,6 +588,10 @@ class CustomerIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CustomerInt>> delete(
     _i1.DatabaseSession session,
     List<CustomerInt> rows, {
@@ -572,6 +600,7 @@ class CustomerIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CustomerInt>(
       rows,
@@ -580,6 +609,7 @@ class CustomerIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -599,6 +629,10 @@ class CustomerIntRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CustomerInt>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CustomerIntTable> where,
@@ -607,6 +641,7 @@ class CustomerIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CustomerInt>(
       where: where(CustomerInt.t),
@@ -615,6 +650,7 @@ class CustomerIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/order.dart
@@ -465,16 +465,22 @@ class OrderUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrderUuid>> insert(
     _i1.DatabaseSession session,
     List<OrderUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<OrderUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -508,6 +514,10 @@ class OrderUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrderUuid>> upsert(
     _i1.DatabaseSession session,
     List<OrderUuid> rows, {
@@ -515,6 +525,7 @@ class OrderUuidRepository {
     _i1.ColumnSelections<OrderUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<OrderUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<OrderUuid>(
       rows,
@@ -522,6 +533,7 @@ class OrderUuidRepository {
       updateColumns: updateColumns?.call(OrderUuid.t),
       updateWhere: updateWhere?.call(OrderUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -560,16 +572,22 @@ class OrderUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrderUuid>> update(
     _i1.DatabaseSession session,
     List<OrderUuid> rows, {
     _i1.ColumnSelections<OrderUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<OrderUuid>(
       rows,
       columns: columns?.call(OrderUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -606,6 +624,10 @@ class OrderUuidRepository {
 
   /// Updates all [OrderUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrderUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<OrderUuidUpdateTable> columnValues,
@@ -617,6 +639,7 @@ class OrderUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<OrderUuid>(
       columnValues: columnValues(OrderUuid.t.updateTable),
@@ -628,6 +651,7 @@ class OrderUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -638,6 +662,10 @@ class OrderUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrderUuid>> delete(
     _i1.DatabaseSession session,
     List<OrderUuid> rows, {
@@ -646,6 +674,7 @@ class OrderUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<OrderUuid>(
       rows,
@@ -654,6 +683,7 @@ class OrderUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -673,6 +703,10 @@ class OrderUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrderUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrderUuidTable> where,
@@ -681,6 +715,7 @@ class OrderUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<OrderUuid>(
       where: where(OrderUuid.t),
@@ -689,6 +724,7 @@ class OrderUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/address.dart
@@ -390,16 +390,22 @@ class AddressUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AddressUuid>> insert(
     _i1.DatabaseSession session,
     List<AddressUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<AddressUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -433,6 +439,10 @@ class AddressUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AddressUuid>> upsert(
     _i1.DatabaseSession session,
     List<AddressUuid> rows, {
@@ -440,6 +450,7 @@ class AddressUuidRepository {
     _i1.ColumnSelections<AddressUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<AddressUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<AddressUuid>(
       rows,
@@ -447,6 +458,7 @@ class AddressUuidRepository {
       updateColumns: updateColumns?.call(AddressUuid.t),
       updateWhere: updateWhere?.call(AddressUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -485,16 +497,22 @@ class AddressUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AddressUuid>> update(
     _i1.DatabaseSession session,
     List<AddressUuid> rows, {
     _i1.ColumnSelections<AddressUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<AddressUuid>(
       rows,
       columns: columns?.call(AddressUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +549,10 @@ class AddressUuidRepository {
 
   /// Updates all [AddressUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AddressUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<AddressUuidUpdateTable> columnValues,
@@ -542,6 +564,7 @@ class AddressUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<AddressUuid>(
       columnValues: columnValues(AddressUuid.t.updateTable),
@@ -553,6 +576,7 @@ class AddressUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -563,6 +587,10 @@ class AddressUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AddressUuid>> delete(
     _i1.DatabaseSession session,
     List<AddressUuid> rows, {
@@ -571,6 +599,7 @@ class AddressUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<AddressUuid>(
       rows,
@@ -579,6 +608,7 @@ class AddressUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -598,6 +628,10 @@ class AddressUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AddressUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AddressUuidTable> where,
@@ -606,6 +640,7 @@ class AddressUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<AddressUuid>(
       where: where(AddressUuid.t),
@@ -614,6 +649,7 @@ class AddressUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/citizen.dart
@@ -515,16 +515,22 @@ class CitizenIntRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CitizenInt>> insert(
     _i1.DatabaseSession session,
     List<CitizenInt> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CitizenInt>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -558,6 +564,10 @@ class CitizenIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CitizenInt>> upsert(
     _i1.DatabaseSession session,
     List<CitizenInt> rows, {
@@ -565,6 +575,7 @@ class CitizenIntRepository {
     _i1.ColumnSelections<CitizenIntTable>? updateColumns,
     _i1.WhereExpressionBuilder<CitizenIntTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CitizenInt>(
       rows,
@@ -572,6 +583,7 @@ class CitizenIntRepository {
       updateColumns: updateColumns?.call(CitizenInt.t),
       updateWhere: updateWhere?.call(CitizenInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -610,16 +622,22 @@ class CitizenIntRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CitizenInt>> update(
     _i1.DatabaseSession session,
     List<CitizenInt> rows, {
     _i1.ColumnSelections<CitizenIntTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CitizenInt>(
       rows,
       columns: columns?.call(CitizenInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -656,6 +674,10 @@ class CitizenIntRepository {
 
   /// Updates all [CitizenInt]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CitizenInt>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CitizenIntUpdateTable> columnValues,
@@ -667,6 +689,7 @@ class CitizenIntRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CitizenInt>(
       columnValues: columnValues(CitizenInt.t.updateTable),
@@ -678,6 +701,7 @@ class CitizenIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -688,6 +712,10 @@ class CitizenIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CitizenInt>> delete(
     _i1.DatabaseSession session,
     List<CitizenInt> rows, {
@@ -696,6 +724,7 @@ class CitizenIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CitizenInt>(
       rows,
@@ -704,6 +733,7 @@ class CitizenIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -723,6 +753,10 @@ class CitizenIntRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CitizenInt>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CitizenIntTable> where,
@@ -731,6 +765,7 @@ class CitizenIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CitizenInt>(
       where: where(CitizenInt.t),
@@ -739,6 +774,7 @@ class CitizenIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/company.dart
@@ -384,16 +384,22 @@ class CompanyUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CompanyUuid>> insert(
     _i1.DatabaseSession session,
     List<CompanyUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CompanyUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -427,6 +433,10 @@ class CompanyUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CompanyUuid>> upsert(
     _i1.DatabaseSession session,
     List<CompanyUuid> rows, {
@@ -434,6 +444,7 @@ class CompanyUuidRepository {
     _i1.ColumnSelections<CompanyUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<CompanyUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CompanyUuid>(
       rows,
@@ -441,6 +452,7 @@ class CompanyUuidRepository {
       updateColumns: updateColumns?.call(CompanyUuid.t),
       updateWhere: updateWhere?.call(CompanyUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -479,16 +491,22 @@ class CompanyUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CompanyUuid>> update(
     _i1.DatabaseSession session,
     List<CompanyUuid> rows, {
     _i1.ColumnSelections<CompanyUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CompanyUuid>(
       rows,
       columns: columns?.call(CompanyUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -525,6 +543,10 @@ class CompanyUuidRepository {
 
   /// Updates all [CompanyUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CompanyUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CompanyUuidUpdateTable> columnValues,
@@ -536,6 +558,7 @@ class CompanyUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CompanyUuid>(
       columnValues: columnValues(CompanyUuid.t.updateTable),
@@ -547,6 +570,7 @@ class CompanyUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -557,6 +581,10 @@ class CompanyUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CompanyUuid>> delete(
     _i1.DatabaseSession session,
     List<CompanyUuid> rows, {
@@ -565,6 +593,7 @@ class CompanyUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CompanyUuid>(
       rows,
@@ -573,6 +602,7 @@ class CompanyUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -592,6 +622,10 @@ class CompanyUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CompanyUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CompanyUuidTable> where,
@@ -600,6 +634,7 @@ class CompanyUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CompanyUuid>(
       where: where(CompanyUuid.t),
@@ -608,6 +643,7 @@ class CompanyUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/town.dart
@@ -386,16 +386,22 @@ class TownIntRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TownInt>> insert(
     _i1.DatabaseSession session,
     List<TownInt> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<TownInt>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -429,6 +435,10 @@ class TownIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TownInt>> upsert(
     _i1.DatabaseSession session,
     List<TownInt> rows, {
@@ -436,6 +446,7 @@ class TownIntRepository {
     _i1.ColumnSelections<TownIntTable>? updateColumns,
     _i1.WhereExpressionBuilder<TownIntTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<TownInt>(
       rows,
@@ -443,6 +454,7 @@ class TownIntRepository {
       updateColumns: updateColumns?.call(TownInt.t),
       updateWhere: updateWhere?.call(TownInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,16 +493,22 @@ class TownIntRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TownInt>> update(
     _i1.DatabaseSession session,
     List<TownInt> rows, {
     _i1.ColumnSelections<TownIntTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<TownInt>(
       rows,
       columns: columns?.call(TownInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -527,6 +545,10 @@ class TownIntRepository {
 
   /// Updates all [TownInt]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TownInt>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TownIntUpdateTable> columnValues,
@@ -538,6 +560,7 @@ class TownIntRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<TownInt>(
       columnValues: columnValues(TownInt.t.updateTable),
@@ -549,6 +572,7 @@ class TownIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -559,6 +583,10 @@ class TownIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TownInt>> delete(
     _i1.DatabaseSession session,
     List<TownInt> rows, {
@@ -567,6 +595,7 @@ class TownIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<TownInt>(
       rows,
@@ -575,6 +604,7 @@ class TownIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -594,6 +624,10 @@ class TownIntRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TownInt>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TownIntTable> where,
@@ -602,6 +636,7 @@ class TownIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<TownInt>(
       where: where(TownInt.t),
@@ -610,6 +645,7 @@ class TownIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/self.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/self.dart
@@ -585,16 +585,22 @@ class ChangedIdTypeSelfRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChangedIdTypeSelf>> insert(
     _i1.DatabaseSession session,
     List<ChangedIdTypeSelf> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ChangedIdTypeSelf>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -628,6 +634,10 @@ class ChangedIdTypeSelfRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChangedIdTypeSelf>> upsert(
     _i1.DatabaseSession session,
     List<ChangedIdTypeSelf> rows, {
@@ -635,6 +645,7 @@ class ChangedIdTypeSelfRepository {
     _i1.ColumnSelections<ChangedIdTypeSelfTable>? updateColumns,
     _i1.WhereExpressionBuilder<ChangedIdTypeSelfTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ChangedIdTypeSelf>(
       rows,
@@ -642,6 +653,7 @@ class ChangedIdTypeSelfRepository {
       updateColumns: updateColumns?.call(ChangedIdTypeSelf.t),
       updateWhere: updateWhere?.call(ChangedIdTypeSelf.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -680,16 +692,22 @@ class ChangedIdTypeSelfRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChangedIdTypeSelf>> update(
     _i1.DatabaseSession session,
     List<ChangedIdTypeSelf> rows, {
     _i1.ColumnSelections<ChangedIdTypeSelfTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ChangedIdTypeSelf>(
       rows,
       columns: columns?.call(ChangedIdTypeSelf.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -727,6 +745,10 @@ class ChangedIdTypeSelfRepository {
 
   /// Updates all [ChangedIdTypeSelf]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChangedIdTypeSelf>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ChangedIdTypeSelfUpdateTable>
@@ -739,6 +761,7 @@ class ChangedIdTypeSelfRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ChangedIdTypeSelf>(
       columnValues: columnValues(ChangedIdTypeSelf.t.updateTable),
@@ -750,6 +773,7 @@ class ChangedIdTypeSelfRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -760,6 +784,10 @@ class ChangedIdTypeSelfRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChangedIdTypeSelf>> delete(
     _i1.DatabaseSession session,
     List<ChangedIdTypeSelf> rows, {
@@ -768,6 +796,7 @@ class ChangedIdTypeSelfRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ChangedIdTypeSelf>(
       rows,
@@ -776,6 +805,7 @@ class ChangedIdTypeSelfRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -795,6 +825,10 @@ class ChangedIdTypeSelfRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChangedIdTypeSelf>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChangedIdTypeSelfTable> where,
@@ -803,6 +837,7 @@ class ChangedIdTypeSelfRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ChangedIdTypeSelf>(
       where: where(ChangedIdTypeSelf.t),
@@ -811,6 +846,7 @@ class ChangedIdTypeSelfRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/server_only.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/server_only.dart
@@ -272,16 +272,22 @@ class ServerOnlyChangedIdFieldClassRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerOnlyChangedIdFieldClass>> insert(
     _i1.DatabaseSession session,
     List<ServerOnlyChangedIdFieldClass> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ServerOnlyChangedIdFieldClass>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -315,6 +321,10 @@ class ServerOnlyChangedIdFieldClassRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerOnlyChangedIdFieldClass>> upsert(
     _i1.DatabaseSession session,
     List<ServerOnlyChangedIdFieldClass> rows, {
@@ -323,6 +333,7 @@ class ServerOnlyChangedIdFieldClassRepository {
     _i1.ColumnSelections<ServerOnlyChangedIdFieldClassTable>? updateColumns,
     _i1.WhereExpressionBuilder<ServerOnlyChangedIdFieldClassTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ServerOnlyChangedIdFieldClass>(
       rows,
@@ -330,6 +341,7 @@ class ServerOnlyChangedIdFieldClassRepository {
       updateColumns: updateColumns?.call(ServerOnlyChangedIdFieldClass.t),
       updateWhere: updateWhere?.call(ServerOnlyChangedIdFieldClass.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -369,16 +381,22 @@ class ServerOnlyChangedIdFieldClassRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerOnlyChangedIdFieldClass>> update(
     _i1.DatabaseSession session,
     List<ServerOnlyChangedIdFieldClass> rows, {
     _i1.ColumnSelections<ServerOnlyChangedIdFieldClassTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ServerOnlyChangedIdFieldClass>(
       rows,
       columns: columns?.call(ServerOnlyChangedIdFieldClass.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -418,6 +436,10 @@ class ServerOnlyChangedIdFieldClassRepository {
 
   /// Updates all [ServerOnlyChangedIdFieldClass]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerOnlyChangedIdFieldClass>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<
@@ -433,6 +455,7 @@ class ServerOnlyChangedIdFieldClassRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ServerOnlyChangedIdFieldClass>(
       columnValues: columnValues(ServerOnlyChangedIdFieldClass.t.updateTable),
@@ -444,6 +467,7 @@ class ServerOnlyChangedIdFieldClassRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -454,6 +478,10 @@ class ServerOnlyChangedIdFieldClassRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerOnlyChangedIdFieldClass>> delete(
     _i1.DatabaseSession session,
     List<ServerOnlyChangedIdFieldClass> rows, {
@@ -462,6 +490,7 @@ class ServerOnlyChangedIdFieldClassRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ServerOnlyChangedIdFieldClass>(
       rows,
@@ -470,6 +499,7 @@ class ServerOnlyChangedIdFieldClassRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -489,6 +519,10 @@ class ServerOnlyChangedIdFieldClassRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerOnlyChangedIdFieldClass>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ServerOnlyChangedIdFieldClassTable>
@@ -498,6 +532,7 @@ class ServerOnlyChangedIdFieldClassRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ServerOnlyChangedIdFieldClass>(
       where: where(ServerOnlyChangedIdFieldClass.t),
@@ -506,6 +541,7 @@ class ServerOnlyChangedIdFieldClassRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default.dart
@@ -350,16 +350,22 @@ class BigIntDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefault>> insert(
     _i1.DatabaseSession session,
     List<BigIntDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BigIntDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -393,6 +399,10 @@ class BigIntDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefault>> upsert(
     _i1.DatabaseSession session,
     List<BigIntDefault> rows, {
@@ -400,6 +410,7 @@ class BigIntDefaultRepository {
     _i1.ColumnSelections<BigIntDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<BigIntDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BigIntDefault>(
       rows,
@@ -407,6 +418,7 @@ class BigIntDefaultRepository {
       updateColumns: updateColumns?.call(BigIntDefault.t),
       updateWhere: updateWhere?.call(BigIntDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -445,16 +457,22 @@ class BigIntDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefault>> update(
     _i1.DatabaseSession session,
     List<BigIntDefault> rows, {
     _i1.ColumnSelections<BigIntDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BigIntDefault>(
       rows,
       columns: columns?.call(BigIntDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -491,6 +509,10 @@ class BigIntDefaultRepository {
 
   /// Updates all [BigIntDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BigIntDefaultUpdateTable> columnValues,
@@ -502,6 +524,7 @@ class BigIntDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BigIntDefault>(
       columnValues: columnValues(BigIntDefault.t.updateTable),
@@ -513,6 +536,7 @@ class BigIntDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -523,6 +547,10 @@ class BigIntDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefault>> delete(
     _i1.DatabaseSession session,
     List<BigIntDefault> rows, {
@@ -531,6 +559,7 @@ class BigIntDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BigIntDefault>(
       rows,
@@ -539,6 +568,7 @@ class BigIntDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -558,6 +588,10 @@ class BigIntDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultTable> where,
@@ -566,6 +600,7 @@ class BigIntDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BigIntDefault>(
       where: where(BigIntDefault.t),
@@ -574,6 +609,7 @@ class BigIntDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default_mix.dart
@@ -393,16 +393,22 @@ class BigIntDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<BigIntDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BigIntDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -436,6 +442,10 @@ class BigIntDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<BigIntDefaultMix> rows, {
@@ -443,6 +453,7 @@ class BigIntDefaultMixRepository {
     _i1.ColumnSelections<BigIntDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<BigIntDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BigIntDefaultMix>(
       rows,
@@ -450,6 +461,7 @@ class BigIntDefaultMixRepository {
       updateColumns: updateColumns?.call(BigIntDefaultMix.t),
       updateWhere: updateWhere?.call(BigIntDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -488,16 +500,22 @@ class BigIntDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultMix>> update(
     _i1.DatabaseSession session,
     List<BigIntDefaultMix> rows, {
     _i1.ColumnSelections<BigIntDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BigIntDefaultMix>(
       rows,
       columns: columns?.call(BigIntDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -535,6 +553,10 @@ class BigIntDefaultMixRepository {
 
   /// Updates all [BigIntDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BigIntDefaultMixUpdateTable>
@@ -547,6 +569,7 @@ class BigIntDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BigIntDefaultMix>(
       columnValues: columnValues(BigIntDefaultMix.t.updateTable),
@@ -558,6 +581,7 @@ class BigIntDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -568,6 +592,10 @@ class BigIntDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<BigIntDefaultMix> rows, {
@@ -576,6 +604,7 @@ class BigIntDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BigIntDefaultMix>(
       rows,
@@ -584,6 +613,7 @@ class BigIntDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -603,6 +633,10 @@ class BigIntDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultMixTable> where,
@@ -611,6 +645,7 @@ class BigIntDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BigIntDefaultMix>(
       where: where(BigIntDefaultMix.t),
@@ -619,6 +654,7 @@ class BigIntDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default_model.dart
@@ -353,16 +353,22 @@ class BigIntDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<BigIntDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BigIntDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -396,6 +402,10 @@ class BigIntDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<BigIntDefaultModel> rows, {
@@ -403,6 +413,7 @@ class BigIntDefaultModelRepository {
     _i1.ColumnSelections<BigIntDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<BigIntDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BigIntDefaultModel>(
       rows,
@@ -410,6 +421,7 @@ class BigIntDefaultModelRepository {
       updateColumns: updateColumns?.call(BigIntDefaultModel.t),
       updateWhere: updateWhere?.call(BigIntDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -448,16 +460,22 @@ class BigIntDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultModel>> update(
     _i1.DatabaseSession session,
     List<BigIntDefaultModel> rows, {
     _i1.ColumnSelections<BigIntDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BigIntDefaultModel>(
       rows,
       columns: columns?.call(BigIntDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -495,6 +513,10 @@ class BigIntDefaultModelRepository {
 
   /// Updates all [BigIntDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BigIntDefaultModelUpdateTable>
@@ -507,6 +529,7 @@ class BigIntDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BigIntDefaultModel>(
       columnValues: columnValues(BigIntDefaultModel.t.updateTable),
@@ -518,6 +541,7 @@ class BigIntDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -528,6 +552,10 @@ class BigIntDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<BigIntDefaultModel> rows, {
@@ -536,6 +564,7 @@ class BigIntDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BigIntDefaultModel>(
       rows,
@@ -544,6 +573,7 @@ class BigIntDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -563,6 +593,10 @@ class BigIntDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultModelTable> where,
@@ -571,6 +605,7 @@ class BigIntDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BigIntDefaultModel>(
       where: where(BigIntDefaultModel.t),
@@ -579,6 +614,7 @@ class BigIntDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default_persist.dart
@@ -321,16 +321,22 @@ class BigIntDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<BigIntDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BigIntDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -364,6 +370,10 @@ class BigIntDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<BigIntDefaultPersist> rows, {
@@ -371,6 +381,7 @@ class BigIntDefaultPersistRepository {
     _i1.ColumnSelections<BigIntDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<BigIntDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BigIntDefaultPersist>(
       rows,
@@ -378,6 +389,7 @@ class BigIntDefaultPersistRepository {
       updateColumns: updateColumns?.call(BigIntDefaultPersist.t),
       updateWhere: updateWhere?.call(BigIntDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -416,16 +428,22 @@ class BigIntDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<BigIntDefaultPersist> rows, {
     _i1.ColumnSelections<BigIntDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BigIntDefaultPersist>(
       rows,
       columns: columns?.call(BigIntDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -463,6 +481,10 @@ class BigIntDefaultPersistRepository {
 
   /// Updates all [BigIntDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BigIntDefaultPersistUpdateTable>
@@ -475,6 +497,7 @@ class BigIntDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BigIntDefaultPersist>(
       columnValues: columnValues(BigIntDefaultPersist.t.updateTable),
@@ -486,6 +509,7 @@ class BigIntDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -496,6 +520,10 @@ class BigIntDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<BigIntDefaultPersist> rows, {
@@ -504,6 +532,7 @@ class BigIntDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BigIntDefaultPersist>(
       rows,
@@ -512,6 +541,7 @@ class BigIntDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +561,10 @@ class BigIntDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultPersistTable> where,
@@ -539,6 +573,7 @@ class BigIntDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BigIntDefaultPersist>(
       where: where(BigIntDefaultPersist.t),
@@ -547,6 +582,7 @@ class BigIntDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
@@ -376,16 +376,22 @@ class BoolDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefault>> insert(
     _i1.DatabaseSession session,
     List<BoolDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BoolDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -419,6 +425,10 @@ class BoolDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefault>> upsert(
     _i1.DatabaseSession session,
     List<BoolDefault> rows, {
@@ -426,6 +436,7 @@ class BoolDefaultRepository {
     _i1.ColumnSelections<BoolDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<BoolDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BoolDefault>(
       rows,
@@ -433,6 +444,7 @@ class BoolDefaultRepository {
       updateColumns: updateColumns?.call(BoolDefault.t),
       updateWhere: updateWhere?.call(BoolDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -471,16 +483,22 @@ class BoolDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefault>> update(
     _i1.DatabaseSession session,
     List<BoolDefault> rows, {
     _i1.ColumnSelections<BoolDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BoolDefault>(
       rows,
       columns: columns?.call(BoolDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -517,6 +535,10 @@ class BoolDefaultRepository {
 
   /// Updates all [BoolDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BoolDefaultUpdateTable> columnValues,
@@ -528,6 +550,7 @@ class BoolDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BoolDefault>(
       columnValues: columnValues(BoolDefault.t.updateTable),
@@ -539,6 +562,7 @@ class BoolDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,6 +573,10 @@ class BoolDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefault>> delete(
     _i1.DatabaseSession session,
     List<BoolDefault> rows, {
@@ -557,6 +585,7 @@ class BoolDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BoolDefault>(
       rows,
@@ -565,6 +594,7 @@ class BoolDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -584,6 +614,10 @@ class BoolDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultTable> where,
@@ -592,6 +626,7 @@ class BoolDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BoolDefault>(
       where: where(BoolDefault.t),
@@ -600,6 +635,7 @@ class BoolDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
@@ -383,16 +383,22 @@ class BoolDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<BoolDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BoolDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -426,6 +432,10 @@ class BoolDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<BoolDefaultMix> rows, {
@@ -433,6 +443,7 @@ class BoolDefaultMixRepository {
     _i1.ColumnSelections<BoolDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<BoolDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BoolDefaultMix>(
       rows,
@@ -440,6 +451,7 @@ class BoolDefaultMixRepository {
       updateColumns: updateColumns?.call(BoolDefaultMix.t),
       updateWhere: updateWhere?.call(BoolDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -478,16 +490,22 @@ class BoolDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultMix>> update(
     _i1.DatabaseSession session,
     List<BoolDefaultMix> rows, {
     _i1.ColumnSelections<BoolDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BoolDefaultMix>(
       rows,
       columns: columns?.call(BoolDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -524,6 +542,10 @@ class BoolDefaultMixRepository {
 
   /// Updates all [BoolDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BoolDefaultMixUpdateTable> columnValues,
@@ -535,6 +557,7 @@ class BoolDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BoolDefaultMix>(
       columnValues: columnValues(BoolDefaultMix.t.updateTable),
@@ -546,6 +569,7 @@ class BoolDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -556,6 +580,10 @@ class BoolDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<BoolDefaultMix> rows, {
@@ -564,6 +592,7 @@ class BoolDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BoolDefaultMix>(
       rows,
@@ -572,6 +601,7 @@ class BoolDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +621,10 @@ class BoolDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultMixTable> where,
@@ -599,6 +633,7 @@ class BoolDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BoolDefaultMix>(
       where: where(BoolDefaultMix.t),
@@ -607,6 +642,7 @@ class BoolDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
@@ -376,16 +376,22 @@ class BoolDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<BoolDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BoolDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -419,6 +425,10 @@ class BoolDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<BoolDefaultModel> rows, {
@@ -426,6 +436,7 @@ class BoolDefaultModelRepository {
     _i1.ColumnSelections<BoolDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<BoolDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BoolDefaultModel>(
       rows,
@@ -433,6 +444,7 @@ class BoolDefaultModelRepository {
       updateColumns: updateColumns?.call(BoolDefaultModel.t),
       updateWhere: updateWhere?.call(BoolDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -471,16 +483,22 @@ class BoolDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultModel>> update(
     _i1.DatabaseSession session,
     List<BoolDefaultModel> rows, {
     _i1.ColumnSelections<BoolDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BoolDefaultModel>(
       rows,
       columns: columns?.call(BoolDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -518,6 +536,10 @@ class BoolDefaultModelRepository {
 
   /// Updates all [BoolDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BoolDefaultModelUpdateTable>
@@ -530,6 +552,7 @@ class BoolDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BoolDefaultModel>(
       columnValues: columnValues(BoolDefaultModel.t.updateTable),
@@ -541,6 +564,7 @@ class BoolDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -551,6 +575,10 @@ class BoolDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<BoolDefaultModel> rows, {
@@ -559,6 +587,7 @@ class BoolDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BoolDefaultModel>(
       rows,
@@ -567,6 +596,7 @@ class BoolDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -586,6 +616,10 @@ class BoolDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultModelTable> where,
@@ -594,6 +628,7 @@ class BoolDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BoolDefaultModel>(
       where: where(BoolDefaultModel.t),
@@ -602,6 +637,7 @@ class BoolDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
@@ -354,16 +354,22 @@ class BoolDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<BoolDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BoolDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -397,6 +403,10 @@ class BoolDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<BoolDefaultPersist> rows, {
@@ -404,6 +414,7 @@ class BoolDefaultPersistRepository {
     _i1.ColumnSelections<BoolDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<BoolDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BoolDefaultPersist>(
       rows,
@@ -411,6 +422,7 @@ class BoolDefaultPersistRepository {
       updateColumns: updateColumns?.call(BoolDefaultPersist.t),
       updateWhere: updateWhere?.call(BoolDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -449,16 +461,22 @@ class BoolDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<BoolDefaultPersist> rows, {
     _i1.ColumnSelections<BoolDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BoolDefaultPersist>(
       rows,
       columns: columns?.call(BoolDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -496,6 +514,10 @@ class BoolDefaultPersistRepository {
 
   /// Updates all [BoolDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BoolDefaultPersistUpdateTable>
@@ -508,6 +530,7 @@ class BoolDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BoolDefaultPersist>(
       columnValues: columnValues(BoolDefaultPersist.t.updateTable),
@@ -519,6 +542,7 @@ class BoolDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -529,6 +553,10 @@ class BoolDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<BoolDefaultPersist> rows, {
@@ -537,6 +565,7 @@ class BoolDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BoolDefaultPersist>(
       rows,
@@ -545,6 +574,7 @@ class BoolDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,6 +594,10 @@ class BoolDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultPersistTable> where,
@@ -572,6 +606,7 @@ class BoolDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BoolDefaultPersist>(
       where: where(BoolDefaultPersist.t),
@@ -580,6 +615,7 @@ class BoolDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
@@ -382,16 +382,22 @@ class DateTimeDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefault>> insert(
     _i1.DatabaseSession session,
     List<DateTimeDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DateTimeDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -425,6 +431,10 @@ class DateTimeDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefault>> upsert(
     _i1.DatabaseSession session,
     List<DateTimeDefault> rows, {
@@ -432,6 +442,7 @@ class DateTimeDefaultRepository {
     _i1.ColumnSelections<DateTimeDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<DateTimeDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DateTimeDefault>(
       rows,
@@ -439,6 +450,7 @@ class DateTimeDefaultRepository {
       updateColumns: updateColumns?.call(DateTimeDefault.t),
       updateWhere: updateWhere?.call(DateTimeDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -477,16 +489,22 @@ class DateTimeDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefault>> update(
     _i1.DatabaseSession session,
     List<DateTimeDefault> rows, {
     _i1.ColumnSelections<DateTimeDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DateTimeDefault>(
       rows,
       columns: columns?.call(DateTimeDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -524,6 +542,10 @@ class DateTimeDefaultRepository {
 
   /// Updates all [DateTimeDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DateTimeDefaultUpdateTable>
@@ -536,6 +558,7 @@ class DateTimeDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DateTimeDefault>(
       columnValues: columnValues(DateTimeDefault.t.updateTable),
@@ -547,6 +570,7 @@ class DateTimeDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -557,6 +581,10 @@ class DateTimeDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefault>> delete(
     _i1.DatabaseSession session,
     List<DateTimeDefault> rows, {
@@ -565,6 +593,7 @@ class DateTimeDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DateTimeDefault>(
       rows,
@@ -573,6 +602,7 @@ class DateTimeDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -592,6 +622,10 @@ class DateTimeDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultTable> where,
@@ -600,6 +634,7 @@ class DateTimeDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DateTimeDefault>(
       where: where(DateTimeDefault.t),
@@ -608,6 +643,7 @@ class DateTimeDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
@@ -398,16 +398,22 @@ class DateTimeDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<DateTimeDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DateTimeDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -441,6 +447,10 @@ class DateTimeDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<DateTimeDefaultMix> rows, {
@@ -448,6 +458,7 @@ class DateTimeDefaultMixRepository {
     _i1.ColumnSelections<DateTimeDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<DateTimeDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DateTimeDefaultMix>(
       rows,
@@ -455,6 +466,7 @@ class DateTimeDefaultMixRepository {
       updateColumns: updateColumns?.call(DateTimeDefaultMix.t),
       updateWhere: updateWhere?.call(DateTimeDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -493,16 +505,22 @@ class DateTimeDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultMix>> update(
     _i1.DatabaseSession session,
     List<DateTimeDefaultMix> rows, {
     _i1.ColumnSelections<DateTimeDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DateTimeDefaultMix>(
       rows,
       columns: columns?.call(DateTimeDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -540,6 +558,10 @@ class DateTimeDefaultMixRepository {
 
   /// Updates all [DateTimeDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DateTimeDefaultMixUpdateTable>
@@ -552,6 +574,7 @@ class DateTimeDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DateTimeDefaultMix>(
       columnValues: columnValues(DateTimeDefaultMix.t.updateTable),
@@ -563,6 +586,7 @@ class DateTimeDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -573,6 +597,10 @@ class DateTimeDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<DateTimeDefaultMix> rows, {
@@ -581,6 +609,7 @@ class DateTimeDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DateTimeDefaultMix>(
       rows,
@@ -589,6 +618,7 @@ class DateTimeDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -608,6 +638,10 @@ class DateTimeDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultMixTable> where,
@@ -616,6 +650,7 @@ class DateTimeDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DateTimeDefaultMix>(
       where: where(DateTimeDefaultMix.t),
@@ -624,6 +659,7 @@ class DateTimeDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
@@ -389,16 +389,22 @@ class DateTimeDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<DateTimeDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DateTimeDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -432,6 +438,10 @@ class DateTimeDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<DateTimeDefaultModel> rows, {
@@ -439,6 +449,7 @@ class DateTimeDefaultModelRepository {
     _i1.ColumnSelections<DateTimeDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<DateTimeDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DateTimeDefaultModel>(
       rows,
@@ -446,6 +457,7 @@ class DateTimeDefaultModelRepository {
       updateColumns: updateColumns?.call(DateTimeDefaultModel.t),
       updateWhere: updateWhere?.call(DateTimeDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -484,16 +496,22 @@ class DateTimeDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultModel>> update(
     _i1.DatabaseSession session,
     List<DateTimeDefaultModel> rows, {
     _i1.ColumnSelections<DateTimeDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DateTimeDefaultModel>(
       rows,
       columns: columns?.call(DateTimeDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +549,10 @@ class DateTimeDefaultModelRepository {
 
   /// Updates all [DateTimeDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DateTimeDefaultModelUpdateTable>
@@ -543,6 +565,7 @@ class DateTimeDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DateTimeDefaultModel>(
       columnValues: columnValues(DateTimeDefaultModel.t.updateTable),
@@ -554,6 +577,7 @@ class DateTimeDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,6 +588,10 @@ class DateTimeDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<DateTimeDefaultModel> rows, {
@@ -572,6 +600,7 @@ class DateTimeDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DateTimeDefaultModel>(
       rows,
@@ -580,6 +609,7 @@ class DateTimeDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -599,6 +629,10 @@ class DateTimeDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultModelTable> where,
@@ -607,6 +641,7 @@ class DateTimeDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DateTimeDefaultModel>(
       where: where(DateTimeDefaultModel.t),
@@ -615,6 +650,7 @@ class DateTimeDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
@@ -358,16 +358,22 @@ class DateTimeDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<DateTimeDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DateTimeDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -401,6 +407,10 @@ class DateTimeDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<DateTimeDefaultPersist> rows, {
@@ -408,6 +418,7 @@ class DateTimeDefaultPersistRepository {
     _i1.ColumnSelections<DateTimeDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<DateTimeDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DateTimeDefaultPersist>(
       rows,
@@ -415,6 +426,7 @@ class DateTimeDefaultPersistRepository {
       updateColumns: updateColumns?.call(DateTimeDefaultPersist.t),
       updateWhere: updateWhere?.call(DateTimeDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -453,16 +465,22 @@ class DateTimeDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<DateTimeDefaultPersist> rows, {
     _i1.ColumnSelections<DateTimeDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DateTimeDefaultPersist>(
       rows,
       columns: columns?.call(DateTimeDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -500,6 +518,10 @@ class DateTimeDefaultPersistRepository {
 
   /// Updates all [DateTimeDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DateTimeDefaultPersistUpdateTable>
@@ -512,6 +534,7 @@ class DateTimeDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DateTimeDefaultPersist>(
       columnValues: columnValues(DateTimeDefaultPersist.t.updateTable),
@@ -523,6 +546,7 @@ class DateTimeDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -533,6 +557,10 @@ class DateTimeDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<DateTimeDefaultPersist> rows, {
@@ -541,6 +569,7 @@ class DateTimeDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DateTimeDefaultPersist>(
       rows,
@@ -549,6 +578,7 @@ class DateTimeDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -568,6 +598,10 @@ class DateTimeDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultPersistTable> where,
@@ -576,6 +610,7 @@ class DateTimeDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DateTimeDefaultPersist>(
       where: where(DateTimeDefaultPersist.t),
@@ -584,6 +619,7 @@ class DateTimeDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
@@ -339,16 +339,22 @@ class DoubleDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefault>> insert(
     _i1.DatabaseSession session,
     List<DoubleDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DoubleDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -382,6 +388,10 @@ class DoubleDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefault>> upsert(
     _i1.DatabaseSession session,
     List<DoubleDefault> rows, {
@@ -389,6 +399,7 @@ class DoubleDefaultRepository {
     _i1.ColumnSelections<DoubleDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<DoubleDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DoubleDefault>(
       rows,
@@ -396,6 +407,7 @@ class DoubleDefaultRepository {
       updateColumns: updateColumns?.call(DoubleDefault.t),
       updateWhere: updateWhere?.call(DoubleDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -434,16 +446,22 @@ class DoubleDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefault>> update(
     _i1.DatabaseSession session,
     List<DoubleDefault> rows, {
     _i1.ColumnSelections<DoubleDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DoubleDefault>(
       rows,
       columns: columns?.call(DoubleDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -480,6 +498,10 @@ class DoubleDefaultRepository {
 
   /// Updates all [DoubleDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DoubleDefaultUpdateTable> columnValues,
@@ -491,6 +513,7 @@ class DoubleDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DoubleDefault>(
       columnValues: columnValues(DoubleDefault.t.updateTable),
@@ -502,6 +525,7 @@ class DoubleDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +536,10 @@ class DoubleDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefault>> delete(
     _i1.DatabaseSession session,
     List<DoubleDefault> rows, {
@@ -520,6 +548,7 @@ class DoubleDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DoubleDefault>(
       rows,
@@ -528,6 +557,7 @@ class DoubleDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -547,6 +577,10 @@ class DoubleDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultTable> where,
@@ -555,6 +589,7 @@ class DoubleDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DoubleDefault>(
       where: where(DoubleDefault.t),
@@ -563,6 +598,7 @@ class DoubleDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
@@ -380,16 +380,22 @@ class DoubleDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<DoubleDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DoubleDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -423,6 +429,10 @@ class DoubleDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<DoubleDefaultMix> rows, {
@@ -430,6 +440,7 @@ class DoubleDefaultMixRepository {
     _i1.ColumnSelections<DoubleDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<DoubleDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DoubleDefaultMix>(
       rows,
@@ -437,6 +448,7 @@ class DoubleDefaultMixRepository {
       updateColumns: updateColumns?.call(DoubleDefaultMix.t),
       updateWhere: updateWhere?.call(DoubleDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -475,16 +487,22 @@ class DoubleDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultMix>> update(
     _i1.DatabaseSession session,
     List<DoubleDefaultMix> rows, {
     _i1.ColumnSelections<DoubleDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DoubleDefaultMix>(
       rows,
       columns: columns?.call(DoubleDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -522,6 +540,10 @@ class DoubleDefaultMixRepository {
 
   /// Updates all [DoubleDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DoubleDefaultMixUpdateTable>
@@ -534,6 +556,7 @@ class DoubleDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DoubleDefaultMix>(
       columnValues: columnValues(DoubleDefaultMix.t.updateTable),
@@ -545,6 +568,7 @@ class DoubleDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -555,6 +579,10 @@ class DoubleDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<DoubleDefaultMix> rows, {
@@ -563,6 +591,7 @@ class DoubleDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DoubleDefaultMix>(
       rows,
@@ -571,6 +600,7 @@ class DoubleDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -590,6 +620,10 @@ class DoubleDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultMixTable> where,
@@ -598,6 +632,7 @@ class DoubleDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DoubleDefaultMix>(
       where: where(DoubleDefaultMix.t),
@@ -606,6 +641,7 @@ class DoubleDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
@@ -338,16 +338,22 @@ class DoubleDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<DoubleDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DoubleDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -381,6 +387,10 @@ class DoubleDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<DoubleDefaultModel> rows, {
@@ -388,6 +398,7 @@ class DoubleDefaultModelRepository {
     _i1.ColumnSelections<DoubleDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<DoubleDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DoubleDefaultModel>(
       rows,
@@ -395,6 +406,7 @@ class DoubleDefaultModelRepository {
       updateColumns: updateColumns?.call(DoubleDefaultModel.t),
       updateWhere: updateWhere?.call(DoubleDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -433,16 +445,22 @@ class DoubleDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultModel>> update(
     _i1.DatabaseSession session,
     List<DoubleDefaultModel> rows, {
     _i1.ColumnSelections<DoubleDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DoubleDefaultModel>(
       rows,
       columns: columns?.call(DoubleDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -480,6 +498,10 @@ class DoubleDefaultModelRepository {
 
   /// Updates all [DoubleDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DoubleDefaultModelUpdateTable>
@@ -492,6 +514,7 @@ class DoubleDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DoubleDefaultModel>(
       columnValues: columnValues(DoubleDefaultModel.t.updateTable),
@@ -503,6 +526,7 @@ class DoubleDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -513,6 +537,10 @@ class DoubleDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<DoubleDefaultModel> rows, {
@@ -521,6 +549,7 @@ class DoubleDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DoubleDefaultModel>(
       rows,
@@ -529,6 +558,7 @@ class DoubleDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -548,6 +578,10 @@ class DoubleDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultModelTable> where,
@@ -556,6 +590,7 @@ class DoubleDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DoubleDefaultModel>(
       where: where(DoubleDefaultModel.t),
@@ -564,6 +599,7 @@ class DoubleDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
@@ -317,16 +317,22 @@ class DoubleDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<DoubleDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DoubleDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -360,6 +366,10 @@ class DoubleDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<DoubleDefaultPersist> rows, {
@@ -367,6 +377,7 @@ class DoubleDefaultPersistRepository {
     _i1.ColumnSelections<DoubleDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<DoubleDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DoubleDefaultPersist>(
       rows,
@@ -374,6 +385,7 @@ class DoubleDefaultPersistRepository {
       updateColumns: updateColumns?.call(DoubleDefaultPersist.t),
       updateWhere: updateWhere?.call(DoubleDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -412,16 +424,22 @@ class DoubleDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<DoubleDefaultPersist> rows, {
     _i1.ColumnSelections<DoubleDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DoubleDefaultPersist>(
       rows,
       columns: columns?.call(DoubleDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -459,6 +477,10 @@ class DoubleDefaultPersistRepository {
 
   /// Updates all [DoubleDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DoubleDefaultPersistUpdateTable>
@@ -471,6 +493,7 @@ class DoubleDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DoubleDefaultPersist>(
       columnValues: columnValues(DoubleDefaultPersist.t.updateTable),
@@ -482,6 +505,7 @@ class DoubleDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -492,6 +516,10 @@ class DoubleDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<DoubleDefaultPersist> rows, {
@@ -500,6 +528,7 @@ class DoubleDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DoubleDefaultPersist>(
       rows,
@@ -508,6 +537,7 @@ class DoubleDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -527,6 +557,10 @@ class DoubleDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultPersistTable> where,
@@ -535,6 +569,7 @@ class DoubleDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DoubleDefaultPersist>(
       where: where(DoubleDefaultPersist.t),
@@ -543,6 +578,7 @@ class DoubleDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
@@ -364,16 +364,22 @@ class DurationDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefault>> insert(
     _i1.DatabaseSession session,
     List<DurationDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DurationDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -407,6 +413,10 @@ class DurationDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefault>> upsert(
     _i1.DatabaseSession session,
     List<DurationDefault> rows, {
@@ -414,6 +424,7 @@ class DurationDefaultRepository {
     _i1.ColumnSelections<DurationDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<DurationDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DurationDefault>(
       rows,
@@ -421,6 +432,7 @@ class DurationDefaultRepository {
       updateColumns: updateColumns?.call(DurationDefault.t),
       updateWhere: updateWhere?.call(DurationDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -459,16 +471,22 @@ class DurationDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefault>> update(
     _i1.DatabaseSession session,
     List<DurationDefault> rows, {
     _i1.ColumnSelections<DurationDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DurationDefault>(
       rows,
       columns: columns?.call(DurationDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -506,6 +524,10 @@ class DurationDefaultRepository {
 
   /// Updates all [DurationDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DurationDefaultUpdateTable>
@@ -518,6 +540,7 @@ class DurationDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DurationDefault>(
       columnValues: columnValues(DurationDefault.t.updateTable),
@@ -529,6 +552,7 @@ class DurationDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -539,6 +563,10 @@ class DurationDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefault>> delete(
     _i1.DatabaseSession session,
     List<DurationDefault> rows, {
@@ -547,6 +575,7 @@ class DurationDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DurationDefault>(
       rows,
@@ -555,6 +584,7 @@ class DurationDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -574,6 +604,10 @@ class DurationDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultTable> where,
@@ -582,6 +616,7 @@ class DurationDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DurationDefault>(
       where: where(DurationDefault.t),
@@ -590,6 +625,7 @@ class DurationDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
@@ -416,16 +416,22 @@ class DurationDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<DurationDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DurationDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -459,6 +465,10 @@ class DurationDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<DurationDefaultMix> rows, {
@@ -466,6 +476,7 @@ class DurationDefaultMixRepository {
     _i1.ColumnSelections<DurationDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<DurationDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DurationDefaultMix>(
       rows,
@@ -473,6 +484,7 @@ class DurationDefaultMixRepository {
       updateColumns: updateColumns?.call(DurationDefaultMix.t),
       updateWhere: updateWhere?.call(DurationDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -511,16 +523,22 @@ class DurationDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultMix>> update(
     _i1.DatabaseSession session,
     List<DurationDefaultMix> rows, {
     _i1.ColumnSelections<DurationDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DurationDefaultMix>(
       rows,
       columns: columns?.call(DurationDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -558,6 +576,10 @@ class DurationDefaultMixRepository {
 
   /// Updates all [DurationDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DurationDefaultMixUpdateTable>
@@ -570,6 +592,7 @@ class DurationDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DurationDefaultMix>(
       columnValues: columnValues(DurationDefaultMix.t.updateTable),
@@ -581,6 +604,7 @@ class DurationDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +615,10 @@ class DurationDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<DurationDefaultMix> rows, {
@@ -599,6 +627,7 @@ class DurationDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DurationDefaultMix>(
       rows,
@@ -607,6 +636,7 @@ class DurationDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -626,6 +656,10 @@ class DurationDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultMixTable> where,
@@ -634,6 +668,7 @@ class DurationDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DurationDefaultMix>(
       where: where(DurationDefaultMix.t),
@@ -642,6 +677,7 @@ class DurationDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
@@ -367,16 +367,22 @@ class DurationDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<DurationDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DurationDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -410,6 +416,10 @@ class DurationDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<DurationDefaultModel> rows, {
@@ -417,6 +427,7 @@ class DurationDefaultModelRepository {
     _i1.ColumnSelections<DurationDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<DurationDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DurationDefaultModel>(
       rows,
@@ -424,6 +435,7 @@ class DurationDefaultModelRepository {
       updateColumns: updateColumns?.call(DurationDefaultModel.t),
       updateWhere: updateWhere?.call(DurationDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -462,16 +474,22 @@ class DurationDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultModel>> update(
     _i1.DatabaseSession session,
     List<DurationDefaultModel> rows, {
     _i1.ColumnSelections<DurationDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DurationDefaultModel>(
       rows,
       columns: columns?.call(DurationDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -509,6 +527,10 @@ class DurationDefaultModelRepository {
 
   /// Updates all [DurationDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DurationDefaultModelUpdateTable>
@@ -521,6 +543,7 @@ class DurationDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DurationDefaultModel>(
       columnValues: columnValues(DurationDefaultModel.t.updateTable),
@@ -532,6 +555,7 @@ class DurationDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -542,6 +566,10 @@ class DurationDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<DurationDefaultModel> rows, {
@@ -550,6 +578,7 @@ class DurationDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DurationDefaultModel>(
       rows,
@@ -558,6 +587,7 @@ class DurationDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -577,6 +607,10 @@ class DurationDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultModelTable> where,
@@ -585,6 +619,7 @@ class DurationDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DurationDefaultModel>(
       where: where(DurationDefaultModel.t),
@@ -593,6 +628,7 @@ class DurationDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
@@ -321,16 +321,22 @@ class DurationDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<DurationDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DurationDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -364,6 +370,10 @@ class DurationDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<DurationDefaultPersist> rows, {
@@ -371,6 +381,7 @@ class DurationDefaultPersistRepository {
     _i1.ColumnSelections<DurationDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<DurationDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DurationDefaultPersist>(
       rows,
@@ -378,6 +389,7 @@ class DurationDefaultPersistRepository {
       updateColumns: updateColumns?.call(DurationDefaultPersist.t),
       updateWhere: updateWhere?.call(DurationDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -416,16 +428,22 @@ class DurationDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<DurationDefaultPersist> rows, {
     _i1.ColumnSelections<DurationDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DurationDefaultPersist>(
       rows,
       columns: columns?.call(DurationDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -463,6 +481,10 @@ class DurationDefaultPersistRepository {
 
   /// Updates all [DurationDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DurationDefaultPersistUpdateTable>
@@ -475,6 +497,7 @@ class DurationDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DurationDefaultPersist>(
       columnValues: columnValues(DurationDefaultPersist.t.updateTable),
@@ -486,6 +509,7 @@ class DurationDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -496,6 +520,10 @@ class DurationDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<DurationDefaultPersist> rows, {
@@ -504,6 +532,7 @@ class DurationDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DurationDefaultPersist>(
       rows,
@@ -512,6 +541,7 @@ class DurationDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +561,10 @@ class DurationDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultPersistTable> where,
@@ -539,6 +573,7 @@ class DurationDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DurationDefaultPersist>(
       where: where(DurationDefaultPersist.t),
@@ -547,6 +582,7 @@ class DurationDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
@@ -425,16 +425,22 @@ class EnumDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefault>> insert(
     _i1.DatabaseSession session,
     List<EnumDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EnumDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -468,6 +474,10 @@ class EnumDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefault>> upsert(
     _i1.DatabaseSession session,
     List<EnumDefault> rows, {
@@ -475,6 +485,7 @@ class EnumDefaultRepository {
     _i1.ColumnSelections<EnumDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<EnumDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EnumDefault>(
       rows,
@@ -482,6 +493,7 @@ class EnumDefaultRepository {
       updateColumns: updateColumns?.call(EnumDefault.t),
       updateWhere: updateWhere?.call(EnumDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -520,16 +532,22 @@ class EnumDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefault>> update(
     _i1.DatabaseSession session,
     List<EnumDefault> rows, {
     _i1.ColumnSelections<EnumDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EnumDefault>(
       rows,
       columns: columns?.call(EnumDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -566,6 +584,10 @@ class EnumDefaultRepository {
 
   /// Updates all [EnumDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnumDefaultUpdateTable> columnValues,
@@ -577,6 +599,7 @@ class EnumDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EnumDefault>(
       columnValues: columnValues(EnumDefault.t.updateTable),
@@ -588,6 +611,7 @@ class EnumDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -598,6 +622,10 @@ class EnumDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefault>> delete(
     _i1.DatabaseSession session,
     List<EnumDefault> rows, {
@@ -606,6 +634,7 @@ class EnumDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EnumDefault>(
       rows,
@@ -614,6 +643,7 @@ class EnumDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -633,6 +663,10 @@ class EnumDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultTable> where,
@@ -641,6 +675,7 @@ class EnumDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EnumDefault>(
       where: where(EnumDefault.t),
@@ -649,6 +684,7 @@ class EnumDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
@@ -402,16 +402,22 @@ class EnumDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<EnumDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EnumDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -445,6 +451,10 @@ class EnumDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<EnumDefaultMix> rows, {
@@ -452,6 +462,7 @@ class EnumDefaultMixRepository {
     _i1.ColumnSelections<EnumDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<EnumDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EnumDefaultMix>(
       rows,
@@ -459,6 +470,7 @@ class EnumDefaultMixRepository {
       updateColumns: updateColumns?.call(EnumDefaultMix.t),
       updateWhere: updateWhere?.call(EnumDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -497,16 +509,22 @@ class EnumDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultMix>> update(
     _i1.DatabaseSession session,
     List<EnumDefaultMix> rows, {
     _i1.ColumnSelections<EnumDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EnumDefaultMix>(
       rows,
       columns: columns?.call(EnumDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -543,6 +561,10 @@ class EnumDefaultMixRepository {
 
   /// Updates all [EnumDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnumDefaultMixUpdateTable> columnValues,
@@ -554,6 +576,7 @@ class EnumDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EnumDefaultMix>(
       columnValues: columnValues(EnumDefaultMix.t.updateTable),
@@ -565,6 +588,7 @@ class EnumDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -575,6 +599,10 @@ class EnumDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<EnumDefaultMix> rows, {
@@ -583,6 +611,7 @@ class EnumDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EnumDefaultMix>(
       rows,
@@ -591,6 +620,7 @@ class EnumDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -610,6 +640,10 @@ class EnumDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultMixTable> where,
@@ -618,6 +652,7 @@ class EnumDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EnumDefaultMix>(
       where: where(EnumDefaultMix.t),
@@ -626,6 +661,7 @@ class EnumDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
@@ -432,16 +432,22 @@ class EnumDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<EnumDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EnumDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -475,6 +481,10 @@ class EnumDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<EnumDefaultModel> rows, {
@@ -482,6 +492,7 @@ class EnumDefaultModelRepository {
     _i1.ColumnSelections<EnumDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<EnumDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EnumDefaultModel>(
       rows,
@@ -489,6 +500,7 @@ class EnumDefaultModelRepository {
       updateColumns: updateColumns?.call(EnumDefaultModel.t),
       updateWhere: updateWhere?.call(EnumDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -527,16 +539,22 @@ class EnumDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultModel>> update(
     _i1.DatabaseSession session,
     List<EnumDefaultModel> rows, {
     _i1.ColumnSelections<EnumDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EnumDefaultModel>(
       rows,
       columns: columns?.call(EnumDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -574,6 +592,10 @@ class EnumDefaultModelRepository {
 
   /// Updates all [EnumDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnumDefaultModelUpdateTable>
@@ -586,6 +608,7 @@ class EnumDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EnumDefaultModel>(
       columnValues: columnValues(EnumDefaultModel.t.updateTable),
@@ -597,6 +620,7 @@ class EnumDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -607,6 +631,10 @@ class EnumDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<EnumDefaultModel> rows, {
@@ -615,6 +643,7 @@ class EnumDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EnumDefaultModel>(
       rows,
@@ -623,6 +652,7 @@ class EnumDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -642,6 +672,10 @@ class EnumDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultModelTable> where,
@@ -650,6 +684,7 @@ class EnumDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EnumDefaultModel>(
       where: where(EnumDefaultModel.t),
@@ -658,6 +693,7 @@ class EnumDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
@@ -360,16 +360,22 @@ class EnumDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<EnumDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EnumDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -403,6 +409,10 @@ class EnumDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<EnumDefaultPersist> rows, {
@@ -410,6 +420,7 @@ class EnumDefaultPersistRepository {
     _i1.ColumnSelections<EnumDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<EnumDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EnumDefaultPersist>(
       rows,
@@ -417,6 +428,7 @@ class EnumDefaultPersistRepository {
       updateColumns: updateColumns?.call(EnumDefaultPersist.t),
       updateWhere: updateWhere?.call(EnumDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -455,16 +467,22 @@ class EnumDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<EnumDefaultPersist> rows, {
     _i1.ColumnSelections<EnumDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EnumDefaultPersist>(
       rows,
       columns: columns?.call(EnumDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -502,6 +520,10 @@ class EnumDefaultPersistRepository {
 
   /// Updates all [EnumDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnumDefaultPersistUpdateTable>
@@ -514,6 +536,7 @@ class EnumDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EnumDefaultPersist>(
       columnValues: columnValues(EnumDefaultPersist.t.updateTable),
@@ -525,6 +548,7 @@ class EnumDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -535,6 +559,10 @@ class EnumDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<EnumDefaultPersist> rows, {
@@ -543,6 +571,7 @@ class EnumDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EnumDefaultPersist>(
       rows,
@@ -551,6 +580,7 @@ class EnumDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -570,6 +600,10 @@ class EnumDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultPersistTable> where,
@@ -578,6 +612,7 @@ class EnumDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EnumDefaultPersist>(
       where: where(EnumDefaultPersist.t),
@@ -586,6 +621,7 @@ class EnumDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
@@ -335,16 +335,22 @@ class IntDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefault>> insert(
     _i1.DatabaseSession session,
     List<IntDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<IntDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -378,6 +384,10 @@ class IntDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefault>> upsert(
     _i1.DatabaseSession session,
     List<IntDefault> rows, {
@@ -385,6 +395,7 @@ class IntDefaultRepository {
     _i1.ColumnSelections<IntDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<IntDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<IntDefault>(
       rows,
@@ -392,6 +403,7 @@ class IntDefaultRepository {
       updateColumns: updateColumns?.call(IntDefault.t),
       updateWhere: updateWhere?.call(IntDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -430,16 +442,22 @@ class IntDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefault>> update(
     _i1.DatabaseSession session,
     List<IntDefault> rows, {
     _i1.ColumnSelections<IntDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<IntDefault>(
       rows,
       columns: columns?.call(IntDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -476,6 +494,10 @@ class IntDefaultRepository {
 
   /// Updates all [IntDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<IntDefaultUpdateTable> columnValues,
@@ -487,6 +509,7 @@ class IntDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<IntDefault>(
       columnValues: columnValues(IntDefault.t.updateTable),
@@ -498,6 +521,7 @@ class IntDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -508,6 +532,10 @@ class IntDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefault>> delete(
     _i1.DatabaseSession session,
     List<IntDefault> rows, {
@@ -516,6 +544,7 @@ class IntDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<IntDefault>(
       rows,
@@ -524,6 +553,7 @@ class IntDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -543,6 +573,10 @@ class IntDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultTable> where,
@@ -551,6 +585,7 @@ class IntDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<IntDefault>(
       where: where(IntDefault.t),
@@ -559,6 +594,7 @@ class IntDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
@@ -371,16 +371,22 @@ class IntDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<IntDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<IntDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -414,6 +420,10 @@ class IntDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<IntDefaultMix> rows, {
@@ -421,6 +431,7 @@ class IntDefaultMixRepository {
     _i1.ColumnSelections<IntDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<IntDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<IntDefaultMix>(
       rows,
@@ -428,6 +439,7 @@ class IntDefaultMixRepository {
       updateColumns: updateColumns?.call(IntDefaultMix.t),
       updateWhere: updateWhere?.call(IntDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -466,16 +478,22 @@ class IntDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultMix>> update(
     _i1.DatabaseSession session,
     List<IntDefaultMix> rows, {
     _i1.ColumnSelections<IntDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<IntDefaultMix>(
       rows,
       columns: columns?.call(IntDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +530,10 @@ class IntDefaultMixRepository {
 
   /// Updates all [IntDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<IntDefaultMixUpdateTable> columnValues,
@@ -523,6 +545,7 @@ class IntDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<IntDefaultMix>(
       columnValues: columnValues(IntDefaultMix.t.updateTable),
@@ -534,6 +557,7 @@ class IntDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -544,6 +568,10 @@ class IntDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<IntDefaultMix> rows, {
@@ -552,6 +580,7 @@ class IntDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<IntDefaultMix>(
       rows,
@@ -560,6 +589,7 @@ class IntDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -579,6 +609,10 @@ class IntDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultMixTable> where,
@@ -587,6 +621,7 @@ class IntDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<IntDefaultMix>(
       where: where(IntDefaultMix.t),
@@ -595,6 +630,7 @@ class IntDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
@@ -332,16 +332,22 @@ class IntDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<IntDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<IntDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -375,6 +381,10 @@ class IntDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<IntDefaultModel> rows, {
@@ -382,6 +392,7 @@ class IntDefaultModelRepository {
     _i1.ColumnSelections<IntDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<IntDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<IntDefaultModel>(
       rows,
@@ -389,6 +400,7 @@ class IntDefaultModelRepository {
       updateColumns: updateColumns?.call(IntDefaultModel.t),
       updateWhere: updateWhere?.call(IntDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -427,16 +439,22 @@ class IntDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultModel>> update(
     _i1.DatabaseSession session,
     List<IntDefaultModel> rows, {
     _i1.ColumnSelections<IntDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<IntDefaultModel>(
       rows,
       columns: columns?.call(IntDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -474,6 +492,10 @@ class IntDefaultModelRepository {
 
   /// Updates all [IntDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<IntDefaultModelUpdateTable>
@@ -486,6 +508,7 @@ class IntDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<IntDefaultModel>(
       columnValues: columnValues(IntDefaultModel.t.updateTable),
@@ -497,6 +520,7 @@ class IntDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -507,6 +531,10 @@ class IntDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<IntDefaultModel> rows, {
@@ -515,6 +543,7 @@ class IntDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<IntDefaultModel>(
       rows,
@@ -523,6 +552,7 @@ class IntDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -542,6 +572,10 @@ class IntDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultModelTable> where,
@@ -550,6 +584,7 @@ class IntDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<IntDefaultModel>(
       where: where(IntDefaultModel.t),
@@ -558,6 +593,7 @@ class IntDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
@@ -311,16 +311,22 @@ class IntDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<IntDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<IntDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -354,6 +360,10 @@ class IntDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<IntDefaultPersist> rows, {
@@ -361,6 +371,7 @@ class IntDefaultPersistRepository {
     _i1.ColumnSelections<IntDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<IntDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<IntDefaultPersist>(
       rows,
@@ -368,6 +379,7 @@ class IntDefaultPersistRepository {
       updateColumns: updateColumns?.call(IntDefaultPersist.t),
       updateWhere: updateWhere?.call(IntDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -406,16 +418,22 @@ class IntDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<IntDefaultPersist> rows, {
     _i1.ColumnSelections<IntDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<IntDefaultPersist>(
       rows,
       columns: columns?.call(IntDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -453,6 +471,10 @@ class IntDefaultPersistRepository {
 
   /// Updates all [IntDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<IntDefaultPersistUpdateTable>
@@ -465,6 +487,7 @@ class IntDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<IntDefaultPersist>(
       columnValues: columnValues(IntDefaultPersist.t.updateTable),
@@ -476,6 +499,7 @@ class IntDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,6 +510,10 @@ class IntDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<IntDefaultPersist> rows, {
@@ -494,6 +522,7 @@ class IntDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<IntDefaultPersist>(
       rows,
@@ -502,6 +531,7 @@ class IntDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -521,6 +551,10 @@ class IntDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultPersistTable> where,
@@ -529,6 +563,7 @@ class IntDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<IntDefaultPersist>(
       where: where(IntDefaultPersist.t),
@@ -537,6 +572,7 @@ class IntDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
@@ -338,16 +338,22 @@ class StringDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefault>> insert(
     _i1.DatabaseSession session,
     List<StringDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<StringDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -381,6 +387,10 @@ class StringDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefault>> upsert(
     _i1.DatabaseSession session,
     List<StringDefault> rows, {
@@ -388,6 +398,7 @@ class StringDefaultRepository {
     _i1.ColumnSelections<StringDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<StringDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<StringDefault>(
       rows,
@@ -395,6 +406,7 @@ class StringDefaultRepository {
       updateColumns: updateColumns?.call(StringDefault.t),
       updateWhere: updateWhere?.call(StringDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -433,16 +445,22 @@ class StringDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefault>> update(
     _i1.DatabaseSession session,
     List<StringDefault> rows, {
     _i1.ColumnSelections<StringDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<StringDefault>(
       rows,
       columns: columns?.call(StringDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -479,6 +497,10 @@ class StringDefaultRepository {
 
   /// Updates all [StringDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<StringDefaultUpdateTable> columnValues,
@@ -490,6 +512,7 @@ class StringDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<StringDefault>(
       columnValues: columnValues(StringDefault.t.updateTable),
@@ -501,6 +524,7 @@ class StringDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -511,6 +535,10 @@ class StringDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefault>> delete(
     _i1.DatabaseSession session,
     List<StringDefault> rows, {
@@ -519,6 +547,7 @@ class StringDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<StringDefault>(
       rows,
@@ -527,6 +556,7 @@ class StringDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -546,6 +576,10 @@ class StringDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultTable> where,
@@ -554,6 +588,7 @@ class StringDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<StringDefault>(
       where: where(StringDefault.t),
@@ -562,6 +597,7 @@ class StringDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
@@ -379,16 +379,22 @@ class StringDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<StringDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<StringDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -422,6 +428,10 @@ class StringDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<StringDefaultMix> rows, {
@@ -429,6 +439,7 @@ class StringDefaultMixRepository {
     _i1.ColumnSelections<StringDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<StringDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<StringDefaultMix>(
       rows,
@@ -436,6 +447,7 @@ class StringDefaultMixRepository {
       updateColumns: updateColumns?.call(StringDefaultMix.t),
       updateWhere: updateWhere?.call(StringDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -474,16 +486,22 @@ class StringDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultMix>> update(
     _i1.DatabaseSession session,
     List<StringDefaultMix> rows, {
     _i1.ColumnSelections<StringDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<StringDefaultMix>(
       rows,
       columns: columns?.call(StringDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -521,6 +539,10 @@ class StringDefaultMixRepository {
 
   /// Updates all [StringDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<StringDefaultMixUpdateTable>
@@ -533,6 +555,7 @@ class StringDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<StringDefaultMix>(
       columnValues: columnValues(StringDefaultMix.t.updateTable),
@@ -544,6 +567,7 @@ class StringDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -554,6 +578,10 @@ class StringDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<StringDefaultMix> rows, {
@@ -562,6 +590,7 @@ class StringDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<StringDefaultMix>(
       rows,
@@ -570,6 +599,7 @@ class StringDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -589,6 +619,10 @@ class StringDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultMixTable> where,
@@ -597,6 +631,7 @@ class StringDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<StringDefaultMix>(
       where: where(StringDefaultMix.t),
@@ -605,6 +640,7 @@ class StringDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
@@ -339,16 +339,22 @@ class StringDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<StringDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<StringDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -382,6 +388,10 @@ class StringDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<StringDefaultModel> rows, {
@@ -389,6 +399,7 @@ class StringDefaultModelRepository {
     _i1.ColumnSelections<StringDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<StringDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<StringDefaultModel>(
       rows,
@@ -396,6 +407,7 @@ class StringDefaultModelRepository {
       updateColumns: updateColumns?.call(StringDefaultModel.t),
       updateWhere: updateWhere?.call(StringDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -434,16 +446,22 @@ class StringDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultModel>> update(
     _i1.DatabaseSession session,
     List<StringDefaultModel> rows, {
     _i1.ColumnSelections<StringDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<StringDefaultModel>(
       rows,
       columns: columns?.call(StringDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,6 +499,10 @@ class StringDefaultModelRepository {
 
   /// Updates all [StringDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<StringDefaultModelUpdateTable>
@@ -493,6 +515,7 @@ class StringDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<StringDefaultModel>(
       columnValues: columnValues(StringDefaultModel.t.updateTable),
@@ -504,6 +527,7 @@ class StringDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -514,6 +538,10 @@ class StringDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<StringDefaultModel> rows, {
@@ -522,6 +550,7 @@ class StringDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<StringDefaultModel>(
       rows,
@@ -530,6 +559,7 @@ class StringDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,6 +579,10 @@ class StringDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultModelTable> where,
@@ -557,6 +591,7 @@ class StringDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<StringDefaultModel>(
       where: where(StringDefaultModel.t),
@@ -565,6 +600,7 @@ class StringDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
@@ -621,16 +621,22 @@ class StringDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<StringDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<StringDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -664,6 +670,10 @@ class StringDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<StringDefaultPersist> rows, {
@@ -671,6 +681,7 @@ class StringDefaultPersistRepository {
     _i1.ColumnSelections<StringDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<StringDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<StringDefaultPersist>(
       rows,
@@ -678,6 +689,7 @@ class StringDefaultPersistRepository {
       updateColumns: updateColumns?.call(StringDefaultPersist.t),
       updateWhere: updateWhere?.call(StringDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -716,16 +728,22 @@ class StringDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<StringDefaultPersist> rows, {
     _i1.ColumnSelections<StringDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<StringDefaultPersist>(
       rows,
       columns: columns?.call(StringDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -763,6 +781,10 @@ class StringDefaultPersistRepository {
 
   /// Updates all [StringDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<StringDefaultPersistUpdateTable>
@@ -775,6 +797,7 @@ class StringDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<StringDefaultPersist>(
       columnValues: columnValues(StringDefaultPersist.t.updateTable),
@@ -786,6 +809,7 @@ class StringDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -796,6 +820,10 @@ class StringDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<StringDefaultPersist> rows, {
@@ -804,6 +832,7 @@ class StringDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<StringDefaultPersist>(
       rows,
@@ -812,6 +841,7 @@ class StringDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -831,6 +861,10 @@ class StringDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultPersistTable> where,
@@ -839,6 +873,7 @@ class StringDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<StringDefaultPersist>(
       where: where(StringDefaultPersist.t),
@@ -847,6 +882,7 @@ class StringDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default.dart
@@ -340,16 +340,22 @@ class UriDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefault>> insert(
     _i1.DatabaseSession session,
     List<UriDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UriDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -383,6 +389,10 @@ class UriDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefault>> upsert(
     _i1.DatabaseSession session,
     List<UriDefault> rows, {
@@ -390,6 +400,7 @@ class UriDefaultRepository {
     _i1.ColumnSelections<UriDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<UriDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UriDefault>(
       rows,
@@ -397,6 +408,7 @@ class UriDefaultRepository {
       updateColumns: updateColumns?.call(UriDefault.t),
       updateWhere: updateWhere?.call(UriDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -435,16 +447,22 @@ class UriDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefault>> update(
     _i1.DatabaseSession session,
     List<UriDefault> rows, {
     _i1.ColumnSelections<UriDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UriDefault>(
       rows,
       columns: columns?.call(UriDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,6 +499,10 @@ class UriDefaultRepository {
 
   /// Updates all [UriDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UriDefaultUpdateTable> columnValues,
@@ -492,6 +514,7 @@ class UriDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UriDefault>(
       columnValues: columnValues(UriDefault.t.updateTable),
@@ -503,6 +526,7 @@ class UriDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -513,6 +537,10 @@ class UriDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefault>> delete(
     _i1.DatabaseSession session,
     List<UriDefault> rows, {
@@ -521,6 +549,7 @@ class UriDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UriDefault>(
       rows,
@@ -529,6 +558,7 @@ class UriDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -548,6 +578,10 @@ class UriDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultTable> where,
@@ -556,6 +590,7 @@ class UriDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UriDefault>(
       where: where(UriDefault.t),
@@ -564,6 +599,7 @@ class UriDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default_mix.dart
@@ -390,16 +390,22 @@ class UriDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<UriDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UriDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -433,6 +439,10 @@ class UriDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<UriDefaultMix> rows, {
@@ -440,6 +450,7 @@ class UriDefaultMixRepository {
     _i1.ColumnSelections<UriDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<UriDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UriDefaultMix>(
       rows,
@@ -447,6 +458,7 @@ class UriDefaultMixRepository {
       updateColumns: updateColumns?.call(UriDefaultMix.t),
       updateWhere: updateWhere?.call(UriDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -485,16 +497,22 @@ class UriDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultMix>> update(
     _i1.DatabaseSession session,
     List<UriDefaultMix> rows, {
     _i1.ColumnSelections<UriDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UriDefaultMix>(
       rows,
       columns: columns?.call(UriDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +549,10 @@ class UriDefaultMixRepository {
 
   /// Updates all [UriDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UriDefaultMixUpdateTable> columnValues,
@@ -542,6 +564,7 @@ class UriDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UriDefaultMix>(
       columnValues: columnValues(UriDefaultMix.t.updateTable),
@@ -553,6 +576,7 @@ class UriDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -563,6 +587,10 @@ class UriDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<UriDefaultMix> rows, {
@@ -571,6 +599,7 @@ class UriDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UriDefaultMix>(
       rows,
@@ -579,6 +608,7 @@ class UriDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -598,6 +628,10 @@ class UriDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultMixTable> where,
@@ -606,6 +640,7 @@ class UriDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UriDefaultMix>(
       where: where(UriDefaultMix.t),
@@ -614,6 +649,7 @@ class UriDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default_model.dart
@@ -345,16 +345,22 @@ class UriDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<UriDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UriDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -388,6 +394,10 @@ class UriDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<UriDefaultModel> rows, {
@@ -395,6 +405,7 @@ class UriDefaultModelRepository {
     _i1.ColumnSelections<UriDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<UriDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UriDefaultModel>(
       rows,
@@ -402,6 +413,7 @@ class UriDefaultModelRepository {
       updateColumns: updateColumns?.call(UriDefaultModel.t),
       updateWhere: updateWhere?.call(UriDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -440,16 +452,22 @@ class UriDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultModel>> update(
     _i1.DatabaseSession session,
     List<UriDefaultModel> rows, {
     _i1.ColumnSelections<UriDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UriDefaultModel>(
       rows,
       columns: columns?.call(UriDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -487,6 +505,10 @@ class UriDefaultModelRepository {
 
   /// Updates all [UriDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UriDefaultModelUpdateTable>
@@ -499,6 +521,7 @@ class UriDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UriDefaultModel>(
       columnValues: columnValues(UriDefaultModel.t.updateTable),
@@ -510,6 +533,7 @@ class UriDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -520,6 +544,10 @@ class UriDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<UriDefaultModel> rows, {
@@ -528,6 +556,7 @@ class UriDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UriDefaultModel>(
       rows,
@@ -536,6 +565,7 @@ class UriDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -555,6 +585,10 @@ class UriDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultModelTable> where,
@@ -563,6 +597,7 @@ class UriDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UriDefaultModel>(
       where: where(UriDefaultModel.t),
@@ -571,6 +606,7 @@ class UriDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default_persist.dart
@@ -317,16 +317,22 @@ class UriDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<UriDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UriDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -360,6 +366,10 @@ class UriDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<UriDefaultPersist> rows, {
@@ -367,6 +377,7 @@ class UriDefaultPersistRepository {
     _i1.ColumnSelections<UriDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<UriDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UriDefaultPersist>(
       rows,
@@ -374,6 +385,7 @@ class UriDefaultPersistRepository {
       updateColumns: updateColumns?.call(UriDefaultPersist.t),
       updateWhere: updateWhere?.call(UriDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -412,16 +424,22 @@ class UriDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<UriDefaultPersist> rows, {
     _i1.ColumnSelections<UriDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UriDefaultPersist>(
       rows,
       columns: columns?.call(UriDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -459,6 +477,10 @@ class UriDefaultPersistRepository {
 
   /// Updates all [UriDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UriDefaultPersistUpdateTable>
@@ -471,6 +493,7 @@ class UriDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UriDefaultPersist>(
       columnValues: columnValues(UriDefaultPersist.t.updateTable),
@@ -482,6 +505,7 @@ class UriDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -492,6 +516,10 @@ class UriDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<UriDefaultPersist> rows, {
@@ -500,6 +528,7 @@ class UriDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UriDefaultPersist>(
       rows,
@@ -508,6 +537,7 @@ class UriDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -527,6 +557,10 @@ class UriDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultPersistTable> where,
@@ -535,6 +569,7 @@ class UriDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UriDefaultPersist>(
       where: where(UriDefaultPersist.t),
@@ -543,6 +578,7 @@ class UriDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
@@ -454,16 +454,22 @@ class UuidDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefault>> insert(
     _i1.DatabaseSession session,
     List<UuidDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UuidDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -497,6 +503,10 @@ class UuidDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefault>> upsert(
     _i1.DatabaseSession session,
     List<UuidDefault> rows, {
@@ -504,6 +514,7 @@ class UuidDefaultRepository {
     _i1.ColumnSelections<UuidDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<UuidDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UuidDefault>(
       rows,
@@ -511,6 +522,7 @@ class UuidDefaultRepository {
       updateColumns: updateColumns?.call(UuidDefault.t),
       updateWhere: updateWhere?.call(UuidDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,16 +561,22 @@ class UuidDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefault>> update(
     _i1.DatabaseSession session,
     List<UuidDefault> rows, {
     _i1.ColumnSelections<UuidDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UuidDefault>(
       rows,
       columns: columns?.call(UuidDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -595,6 +613,10 @@ class UuidDefaultRepository {
 
   /// Updates all [UuidDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UuidDefaultUpdateTable> columnValues,
@@ -606,6 +628,7 @@ class UuidDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UuidDefault>(
       columnValues: columnValues(UuidDefault.t.updateTable),
@@ -617,6 +640,7 @@ class UuidDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -627,6 +651,10 @@ class UuidDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefault>> delete(
     _i1.DatabaseSession session,
     List<UuidDefault> rows, {
@@ -635,6 +663,7 @@ class UuidDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UuidDefault>(
       rows,
@@ -643,6 +672,7 @@ class UuidDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -662,6 +692,10 @@ class UuidDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultTable> where,
@@ -670,6 +704,7 @@ class UuidDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UuidDefault>(
       where: where(UuidDefault.t),
@@ -678,6 +713,7 @@ class UuidDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
@@ -392,16 +392,22 @@ class UuidDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<UuidDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UuidDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -435,6 +441,10 @@ class UuidDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<UuidDefaultMix> rows, {
@@ -442,6 +452,7 @@ class UuidDefaultMixRepository {
     _i1.ColumnSelections<UuidDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<UuidDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UuidDefaultMix>(
       rows,
@@ -449,6 +460,7 @@ class UuidDefaultMixRepository {
       updateColumns: updateColumns?.call(UuidDefaultMix.t),
       updateWhere: updateWhere?.call(UuidDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -487,16 +499,22 @@ class UuidDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultMix>> update(
     _i1.DatabaseSession session,
     List<UuidDefaultMix> rows, {
     _i1.ColumnSelections<UuidDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UuidDefaultMix>(
       rows,
       columns: columns?.call(UuidDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -533,6 +551,10 @@ class UuidDefaultMixRepository {
 
   /// Updates all [UuidDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UuidDefaultMixUpdateTable> columnValues,
@@ -544,6 +566,7 @@ class UuidDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UuidDefaultMix>(
       columnValues: columnValues(UuidDefaultMix.t.updateTable),
@@ -555,6 +578,7 @@ class UuidDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -565,6 +589,10 @@ class UuidDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<UuidDefaultMix> rows, {
@@ -573,6 +601,7 @@ class UuidDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UuidDefaultMix>(
       rows,
@@ -581,6 +610,7 @@ class UuidDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -600,6 +630,10 @@ class UuidDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultMixTable> where,
@@ -608,6 +642,7 @@ class UuidDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UuidDefaultMix>(
       where: where(UuidDefaultMix.t),
@@ -616,6 +651,7 @@ class UuidDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
@@ -459,16 +459,22 @@ class UuidDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<UuidDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UuidDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -502,6 +508,10 @@ class UuidDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<UuidDefaultModel> rows, {
@@ -509,6 +519,7 @@ class UuidDefaultModelRepository {
     _i1.ColumnSelections<UuidDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<UuidDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UuidDefaultModel>(
       rows,
@@ -516,6 +527,7 @@ class UuidDefaultModelRepository {
       updateColumns: updateColumns?.call(UuidDefaultModel.t),
       updateWhere: updateWhere?.call(UuidDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -554,16 +566,22 @@ class UuidDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultModel>> update(
     _i1.DatabaseSession session,
     List<UuidDefaultModel> rows, {
     _i1.ColumnSelections<UuidDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UuidDefaultModel>(
       rows,
       columns: columns?.call(UuidDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -601,6 +619,10 @@ class UuidDefaultModelRepository {
 
   /// Updates all [UuidDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UuidDefaultModelUpdateTable>
@@ -613,6 +635,7 @@ class UuidDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UuidDefaultModel>(
       columnValues: columnValues(UuidDefaultModel.t.updateTable),
@@ -624,6 +647,7 @@ class UuidDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -634,6 +658,10 @@ class UuidDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<UuidDefaultModel> rows, {
@@ -642,6 +670,7 @@ class UuidDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UuidDefaultModel>(
       rows,
@@ -650,6 +679,7 @@ class UuidDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -669,6 +699,10 @@ class UuidDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultModelTable> where,
@@ -677,6 +711,7 @@ class UuidDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UuidDefaultModel>(
       where: where(UuidDefaultModel.t),
@@ -685,6 +720,7 @@ class UuidDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
@@ -391,16 +391,22 @@ class UuidDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<UuidDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UuidDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -434,6 +440,10 @@ class UuidDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<UuidDefaultPersist> rows, {
@@ -441,6 +451,7 @@ class UuidDefaultPersistRepository {
     _i1.ColumnSelections<UuidDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<UuidDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UuidDefaultPersist>(
       rows,
@@ -448,6 +459,7 @@ class UuidDefaultPersistRepository {
       updateColumns: updateColumns?.call(UuidDefaultPersist.t),
       updateWhere: updateWhere?.call(UuidDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,16 +498,22 @@ class UuidDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<UuidDefaultPersist> rows, {
     _i1.ColumnSelections<UuidDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UuidDefaultPersist>(
       rows,
       columns: columns?.call(UuidDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -533,6 +551,10 @@ class UuidDefaultPersistRepository {
 
   /// Updates all [UuidDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UuidDefaultPersistUpdateTable>
@@ -545,6 +567,7 @@ class UuidDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UuidDefaultPersist>(
       columnValues: columnValues(UuidDefaultPersist.t.updateTable),
@@ -556,6 +579,7 @@ class UuidDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -566,6 +590,10 @@ class UuidDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<UuidDefaultPersist> rows, {
@@ -574,6 +602,7 @@ class UuidDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UuidDefaultPersist>(
       rows,
@@ -582,6 +611,7 @@ class UuidDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -601,6 +631,10 @@ class UuidDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultPersistTable> where,
@@ -609,6 +643,7 @@ class UuidDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UuidDefaultPersist>(
       where: where(UuidDefaultPersist.t),
@@ -617,6 +652,7 @@ class UuidDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
@@ -368,16 +368,22 @@ class EmptyModelRelationItemRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> insert(
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EmptyModelRelationItem>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -411,6 +417,10 @@ class EmptyModelRelationItemRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> upsert(
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
@@ -418,6 +428,7 @@ class EmptyModelRelationItemRepository {
     _i1.ColumnSelections<EmptyModelRelationItemTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmptyModelRelationItemTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EmptyModelRelationItem>(
       rows,
@@ -425,6 +436,7 @@ class EmptyModelRelationItemRepository {
       updateColumns: updateColumns?.call(EmptyModelRelationItem.t),
       updateWhere: updateWhere?.call(EmptyModelRelationItem.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -463,16 +475,22 @@ class EmptyModelRelationItemRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> update(
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
     _i1.ColumnSelections<EmptyModelRelationItemTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EmptyModelRelationItem>(
       rows,
       columns: columns?.call(EmptyModelRelationItem.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -510,6 +528,10 @@ class EmptyModelRelationItemRepository {
 
   /// Updates all [EmptyModelRelationItem]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmptyModelRelationItemUpdateTable>
@@ -522,6 +544,7 @@ class EmptyModelRelationItemRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EmptyModelRelationItem>(
       columnValues: columnValues(EmptyModelRelationItem.t.updateTable),
@@ -533,6 +556,7 @@ class EmptyModelRelationItemRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -543,6 +567,10 @@ class EmptyModelRelationItemRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> delete(
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
@@ -551,6 +579,7 @@ class EmptyModelRelationItemRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EmptyModelRelationItem>(
       rows,
@@ -559,6 +588,7 @@ class EmptyModelRelationItemRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -578,6 +608,10 @@ class EmptyModelRelationItemRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmptyModelRelationItemTable> where,
@@ -586,6 +620,7 @@ class EmptyModelRelationItemRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EmptyModelRelationItem>(
       where: where(EmptyModelRelationItem.t),
@@ -594,6 +629,7 @@ class EmptyModelRelationItemRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
@@ -266,16 +266,22 @@ class EmptyModelWithTableRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> insert(
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EmptyModelWithTable>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -309,6 +315,10 @@ class EmptyModelWithTableRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> upsert(
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
@@ -316,6 +326,7 @@ class EmptyModelWithTableRepository {
     _i1.ColumnSelections<EmptyModelWithTableTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmptyModelWithTableTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EmptyModelWithTable>(
       rows,
@@ -323,6 +334,7 @@ class EmptyModelWithTableRepository {
       updateColumns: updateColumns?.call(EmptyModelWithTable.t),
       updateWhere: updateWhere?.call(EmptyModelWithTable.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -361,16 +373,22 @@ class EmptyModelWithTableRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> update(
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
     _i1.ColumnSelections<EmptyModelWithTableTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EmptyModelWithTable>(
       rows,
       columns: columns?.call(EmptyModelWithTable.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -408,6 +426,10 @@ class EmptyModelWithTableRepository {
 
   /// Updates all [EmptyModelWithTable]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmptyModelWithTableUpdateTable>
@@ -420,6 +442,7 @@ class EmptyModelWithTableRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EmptyModelWithTable>(
       columnValues: columnValues(EmptyModelWithTable.t.updateTable),
@@ -431,6 +454,7 @@ class EmptyModelWithTableRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -441,6 +465,10 @@ class EmptyModelWithTableRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> delete(
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
@@ -449,6 +477,7 @@ class EmptyModelWithTableRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EmptyModelWithTable>(
       rows,
@@ -457,6 +486,7 @@ class EmptyModelWithTableRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -476,6 +506,10 @@ class EmptyModelWithTableRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmptyModelWithTableTable> where,
@@ -484,6 +518,7 @@ class EmptyModelWithTableRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EmptyModelWithTable>(
       where: where(EmptyModelWithTable.t),
@@ -492,6 +527,7 @@ class EmptyModelWithTableRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
@@ -374,16 +374,22 @@ class RelationEmptyModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> insert(
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<RelationEmptyModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -417,6 +423,10 @@ class RelationEmptyModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> upsert(
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
@@ -424,6 +434,7 @@ class RelationEmptyModelRepository {
     _i1.ColumnSelections<RelationEmptyModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<RelationEmptyModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<RelationEmptyModel>(
       rows,
@@ -431,6 +442,7 @@ class RelationEmptyModelRepository {
       updateColumns: updateColumns?.call(RelationEmptyModel.t),
       updateWhere: updateWhere?.call(RelationEmptyModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -469,16 +481,22 @@ class RelationEmptyModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> update(
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
     _i1.ColumnSelections<RelationEmptyModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<RelationEmptyModel>(
       rows,
       columns: columns?.call(RelationEmptyModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -516,6 +534,10 @@ class RelationEmptyModelRepository {
 
   /// Updates all [RelationEmptyModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<RelationEmptyModelUpdateTable>
@@ -528,6 +550,7 @@ class RelationEmptyModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<RelationEmptyModel>(
       columnValues: columnValues(RelationEmptyModel.t.updateTable),
@@ -539,6 +562,7 @@ class RelationEmptyModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,6 +573,10 @@ class RelationEmptyModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> delete(
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
@@ -557,6 +585,7 @@ class RelationEmptyModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<RelationEmptyModel>(
       rows,
@@ -565,6 +594,7 @@ class RelationEmptyModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -584,6 +614,10 @@ class RelationEmptyModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelationEmptyModelTable> where,
@@ -592,6 +626,7 @@ class RelationEmptyModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<RelationEmptyModel>(
       where: where(RelationEmptyModel.t),
@@ -600,6 +635,7 @@ class RelationEmptyModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/inheritance/child_class_explicit_column.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/inheritance/child_class_explicit_column.dart
@@ -337,16 +337,22 @@ class ChildClassExplicitColumnRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassExplicitColumn>> insert(
     _i2.DatabaseSession session,
     List<ChildClassExplicitColumn> rows, {
     _i2.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ChildClassExplicitColumn>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -380,6 +386,10 @@ class ChildClassExplicitColumnRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassExplicitColumn>> upsert(
     _i2.DatabaseSession session,
     List<ChildClassExplicitColumn> rows, {
@@ -388,6 +398,7 @@ class ChildClassExplicitColumnRepository {
     _i2.ColumnSelections<ChildClassExplicitColumnTable>? updateColumns,
     _i2.WhereExpressionBuilder<ChildClassExplicitColumnTable>? updateWhere,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ChildClassExplicitColumn>(
       rows,
@@ -395,6 +406,7 @@ class ChildClassExplicitColumnRepository {
       updateColumns: updateColumns?.call(ChildClassExplicitColumn.t),
       updateWhere: updateWhere?.call(ChildClassExplicitColumn.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -434,16 +446,22 @@ class ChildClassExplicitColumnRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassExplicitColumn>> update(
     _i2.DatabaseSession session,
     List<ChildClassExplicitColumn> rows, {
     _i2.ColumnSelections<ChildClassExplicitColumnTable>? columns,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ChildClassExplicitColumn>(
       rows,
       columns: columns?.call(ChildClassExplicitColumn.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,6 +499,10 @@ class ChildClassExplicitColumnRepository {
 
   /// Updates all [ChildClassExplicitColumn]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassExplicitColumn>> updateWhere(
     _i2.DatabaseSession session, {
     required _i2.ColumnValueListBuilder<ChildClassExplicitColumnUpdateTable>
@@ -493,6 +515,7 @@ class ChildClassExplicitColumnRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ChildClassExplicitColumn>(
       columnValues: columnValues(ChildClassExplicitColumn.t.updateTable),
@@ -504,6 +527,7 @@ class ChildClassExplicitColumnRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -514,6 +538,10 @@ class ChildClassExplicitColumnRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassExplicitColumn>> delete(
     _i2.DatabaseSession session,
     List<ChildClassExplicitColumn> rows, {
@@ -522,6 +550,7 @@ class ChildClassExplicitColumnRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ChildClassExplicitColumn>(
       rows,
@@ -530,6 +559,7 @@ class ChildClassExplicitColumnRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,6 +579,10 @@ class ChildClassExplicitColumnRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassExplicitColumn>> deleteWhere(
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<ChildClassExplicitColumnTable> where,
@@ -557,6 +591,7 @@ class ChildClassExplicitColumnRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ChildClassExplicitColumn>(
       where: where(ChildClassExplicitColumn.t),
@@ -565,6 +600,7 @@ class ChildClassExplicitColumnRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/modified_column_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/modified_column_name.dart
@@ -335,16 +335,22 @@ class ModifiedColumnNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModifiedColumnName>> insert(
     _i1.DatabaseSession session,
     List<ModifiedColumnName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ModifiedColumnName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -378,6 +384,10 @@ class ModifiedColumnNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModifiedColumnName>> upsert(
     _i1.DatabaseSession session,
     List<ModifiedColumnName> rows, {
@@ -385,6 +395,7 @@ class ModifiedColumnNameRepository {
     _i1.ColumnSelections<ModifiedColumnNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<ModifiedColumnNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ModifiedColumnName>(
       rows,
@@ -392,6 +403,7 @@ class ModifiedColumnNameRepository {
       updateColumns: updateColumns?.call(ModifiedColumnName.t),
       updateWhere: updateWhere?.call(ModifiedColumnName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -430,16 +442,22 @@ class ModifiedColumnNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModifiedColumnName>> update(
     _i1.DatabaseSession session,
     List<ModifiedColumnName> rows, {
     _i1.ColumnSelections<ModifiedColumnNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ModifiedColumnName>(
       rows,
       columns: columns?.call(ModifiedColumnName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -477,6 +495,10 @@ class ModifiedColumnNameRepository {
 
   /// Updates all [ModifiedColumnName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModifiedColumnName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ModifiedColumnNameUpdateTable>
@@ -489,6 +511,7 @@ class ModifiedColumnNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ModifiedColumnName>(
       columnValues: columnValues(ModifiedColumnName.t.updateTable),
@@ -500,6 +523,7 @@ class ModifiedColumnNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -510,6 +534,10 @@ class ModifiedColumnNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModifiedColumnName>> delete(
     _i1.DatabaseSession session,
     List<ModifiedColumnName> rows, {
@@ -518,6 +546,7 @@ class ModifiedColumnNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ModifiedColumnName>(
       rows,
@@ -526,6 +555,7 @@ class ModifiedColumnNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -545,6 +575,10 @@ class ModifiedColumnNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModifiedColumnName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ModifiedColumnNameTable> where,
@@ -553,6 +587,7 @@ class ModifiedColumnNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ModifiedColumnName>(
       where: where(ModifiedColumnName.t),
@@ -561,6 +596,7 @@ class ModifiedColumnNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_many/department.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_many/department.dart
@@ -390,16 +390,22 @@ class DepartmentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Department>> insert(
     _i1.DatabaseSession session,
     List<Department> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Department>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -433,6 +439,10 @@ class DepartmentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Department>> upsert(
     _i1.DatabaseSession session,
     List<Department> rows, {
@@ -440,6 +450,7 @@ class DepartmentRepository {
     _i1.ColumnSelections<DepartmentTable>? updateColumns,
     _i1.WhereExpressionBuilder<DepartmentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Department>(
       rows,
@@ -447,6 +458,7 @@ class DepartmentRepository {
       updateColumns: updateColumns?.call(Department.t),
       updateWhere: updateWhere?.call(Department.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -485,16 +497,22 @@ class DepartmentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Department>> update(
     _i1.DatabaseSession session,
     List<Department> rows, {
     _i1.ColumnSelections<DepartmentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Department>(
       rows,
       columns: columns?.call(Department.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +549,10 @@ class DepartmentRepository {
 
   /// Updates all [Department]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Department>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DepartmentUpdateTable> columnValues,
@@ -542,6 +564,7 @@ class DepartmentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Department>(
       columnValues: columnValues(Department.t.updateTable),
@@ -553,6 +576,7 @@ class DepartmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -563,6 +587,10 @@ class DepartmentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Department>> delete(
     _i1.DatabaseSession session,
     List<Department> rows, {
@@ -571,6 +599,7 @@ class DepartmentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Department>(
       rows,
@@ -579,6 +608,7 @@ class DepartmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -598,6 +628,10 @@ class DepartmentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Department>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DepartmentTable> where,
@@ -606,6 +640,7 @@ class DepartmentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Department>(
       where: where(Department.t),
@@ -614,6 +649,7 @@ class DepartmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_many/employee.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_many/employee.dart
@@ -331,16 +331,22 @@ class EmployeeRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Employee>> insert(
     _i1.DatabaseSession session,
     List<Employee> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Employee>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -374,6 +380,10 @@ class EmployeeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Employee>> upsert(
     _i1.DatabaseSession session,
     List<Employee> rows, {
@@ -381,6 +391,7 @@ class EmployeeRepository {
     _i1.ColumnSelections<EmployeeTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmployeeTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Employee>(
       rows,
@@ -388,6 +399,7 @@ class EmployeeRepository {
       updateColumns: updateColumns?.call(Employee.t),
       updateWhere: updateWhere?.call(Employee.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -426,16 +438,22 @@ class EmployeeRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Employee>> update(
     _i1.DatabaseSession session,
     List<Employee> rows, {
     _i1.ColumnSelections<EmployeeTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Employee>(
       rows,
       columns: columns?.call(Employee.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -472,6 +490,10 @@ class EmployeeRepository {
 
   /// Updates all [Employee]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Employee>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmployeeUpdateTable> columnValues,
@@ -483,6 +505,7 @@ class EmployeeRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Employee>(
       columnValues: columnValues(Employee.t.updateTable),
@@ -494,6 +517,7 @@ class EmployeeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -504,6 +528,10 @@ class EmployeeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Employee>> delete(
     _i1.DatabaseSession session,
     List<Employee> rows, {
@@ -512,6 +540,7 @@ class EmployeeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Employee>(
       rows,
@@ -520,6 +549,7 @@ class EmployeeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -539,6 +569,10 @@ class EmployeeRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Employee>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmployeeTable> where,
@@ -547,6 +581,7 @@ class EmployeeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Employee>(
       where: where(Employee.t),
@@ -555,6 +590,7 @@ class EmployeeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_one/contractor.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_one/contractor.dart
@@ -389,16 +389,22 @@ class ContractorRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Contractor>> insert(
     _i1.DatabaseSession session,
     List<Contractor> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Contractor>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -432,6 +438,10 @@ class ContractorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Contractor>> upsert(
     _i1.DatabaseSession session,
     List<Contractor> rows, {
@@ -439,6 +449,7 @@ class ContractorRepository {
     _i1.ColumnSelections<ContractorTable>? updateColumns,
     _i1.WhereExpressionBuilder<ContractorTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Contractor>(
       rows,
@@ -446,6 +457,7 @@ class ContractorRepository {
       updateColumns: updateColumns?.call(Contractor.t),
       updateWhere: updateWhere?.call(Contractor.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -484,16 +496,22 @@ class ContractorRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Contractor>> update(
     _i1.DatabaseSession session,
     List<Contractor> rows, {
     _i1.ColumnSelections<ContractorTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Contractor>(
       rows,
       columns: columns?.call(Contractor.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -530,6 +548,10 @@ class ContractorRepository {
 
   /// Updates all [Contractor]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Contractor>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ContractorUpdateTable> columnValues,
@@ -541,6 +563,7 @@ class ContractorRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Contractor>(
       columnValues: columnValues(Contractor.t.updateTable),
@@ -552,6 +575,7 @@ class ContractorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -562,6 +586,10 @@ class ContractorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Contractor>> delete(
     _i1.DatabaseSession session,
     List<Contractor> rows, {
@@ -570,6 +598,7 @@ class ContractorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Contractor>(
       rows,
@@ -578,6 +607,7 @@ class ContractorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -597,6 +627,10 @@ class ContractorRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Contractor>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ContractorTable> where,
@@ -605,6 +639,7 @@ class ContractorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Contractor>(
       where: where(Contractor.t),
@@ -613,6 +648,7 @@ class ContractorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_one/service.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_one/service.dart
@@ -330,16 +330,22 @@ class ServiceRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Service>> insert(
     _i1.DatabaseSession session,
     List<Service> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Service>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -373,6 +379,10 @@ class ServiceRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Service>> upsert(
     _i1.DatabaseSession session,
     List<Service> rows, {
@@ -380,6 +390,7 @@ class ServiceRepository {
     _i1.ColumnSelections<ServiceTable>? updateColumns,
     _i1.WhereExpressionBuilder<ServiceTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Service>(
       rows,
@@ -387,6 +398,7 @@ class ServiceRepository {
       updateColumns: updateColumns?.call(Service.t),
       updateWhere: updateWhere?.call(Service.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -425,16 +437,22 @@ class ServiceRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Service>> update(
     _i1.DatabaseSession session,
     List<Service> rows, {
     _i1.ColumnSelections<ServiceTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Service>(
       rows,
       columns: columns?.call(Service.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -471,6 +489,10 @@ class ServiceRepository {
 
   /// Updates all [Service]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Service>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ServiceUpdateTable> columnValues,
@@ -482,6 +504,7 @@ class ServiceRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Service>(
       columnValues: columnValues(Service.t.updateTable),
@@ -493,6 +516,7 @@ class ServiceRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -503,6 +527,10 @@ class ServiceRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Service>> delete(
     _i1.DatabaseSession session,
     List<Service> rows, {
@@ -511,6 +539,7 @@ class ServiceRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Service>(
       rows,
@@ -519,6 +548,7 @@ class ServiceRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -538,6 +568,10 @@ class ServiceRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Service>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ServiceTable> where,
@@ -546,6 +580,7 @@ class ServiceRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Service>(
       where: where(Service.t),
@@ -554,6 +589,7 @@ class ServiceRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/table_with_explicit_column_names.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/table_with_explicit_column_names.dart
@@ -337,16 +337,22 @@ class TableWithExplicitColumnNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TableWithExplicitColumnName>> insert(
     _i1.DatabaseSession session,
     List<TableWithExplicitColumnName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<TableWithExplicitColumnName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -380,6 +386,10 @@ class TableWithExplicitColumnNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TableWithExplicitColumnName>> upsert(
     _i1.DatabaseSession session,
     List<TableWithExplicitColumnName> rows, {
@@ -388,6 +398,7 @@ class TableWithExplicitColumnNameRepository {
     _i1.ColumnSelections<TableWithExplicitColumnNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<TableWithExplicitColumnNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<TableWithExplicitColumnName>(
       rows,
@@ -395,6 +406,7 @@ class TableWithExplicitColumnNameRepository {
       updateColumns: updateColumns?.call(TableWithExplicitColumnName.t),
       updateWhere: updateWhere?.call(TableWithExplicitColumnName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -434,16 +446,22 @@ class TableWithExplicitColumnNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TableWithExplicitColumnName>> update(
     _i1.DatabaseSession session,
     List<TableWithExplicitColumnName> rows, {
     _i1.ColumnSelections<TableWithExplicitColumnNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<TableWithExplicitColumnName>(
       rows,
       columns: columns?.call(TableWithExplicitColumnName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,6 +499,10 @@ class TableWithExplicitColumnNameRepository {
 
   /// Updates all [TableWithExplicitColumnName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TableWithExplicitColumnName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TableWithExplicitColumnNameUpdateTable>
@@ -493,6 +515,7 @@ class TableWithExplicitColumnNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<TableWithExplicitColumnName>(
       columnValues: columnValues(TableWithExplicitColumnName.t.updateTable),
@@ -504,6 +527,7 @@ class TableWithExplicitColumnNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -514,6 +538,10 @@ class TableWithExplicitColumnNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TableWithExplicitColumnName>> delete(
     _i1.DatabaseSession session,
     List<TableWithExplicitColumnName> rows, {
@@ -522,6 +550,7 @@ class TableWithExplicitColumnNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<TableWithExplicitColumnName>(
       rows,
@@ -530,6 +559,7 @@ class TableWithExplicitColumnNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,6 +579,10 @@ class TableWithExplicitColumnNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TableWithExplicitColumnName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TableWithExplicitColumnNameTable> where,
@@ -557,6 +591,7 @@ class TableWithExplicitColumnNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<TableWithExplicitColumnName>(
       where: where(TableWithExplicitColumnName.t),
@@ -565,6 +600,7 @@ class TableWithExplicitColumnNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/immutable/immutable_object_with_table.dart
+++ b/tests/serverpod_test_server/lib/src/generated/immutable/immutable_object_with_table.dart
@@ -340,16 +340,22 @@ class ImmutableObjectWithTableRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ImmutableObjectWithTable>> insert(
     _i1.DatabaseSession session,
     List<ImmutableObjectWithTable> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ImmutableObjectWithTable>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -383,6 +389,10 @@ class ImmutableObjectWithTableRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ImmutableObjectWithTable>> upsert(
     _i1.DatabaseSession session,
     List<ImmutableObjectWithTable> rows, {
@@ -391,6 +401,7 @@ class ImmutableObjectWithTableRepository {
     _i1.ColumnSelections<ImmutableObjectWithTableTable>? updateColumns,
     _i1.WhereExpressionBuilder<ImmutableObjectWithTableTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ImmutableObjectWithTable>(
       rows,
@@ -398,6 +409,7 @@ class ImmutableObjectWithTableRepository {
       updateColumns: updateColumns?.call(ImmutableObjectWithTable.t),
       updateWhere: updateWhere?.call(ImmutableObjectWithTable.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -437,16 +449,22 @@ class ImmutableObjectWithTableRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ImmutableObjectWithTable>> update(
     _i1.DatabaseSession session,
     List<ImmutableObjectWithTable> rows, {
     _i1.ColumnSelections<ImmutableObjectWithTableTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ImmutableObjectWithTable>(
       rows,
       columns: columns?.call(ImmutableObjectWithTable.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -484,6 +502,10 @@ class ImmutableObjectWithTableRepository {
 
   /// Updates all [ImmutableObjectWithTable]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ImmutableObjectWithTable>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ImmutableObjectWithTableUpdateTable>
@@ -496,6 +518,7 @@ class ImmutableObjectWithTableRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ImmutableObjectWithTable>(
       columnValues: columnValues(ImmutableObjectWithTable.t.updateTable),
@@ -507,6 +530,7 @@ class ImmutableObjectWithTableRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -517,6 +541,10 @@ class ImmutableObjectWithTableRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ImmutableObjectWithTable>> delete(
     _i1.DatabaseSession session,
     List<ImmutableObjectWithTable> rows, {
@@ -525,6 +553,7 @@ class ImmutableObjectWithTableRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ImmutableObjectWithTableTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ImmutableObjectWithTable>(
       rows,
@@ -533,6 +562,7 @@ class ImmutableObjectWithTableRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -552,6 +582,10 @@ class ImmutableObjectWithTableRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ImmutableObjectWithTable>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ImmutableObjectWithTableTable> where,
@@ -560,6 +594,7 @@ class ImmutableObjectWithTableRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ImmutableObjectWithTableTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ImmutableObjectWithTable>(
       where: where(ImmutableObjectWithTable.t),
@@ -568,6 +603,7 @@ class ImmutableObjectWithTableRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/child_with_inherited_id.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/child_with_inherited_id.dart
@@ -396,16 +396,22 @@ class ChildWithInheritedIdRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildWithInheritedId>> insert(
     _i2.DatabaseSession session,
     List<ChildWithInheritedId> rows, {
     _i2.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ChildWithInheritedId>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -439,6 +445,10 @@ class ChildWithInheritedIdRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildWithInheritedId>> upsert(
     _i2.DatabaseSession session,
     List<ChildWithInheritedId> rows, {
@@ -446,6 +456,7 @@ class ChildWithInheritedIdRepository {
     _i2.ColumnSelections<ChildWithInheritedIdTable>? updateColumns,
     _i2.WhereExpressionBuilder<ChildWithInheritedIdTable>? updateWhere,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ChildWithInheritedId>(
       rows,
@@ -453,6 +464,7 @@ class ChildWithInheritedIdRepository {
       updateColumns: updateColumns?.call(ChildWithInheritedId.t),
       updateWhere: updateWhere?.call(ChildWithInheritedId.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -491,16 +503,22 @@ class ChildWithInheritedIdRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildWithInheritedId>> update(
     _i2.DatabaseSession session,
     List<ChildWithInheritedId> rows, {
     _i2.ColumnSelections<ChildWithInheritedIdTable>? columns,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ChildWithInheritedId>(
       rows,
       columns: columns?.call(ChildWithInheritedId.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -538,6 +556,10 @@ class ChildWithInheritedIdRepository {
 
   /// Updates all [ChildWithInheritedId]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildWithInheritedId>> updateWhere(
     _i2.DatabaseSession session, {
     required _i2.ColumnValueListBuilder<ChildWithInheritedIdUpdateTable>
@@ -550,6 +572,7 @@ class ChildWithInheritedIdRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ChildWithInheritedId>(
       columnValues: columnValues(ChildWithInheritedId.t.updateTable),
@@ -561,6 +584,7 @@ class ChildWithInheritedIdRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -571,6 +595,10 @@ class ChildWithInheritedIdRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildWithInheritedId>> delete(
     _i2.DatabaseSession session,
     List<ChildWithInheritedId> rows, {
@@ -579,6 +607,7 @@ class ChildWithInheritedIdRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<ChildWithInheritedIdTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ChildWithInheritedId>(
       rows,
@@ -587,6 +616,7 @@ class ChildWithInheritedIdRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -606,6 +636,10 @@ class ChildWithInheritedIdRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildWithInheritedId>> deleteWhere(
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<ChildWithInheritedIdTable> where,
@@ -614,6 +648,7 @@ class ChildWithInheritedIdRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<ChildWithInheritedIdTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ChildWithInheritedId>(
       where: where(ChildWithInheritedId.t),
@@ -622,6 +657,7 @@ class ChildWithInheritedIdRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/child_without_id.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/child_without_id.dart
@@ -357,16 +357,22 @@ class ChildClassWithoutIdRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassWithoutId>> insert(
     _i2.DatabaseSession session,
     List<ChildClassWithoutId> rows, {
     _i2.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ChildClassWithoutId>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -400,6 +406,10 @@ class ChildClassWithoutIdRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassWithoutId>> upsert(
     _i2.DatabaseSession session,
     List<ChildClassWithoutId> rows, {
@@ -407,6 +417,7 @@ class ChildClassWithoutIdRepository {
     _i2.ColumnSelections<ChildClassWithoutIdTable>? updateColumns,
     _i2.WhereExpressionBuilder<ChildClassWithoutIdTable>? updateWhere,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ChildClassWithoutId>(
       rows,
@@ -414,6 +425,7 @@ class ChildClassWithoutIdRepository {
       updateColumns: updateColumns?.call(ChildClassWithoutId.t),
       updateWhere: updateWhere?.call(ChildClassWithoutId.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -452,16 +464,22 @@ class ChildClassWithoutIdRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassWithoutId>> update(
     _i2.DatabaseSession session,
     List<ChildClassWithoutId> rows, {
     _i2.ColumnSelections<ChildClassWithoutIdTable>? columns,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ChildClassWithoutId>(
       rows,
       columns: columns?.call(ChildClassWithoutId.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -499,6 +517,10 @@ class ChildClassWithoutIdRepository {
 
   /// Updates all [ChildClassWithoutId]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassWithoutId>> updateWhere(
     _i2.DatabaseSession session, {
     required _i2.ColumnValueListBuilder<ChildClassWithoutIdUpdateTable>
@@ -511,6 +533,7 @@ class ChildClassWithoutIdRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ChildClassWithoutId>(
       columnValues: columnValues(ChildClassWithoutId.t.updateTable),
@@ -522,6 +545,7 @@ class ChildClassWithoutIdRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -532,6 +556,10 @@ class ChildClassWithoutIdRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassWithoutId>> delete(
     _i2.DatabaseSession session,
     List<ChildClassWithoutId> rows, {
@@ -540,6 +568,7 @@ class ChildClassWithoutIdRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassWithoutIdTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ChildClassWithoutId>(
       rows,
@@ -548,6 +577,7 @@ class ChildClassWithoutIdRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -567,6 +597,10 @@ class ChildClassWithoutIdRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassWithoutId>> deleteWhere(
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<ChildClassWithoutIdTable> where,
@@ -575,6 +609,7 @@ class ChildClassWithoutIdRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassWithoutIdTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ChildClassWithoutId>(
       where: where(ChildClassWithoutId.t),
@@ -583,6 +618,7 @@ class ChildClassWithoutIdRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/list_relation_of_child/child_entity.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/list_relation_of_child/child_entity.dart
@@ -390,16 +390,22 @@ class ChildEntityRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildEntity>> insert(
     _i2.DatabaseSession session,
     List<ChildEntity> rows, {
     _i2.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ChildEntity>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -433,6 +439,10 @@ class ChildEntityRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildEntity>> upsert(
     _i2.DatabaseSession session,
     List<ChildEntity> rows, {
@@ -440,6 +450,7 @@ class ChildEntityRepository {
     _i2.ColumnSelections<ChildEntityTable>? updateColumns,
     _i2.WhereExpressionBuilder<ChildEntityTable>? updateWhere,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ChildEntity>(
       rows,
@@ -447,6 +458,7 @@ class ChildEntityRepository {
       updateColumns: updateColumns?.call(ChildEntity.t),
       updateWhere: updateWhere?.call(ChildEntity.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -485,16 +497,22 @@ class ChildEntityRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildEntity>> update(
     _i2.DatabaseSession session,
     List<ChildEntity> rows, {
     _i2.ColumnSelections<ChildEntityTable>? columns,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ChildEntity>(
       rows,
       columns: columns?.call(ChildEntity.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +549,10 @@ class ChildEntityRepository {
 
   /// Updates all [ChildEntity]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildEntity>> updateWhere(
     _i2.DatabaseSession session, {
     required _i2.ColumnValueListBuilder<ChildEntityUpdateTable> columnValues,
@@ -542,6 +564,7 @@ class ChildEntityRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ChildEntity>(
       columnValues: columnValues(ChildEntity.t.updateTable),
@@ -553,6 +576,7 @@ class ChildEntityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -563,6 +587,10 @@ class ChildEntityRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildEntity>> delete(
     _i2.DatabaseSession session,
     List<ChildEntity> rows, {
@@ -571,6 +599,7 @@ class ChildEntityRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<ChildEntityTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ChildEntity>(
       rows,
@@ -579,6 +608,7 @@ class ChildEntityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -598,6 +628,10 @@ class ChildEntityRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildEntity>> deleteWhere(
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<ChildEntityTable> where,
@@ -606,6 +640,7 @@ class ChildEntityRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<ChildEntityTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ChildEntity>(
       where: where(ChildEntity.t),
@@ -614,6 +649,7 @@ class ChildEntityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/list_relation_of_child/parent_entity.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/list_relation_of_child/parent_entity.dart
@@ -365,16 +365,22 @@ class ParentEntityRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentEntity>> insert(
     _i1.DatabaseSession session,
     List<ParentEntity> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ParentEntity>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -408,6 +414,10 @@ class ParentEntityRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentEntity>> upsert(
     _i1.DatabaseSession session,
     List<ParentEntity> rows, {
@@ -415,6 +425,7 @@ class ParentEntityRepository {
     _i1.ColumnSelections<ParentEntityTable>? updateColumns,
     _i1.WhereExpressionBuilder<ParentEntityTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ParentEntity>(
       rows,
@@ -422,6 +433,7 @@ class ParentEntityRepository {
       updateColumns: updateColumns?.call(ParentEntity.t),
       updateWhere: updateWhere?.call(ParentEntity.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -460,16 +472,22 @@ class ParentEntityRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentEntity>> update(
     _i1.DatabaseSession session,
     List<ParentEntity> rows, {
     _i1.ColumnSelections<ParentEntityTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ParentEntity>(
       rows,
       columns: columns?.call(ParentEntity.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -506,6 +524,10 @@ class ParentEntityRepository {
 
   /// Updates all [ParentEntity]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentEntity>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ParentEntityUpdateTable> columnValues,
@@ -517,6 +539,7 @@ class ParentEntityRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ParentEntity>(
       columnValues: columnValues(ParentEntity.t.updateTable),
@@ -528,6 +551,7 @@ class ParentEntityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -538,6 +562,10 @@ class ParentEntityRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentEntity>> delete(
     _i1.DatabaseSession session,
     List<ParentEntity> rows, {
@@ -546,6 +574,7 @@ class ParentEntityRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ParentEntityTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ParentEntity>(
       rows,
@@ -554,6 +583,7 @@ class ParentEntityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -573,6 +603,10 @@ class ParentEntityRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentEntity>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ParentEntityTable> where,
@@ -581,6 +615,7 @@ class ParentEntityRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ParentEntityTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ParentEntity>(
       where: where(ParentEntity.t),
@@ -589,6 +624,7 @@ class ParentEntityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/parent_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/parent_class.dart
@@ -304,16 +304,22 @@ class ParentClassRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentClass>> insert(
     _i2.DatabaseSession session,
     List<ParentClass> rows, {
     _i2.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ParentClass>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -347,6 +353,10 @@ class ParentClassRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentClass>> upsert(
     _i2.DatabaseSession session,
     List<ParentClass> rows, {
@@ -354,6 +364,7 @@ class ParentClassRepository {
     _i2.ColumnSelections<ParentClassTable>? updateColumns,
     _i2.WhereExpressionBuilder<ParentClassTable>? updateWhere,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ParentClass>(
       rows,
@@ -361,6 +372,7 @@ class ParentClassRepository {
       updateColumns: updateColumns?.call(ParentClass.t),
       updateWhere: updateWhere?.call(ParentClass.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -399,16 +411,22 @@ class ParentClassRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentClass>> update(
     _i2.DatabaseSession session,
     List<ParentClass> rows, {
     _i2.ColumnSelections<ParentClassTable>? columns,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ParentClass>(
       rows,
       columns: columns?.call(ParentClass.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -445,6 +463,10 @@ class ParentClassRepository {
 
   /// Updates all [ParentClass]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentClass>> updateWhere(
     _i2.DatabaseSession session, {
     required _i2.ColumnValueListBuilder<ParentClassUpdateTable> columnValues,
@@ -456,6 +478,7 @@ class ParentClassRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ParentClass>(
       columnValues: columnValues(ParentClass.t.updateTable),
@@ -467,6 +490,7 @@ class ParentClassRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -477,6 +501,10 @@ class ParentClassRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentClass>> delete(
     _i2.DatabaseSession session,
     List<ParentClass> rows, {
@@ -485,6 +513,7 @@ class ParentClassRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<ParentClassTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ParentClass>(
       rows,
@@ -493,6 +522,7 @@ class ParentClassRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +542,10 @@ class ParentClassRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentClass>> deleteWhere(
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<ParentClassTable> where,
@@ -520,6 +554,7 @@ class ParentClassRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<ParentClassTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ParentClass>(
       where: where(ParentClass.t),
@@ -528,6 +563,7 @@ class ParentClassRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -484,16 +484,22 @@ class CityWithLongTableNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CityWithLongTableName>> insert(
     _i1.DatabaseSession session,
     List<CityWithLongTableName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CityWithLongTableName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -527,6 +533,10 @@ class CityWithLongTableNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CityWithLongTableName>> upsert(
     _i1.DatabaseSession session,
     List<CityWithLongTableName> rows, {
@@ -534,6 +544,7 @@ class CityWithLongTableNameRepository {
     _i1.ColumnSelections<CityWithLongTableNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<CityWithLongTableNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CityWithLongTableName>(
       rows,
@@ -541,6 +552,7 @@ class CityWithLongTableNameRepository {
       updateColumns: updateColumns?.call(CityWithLongTableName.t),
       updateWhere: updateWhere?.call(CityWithLongTableName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -579,16 +591,22 @@ class CityWithLongTableNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CityWithLongTableName>> update(
     _i1.DatabaseSession session,
     List<CityWithLongTableName> rows, {
     _i1.ColumnSelections<CityWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CityWithLongTableName>(
       rows,
       columns: columns?.call(CityWithLongTableName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -626,6 +644,10 @@ class CityWithLongTableNameRepository {
 
   /// Updates all [CityWithLongTableName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CityWithLongTableName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CityWithLongTableNameUpdateTable>
@@ -638,6 +660,7 @@ class CityWithLongTableNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CityWithLongTableName>(
       columnValues: columnValues(CityWithLongTableName.t.updateTable),
@@ -649,6 +672,7 @@ class CityWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -659,6 +683,10 @@ class CityWithLongTableNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CityWithLongTableName>> delete(
     _i1.DatabaseSession session,
     List<CityWithLongTableName> rows, {
@@ -667,6 +695,7 @@ class CityWithLongTableNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CityWithLongTableName>(
       rows,
@@ -675,6 +704,7 @@ class CityWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -694,6 +724,10 @@ class CityWithLongTableNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CityWithLongTableName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CityWithLongTableNameTable> where,
@@ -702,6 +736,7 @@ class CityWithLongTableNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CityWithLongTableName>(
       where: where(CityWithLongTableName.t),
@@ -710,6 +745,7 @@ class CityWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -473,16 +473,22 @@ class OrganizationWithLongTableNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrganizationWithLongTableName>> insert(
     _i1.DatabaseSession session,
     List<OrganizationWithLongTableName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<OrganizationWithLongTableName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -516,6 +522,10 @@ class OrganizationWithLongTableNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrganizationWithLongTableName>> upsert(
     _i1.DatabaseSession session,
     List<OrganizationWithLongTableName> rows, {
@@ -524,6 +534,7 @@ class OrganizationWithLongTableNameRepository {
     _i1.ColumnSelections<OrganizationWithLongTableNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<OrganizationWithLongTableNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<OrganizationWithLongTableName>(
       rows,
@@ -531,6 +542,7 @@ class OrganizationWithLongTableNameRepository {
       updateColumns: updateColumns?.call(OrganizationWithLongTableName.t),
       updateWhere: updateWhere?.call(OrganizationWithLongTableName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -570,16 +582,22 @@ class OrganizationWithLongTableNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrganizationWithLongTableName>> update(
     _i1.DatabaseSession session,
     List<OrganizationWithLongTableName> rows, {
     _i1.ColumnSelections<OrganizationWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<OrganizationWithLongTableName>(
       rows,
       columns: columns?.call(OrganizationWithLongTableName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -619,6 +637,10 @@ class OrganizationWithLongTableNameRepository {
 
   /// Updates all [OrganizationWithLongTableName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrganizationWithLongTableName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<
@@ -634,6 +656,7 @@ class OrganizationWithLongTableNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<OrganizationWithLongTableName>(
       columnValues: columnValues(OrganizationWithLongTableName.t.updateTable),
@@ -645,6 +668,7 @@ class OrganizationWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -655,6 +679,10 @@ class OrganizationWithLongTableNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrganizationWithLongTableName>> delete(
     _i1.DatabaseSession session,
     List<OrganizationWithLongTableName> rows, {
@@ -663,6 +691,7 @@ class OrganizationWithLongTableNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<OrganizationWithLongTableName>(
       rows,
@@ -671,6 +700,7 @@ class OrganizationWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -690,6 +720,10 @@ class OrganizationWithLongTableNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrganizationWithLongTableName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrganizationWithLongTableNameTable>
@@ -699,6 +733,7 @@ class OrganizationWithLongTableNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<OrganizationWithLongTableName>(
       where: where(OrganizationWithLongTableName.t),
@@ -707,6 +742,7 @@ class OrganizationWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -471,16 +471,22 @@ class PersonWithLongTableNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PersonWithLongTableName>> insert(
     _i1.DatabaseSession session,
     List<PersonWithLongTableName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<PersonWithLongTableName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -514,6 +520,10 @@ class PersonWithLongTableNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PersonWithLongTableName>> upsert(
     _i1.DatabaseSession session,
     List<PersonWithLongTableName> rows, {
@@ -521,6 +531,7 @@ class PersonWithLongTableNameRepository {
     _i1.ColumnSelections<PersonWithLongTableNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<PersonWithLongTableNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<PersonWithLongTableName>(
       rows,
@@ -528,6 +539,7 @@ class PersonWithLongTableNameRepository {
       updateColumns: updateColumns?.call(PersonWithLongTableName.t),
       updateWhere: updateWhere?.call(PersonWithLongTableName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -566,16 +578,22 @@ class PersonWithLongTableNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PersonWithLongTableName>> update(
     _i1.DatabaseSession session,
     List<PersonWithLongTableName> rows, {
     _i1.ColumnSelections<PersonWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<PersonWithLongTableName>(
       rows,
       columns: columns?.call(PersonWithLongTableName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -613,6 +631,10 @@ class PersonWithLongTableNameRepository {
 
   /// Updates all [PersonWithLongTableName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PersonWithLongTableName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PersonWithLongTableNameUpdateTable>
@@ -625,6 +647,7 @@ class PersonWithLongTableNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<PersonWithLongTableName>(
       columnValues: columnValues(PersonWithLongTableName.t.updateTable),
@@ -636,6 +659,7 @@ class PersonWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -646,6 +670,10 @@ class PersonWithLongTableNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PersonWithLongTableName>> delete(
     _i1.DatabaseSession session,
     List<PersonWithLongTableName> rows, {
@@ -654,6 +682,7 @@ class PersonWithLongTableNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<PersonWithLongTableName>(
       rows,
@@ -662,6 +691,7 @@ class PersonWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -681,6 +711,10 @@ class PersonWithLongTableNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PersonWithLongTableName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PersonWithLongTableNameTable> where,
@@ -689,6 +723,7 @@ class PersonWithLongTableNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<PersonWithLongTableName>(
       where: where(PersonWithLongTableName.t),
@@ -697,6 +732,7 @@ class PersonWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
@@ -320,16 +320,22 @@ class MaxFieldNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MaxFieldName>> insert(
     _i1.DatabaseSession session,
     List<MaxFieldName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<MaxFieldName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -363,6 +369,10 @@ class MaxFieldNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MaxFieldName>> upsert(
     _i1.DatabaseSession session,
     List<MaxFieldName> rows, {
@@ -370,6 +380,7 @@ class MaxFieldNameRepository {
     _i1.ColumnSelections<MaxFieldNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<MaxFieldNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<MaxFieldName>(
       rows,
@@ -377,6 +388,7 @@ class MaxFieldNameRepository {
       updateColumns: updateColumns?.call(MaxFieldName.t),
       updateWhere: updateWhere?.call(MaxFieldName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -415,16 +427,22 @@ class MaxFieldNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MaxFieldName>> update(
     _i1.DatabaseSession session,
     List<MaxFieldName> rows, {
     _i1.ColumnSelections<MaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<MaxFieldName>(
       rows,
       columns: columns?.call(MaxFieldName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -461,6 +479,10 @@ class MaxFieldNameRepository {
 
   /// Updates all [MaxFieldName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MaxFieldName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<MaxFieldNameUpdateTable> columnValues,
@@ -472,6 +494,7 @@ class MaxFieldNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<MaxFieldName>(
       columnValues: columnValues(MaxFieldName.t.updateTable),
@@ -483,6 +506,7 @@ class MaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -493,6 +517,10 @@ class MaxFieldNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MaxFieldName>> delete(
     _i1.DatabaseSession session,
     List<MaxFieldName> rows, {
@@ -501,6 +529,7 @@ class MaxFieldNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<MaxFieldName>(
       rows,
@@ -509,6 +538,7 @@ class MaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -528,6 +558,10 @@ class MaxFieldNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MaxFieldName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MaxFieldNameTable> where,
@@ -536,6 +570,7 @@ class MaxFieldNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<MaxFieldName>(
       where: where(MaxFieldName.t),
@@ -544,6 +579,7 @@ class MaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -370,16 +370,22 @@ class LongImplicitIdFieldRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdField>> insert(
     _i1.DatabaseSession session,
     List<LongImplicitIdField> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<LongImplicitIdField>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -413,6 +419,10 @@ class LongImplicitIdFieldRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdField>> upsert(
     _i1.DatabaseSession session,
     List<LongImplicitIdField> rows, {
@@ -420,6 +430,7 @@ class LongImplicitIdFieldRepository {
     _i1.ColumnSelections<LongImplicitIdFieldTable>? updateColumns,
     _i1.WhereExpressionBuilder<LongImplicitIdFieldTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<LongImplicitIdField>(
       rows,
@@ -427,6 +438,7 @@ class LongImplicitIdFieldRepository {
       updateColumns: updateColumns?.call(LongImplicitIdField.t),
       updateWhere: updateWhere?.call(LongImplicitIdField.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -465,16 +477,22 @@ class LongImplicitIdFieldRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdField>> update(
     _i1.DatabaseSession session,
     List<LongImplicitIdField> rows, {
     _i1.ColumnSelections<LongImplicitIdFieldTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<LongImplicitIdField>(
       rows,
       columns: columns?.call(LongImplicitIdField.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +530,10 @@ class LongImplicitIdFieldRepository {
 
   /// Updates all [LongImplicitIdField]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdField>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<LongImplicitIdFieldUpdateTable>
@@ -524,6 +546,7 @@ class LongImplicitIdFieldRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<LongImplicitIdField>(
       columnValues: columnValues(LongImplicitIdField.t.updateTable),
@@ -535,6 +558,7 @@ class LongImplicitIdFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -545,6 +569,10 @@ class LongImplicitIdFieldRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdField>> delete(
     _i1.DatabaseSession session,
     List<LongImplicitIdField> rows, {
@@ -553,6 +581,7 @@ class LongImplicitIdFieldRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<LongImplicitIdField>(
       rows,
@@ -561,6 +590,7 @@ class LongImplicitIdFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -580,6 +610,10 @@ class LongImplicitIdFieldRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdField>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<LongImplicitIdFieldTable> where,
@@ -588,6 +622,7 @@ class LongImplicitIdFieldRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<LongImplicitIdField>(
       where: where(LongImplicitIdField.t),
@@ -596,6 +631,7 @@ class LongImplicitIdFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -444,16 +444,22 @@ class LongImplicitIdFieldCollectionRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdFieldCollection>> insert(
     _i1.DatabaseSession session,
     List<LongImplicitIdFieldCollection> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<LongImplicitIdFieldCollection>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -487,6 +493,10 @@ class LongImplicitIdFieldCollectionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdFieldCollection>> upsert(
     _i1.DatabaseSession session,
     List<LongImplicitIdFieldCollection> rows, {
@@ -495,6 +505,7 @@ class LongImplicitIdFieldCollectionRepository {
     _i1.ColumnSelections<LongImplicitIdFieldCollectionTable>? updateColumns,
     _i1.WhereExpressionBuilder<LongImplicitIdFieldCollectionTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<LongImplicitIdFieldCollection>(
       rows,
@@ -502,6 +513,7 @@ class LongImplicitIdFieldCollectionRepository {
       updateColumns: updateColumns?.call(LongImplicitIdFieldCollection.t),
       updateWhere: updateWhere?.call(LongImplicitIdFieldCollection.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -541,16 +553,22 @@ class LongImplicitIdFieldCollectionRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdFieldCollection>> update(
     _i1.DatabaseSession session,
     List<LongImplicitIdFieldCollection> rows, {
     _i1.ColumnSelections<LongImplicitIdFieldCollectionTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<LongImplicitIdFieldCollection>(
       rows,
       columns: columns?.call(LongImplicitIdFieldCollection.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -590,6 +608,10 @@ class LongImplicitIdFieldCollectionRepository {
 
   /// Updates all [LongImplicitIdFieldCollection]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdFieldCollection>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<
@@ -605,6 +627,7 @@ class LongImplicitIdFieldCollectionRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<LongImplicitIdFieldCollection>(
       columnValues: columnValues(LongImplicitIdFieldCollection.t.updateTable),
@@ -616,6 +639,7 @@ class LongImplicitIdFieldCollectionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -626,6 +650,10 @@ class LongImplicitIdFieldCollectionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdFieldCollection>> delete(
     _i1.DatabaseSession session,
     List<LongImplicitIdFieldCollection> rows, {
@@ -634,6 +662,7 @@ class LongImplicitIdFieldCollectionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<LongImplicitIdFieldCollection>(
       rows,
@@ -642,6 +671,7 @@ class LongImplicitIdFieldCollectionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -661,6 +691,10 @@ class LongImplicitIdFieldCollectionRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdFieldCollection>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<LongImplicitIdFieldCollectionTable>
@@ -670,6 +704,7 @@ class LongImplicitIdFieldCollectionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<LongImplicitIdFieldCollection>(
       where: where(LongImplicitIdFieldCollection.t),
@@ -678,6 +713,7 @@ class LongImplicitIdFieldCollectionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -415,16 +415,22 @@ class RelationToMultipleMaxFieldNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationToMultipleMaxFieldName>> insert(
     _i1.DatabaseSession session,
     List<RelationToMultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<RelationToMultipleMaxFieldName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -458,6 +464,10 @@ class RelationToMultipleMaxFieldNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationToMultipleMaxFieldName>> upsert(
     _i1.DatabaseSession session,
     List<RelationToMultipleMaxFieldName> rows, {
@@ -467,6 +477,7 @@ class RelationToMultipleMaxFieldNameRepository {
     _i1.WhereExpressionBuilder<RelationToMultipleMaxFieldNameTable>?
     updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<RelationToMultipleMaxFieldName>(
       rows,
@@ -474,6 +485,7 @@ class RelationToMultipleMaxFieldNameRepository {
       updateColumns: updateColumns?.call(RelationToMultipleMaxFieldName.t),
       updateWhere: updateWhere?.call(RelationToMultipleMaxFieldName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -514,16 +526,22 @@ class RelationToMultipleMaxFieldNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationToMultipleMaxFieldName>> update(
     _i1.DatabaseSession session,
     List<RelationToMultipleMaxFieldName> rows, {
     _i1.ColumnSelections<RelationToMultipleMaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<RelationToMultipleMaxFieldName>(
       rows,
       columns: columns?.call(RelationToMultipleMaxFieldName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -563,6 +581,10 @@ class RelationToMultipleMaxFieldNameRepository {
 
   /// Updates all [RelationToMultipleMaxFieldName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationToMultipleMaxFieldName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<
@@ -578,6 +600,7 @@ class RelationToMultipleMaxFieldNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<RelationToMultipleMaxFieldName>(
       columnValues: columnValues(RelationToMultipleMaxFieldName.t.updateTable),
@@ -589,6 +612,7 @@ class RelationToMultipleMaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -599,6 +623,10 @@ class RelationToMultipleMaxFieldNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationToMultipleMaxFieldName>> delete(
     _i1.DatabaseSession session,
     List<RelationToMultipleMaxFieldName> rows, {
@@ -607,6 +635,7 @@ class RelationToMultipleMaxFieldNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<RelationToMultipleMaxFieldName>(
       rows,
@@ -615,6 +644,7 @@ class RelationToMultipleMaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -634,6 +664,10 @@ class RelationToMultipleMaxFieldNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationToMultipleMaxFieldName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelationToMultipleMaxFieldNameTable>
@@ -643,6 +677,7 @@ class RelationToMultipleMaxFieldNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<RelationToMultipleMaxFieldName>(
       where: where(RelationToMultipleMaxFieldName.t),
@@ -651,6 +686,7 @@ class RelationToMultipleMaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
@@ -367,16 +367,22 @@ class UserNoteRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNote>> insert(
     _i1.DatabaseSession session,
     List<UserNote> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UserNote>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -410,6 +416,10 @@ class UserNoteRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNote>> upsert(
     _i1.DatabaseSession session,
     List<UserNote> rows, {
@@ -417,6 +427,7 @@ class UserNoteRepository {
     _i1.ColumnSelections<UserNoteTable>? updateColumns,
     _i1.WhereExpressionBuilder<UserNoteTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UserNote>(
       rows,
@@ -424,6 +435,7 @@ class UserNoteRepository {
       updateColumns: updateColumns?.call(UserNote.t),
       updateWhere: updateWhere?.call(UserNote.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -462,16 +474,22 @@ class UserNoteRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNote>> update(
     _i1.DatabaseSession session,
     List<UserNote> rows, {
     _i1.ColumnSelections<UserNoteTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UserNote>(
       rows,
       columns: columns?.call(UserNote.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -508,6 +526,10 @@ class UserNoteRepository {
 
   /// Updates all [UserNote]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNote>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UserNoteUpdateTable> columnValues,
@@ -519,6 +541,7 @@ class UserNoteRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UserNote>(
       columnValues: columnValues(UserNote.t.updateTable),
@@ -530,6 +553,7 @@ class UserNoteRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -540,6 +564,10 @@ class UserNoteRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNote>> delete(
     _i1.DatabaseSession session,
     List<UserNote> rows, {
@@ -548,6 +576,7 @@ class UserNoteRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UserNote>(
       rows,
@@ -556,6 +585,7 @@ class UserNoteRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -575,6 +605,10 @@ class UserNoteRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNote>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteTable> where,
@@ -583,6 +617,7 @@ class UserNoteRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UserNote>(
       where: where(UserNote.t),
@@ -591,6 +626,7 @@ class UserNoteRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -411,16 +411,22 @@ class UserNoteCollectionRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollection>> insert(
     _i1.DatabaseSession session,
     List<UserNoteCollection> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UserNoteCollection>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -454,6 +460,10 @@ class UserNoteCollectionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollection>> upsert(
     _i1.DatabaseSession session,
     List<UserNoteCollection> rows, {
@@ -461,6 +471,7 @@ class UserNoteCollectionRepository {
     _i1.ColumnSelections<UserNoteCollectionTable>? updateColumns,
     _i1.WhereExpressionBuilder<UserNoteCollectionTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UserNoteCollection>(
       rows,
@@ -468,6 +479,7 @@ class UserNoteCollectionRepository {
       updateColumns: updateColumns?.call(UserNoteCollection.t),
       updateWhere: updateWhere?.call(UserNoteCollection.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -506,16 +518,22 @@ class UserNoteCollectionRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollection>> update(
     _i1.DatabaseSession session,
     List<UserNoteCollection> rows, {
     _i1.ColumnSelections<UserNoteCollectionTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UserNoteCollection>(
       rows,
       columns: columns?.call(UserNoteCollection.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -553,6 +571,10 @@ class UserNoteCollectionRepository {
 
   /// Updates all [UserNoteCollection]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollection>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UserNoteCollectionUpdateTable>
@@ -565,6 +587,7 @@ class UserNoteCollectionRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UserNoteCollection>(
       columnValues: columnValues(UserNoteCollection.t.updateTable),
@@ -576,6 +599,7 @@ class UserNoteCollectionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -586,6 +610,10 @@ class UserNoteCollectionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollection>> delete(
     _i1.DatabaseSession session,
     List<UserNoteCollection> rows, {
@@ -594,6 +622,7 @@ class UserNoteCollectionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UserNoteCollection>(
       rows,
@@ -602,6 +631,7 @@ class UserNoteCollectionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -621,6 +651,10 @@ class UserNoteCollectionRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollection>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteCollectionTable> where,
@@ -629,6 +663,7 @@ class UserNoteCollectionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UserNoteCollection>(
       where: where(UserNoteCollection.t),
@@ -637,6 +672,7 @@ class UserNoteCollectionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -408,16 +408,22 @@ class UserNoteCollectionWithALongNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollectionWithALongName>> insert(
     _i1.DatabaseSession session,
     List<UserNoteCollectionWithALongName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UserNoteCollectionWithALongName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -451,6 +457,10 @@ class UserNoteCollectionWithALongNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollectionWithALongName>> upsert(
     _i1.DatabaseSession session,
     List<UserNoteCollectionWithALongName> rows, {
@@ -460,6 +470,7 @@ class UserNoteCollectionWithALongNameRepository {
     _i1.WhereExpressionBuilder<UserNoteCollectionWithALongNameTable>?
     updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UserNoteCollectionWithALongName>(
       rows,
@@ -467,6 +478,7 @@ class UserNoteCollectionWithALongNameRepository {
       updateColumns: updateColumns?.call(UserNoteCollectionWithALongName.t),
       updateWhere: updateWhere?.call(UserNoteCollectionWithALongName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -507,16 +519,22 @@ class UserNoteCollectionWithALongNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollectionWithALongName>> update(
     _i1.DatabaseSession session,
     List<UserNoteCollectionWithALongName> rows, {
     _i1.ColumnSelections<UserNoteCollectionWithALongNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UserNoteCollectionWithALongName>(
       rows,
       columns: columns?.call(UserNoteCollectionWithALongName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -556,6 +574,10 @@ class UserNoteCollectionWithALongNameRepository {
 
   /// Updates all [UserNoteCollectionWithALongName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollectionWithALongName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<
@@ -571,6 +593,7 @@ class UserNoteCollectionWithALongNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UserNoteCollectionWithALongName>(
       columnValues: columnValues(UserNoteCollectionWithALongName.t.updateTable),
@@ -582,6 +605,7 @@ class UserNoteCollectionWithALongNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -592,6 +616,10 @@ class UserNoteCollectionWithALongNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollectionWithALongName>> delete(
     _i1.DatabaseSession session,
     List<UserNoteCollectionWithALongName> rows, {
@@ -600,6 +628,7 @@ class UserNoteCollectionWithALongNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UserNoteCollectionWithALongName>(
       rows,
@@ -608,6 +637,7 @@ class UserNoteCollectionWithALongNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -627,6 +657,10 @@ class UserNoteCollectionWithALongNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollectionWithALongName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteCollectionWithALongNameTable>
@@ -636,6 +670,7 @@ class UserNoteCollectionWithALongNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UserNoteCollectionWithALongName>(
       where: where(UserNoteCollectionWithALongName.t),
@@ -644,6 +679,7 @@ class UserNoteCollectionWithALongNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -372,16 +372,22 @@ class UserNoteWithALongNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteWithALongName>> insert(
     _i1.DatabaseSession session,
     List<UserNoteWithALongName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UserNoteWithALongName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -415,6 +421,10 @@ class UserNoteWithALongNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteWithALongName>> upsert(
     _i1.DatabaseSession session,
     List<UserNoteWithALongName> rows, {
@@ -422,6 +432,7 @@ class UserNoteWithALongNameRepository {
     _i1.ColumnSelections<UserNoteWithALongNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<UserNoteWithALongNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UserNoteWithALongName>(
       rows,
@@ -429,6 +440,7 @@ class UserNoteWithALongNameRepository {
       updateColumns: updateColumns?.call(UserNoteWithALongName.t),
       updateWhere: updateWhere?.call(UserNoteWithALongName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -467,16 +479,22 @@ class UserNoteWithALongNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteWithALongName>> update(
     _i1.DatabaseSession session,
     List<UserNoteWithALongName> rows, {
     _i1.ColumnSelections<UserNoteWithALongNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UserNoteWithALongName>(
       rows,
       columns: columns?.call(UserNoteWithALongName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -514,6 +532,10 @@ class UserNoteWithALongNameRepository {
 
   /// Updates all [UserNoteWithALongName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteWithALongName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UserNoteWithALongNameUpdateTable>
@@ -526,6 +548,7 @@ class UserNoteWithALongNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UserNoteWithALongName>(
       columnValues: columnValues(UserNoteWithALongName.t.updateTable),
@@ -537,6 +560,7 @@ class UserNoteWithALongNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -547,6 +571,10 @@ class UserNoteWithALongNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteWithALongName>> delete(
     _i1.DatabaseSession session,
     List<UserNoteWithALongName> rows, {
@@ -555,6 +583,7 @@ class UserNoteWithALongNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UserNoteWithALongName>(
       rows,
@@ -563,6 +592,7 @@ class UserNoteWithALongNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -582,6 +612,10 @@ class UserNoteWithALongNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteWithALongName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteWithALongNameTable> where,
@@ -590,6 +624,7 @@ class UserNoteWithALongNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UserNoteWithALongName>(
       where: where(UserNoteWithALongName.t),
@@ -598,6 +633,7 @@ class UserNoteWithALongNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
@@ -434,16 +434,22 @@ class MultipleMaxFieldNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MultipleMaxFieldName>> insert(
     _i1.DatabaseSession session,
     List<MultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<MultipleMaxFieldName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -477,6 +483,10 @@ class MultipleMaxFieldNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MultipleMaxFieldName>> upsert(
     _i1.DatabaseSession session,
     List<MultipleMaxFieldName> rows, {
@@ -484,6 +494,7 @@ class MultipleMaxFieldNameRepository {
     _i1.ColumnSelections<MultipleMaxFieldNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<MultipleMaxFieldName>(
       rows,
@@ -491,6 +502,7 @@ class MultipleMaxFieldNameRepository {
       updateColumns: updateColumns?.call(MultipleMaxFieldName.t),
       updateWhere: updateWhere?.call(MultipleMaxFieldName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -529,16 +541,22 @@ class MultipleMaxFieldNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MultipleMaxFieldName>> update(
     _i1.DatabaseSession session,
     List<MultipleMaxFieldName> rows, {
     _i1.ColumnSelections<MultipleMaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<MultipleMaxFieldName>(
       rows,
       columns: columns?.call(MultipleMaxFieldName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -576,6 +594,10 @@ class MultipleMaxFieldNameRepository {
 
   /// Updates all [MultipleMaxFieldName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MultipleMaxFieldName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<MultipleMaxFieldNameUpdateTable>
@@ -588,6 +610,7 @@ class MultipleMaxFieldNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<MultipleMaxFieldName>(
       columnValues: columnValues(MultipleMaxFieldName.t.updateTable),
@@ -599,6 +622,7 @@ class MultipleMaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -609,6 +633,10 @@ class MultipleMaxFieldNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MultipleMaxFieldName>> delete(
     _i1.DatabaseSession session,
     List<MultipleMaxFieldName> rows, {
@@ -617,6 +645,7 @@ class MultipleMaxFieldNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<MultipleMaxFieldName>(
       rows,
@@ -625,6 +654,7 @@ class MultipleMaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -644,6 +674,10 @@ class MultipleMaxFieldNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MultipleMaxFieldName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable> where,
@@ -652,6 +686,7 @@ class MultipleMaxFieldNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<MultipleMaxFieldName>(
       where: where(MultipleMaxFieldName.t),
@@ -660,6 +695,7 @@ class MultipleMaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -467,16 +467,22 @@ class CityRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> insert(
     _i1.DatabaseSession session,
     List<City> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<City>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -510,6 +516,10 @@ class CityRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> upsert(
     _i1.DatabaseSession session,
     List<City> rows, {
@@ -517,6 +527,7 @@ class CityRepository {
     _i1.ColumnSelections<CityTable>? updateColumns,
     _i1.WhereExpressionBuilder<CityTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<City>(
       rows,
@@ -524,6 +535,7 @@ class CityRepository {
       updateColumns: updateColumns?.call(City.t),
       updateWhere: updateWhere?.call(City.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -562,16 +574,22 @@ class CityRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> update(
     _i1.DatabaseSession session,
     List<City> rows, {
     _i1.ColumnSelections<CityTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<City>(
       rows,
       columns: columns?.call(City.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -608,6 +626,10 @@ class CityRepository {
 
   /// Updates all [City]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CityUpdateTable> columnValues,
@@ -619,6 +641,7 @@ class CityRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<City>(
       columnValues: columnValues(City.t.updateTable),
@@ -630,6 +653,7 @@ class CityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -640,6 +664,10 @@ class CityRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> delete(
     _i1.DatabaseSession session,
     List<City> rows, {
@@ -648,6 +676,7 @@ class CityRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<City>(
       rows,
@@ -656,6 +685,7 @@ class CityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -675,6 +705,10 @@ class CityRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CityTable> where,
@@ -683,6 +717,7 @@ class CityRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<City>(
       where: where(City.t),
@@ -691,6 +726,7 @@ class CityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -463,16 +463,22 @@ class OrganizationRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> insert(
     _i1.DatabaseSession session,
     List<Organization> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Organization>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -506,6 +512,10 @@ class OrganizationRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> upsert(
     _i1.DatabaseSession session,
     List<Organization> rows, {
@@ -513,6 +523,7 @@ class OrganizationRepository {
     _i1.ColumnSelections<OrganizationTable>? updateColumns,
     _i1.WhereExpressionBuilder<OrganizationTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Organization>(
       rows,
@@ -520,6 +531,7 @@ class OrganizationRepository {
       updateColumns: updateColumns?.call(Organization.t),
       updateWhere: updateWhere?.call(Organization.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -558,16 +570,22 @@ class OrganizationRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> update(
     _i1.DatabaseSession session,
     List<Organization> rows, {
     _i1.ColumnSelections<OrganizationTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Organization>(
       rows,
       columns: columns?.call(Organization.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -604,6 +622,10 @@ class OrganizationRepository {
 
   /// Updates all [Organization]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<OrganizationUpdateTable> columnValues,
@@ -615,6 +637,7 @@ class OrganizationRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Organization>(
       columnValues: columnValues(Organization.t.updateTable),
@@ -626,6 +649,7 @@ class OrganizationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -636,6 +660,10 @@ class OrganizationRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> delete(
     _i1.DatabaseSession session,
     List<Organization> rows, {
@@ -644,6 +672,7 @@ class OrganizationRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Organization>(
       rows,
@@ -652,6 +681,7 @@ class OrganizationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -671,6 +701,10 @@ class OrganizationRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrganizationTable> where,
@@ -679,6 +713,7 @@ class OrganizationRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Organization>(
       where: where(Organization.t),
@@ -687,6 +722,7 @@ class OrganizationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -447,16 +447,22 @@ class PersonRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> insert(
     _i1.DatabaseSession session,
     List<Person> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Person>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -490,6 +496,10 @@ class PersonRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> upsert(
     _i1.DatabaseSession session,
     List<Person> rows, {
@@ -497,6 +507,7 @@ class PersonRepository {
     _i1.ColumnSelections<PersonTable>? updateColumns,
     _i1.WhereExpressionBuilder<PersonTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Person>(
       rows,
@@ -504,6 +515,7 @@ class PersonRepository {
       updateColumns: updateColumns?.call(Person.t),
       updateWhere: updateWhere?.call(Person.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -542,16 +554,22 @@ class PersonRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> update(
     _i1.DatabaseSession session,
     List<Person> rows, {
     _i1.ColumnSelections<PersonTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Person>(
       rows,
       columns: columns?.call(Person.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -588,6 +606,10 @@ class PersonRepository {
 
   /// Updates all [Person]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PersonUpdateTable> columnValues,
@@ -599,6 +621,7 @@ class PersonRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Person>(
       columnValues: columnValues(Person.t.updateTable),
@@ -610,6 +633,7 @@ class PersonRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -620,6 +644,10 @@ class PersonRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> delete(
     _i1.DatabaseSession session,
     List<Person> rows, {
@@ -628,6 +656,7 @@ class PersonRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Person>(
       rows,
@@ -636,6 +665,7 @@ class PersonRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -655,6 +685,10 @@ class PersonRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PersonTable> where,
@@ -663,6 +697,7 @@ class PersonRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Person>(
       where: where(Person.t),
@@ -671,6 +706,7 @@ class PersonRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/column_alias_collision/bleed_child.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/column_alias_collision/bleed_child.dart
@@ -314,16 +314,22 @@ class BleedChildRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BleedChild>> insert(
     _i1.DatabaseSession session,
     List<BleedChild> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BleedChild>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -357,6 +363,10 @@ class BleedChildRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BleedChild>> upsert(
     _i1.DatabaseSession session,
     List<BleedChild> rows, {
@@ -364,6 +374,7 @@ class BleedChildRepository {
     _i1.ColumnSelections<BleedChildTable>? updateColumns,
     _i1.WhereExpressionBuilder<BleedChildTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BleedChild>(
       rows,
@@ -371,6 +382,7 @@ class BleedChildRepository {
       updateColumns: updateColumns?.call(BleedChild.t),
       updateWhere: updateWhere?.call(BleedChild.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -409,16 +421,22 @@ class BleedChildRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BleedChild>> update(
     _i1.DatabaseSession session,
     List<BleedChild> rows, {
     _i1.ColumnSelections<BleedChildTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BleedChild>(
       rows,
       columns: columns?.call(BleedChild.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -455,6 +473,10 @@ class BleedChildRepository {
 
   /// Updates all [BleedChild]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BleedChild>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BleedChildUpdateTable> columnValues,
@@ -466,6 +488,7 @@ class BleedChildRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BleedChild>(
       columnValues: columnValues(BleedChild.t.updateTable),
@@ -477,6 +500,7 @@ class BleedChildRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -487,6 +511,10 @@ class BleedChildRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BleedChild>> delete(
     _i1.DatabaseSession session,
     List<BleedChild> rows, {
@@ -495,6 +523,7 @@ class BleedChildRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BleedChildTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BleedChild>(
       rows,
@@ -503,6 +532,7 @@ class BleedChildRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -522,6 +552,10 @@ class BleedChildRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BleedChild>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BleedChildTable> where,
@@ -530,6 +564,7 @@ class BleedChildRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BleedChildTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BleedChild>(
       where: where(BleedChild.t),
@@ -538,6 +573,7 @@ class BleedChildRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/column_alias_collision/bleed_root.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/column_alias_collision/bleed_root.dart
@@ -512,16 +512,22 @@ class BleedRootRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BleedRoot>> insert(
     _i1.DatabaseSession session,
     List<BleedRoot> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BleedRoot>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -555,6 +561,10 @@ class BleedRootRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BleedRoot>> upsert(
     _i1.DatabaseSession session,
     List<BleedRoot> rows, {
@@ -562,6 +572,7 @@ class BleedRootRepository {
     _i1.ColumnSelections<BleedRootTable>? updateColumns,
     _i1.WhereExpressionBuilder<BleedRootTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BleedRoot>(
       rows,
@@ -569,6 +580,7 @@ class BleedRootRepository {
       updateColumns: updateColumns?.call(BleedRoot.t),
       updateWhere: updateWhere?.call(BleedRoot.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -607,16 +619,22 @@ class BleedRootRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BleedRoot>> update(
     _i1.DatabaseSession session,
     List<BleedRoot> rows, {
     _i1.ColumnSelections<BleedRootTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BleedRoot>(
       rows,
       columns: columns?.call(BleedRoot.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -653,6 +671,10 @@ class BleedRootRepository {
 
   /// Updates all [BleedRoot]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BleedRoot>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BleedRootUpdateTable> columnValues,
@@ -664,6 +686,7 @@ class BleedRootRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BleedRoot>(
       columnValues: columnValues(BleedRoot.t.updateTable),
@@ -675,6 +698,7 @@ class BleedRootRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -685,6 +709,10 @@ class BleedRootRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BleedRoot>> delete(
     _i1.DatabaseSession session,
     List<BleedRoot> rows, {
@@ -693,6 +721,7 @@ class BleedRootRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BleedRootTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BleedRoot>(
       rows,
@@ -701,6 +730,7 @@ class BleedRootRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -720,6 +750,10 @@ class BleedRootRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BleedRoot>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BleedRootTable> where,
@@ -728,6 +762,7 @@ class BleedRootRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BleedRootTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BleedRoot>(
       where: where(BleedRoot.t),
@@ -736,6 +771,7 @@ class BleedRootRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -392,16 +392,22 @@ class CourseRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> insert(
     _i1.DatabaseSession session,
     List<Course> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Course>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -435,6 +441,10 @@ class CourseRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> upsert(
     _i1.DatabaseSession session,
     List<Course> rows, {
@@ -442,6 +452,7 @@ class CourseRepository {
     _i1.ColumnSelections<CourseTable>? updateColumns,
     _i1.WhereExpressionBuilder<CourseTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Course>(
       rows,
@@ -449,6 +460,7 @@ class CourseRepository {
       updateColumns: updateColumns?.call(Course.t),
       updateWhere: updateWhere?.call(Course.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -487,16 +499,22 @@ class CourseRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> update(
     _i1.DatabaseSession session,
     List<Course> rows, {
     _i1.ColumnSelections<CourseTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Course>(
       rows,
       columns: columns?.call(Course.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -533,6 +551,10 @@ class CourseRepository {
 
   /// Updates all [Course]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CourseUpdateTable> columnValues,
@@ -544,6 +566,7 @@ class CourseRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Course>(
       columnValues: columnValues(Course.t.updateTable),
@@ -555,6 +578,7 @@ class CourseRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -565,6 +589,10 @@ class CourseRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> delete(
     _i1.DatabaseSession session,
     List<Course> rows, {
@@ -573,6 +601,7 @@ class CourseRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Course>(
       rows,
@@ -581,6 +610,7 @@ class CourseRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -600,6 +630,10 @@ class CourseRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CourseTable> where,
@@ -608,6 +642,7 @@ class CourseRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Course>(
       where: where(Course.t),
@@ -616,6 +651,7 @@ class CourseRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -432,16 +432,22 @@ class EnrollmentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> insert(
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Enrollment>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -475,6 +481,10 @@ class EnrollmentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> upsert(
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
@@ -482,6 +492,7 @@ class EnrollmentRepository {
     _i1.ColumnSelections<EnrollmentTable>? updateColumns,
     _i1.WhereExpressionBuilder<EnrollmentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Enrollment>(
       rows,
@@ -489,6 +500,7 @@ class EnrollmentRepository {
       updateColumns: updateColumns?.call(Enrollment.t),
       updateWhere: updateWhere?.call(Enrollment.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -527,16 +539,22 @@ class EnrollmentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> update(
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
     _i1.ColumnSelections<EnrollmentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Enrollment>(
       rows,
       columns: columns?.call(Enrollment.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -573,6 +591,10 @@ class EnrollmentRepository {
 
   /// Updates all [Enrollment]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnrollmentUpdateTable> columnValues,
@@ -584,6 +606,7 @@ class EnrollmentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Enrollment>(
       columnValues: columnValues(Enrollment.t.updateTable),
@@ -595,6 +618,7 @@ class EnrollmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -605,6 +629,10 @@ class EnrollmentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> delete(
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
@@ -613,6 +641,7 @@ class EnrollmentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Enrollment>(
       rows,
@@ -621,6 +650,7 @@ class EnrollmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -640,6 +670,10 @@ class EnrollmentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnrollmentTable> where,
@@ -648,6 +682,7 @@ class EnrollmentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Enrollment>(
       where: where(Enrollment.t),
@@ -656,6 +691,7 @@ class EnrollmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -389,16 +389,22 @@ class StudentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> insert(
     _i1.DatabaseSession session,
     List<Student> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Student>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -432,6 +438,10 @@ class StudentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> upsert(
     _i1.DatabaseSession session,
     List<Student> rows, {
@@ -439,6 +449,7 @@ class StudentRepository {
     _i1.ColumnSelections<StudentTable>? updateColumns,
     _i1.WhereExpressionBuilder<StudentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Student>(
       rows,
@@ -446,6 +457,7 @@ class StudentRepository {
       updateColumns: updateColumns?.call(Student.t),
       updateWhere: updateWhere?.call(Student.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -484,16 +496,22 @@ class StudentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> update(
     _i1.DatabaseSession session,
     List<Student> rows, {
     _i1.ColumnSelections<StudentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Student>(
       rows,
       columns: columns?.call(Student.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -530,6 +548,10 @@ class StudentRepository {
 
   /// Updates all [Student]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<StudentUpdateTable> columnValues,
@@ -541,6 +563,7 @@ class StudentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Student>(
       columnValues: columnValues(Student.t.updateTable),
@@ -552,6 +575,7 @@ class StudentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -562,6 +586,10 @@ class StudentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> delete(
     _i1.DatabaseSession session,
     List<Student> rows, {
@@ -570,6 +598,7 @@ class StudentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Student>(
       rows,
@@ -578,6 +607,7 @@ class StudentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -597,6 +627,10 @@ class StudentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StudentTable> where,
@@ -605,6 +639,7 @@ class StudentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Student>(
       where: where(Student.t),
@@ -613,6 +648,7 @@ class StudentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -386,16 +386,22 @@ class ObjectUserRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectUser>> insert(
     _i1.DatabaseSession session,
     List<ObjectUser> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectUser>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -429,6 +435,10 @@ class ObjectUserRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectUser>> upsert(
     _i1.DatabaseSession session,
     List<ObjectUser> rows, {
@@ -436,6 +446,7 @@ class ObjectUserRepository {
     _i1.ColumnSelections<ObjectUserTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectUserTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectUser>(
       rows,
@@ -443,6 +454,7 @@ class ObjectUserRepository {
       updateColumns: updateColumns?.call(ObjectUser.t),
       updateWhere: updateWhere?.call(ObjectUser.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,16 +493,22 @@ class ObjectUserRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectUser>> update(
     _i1.DatabaseSession session,
     List<ObjectUser> rows, {
     _i1.ColumnSelections<ObjectUserTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectUser>(
       rows,
       columns: columns?.call(ObjectUser.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -527,6 +545,10 @@ class ObjectUserRepository {
 
   /// Updates all [ObjectUser]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectUser>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectUserUpdateTable> columnValues,
@@ -538,6 +560,7 @@ class ObjectUserRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectUser>(
       columnValues: columnValues(ObjectUser.t.updateTable),
@@ -549,6 +572,7 @@ class ObjectUserRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -559,6 +583,10 @@ class ObjectUserRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectUser>> delete(
     _i1.DatabaseSession session,
     List<ObjectUser> rows, {
@@ -567,6 +595,7 @@ class ObjectUserRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectUserTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectUser>(
       rows,
@@ -575,6 +604,7 @@ class ObjectUserRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -594,6 +624,10 @@ class ObjectUserRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectUser>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectUserTable> where,
@@ -602,6 +636,7 @@ class ObjectUserRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectUserTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectUser>(
       where: where(ObjectUser.t),
@@ -610,6 +645,7 @@ class ObjectUserRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
@@ -330,16 +330,22 @@ class ParentUserRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentUser>> insert(
     _i1.DatabaseSession session,
     List<ParentUser> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ParentUser>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -373,6 +379,10 @@ class ParentUserRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentUser>> upsert(
     _i1.DatabaseSession session,
     List<ParentUser> rows, {
@@ -380,6 +390,7 @@ class ParentUserRepository {
     _i1.ColumnSelections<ParentUserTable>? updateColumns,
     _i1.WhereExpressionBuilder<ParentUserTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ParentUser>(
       rows,
@@ -387,6 +398,7 @@ class ParentUserRepository {
       updateColumns: updateColumns?.call(ParentUser.t),
       updateWhere: updateWhere?.call(ParentUser.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -425,16 +437,22 @@ class ParentUserRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentUser>> update(
     _i1.DatabaseSession session,
     List<ParentUser> rows, {
     _i1.ColumnSelections<ParentUserTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ParentUser>(
       rows,
       columns: columns?.call(ParentUser.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -471,6 +489,10 @@ class ParentUserRepository {
 
   /// Updates all [ParentUser]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentUser>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ParentUserUpdateTable> columnValues,
@@ -482,6 +504,7 @@ class ParentUserRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ParentUser>(
       columnValues: columnValues(ParentUser.t.updateTable),
@@ -493,6 +516,7 @@ class ParentUserRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -503,6 +527,10 @@ class ParentUserRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentUser>> delete(
     _i1.DatabaseSession session,
     List<ParentUser> rows, {
@@ -511,6 +539,7 @@ class ParentUserRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ParentUserTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ParentUser>(
       rows,
@@ -519,6 +548,7 @@ class ParentUserRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -538,6 +568,10 @@ class ParentUserRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ParentUser>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ParentUserTable> where,
@@ -546,6 +580,7 @@ class ParentUserRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ParentUserTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ParentUser>(
       where: where(ParentUser.t),
@@ -554,6 +589,7 @@ class ParentUserRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -359,16 +359,22 @@ class ArenaRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> insert(
     _i1.DatabaseSession session,
     List<Arena> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Arena>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -402,6 +408,10 @@ class ArenaRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> upsert(
     _i1.DatabaseSession session,
     List<Arena> rows, {
@@ -409,6 +419,7 @@ class ArenaRepository {
     _i1.ColumnSelections<ArenaTable>? updateColumns,
     _i1.WhereExpressionBuilder<ArenaTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Arena>(
       rows,
@@ -416,6 +427,7 @@ class ArenaRepository {
       updateColumns: updateColumns?.call(Arena.t),
       updateWhere: updateWhere?.call(Arena.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -454,16 +466,22 @@ class ArenaRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> update(
     _i1.DatabaseSession session,
     List<Arena> rows, {
     _i1.ColumnSelections<ArenaTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Arena>(
       rows,
       columns: columns?.call(Arena.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -500,6 +518,10 @@ class ArenaRepository {
 
   /// Updates all [Arena]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ArenaUpdateTable> columnValues,
@@ -511,6 +533,7 @@ class ArenaRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Arena>(
       columnValues: columnValues(Arena.t.updateTable),
@@ -522,6 +545,7 @@ class ArenaRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -532,6 +556,10 @@ class ArenaRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> delete(
     _i1.DatabaseSession session,
     List<Arena> rows, {
@@ -540,6 +568,7 @@ class ArenaRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Arena>(
       rows,
@@ -548,6 +577,7 @@ class ArenaRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -567,6 +597,10 @@ class ArenaRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ArenaTable> where,
@@ -575,6 +609,7 @@ class ArenaRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Arena>(
       where: where(Arena.t),
@@ -583,6 +618,7 @@ class ArenaRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -383,16 +383,22 @@ class PlayerRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> insert(
     _i1.DatabaseSession session,
     List<Player> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Player>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -426,6 +432,10 @@ class PlayerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> upsert(
     _i1.DatabaseSession session,
     List<Player> rows, {
@@ -433,6 +443,7 @@ class PlayerRepository {
     _i1.ColumnSelections<PlayerTable>? updateColumns,
     _i1.WhereExpressionBuilder<PlayerTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Player>(
       rows,
@@ -440,6 +451,7 @@ class PlayerRepository {
       updateColumns: updateColumns?.call(Player.t),
       updateWhere: updateWhere?.call(Player.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -478,16 +490,22 @@ class PlayerRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> update(
     _i1.DatabaseSession session,
     List<Player> rows, {
     _i1.ColumnSelections<PlayerTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Player>(
       rows,
       columns: columns?.call(Player.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -524,6 +542,10 @@ class PlayerRepository {
 
   /// Updates all [Player]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PlayerUpdateTable> columnValues,
@@ -535,6 +557,7 @@ class PlayerRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Player>(
       columnValues: columnValues(Player.t.updateTable),
@@ -546,6 +569,7 @@ class PlayerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -556,6 +580,10 @@ class PlayerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> delete(
     _i1.DatabaseSession session,
     List<Player> rows, {
@@ -564,6 +592,7 @@ class PlayerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Player>(
       rows,
@@ -572,6 +601,7 @@ class PlayerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +621,10 @@ class PlayerRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PlayerTable> where,
@@ -599,6 +633,7 @@ class PlayerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Player>(
       where: where(Player.t),
@@ -607,6 +642,7 @@ class PlayerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -462,16 +462,22 @@ class TeamRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> insert(
     _i1.DatabaseSession session,
     List<Team> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Team>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -505,6 +511,10 @@ class TeamRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> upsert(
     _i1.DatabaseSession session,
     List<Team> rows, {
@@ -512,6 +522,7 @@ class TeamRepository {
     _i1.ColumnSelections<TeamTable>? updateColumns,
     _i1.WhereExpressionBuilder<TeamTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Team>(
       rows,
@@ -519,6 +530,7 @@ class TeamRepository {
       updateColumns: updateColumns?.call(Team.t),
       updateWhere: updateWhere?.call(Team.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -557,16 +569,22 @@ class TeamRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> update(
     _i1.DatabaseSession session,
     List<Team> rows, {
     _i1.ColumnSelections<TeamTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Team>(
       rows,
       columns: columns?.call(Team.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -603,6 +621,10 @@ class TeamRepository {
 
   /// Updates all [Team]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TeamUpdateTable> columnValues,
@@ -614,6 +636,7 @@ class TeamRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Team>(
       columnValues: columnValues(Team.t.updateTable),
@@ -625,6 +648,7 @@ class TeamRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -635,6 +659,10 @@ class TeamRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> delete(
     _i1.DatabaseSession session,
     List<Team> rows, {
@@ -643,6 +671,7 @@ class TeamRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Team>(
       rows,
@@ -651,6 +680,7 @@ class TeamRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -670,6 +700,10 @@ class TeamRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TeamTable> where,
@@ -678,6 +712,7 @@ class TeamRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Team>(
       where: where(Team.t),
@@ -686,6 +721,7 @@ class TeamRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -382,16 +382,22 @@ class CommentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> insert(
     _i1.DatabaseSession session,
     List<Comment> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Comment>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -425,6 +431,10 @@ class CommentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> upsert(
     _i1.DatabaseSession session,
     List<Comment> rows, {
@@ -432,6 +442,7 @@ class CommentRepository {
     _i1.ColumnSelections<CommentTable>? updateColumns,
     _i1.WhereExpressionBuilder<CommentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Comment>(
       rows,
@@ -439,6 +450,7 @@ class CommentRepository {
       updateColumns: updateColumns?.call(Comment.t),
       updateWhere: updateWhere?.call(Comment.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -477,16 +489,22 @@ class CommentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> update(
     _i1.DatabaseSession session,
     List<Comment> rows, {
     _i1.ColumnSelections<CommentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Comment>(
       rows,
       columns: columns?.call(Comment.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -523,6 +541,10 @@ class CommentRepository {
 
   /// Updates all [Comment]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CommentUpdateTable> columnValues,
@@ -534,6 +556,7 @@ class CommentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Comment>(
       columnValues: columnValues(Comment.t.updateTable),
@@ -545,6 +568,7 @@ class CommentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -555,6 +579,10 @@ class CommentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> delete(
     _i1.DatabaseSession session,
     List<Comment> rows, {
@@ -563,6 +591,7 @@ class CommentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Comment>(
       rows,
@@ -571,6 +600,7 @@ class CommentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -590,6 +620,10 @@ class CommentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CommentTable> where,
@@ -598,6 +632,7 @@ class CommentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Comment>(
       where: where(Comment.t),
@@ -606,6 +641,7 @@ class CommentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -391,16 +391,22 @@ class CustomerRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> insert(
     _i1.DatabaseSession session,
     List<Customer> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Customer>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -434,6 +440,10 @@ class CustomerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> upsert(
     _i1.DatabaseSession session,
     List<Customer> rows, {
@@ -441,6 +451,7 @@ class CustomerRepository {
     _i1.ColumnSelections<CustomerTable>? updateColumns,
     _i1.WhereExpressionBuilder<CustomerTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Customer>(
       rows,
@@ -448,6 +459,7 @@ class CustomerRepository {
       updateColumns: updateColumns?.call(Customer.t),
       updateWhere: updateWhere?.call(Customer.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,16 +498,22 @@ class CustomerRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> update(
     _i1.DatabaseSession session,
     List<Customer> rows, {
     _i1.ColumnSelections<CustomerTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Customer>(
       rows,
       columns: columns?.call(Customer.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -532,6 +550,10 @@ class CustomerRepository {
 
   /// Updates all [Customer]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CustomerUpdateTable> columnValues,
@@ -543,6 +565,7 @@ class CustomerRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Customer>(
       columnValues: columnValues(Customer.t.updateTable),
@@ -554,6 +577,7 @@ class CustomerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,6 +588,10 @@ class CustomerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> delete(
     _i1.DatabaseSession session,
     List<Customer> rows, {
@@ -572,6 +600,7 @@ class CustomerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Customer>(
       rows,
@@ -580,6 +609,7 @@ class CustomerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -599,6 +629,10 @@ class CustomerRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CustomerTable> where,
@@ -607,6 +641,7 @@ class CustomerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Customer>(
       where: where(Customer.t),
@@ -615,6 +650,7 @@ class CustomerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/implicit/book.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/implicit/book.dart
@@ -391,16 +391,22 @@ class BookRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> insert(
     _i1.DatabaseSession session,
     List<Book> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Book>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -434,6 +440,10 @@ class BookRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> upsert(
     _i1.DatabaseSession session,
     List<Book> rows, {
@@ -441,6 +451,7 @@ class BookRepository {
     _i1.ColumnSelections<BookTable>? updateColumns,
     _i1.WhereExpressionBuilder<BookTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Book>(
       rows,
@@ -448,6 +459,7 @@ class BookRepository {
       updateColumns: updateColumns?.call(Book.t),
       updateWhere: updateWhere?.call(Book.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,16 +498,22 @@ class BookRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> update(
     _i1.DatabaseSession session,
     List<Book> rows, {
     _i1.ColumnSelections<BookTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Book>(
       rows,
       columns: columns?.call(Book.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -532,6 +550,10 @@ class BookRepository {
 
   /// Updates all [Book]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BookUpdateTable> columnValues,
@@ -543,6 +565,7 @@ class BookRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Book>(
       columnValues: columnValues(Book.t.updateTable),
@@ -554,6 +577,7 @@ class BookRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,6 +588,10 @@ class BookRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> delete(
     _i1.DatabaseSession session,
     List<Book> rows, {
@@ -572,6 +600,7 @@ class BookRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Book>(
       rows,
@@ -580,6 +609,7 @@ class BookRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -599,6 +629,10 @@ class BookRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BookTable> where,
@@ -607,6 +641,7 @@ class BookRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Book>(
       where: where(Book.t),
@@ -615,6 +650,7 @@ class BookRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/implicit/chapter.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/implicit/chapter.dart
@@ -356,16 +356,22 @@ class ChapterRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> insert(
     _i1.DatabaseSession session,
     List<Chapter> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Chapter>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -399,6 +405,10 @@ class ChapterRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> upsert(
     _i1.DatabaseSession session,
     List<Chapter> rows, {
@@ -406,6 +416,7 @@ class ChapterRepository {
     _i1.ColumnSelections<ChapterTable>? updateColumns,
     _i1.WhereExpressionBuilder<ChapterTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Chapter>(
       rows,
@@ -413,6 +424,7 @@ class ChapterRepository {
       updateColumns: updateColumns?.call(Chapter.t),
       updateWhere: updateWhere?.call(Chapter.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -451,16 +463,22 @@ class ChapterRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> update(
     _i1.DatabaseSession session,
     List<Chapter> rows, {
     _i1.ColumnSelections<ChapterTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Chapter>(
       rows,
       columns: columns?.call(Chapter.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -497,6 +515,10 @@ class ChapterRepository {
 
   /// Updates all [Chapter]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ChapterUpdateTable> columnValues,
@@ -508,6 +530,7 @@ class ChapterRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Chapter>(
       columnValues: columnValues(Chapter.t.updateTable),
@@ -519,6 +542,7 @@ class ChapterRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -529,6 +553,10 @@ class ChapterRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> delete(
     _i1.DatabaseSession session,
     List<Chapter> rows, {
@@ -537,6 +565,7 @@ class ChapterRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Chapter>(
       rows,
@@ -545,6 +574,7 @@ class ChapterRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,6 +594,10 @@ class ChapterRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChapterTable> where,
@@ -572,6 +606,7 @@ class ChapterRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Chapter>(
       where: where(Chapter.t),
@@ -580,6 +615,7 @@ class ChapterRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -462,16 +462,22 @@ class OrderRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> insert(
     _i1.DatabaseSession session,
     List<Order> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Order>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -505,6 +511,10 @@ class OrderRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> upsert(
     _i1.DatabaseSession session,
     List<Order> rows, {
@@ -512,6 +522,7 @@ class OrderRepository {
     _i1.ColumnSelections<OrderTable>? updateColumns,
     _i1.WhereExpressionBuilder<OrderTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Order>(
       rows,
@@ -519,6 +530,7 @@ class OrderRepository {
       updateColumns: updateColumns?.call(Order.t),
       updateWhere: updateWhere?.call(Order.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -557,16 +569,22 @@ class OrderRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> update(
     _i1.DatabaseSession session,
     List<Order> rows, {
     _i1.ColumnSelections<OrderTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Order>(
       rows,
       columns: columns?.call(Order.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -603,6 +621,10 @@ class OrderRepository {
 
   /// Updates all [Order]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<OrderUpdateTable> columnValues,
@@ -614,6 +636,7 @@ class OrderRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Order>(
       columnValues: columnValues(Order.t.updateTable),
@@ -625,6 +648,7 @@ class OrderRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -635,6 +659,10 @@ class OrderRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> delete(
     _i1.DatabaseSession session,
     List<Order> rows, {
@@ -643,6 +671,7 @@ class OrderRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Order>(
       rows,
@@ -651,6 +680,7 @@ class OrderRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -670,6 +700,10 @@ class OrderRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrderTable> where,
@@ -678,6 +712,7 @@ class OrderRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Order>(
       where: where(Order.t),
@@ -686,6 +721,7 @@ class OrderRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -388,16 +388,22 @@ class AddressRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> insert(
     _i1.DatabaseSession session,
     List<Address> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Address>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -431,6 +437,10 @@ class AddressRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> upsert(
     _i1.DatabaseSession session,
     List<Address> rows, {
@@ -438,6 +448,7 @@ class AddressRepository {
     _i1.ColumnSelections<AddressTable>? updateColumns,
     _i1.WhereExpressionBuilder<AddressTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Address>(
       rows,
@@ -445,6 +456,7 @@ class AddressRepository {
       updateColumns: updateColumns?.call(Address.t),
       updateWhere: updateWhere?.call(Address.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -483,16 +495,22 @@ class AddressRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> update(
     _i1.DatabaseSession session,
     List<Address> rows, {
     _i1.ColumnSelections<AddressTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Address>(
       rows,
       columns: columns?.call(Address.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -529,6 +547,10 @@ class AddressRepository {
 
   /// Updates all [Address]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<AddressUpdateTable> columnValues,
@@ -540,6 +562,7 @@ class AddressRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Address>(
       columnValues: columnValues(Address.t.updateTable),
@@ -551,6 +574,7 @@ class AddressRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -561,6 +585,10 @@ class AddressRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> delete(
     _i1.DatabaseSession session,
     List<Address> rows, {
@@ -569,6 +597,7 @@ class AddressRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Address>(
       rows,
@@ -577,6 +606,7 @@ class AddressRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -596,6 +626,10 @@ class AddressRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AddressTable> where,
@@ -604,6 +638,7 @@ class AddressRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Address>(
       where: where(Address.t),
@@ -612,6 +647,7 @@ class AddressRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -503,16 +503,22 @@ class CitizenRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> insert(
     _i1.DatabaseSession session,
     List<Citizen> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Citizen>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -546,6 +552,10 @@ class CitizenRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> upsert(
     _i1.DatabaseSession session,
     List<Citizen> rows, {
@@ -553,6 +563,7 @@ class CitizenRepository {
     _i1.ColumnSelections<CitizenTable>? updateColumns,
     _i1.WhereExpressionBuilder<CitizenTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Citizen>(
       rows,
@@ -560,6 +571,7 @@ class CitizenRepository {
       updateColumns: updateColumns?.call(Citizen.t),
       updateWhere: updateWhere?.call(Citizen.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -598,16 +610,22 @@ class CitizenRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> update(
     _i1.DatabaseSession session,
     List<Citizen> rows, {
     _i1.ColumnSelections<CitizenTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Citizen>(
       rows,
       columns: columns?.call(Citizen.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -644,6 +662,10 @@ class CitizenRepository {
 
   /// Updates all [Citizen]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CitizenUpdateTable> columnValues,
@@ -655,6 +677,7 @@ class CitizenRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Citizen>(
       columnValues: columnValues(Citizen.t.updateTable),
@@ -666,6 +689,7 @@ class CitizenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -676,6 +700,10 @@ class CitizenRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> delete(
     _i1.DatabaseSession session,
     List<Citizen> rows, {
@@ -684,6 +712,7 @@ class CitizenRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Citizen>(
       rows,
@@ -692,6 +721,7 @@ class CitizenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -711,6 +741,10 @@ class CitizenRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CitizenTable> where,
@@ -719,6 +753,7 @@ class CitizenRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Citizen>(
       where: where(Citizen.t),
@@ -727,6 +762,7 @@ class CitizenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -382,16 +382,22 @@ class CompanyRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> insert(
     _i1.DatabaseSession session,
     List<Company> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Company>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -425,6 +431,10 @@ class CompanyRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> upsert(
     _i1.DatabaseSession session,
     List<Company> rows, {
@@ -432,6 +442,7 @@ class CompanyRepository {
     _i1.ColumnSelections<CompanyTable>? updateColumns,
     _i1.WhereExpressionBuilder<CompanyTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Company>(
       rows,
@@ -439,6 +450,7 @@ class CompanyRepository {
       updateColumns: updateColumns?.call(Company.t),
       updateWhere: updateWhere?.call(Company.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -477,16 +489,22 @@ class CompanyRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> update(
     _i1.DatabaseSession session,
     List<Company> rows, {
     _i1.ColumnSelections<CompanyTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Company>(
       rows,
       columns: columns?.call(Company.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -523,6 +541,10 @@ class CompanyRepository {
 
   /// Updates all [Company]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CompanyUpdateTable> columnValues,
@@ -534,6 +556,7 @@ class CompanyRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Company>(
       columnValues: columnValues(Company.t.updateTable),
@@ -545,6 +568,7 @@ class CompanyRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -555,6 +579,10 @@ class CompanyRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> delete(
     _i1.DatabaseSession session,
     List<Company> rows, {
@@ -563,6 +591,7 @@ class CompanyRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Company>(
       rows,
@@ -571,6 +600,7 @@ class CompanyRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -590,6 +620,10 @@ class CompanyRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CompanyTable> where,
@@ -598,6 +632,7 @@ class CompanyRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Company>(
       where: where(Company.t),
@@ -606,6 +641,7 @@ class CompanyRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -383,16 +383,22 @@ class TownRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> insert(
     _i1.DatabaseSession session,
     List<Town> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Town>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -426,6 +432,10 @@ class TownRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> upsert(
     _i1.DatabaseSession session,
     List<Town> rows, {
@@ -433,6 +443,7 @@ class TownRepository {
     _i1.ColumnSelections<TownTable>? updateColumns,
     _i1.WhereExpressionBuilder<TownTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Town>(
       rows,
@@ -440,6 +451,7 @@ class TownRepository {
       updateColumns: updateColumns?.call(Town.t),
       updateWhere: updateWhere?.call(Town.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -478,16 +490,22 @@ class TownRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> update(
     _i1.DatabaseSession session,
     List<Town> rows, {
     _i1.ColumnSelections<TownTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Town>(
       rows,
       columns: columns?.call(Town.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -524,6 +542,10 @@ class TownRepository {
 
   /// Updates all [Town]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TownUpdateTable> columnValues,
@@ -535,6 +557,7 @@ class TownRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Town>(
       columnValues: columnValues(Town.t.updateTable),
@@ -546,6 +569,7 @@ class TownRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -556,6 +580,10 @@ class TownRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> delete(
     _i1.DatabaseSession session,
     List<Town> rows, {
@@ -564,6 +592,7 @@ class TownRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Town>(
       rows,
@@ -572,6 +601,7 @@ class TownRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +621,10 @@ class TownRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TownTable> where,
@@ -599,6 +633,7 @@ class TownRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Town>(
       where: where(Town.t),
@@ -607,6 +642,7 @@ class TownRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -436,16 +436,22 @@ class BlockingRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> insert(
     _i1.DatabaseSession session,
     List<Blocking> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Blocking>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -479,6 +485,10 @@ class BlockingRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> upsert(
     _i1.DatabaseSession session,
     List<Blocking> rows, {
@@ -486,6 +496,7 @@ class BlockingRepository {
     _i1.ColumnSelections<BlockingTable>? updateColumns,
     _i1.WhereExpressionBuilder<BlockingTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Blocking>(
       rows,
@@ -493,6 +504,7 @@ class BlockingRepository {
       updateColumns: updateColumns?.call(Blocking.t),
       updateWhere: updateWhere?.call(Blocking.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,16 +543,22 @@ class BlockingRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> update(
     _i1.DatabaseSession session,
     List<Blocking> rows, {
     _i1.ColumnSelections<BlockingTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Blocking>(
       rows,
       columns: columns?.call(Blocking.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -577,6 +595,10 @@ class BlockingRepository {
 
   /// Updates all [Blocking]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BlockingUpdateTable> columnValues,
@@ -588,6 +610,7 @@ class BlockingRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Blocking>(
       columnValues: columnValues(Blocking.t.updateTable),
@@ -599,6 +622,7 @@ class BlockingRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -609,6 +633,10 @@ class BlockingRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> delete(
     _i1.DatabaseSession session,
     List<Blocking> rows, {
@@ -617,6 +645,7 @@ class BlockingRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Blocking>(
       rows,
@@ -625,6 +654,7 @@ class BlockingRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -644,6 +674,10 @@ class BlockingRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BlockingTable> where,
@@ -652,6 +686,7 @@ class BlockingRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Blocking>(
       where: where(Blocking.t),
@@ -660,6 +695,7 @@ class BlockingRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -463,16 +463,22 @@ class MemberRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> insert(
     _i1.DatabaseSession session,
     List<Member> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Member>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -506,6 +512,10 @@ class MemberRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> upsert(
     _i1.DatabaseSession session,
     List<Member> rows, {
@@ -513,6 +523,7 @@ class MemberRepository {
     _i1.ColumnSelections<MemberTable>? updateColumns,
     _i1.WhereExpressionBuilder<MemberTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Member>(
       rows,
@@ -520,6 +531,7 @@ class MemberRepository {
       updateColumns: updateColumns?.call(Member.t),
       updateWhere: updateWhere?.call(Member.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -558,16 +570,22 @@ class MemberRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> update(
     _i1.DatabaseSession session,
     List<Member> rows, {
     _i1.ColumnSelections<MemberTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Member>(
       rows,
       columns: columns?.call(Member.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -604,6 +622,10 @@ class MemberRepository {
 
   /// Updates all [Member]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<MemberUpdateTable> columnValues,
@@ -615,6 +637,7 @@ class MemberRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Member>(
       columnValues: columnValues(Member.t.updateTable),
@@ -626,6 +649,7 @@ class MemberRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -636,6 +660,10 @@ class MemberRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> delete(
     _i1.DatabaseSession session,
     List<Member> rows, {
@@ -644,6 +672,7 @@ class MemberRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Member>(
       rows,
@@ -652,6 +681,7 @@ class MemberRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -671,6 +701,10 @@ class MemberRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MemberTable> where,
@@ -679,6 +713,7 @@ class MemberRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Member>(
       where: where(Member.t),
@@ -687,6 +722,7 @@ class MemberRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -462,16 +462,22 @@ class CatRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> insert(
     _i1.DatabaseSession session,
     List<Cat> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Cat>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -505,6 +511,10 @@ class CatRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> upsert(
     _i1.DatabaseSession session,
     List<Cat> rows, {
@@ -512,6 +522,7 @@ class CatRepository {
     _i1.ColumnSelections<CatTable>? updateColumns,
     _i1.WhereExpressionBuilder<CatTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Cat>(
       rows,
@@ -519,6 +530,7 @@ class CatRepository {
       updateColumns: updateColumns?.call(Cat.t),
       updateWhere: updateWhere?.call(Cat.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -557,16 +569,22 @@ class CatRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> update(
     _i1.DatabaseSession session,
     List<Cat> rows, {
     _i1.ColumnSelections<CatTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Cat>(
       rows,
       columns: columns?.call(Cat.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -603,6 +621,10 @@ class CatRepository {
 
   /// Updates all [Cat]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CatUpdateTable> columnValues,
@@ -614,6 +636,7 @@ class CatRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Cat>(
       columnValues: columnValues(Cat.t.updateTable),
@@ -625,6 +648,7 @@ class CatRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -635,6 +659,10 @@ class CatRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> delete(
     _i1.DatabaseSession session,
     List<Cat> rows, {
@@ -643,6 +671,7 @@ class CatRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Cat>(
       rows,
@@ -651,6 +680,7 @@ class CatRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -670,6 +700,10 @@ class CatRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CatTable> where,
@@ -678,6 +712,7 @@ class CatRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Cat>(
       where: where(Cat.t),
@@ -686,6 +721,7 @@ class CatRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -431,16 +431,22 @@ class PostRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> insert(
     _i1.DatabaseSession session,
     List<Post> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Post>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -474,6 +480,10 @@ class PostRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> upsert(
     _i1.DatabaseSession session,
     List<Post> rows, {
@@ -481,6 +491,7 @@ class PostRepository {
     _i1.ColumnSelections<PostTable>? updateColumns,
     _i1.WhereExpressionBuilder<PostTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Post>(
       rows,
@@ -488,6 +499,7 @@ class PostRepository {
       updateColumns: updateColumns?.call(Post.t),
       updateWhere: updateWhere?.call(Post.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -526,16 +538,22 @@ class PostRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> update(
     _i1.DatabaseSession session,
     List<Post> rows, {
     _i1.ColumnSelections<PostTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Post>(
       rows,
       columns: columns?.call(Post.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -572,6 +590,10 @@ class PostRepository {
 
   /// Updates all [Post]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PostUpdateTable> columnValues,
@@ -583,6 +605,7 @@ class PostRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Post>(
       columnValues: columnValues(Post.t.updateTable),
@@ -594,6 +617,7 @@ class PostRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -604,6 +628,10 @@ class PostRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> delete(
     _i1.DatabaseSession session,
     List<Post> rows, {
@@ -612,6 +640,7 @@ class PostRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Post>(
       rows,
@@ -620,6 +649,7 @@ class PostRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -639,6 +669,10 @@ class PostRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PostTable> where,
@@ -647,6 +681,7 @@ class PostRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Post>(
       where: where(Post.t),
@@ -655,6 +690,7 @@ class PostRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
@@ -338,16 +338,22 @@ class ObjectFieldPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> insert(
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectFieldPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -381,6 +387,10 @@ class ObjectFieldPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> upsert(
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
@@ -388,6 +398,7 @@ class ObjectFieldPersistRepository {
     _i1.ColumnSelections<ObjectFieldPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectFieldPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectFieldPersist>(
       rows,
@@ -395,6 +406,7 @@ class ObjectFieldPersistRepository {
       updateColumns: updateColumns?.call(ObjectFieldPersist.t),
       updateWhere: updateWhere?.call(ObjectFieldPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -433,16 +445,22 @@ class ObjectFieldPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> update(
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
     _i1.ColumnSelections<ObjectFieldPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectFieldPersist>(
       rows,
       columns: columns?.call(ObjectFieldPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -480,6 +498,10 @@ class ObjectFieldPersistRepository {
 
   /// Updates all [ObjectFieldPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectFieldPersistUpdateTable>
@@ -492,6 +514,7 @@ class ObjectFieldPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectFieldPersist>(
       columnValues: columnValues(ObjectFieldPersist.t.updateTable),
@@ -503,6 +526,7 @@ class ObjectFieldPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -513,6 +537,10 @@ class ObjectFieldPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> delete(
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
@@ -521,6 +549,7 @@ class ObjectFieldPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectFieldPersist>(
       rows,
@@ -529,6 +558,7 @@ class ObjectFieldPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -548,6 +578,10 @@ class ObjectFieldPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectFieldPersistTable> where,
@@ -556,6 +590,7 @@ class ObjectFieldPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectFieldPersist>(
       where: where(ObjectFieldPersist.t),
@@ -564,6 +599,7 @@ class ObjectFieldPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -343,16 +343,22 @@ class ObjectFieldScopesRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldScopes>> insert(
     _i1.DatabaseSession session,
     List<ObjectFieldScopes> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectFieldScopes>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -386,6 +392,10 @@ class ObjectFieldScopesRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldScopes>> upsert(
     _i1.DatabaseSession session,
     List<ObjectFieldScopes> rows, {
@@ -393,6 +403,7 @@ class ObjectFieldScopesRepository {
     _i1.ColumnSelections<ObjectFieldScopesTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectFieldScopesTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectFieldScopes>(
       rows,
@@ -400,6 +411,7 @@ class ObjectFieldScopesRepository {
       updateColumns: updateColumns?.call(ObjectFieldScopes.t),
       updateWhere: updateWhere?.call(ObjectFieldScopes.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -438,16 +450,22 @@ class ObjectFieldScopesRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldScopes>> update(
     _i1.DatabaseSession session,
     List<ObjectFieldScopes> rows, {
     _i1.ColumnSelections<ObjectFieldScopesTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectFieldScopes>(
       rows,
       columns: columns?.call(ObjectFieldScopes.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -485,6 +503,10 @@ class ObjectFieldScopesRepository {
 
   /// Updates all [ObjectFieldScopes]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldScopes>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectFieldScopesUpdateTable>
@@ -497,6 +519,7 @@ class ObjectFieldScopesRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectFieldScopes>(
       columnValues: columnValues(ObjectFieldScopes.t.updateTable),
@@ -508,6 +531,7 @@ class ObjectFieldScopesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -518,6 +542,10 @@ class ObjectFieldScopesRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldScopes>> delete(
     _i1.DatabaseSession session,
     List<ObjectFieldScopes> rows, {
@@ -526,6 +554,7 @@ class ObjectFieldScopesRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectFieldScopes>(
       rows,
@@ -534,6 +563,7 @@ class ObjectFieldScopesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -553,6 +583,10 @@ class ObjectFieldScopesRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldScopes>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectFieldScopesTable> where,
@@ -561,6 +595,7 @@ class ObjectFieldScopesRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectFieldScopes>(
       where: where(ObjectFieldScopes.t),
@@ -569,6 +604,7 @@ class ObjectFieldScopesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bit.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bit.dart
@@ -454,16 +454,22 @@ class ObjectWithBitRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithBit>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithBit> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithBit>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -497,6 +503,10 @@ class ObjectWithBitRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithBit>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithBit> rows, {
@@ -504,6 +514,7 @@ class ObjectWithBitRepository {
     _i1.ColumnSelections<ObjectWithBitTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithBitTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithBit>(
       rows,
@@ -511,6 +522,7 @@ class ObjectWithBitRepository {
       updateColumns: updateColumns?.call(ObjectWithBit.t),
       updateWhere: updateWhere?.call(ObjectWithBit.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,16 +561,22 @@ class ObjectWithBitRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithBit>> update(
     _i1.DatabaseSession session,
     List<ObjectWithBit> rows, {
     _i1.ColumnSelections<ObjectWithBitTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithBit>(
       rows,
       columns: columns?.call(ObjectWithBit.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -595,6 +613,10 @@ class ObjectWithBitRepository {
 
   /// Updates all [ObjectWithBit]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithBit>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithBitUpdateTable> columnValues,
@@ -606,6 +628,7 @@ class ObjectWithBitRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithBit>(
       columnValues: columnValues(ObjectWithBit.t.updateTable),
@@ -617,6 +640,7 @@ class ObjectWithBitRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -627,6 +651,10 @@ class ObjectWithBitRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithBit>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithBit> rows, {
@@ -635,6 +663,7 @@ class ObjectWithBitRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithBit>(
       rows,
@@ -643,6 +672,7 @@ class ObjectWithBitRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -662,6 +692,10 @@ class ObjectWithBitRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithBit>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithBitTable> where,
@@ -670,6 +704,7 @@ class ObjectWithBitRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithBit>(
       where: where(ObjectWithBit.t),
@@ -678,6 +713,7 @@ class ObjectWithBitRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -312,16 +312,22 @@ class ObjectWithByteDataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithByteData>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithByteData> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithByteData>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -355,6 +361,10 @@ class ObjectWithByteDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithByteData>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithByteData> rows, {
@@ -362,6 +372,7 @@ class ObjectWithByteDataRepository {
     _i1.ColumnSelections<ObjectWithByteDataTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithByteDataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithByteData>(
       rows,
@@ -369,6 +380,7 @@ class ObjectWithByteDataRepository {
       updateColumns: updateColumns?.call(ObjectWithByteData.t),
       updateWhere: updateWhere?.call(ObjectWithByteData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -407,16 +419,22 @@ class ObjectWithByteDataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithByteData>> update(
     _i1.DatabaseSession session,
     List<ObjectWithByteData> rows, {
     _i1.ColumnSelections<ObjectWithByteDataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithByteData>(
       rows,
       columns: columns?.call(ObjectWithByteData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -454,6 +472,10 @@ class ObjectWithByteDataRepository {
 
   /// Updates all [ObjectWithByteData]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithByteData>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithByteDataUpdateTable>
@@ -466,6 +488,7 @@ class ObjectWithByteDataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithByteData>(
       columnValues: columnValues(ObjectWithByteData.t.updateTable),
@@ -477,6 +500,7 @@ class ObjectWithByteDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -487,6 +511,10 @@ class ObjectWithByteDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithByteData>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithByteData> rows, {
@@ -495,6 +523,7 @@ class ObjectWithByteDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithByteData>(
       rows,
@@ -503,6 +532,7 @@ class ObjectWithByteDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -522,6 +552,10 @@ class ObjectWithByteDataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithByteData>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithByteDataTable> where,
@@ -530,6 +564,7 @@ class ObjectWithByteDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithByteData>(
       where: where(ObjectWithByteData.t),
@@ -538,6 +573,7 @@ class ObjectWithByteDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -311,16 +311,22 @@ class ObjectWithDurationRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDuration>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithDuration> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithDuration>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -354,6 +360,10 @@ class ObjectWithDurationRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDuration>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithDuration> rows, {
@@ -361,6 +371,7 @@ class ObjectWithDurationRepository {
     _i1.ColumnSelections<ObjectWithDurationTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithDurationTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithDuration>(
       rows,
@@ -368,6 +379,7 @@ class ObjectWithDurationRepository {
       updateColumns: updateColumns?.call(ObjectWithDuration.t),
       updateWhere: updateWhere?.call(ObjectWithDuration.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -406,16 +418,22 @@ class ObjectWithDurationRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDuration>> update(
     _i1.DatabaseSession session,
     List<ObjectWithDuration> rows, {
     _i1.ColumnSelections<ObjectWithDurationTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithDuration>(
       rows,
       columns: columns?.call(ObjectWithDuration.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -453,6 +471,10 @@ class ObjectWithDurationRepository {
 
   /// Updates all [ObjectWithDuration]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDuration>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithDurationUpdateTable>
@@ -465,6 +487,7 @@ class ObjectWithDurationRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithDuration>(
       columnValues: columnValues(ObjectWithDuration.t.updateTable),
@@ -476,6 +499,7 @@ class ObjectWithDurationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,6 +510,10 @@ class ObjectWithDurationRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDuration>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithDuration> rows, {
@@ -494,6 +522,7 @@ class ObjectWithDurationRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithDuration>(
       rows,
@@ -502,6 +531,7 @@ class ObjectWithDurationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -521,6 +551,10 @@ class ObjectWithDurationRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDuration>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithDurationTable> where,
@@ -529,6 +563,7 @@ class ObjectWithDurationRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithDuration>(
       where: where(ObjectWithDuration.t),
@@ -537,6 +572,7 @@ class ObjectWithDurationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_dynamic.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_dynamic.dart
@@ -511,16 +511,22 @@ class ObjectWithDynamicRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDynamic>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithDynamic> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithDynamic>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -554,6 +560,10 @@ class ObjectWithDynamicRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDynamic>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithDynamic> rows, {
@@ -561,6 +571,7 @@ class ObjectWithDynamicRepository {
     _i1.ColumnSelections<ObjectWithDynamicTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithDynamicTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithDynamic>(
       rows,
@@ -568,6 +579,7 @@ class ObjectWithDynamicRepository {
       updateColumns: updateColumns?.call(ObjectWithDynamic.t),
       updateWhere: updateWhere?.call(ObjectWithDynamic.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -606,16 +618,22 @@ class ObjectWithDynamicRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDynamic>> update(
     _i1.DatabaseSession session,
     List<ObjectWithDynamic> rows, {
     _i1.ColumnSelections<ObjectWithDynamicTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithDynamic>(
       rows,
       columns: columns?.call(ObjectWithDynamic.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -653,6 +671,10 @@ class ObjectWithDynamicRepository {
 
   /// Updates all [ObjectWithDynamic]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDynamic>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithDynamicUpdateTable>
@@ -665,6 +687,7 @@ class ObjectWithDynamicRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithDynamic>(
       columnValues: columnValues(ObjectWithDynamic.t.updateTable),
@@ -676,6 +699,7 @@ class ObjectWithDynamicRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -686,6 +710,10 @@ class ObjectWithDynamicRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDynamic>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithDynamic> rows, {
@@ -694,6 +722,7 @@ class ObjectWithDynamicRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithDynamic>(
       rows,
@@ -702,6 +731,7 @@ class ObjectWithDynamicRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -721,6 +751,10 @@ class ObjectWithDynamicRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDynamic>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithDynamicTable> where,
@@ -729,6 +763,7 @@ class ObjectWithDynamicRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithDynamic>(
       where: where(ObjectWithDynamic.t),
@@ -737,6 +772,7 @@ class ObjectWithDynamicRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -436,16 +436,22 @@ class ObjectWithEnumRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnum>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithEnum> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithEnum>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -479,6 +485,10 @@ class ObjectWithEnumRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnum>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithEnum> rows, {
@@ -486,6 +496,7 @@ class ObjectWithEnumRepository {
     _i1.ColumnSelections<ObjectWithEnumTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithEnumTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithEnum>(
       rows,
@@ -493,6 +504,7 @@ class ObjectWithEnumRepository {
       updateColumns: updateColumns?.call(ObjectWithEnum.t),
       updateWhere: updateWhere?.call(ObjectWithEnum.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,16 +543,22 @@ class ObjectWithEnumRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnum>> update(
     _i1.DatabaseSession session,
     List<ObjectWithEnum> rows, {
     _i1.ColumnSelections<ObjectWithEnumTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithEnum>(
       rows,
       columns: columns?.call(ObjectWithEnum.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -577,6 +595,10 @@ class ObjectWithEnumRepository {
 
   /// Updates all [ObjectWithEnum]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnum>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithEnumUpdateTable> columnValues,
@@ -588,6 +610,7 @@ class ObjectWithEnumRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithEnum>(
       columnValues: columnValues(ObjectWithEnum.t.updateTable),
@@ -599,6 +622,7 @@ class ObjectWithEnumRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -609,6 +633,10 @@ class ObjectWithEnumRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnum>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithEnum> rows, {
@@ -617,6 +645,7 @@ class ObjectWithEnumRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithEnum>(
       rows,
@@ -625,6 +654,7 @@ class ObjectWithEnumRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -644,6 +674,10 @@ class ObjectWithEnumRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnum>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithEnumTable> where,
@@ -652,6 +686,7 @@ class ObjectWithEnumRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithEnum>(
       where: where(ObjectWithEnum.t),
@@ -660,6 +695,7 @@ class ObjectWithEnumRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum_enhanced.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum_enhanced.dart
@@ -469,16 +469,22 @@ class ObjectWithEnumEnhancedRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnumEnhanced>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithEnumEnhanced> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithEnumEnhanced>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +518,10 @@ class ObjectWithEnumEnhancedRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnumEnhanced>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithEnumEnhanced> rows, {
@@ -519,6 +529,7 @@ class ObjectWithEnumEnhancedRepository {
     _i1.ColumnSelections<ObjectWithEnumEnhancedTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithEnumEnhancedTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithEnumEnhanced>(
       rows,
@@ -526,6 +537,7 @@ class ObjectWithEnumEnhancedRepository {
       updateColumns: updateColumns?.call(ObjectWithEnumEnhanced.t),
       updateWhere: updateWhere?.call(ObjectWithEnumEnhanced.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,16 +576,22 @@ class ObjectWithEnumEnhancedRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnumEnhanced>> update(
     _i1.DatabaseSession session,
     List<ObjectWithEnumEnhanced> rows, {
     _i1.ColumnSelections<ObjectWithEnumEnhancedTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithEnumEnhanced>(
       rows,
       columns: columns?.call(ObjectWithEnumEnhanced.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -611,6 +629,10 @@ class ObjectWithEnumEnhancedRepository {
 
   /// Updates all [ObjectWithEnumEnhanced]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnumEnhanced>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithEnumEnhancedUpdateTable>
@@ -623,6 +645,7 @@ class ObjectWithEnumEnhancedRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithEnumEnhanced>(
       columnValues: columnValues(ObjectWithEnumEnhanced.t.updateTable),
@@ -634,6 +657,7 @@ class ObjectWithEnumEnhancedRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -644,6 +668,10 @@ class ObjectWithEnumEnhancedRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnumEnhanced>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithEnumEnhanced> rows, {
@@ -652,6 +680,7 @@ class ObjectWithEnumEnhancedRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithEnumEnhanced>(
       rows,
@@ -660,6 +689,7 @@ class ObjectWithEnumEnhancedRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -679,6 +709,10 @@ class ObjectWithEnumEnhancedRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnumEnhanced>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithEnumEnhancedTable> where,
@@ -687,6 +721,7 @@ class ObjectWithEnumEnhancedRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithEnumEnhanced>(
       where: where(ObjectWithEnumEnhanced.t),
@@ -695,6 +730,7 @@ class ObjectWithEnumEnhancedRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_half_vector.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_half_vector.dart
@@ -474,16 +474,22 @@ class ObjectWithHalfVectorRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithHalfVector>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithHalfVector> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithHalfVector>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -517,6 +523,10 @@ class ObjectWithHalfVectorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithHalfVector>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithHalfVector> rows, {
@@ -524,6 +534,7 @@ class ObjectWithHalfVectorRepository {
     _i1.ColumnSelections<ObjectWithHalfVectorTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithHalfVectorTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithHalfVector>(
       rows,
@@ -531,6 +542,7 @@ class ObjectWithHalfVectorRepository {
       updateColumns: updateColumns?.call(ObjectWithHalfVector.t),
       updateWhere: updateWhere?.call(ObjectWithHalfVector.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -569,16 +581,22 @@ class ObjectWithHalfVectorRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithHalfVector>> update(
     _i1.DatabaseSession session,
     List<ObjectWithHalfVector> rows, {
     _i1.ColumnSelections<ObjectWithHalfVectorTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithHalfVector>(
       rows,
       columns: columns?.call(ObjectWithHalfVector.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -616,6 +634,10 @@ class ObjectWithHalfVectorRepository {
 
   /// Updates all [ObjectWithHalfVector]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithHalfVector>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithHalfVectorUpdateTable>
@@ -628,6 +650,7 @@ class ObjectWithHalfVectorRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithHalfVector>(
       columnValues: columnValues(ObjectWithHalfVector.t.updateTable),
@@ -639,6 +662,7 @@ class ObjectWithHalfVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -649,6 +673,10 @@ class ObjectWithHalfVectorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithHalfVector>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithHalfVector> rows, {
@@ -657,6 +685,7 @@ class ObjectWithHalfVectorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithHalfVector>(
       rows,
@@ -665,6 +694,7 @@ class ObjectWithHalfVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -684,6 +714,10 @@ class ObjectWithHalfVectorRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithHalfVector>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithHalfVectorTable> where,
@@ -692,6 +726,7 @@ class ObjectWithHalfVectorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithHalfVector>(
       where: where(ObjectWithHalfVector.t),
@@ -700,6 +735,7 @@ class ObjectWithHalfVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -331,16 +331,22 @@ class ObjectWithIndexRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithIndex>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithIndex> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithIndex>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -374,6 +380,10 @@ class ObjectWithIndexRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithIndex>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithIndex> rows, {
@@ -381,6 +391,7 @@ class ObjectWithIndexRepository {
     _i1.ColumnSelections<ObjectWithIndexTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithIndexTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithIndex>(
       rows,
@@ -388,6 +399,7 @@ class ObjectWithIndexRepository {
       updateColumns: updateColumns?.call(ObjectWithIndex.t),
       updateWhere: updateWhere?.call(ObjectWithIndex.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -426,16 +438,22 @@ class ObjectWithIndexRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithIndex>> update(
     _i1.DatabaseSession session,
     List<ObjectWithIndex> rows, {
     _i1.ColumnSelections<ObjectWithIndexTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithIndex>(
       rows,
       columns: columns?.call(ObjectWithIndex.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -473,6 +491,10 @@ class ObjectWithIndexRepository {
 
   /// Updates all [ObjectWithIndex]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithIndex>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithIndexUpdateTable>
@@ -485,6 +507,7 @@ class ObjectWithIndexRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithIndex>(
       columnValues: columnValues(ObjectWithIndex.t.updateTable),
@@ -496,6 +519,7 @@ class ObjectWithIndexRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -506,6 +530,10 @@ class ObjectWithIndexRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithIndex>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithIndex> rows, {
@@ -514,6 +542,7 @@ class ObjectWithIndexRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithIndex>(
       rows,
@@ -522,6 +551,7 @@ class ObjectWithIndexRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -541,6 +571,10 @@ class ObjectWithIndexRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithIndex>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithIndexTable> where,
@@ -549,6 +583,7 @@ class ObjectWithIndexRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithIndex>(
       where: where(ObjectWithIndex.t),
@@ -557,6 +592,7 @@ class ObjectWithIndexRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_jsonb.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_jsonb.dart
@@ -554,16 +554,22 @@ class ObjectWithJsonbRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonb>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithJsonb> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithJsonb>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -597,6 +603,10 @@ class ObjectWithJsonbRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonb>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithJsonb> rows, {
@@ -604,6 +614,7 @@ class ObjectWithJsonbRepository {
     _i1.ColumnSelections<ObjectWithJsonbTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithJsonbTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithJsonb>(
       rows,
@@ -611,6 +622,7 @@ class ObjectWithJsonbRepository {
       updateColumns: updateColumns?.call(ObjectWithJsonb.t),
       updateWhere: updateWhere?.call(ObjectWithJsonb.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -649,16 +661,22 @@ class ObjectWithJsonbRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonb>> update(
     _i1.DatabaseSession session,
     List<ObjectWithJsonb> rows, {
     _i1.ColumnSelections<ObjectWithJsonbTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithJsonb>(
       rows,
       columns: columns?.call(ObjectWithJsonb.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -696,6 +714,10 @@ class ObjectWithJsonbRepository {
 
   /// Updates all [ObjectWithJsonb]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonb>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithJsonbUpdateTable>
@@ -708,6 +730,7 @@ class ObjectWithJsonbRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithJsonb>(
       columnValues: columnValues(ObjectWithJsonb.t.updateTable),
@@ -719,6 +742,7 @@ class ObjectWithJsonbRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -729,6 +753,10 @@ class ObjectWithJsonbRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonb>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithJsonb> rows, {
@@ -737,6 +765,7 @@ class ObjectWithJsonbRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithJsonb>(
       rows,
@@ -745,6 +774,7 @@ class ObjectWithJsonbRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -764,6 +794,10 @@ class ObjectWithJsonbRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonb>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithJsonbTable> where,
@@ -772,6 +806,7 @@ class ObjectWithJsonbRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithJsonb>(
       where: where(ObjectWithJsonb.t),
@@ -780,6 +815,7 @@ class ObjectWithJsonbRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_jsonb_class_level.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_jsonb_class_level.dart
@@ -370,16 +370,22 @@ class ObjectWithJsonbClassLevelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonbClassLevel>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithJsonbClassLevel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithJsonbClassLevel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -413,6 +419,10 @@ class ObjectWithJsonbClassLevelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonbClassLevel>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithJsonbClassLevel> rows, {
@@ -421,6 +431,7 @@ class ObjectWithJsonbClassLevelRepository {
     _i1.ColumnSelections<ObjectWithJsonbClassLevelTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithJsonbClassLevelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithJsonbClassLevel>(
       rows,
@@ -428,6 +439,7 @@ class ObjectWithJsonbClassLevelRepository {
       updateColumns: updateColumns?.call(ObjectWithJsonbClassLevel.t),
       updateWhere: updateWhere?.call(ObjectWithJsonbClassLevel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -467,16 +479,22 @@ class ObjectWithJsonbClassLevelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonbClassLevel>> update(
     _i1.DatabaseSession session,
     List<ObjectWithJsonbClassLevel> rows, {
     _i1.ColumnSelections<ObjectWithJsonbClassLevelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithJsonbClassLevel>(
       rows,
       columns: columns?.call(ObjectWithJsonbClassLevel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -514,6 +532,10 @@ class ObjectWithJsonbClassLevelRepository {
 
   /// Updates all [ObjectWithJsonbClassLevel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonbClassLevel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithJsonbClassLevelUpdateTable>
@@ -526,6 +548,7 @@ class ObjectWithJsonbClassLevelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithJsonbClassLevel>(
       columnValues: columnValues(ObjectWithJsonbClassLevel.t.updateTable),
@@ -537,6 +560,7 @@ class ObjectWithJsonbClassLevelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -547,6 +571,10 @@ class ObjectWithJsonbClassLevelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonbClassLevel>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithJsonbClassLevel> rows, {
@@ -555,6 +583,7 @@ class ObjectWithJsonbClassLevelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithJsonbClassLevel>(
       rows,
@@ -563,6 +592,7 @@ class ObjectWithJsonbClassLevelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -582,6 +612,10 @@ class ObjectWithJsonbClassLevelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonbClassLevel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithJsonbClassLevelTable> where,
@@ -590,6 +624,7 @@ class ObjectWithJsonbClassLevelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithJsonbClassLevel>(
       where: where(ObjectWithJsonbClassLevel.t),
@@ -598,6 +633,7 @@ class ObjectWithJsonbClassLevelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -671,16 +671,22 @@ class ObjectWithObjectRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithObject>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithObject> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithObject>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -714,6 +720,10 @@ class ObjectWithObjectRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithObject>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithObject> rows, {
@@ -721,6 +731,7 @@ class ObjectWithObjectRepository {
     _i1.ColumnSelections<ObjectWithObjectTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithObjectTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithObject>(
       rows,
@@ -728,6 +739,7 @@ class ObjectWithObjectRepository {
       updateColumns: updateColumns?.call(ObjectWithObject.t),
       updateWhere: updateWhere?.call(ObjectWithObject.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -766,16 +778,22 @@ class ObjectWithObjectRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithObject>> update(
     _i1.DatabaseSession session,
     List<ObjectWithObject> rows, {
     _i1.ColumnSelections<ObjectWithObjectTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithObject>(
       rows,
       columns: columns?.call(ObjectWithObject.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -813,6 +831,10 @@ class ObjectWithObjectRepository {
 
   /// Updates all [ObjectWithObject]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithObject>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithObjectUpdateTable>
@@ -825,6 +847,7 @@ class ObjectWithObjectRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithObject>(
       columnValues: columnValues(ObjectWithObject.t.updateTable),
@@ -836,6 +859,7 @@ class ObjectWithObjectRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -846,6 +870,10 @@ class ObjectWithObjectRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithObject>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithObject> rows, {
@@ -854,6 +882,7 @@ class ObjectWithObjectRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithObject>(
       rows,
@@ -862,6 +891,7 @@ class ObjectWithObjectRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -881,6 +911,10 @@ class ObjectWithObjectRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithObject>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithObjectTable> where,
@@ -889,6 +923,7 @@ class ObjectWithObjectRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithObject>(
       where: where(ObjectWithObject.t),
@@ -897,6 +932,7 @@ class ObjectWithObjectRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -308,16 +308,22 @@ class ObjectWithParentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithParent>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithParent> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithParent>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -351,6 +357,10 @@ class ObjectWithParentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithParent>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithParent> rows, {
@@ -358,6 +368,7 @@ class ObjectWithParentRepository {
     _i1.ColumnSelections<ObjectWithParentTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithParentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithParent>(
       rows,
@@ -365,6 +376,7 @@ class ObjectWithParentRepository {
       updateColumns: updateColumns?.call(ObjectWithParent.t),
       updateWhere: updateWhere?.call(ObjectWithParent.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -403,16 +415,22 @@ class ObjectWithParentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithParent>> update(
     _i1.DatabaseSession session,
     List<ObjectWithParent> rows, {
     _i1.ColumnSelections<ObjectWithParentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithParent>(
       rows,
       columns: columns?.call(ObjectWithParent.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -450,6 +468,10 @@ class ObjectWithParentRepository {
 
   /// Updates all [ObjectWithParent]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithParent>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithParentUpdateTable>
@@ -462,6 +484,7 @@ class ObjectWithParentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithParent>(
       columnValues: columnValues(ObjectWithParent.t.updateTable),
@@ -473,6 +496,7 @@ class ObjectWithParentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -483,6 +507,10 @@ class ObjectWithParentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithParent>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithParent> rows, {
@@ -491,6 +519,7 @@ class ObjectWithParentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithParent>(
       rows,
@@ -499,6 +528,7 @@ class ObjectWithParentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -518,6 +548,10 @@ class ObjectWithParentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithParent>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithParentTable> where,
@@ -526,6 +560,7 @@ class ObjectWithParentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithParent>(
       where: where(ObjectWithParent.t),
@@ -534,6 +569,7 @@ class ObjectWithParentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -310,16 +310,22 @@ class ObjectWithSelfParentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSelfParent>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithSelfParent> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithSelfParent>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -353,6 +359,10 @@ class ObjectWithSelfParentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSelfParent>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithSelfParent> rows, {
@@ -360,6 +370,7 @@ class ObjectWithSelfParentRepository {
     _i1.ColumnSelections<ObjectWithSelfParentTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithSelfParentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithSelfParent>(
       rows,
@@ -367,6 +378,7 @@ class ObjectWithSelfParentRepository {
       updateColumns: updateColumns?.call(ObjectWithSelfParent.t),
       updateWhere: updateWhere?.call(ObjectWithSelfParent.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -405,16 +417,22 @@ class ObjectWithSelfParentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSelfParent>> update(
     _i1.DatabaseSession session,
     List<ObjectWithSelfParent> rows, {
     _i1.ColumnSelections<ObjectWithSelfParentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithSelfParent>(
       rows,
       columns: columns?.call(ObjectWithSelfParent.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -452,6 +470,10 @@ class ObjectWithSelfParentRepository {
 
   /// Updates all [ObjectWithSelfParent]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSelfParent>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithSelfParentUpdateTable>
@@ -464,6 +486,7 @@ class ObjectWithSelfParentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithSelfParent>(
       columnValues: columnValues(ObjectWithSelfParent.t.updateTable),
@@ -475,6 +498,7 @@ class ObjectWithSelfParentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -485,6 +509,10 @@ class ObjectWithSelfParentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSelfParent>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithSelfParent> rows, {
@@ -493,6 +521,7 @@ class ObjectWithSelfParentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithSelfParent>(
       rows,
@@ -501,6 +530,7 @@ class ObjectWithSelfParentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -520,6 +550,10 @@ class ObjectWithSelfParentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSelfParent>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithSelfParentTable> where,
@@ -528,6 +562,7 @@ class ObjectWithSelfParentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithSelfParent>(
       where: where(ObjectWithSelfParent.t),
@@ -536,6 +571,7 @@ class ObjectWithSelfParentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_sparse_vector.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_sparse_vector.dart
@@ -412,16 +412,22 @@ class ObjectWithSparseVectorRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSparseVector>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithSparseVector> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithSparseVector>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -455,6 +461,10 @@ class ObjectWithSparseVectorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSparseVector>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithSparseVector> rows, {
@@ -462,6 +472,7 @@ class ObjectWithSparseVectorRepository {
     _i1.ColumnSelections<ObjectWithSparseVectorTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithSparseVectorTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithSparseVector>(
       rows,
@@ -469,6 +480,7 @@ class ObjectWithSparseVectorRepository {
       updateColumns: updateColumns?.call(ObjectWithSparseVector.t),
       updateWhere: updateWhere?.call(ObjectWithSparseVector.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -507,16 +519,22 @@ class ObjectWithSparseVectorRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSparseVector>> update(
     _i1.DatabaseSession session,
     List<ObjectWithSparseVector> rows, {
     _i1.ColumnSelections<ObjectWithSparseVectorTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithSparseVector>(
       rows,
       columns: columns?.call(ObjectWithSparseVector.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -554,6 +572,10 @@ class ObjectWithSparseVectorRepository {
 
   /// Updates all [ObjectWithSparseVector]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSparseVector>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithSparseVectorUpdateTable>
@@ -566,6 +588,7 @@ class ObjectWithSparseVectorRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithSparseVector>(
       columnValues: columnValues(ObjectWithSparseVector.t.updateTable),
@@ -577,6 +600,7 @@ class ObjectWithSparseVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -587,6 +611,10 @@ class ObjectWithSparseVectorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSparseVector>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithSparseVector> rows, {
@@ -595,6 +623,7 @@ class ObjectWithSparseVectorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithSparseVector>(
       rows,
@@ -603,6 +632,7 @@ class ObjectWithSparseVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -622,6 +652,10 @@ class ObjectWithSparseVectorRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSparseVector>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithSparseVectorTable> where,
@@ -630,6 +664,7 @@ class ObjectWithSparseVectorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithSparseVector>(
       where: where(ObjectWithSparseVector.t),
@@ -638,6 +673,7 @@ class ObjectWithSparseVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -340,16 +340,22 @@ class ObjectWithUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithUuid>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -383,6 +389,10 @@ class ObjectWithUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithUuid>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithUuid> rows, {
@@ -390,6 +400,7 @@ class ObjectWithUuidRepository {
     _i1.ColumnSelections<ObjectWithUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithUuid>(
       rows,
@@ -397,6 +408,7 @@ class ObjectWithUuidRepository {
       updateColumns: updateColumns?.call(ObjectWithUuid.t),
       updateWhere: updateWhere?.call(ObjectWithUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -435,16 +447,22 @@ class ObjectWithUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithUuid>> update(
     _i1.DatabaseSession session,
     List<ObjectWithUuid> rows, {
     _i1.ColumnSelections<ObjectWithUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithUuid>(
       rows,
       columns: columns?.call(ObjectWithUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,6 +499,10 @@ class ObjectWithUuidRepository {
 
   /// Updates all [ObjectWithUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithUuidUpdateTable> columnValues,
@@ -492,6 +514,7 @@ class ObjectWithUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithUuid>(
       columnValues: columnValues(ObjectWithUuid.t.updateTable),
@@ -503,6 +526,7 @@ class ObjectWithUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -513,6 +537,10 @@ class ObjectWithUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithUuid>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithUuid> rows, {
@@ -521,6 +549,7 @@ class ObjectWithUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithUuid>(
       rows,
@@ -529,6 +558,7 @@ class ObjectWithUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -548,6 +578,10 @@ class ObjectWithUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithUuidTable> where,
@@ -556,6 +590,7 @@ class ObjectWithUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithUuid>(
       where: where(ObjectWithUuid.t),
@@ -564,6 +599,7 @@ class ObjectWithUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/object_with_vector.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_vector.dart
@@ -462,16 +462,22 @@ class ObjectWithVectorRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithVector>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithVector> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithVector>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -505,6 +511,10 @@ class ObjectWithVectorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithVector>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithVector> rows, {
@@ -512,6 +522,7 @@ class ObjectWithVectorRepository {
     _i1.ColumnSelections<ObjectWithVectorTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithVectorTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithVector>(
       rows,
@@ -519,6 +530,7 @@ class ObjectWithVectorRepository {
       updateColumns: updateColumns?.call(ObjectWithVector.t),
       updateWhere: updateWhere?.call(ObjectWithVector.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -557,16 +569,22 @@ class ObjectWithVectorRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithVector>> update(
     _i1.DatabaseSession session,
     List<ObjectWithVector> rows, {
     _i1.ColumnSelections<ObjectWithVectorTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithVector>(
       rows,
       columns: columns?.call(ObjectWithVector.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -604,6 +622,10 @@ class ObjectWithVectorRepository {
 
   /// Updates all [ObjectWithVector]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithVector>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithVectorUpdateTable>
@@ -616,6 +638,7 @@ class ObjectWithVectorRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithVector>(
       columnValues: columnValues(ObjectWithVector.t.updateTable),
@@ -627,6 +650,7 @@ class ObjectWithVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -637,6 +661,10 @@ class ObjectWithVectorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithVector>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithVector> rows, {
@@ -645,6 +673,7 @@ class ObjectWithVectorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithVector>(
       rows,
@@ -653,6 +682,7 @@ class ObjectWithVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -672,6 +702,10 @@ class ObjectWithVectorRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithVector>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithVectorTable> where,
@@ -680,6 +714,7 @@ class ObjectWithVectorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithVector>(
       where: where(ObjectWithVector.t),
@@ -688,6 +723,7 @@ class ObjectWithVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -388,16 +388,22 @@ class RelatedUniqueDataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> insert(
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<RelatedUniqueData>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -431,6 +437,10 @@ class RelatedUniqueDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> upsert(
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
@@ -438,6 +448,7 @@ class RelatedUniqueDataRepository {
     _i1.ColumnSelections<RelatedUniqueDataTable>? updateColumns,
     _i1.WhereExpressionBuilder<RelatedUniqueDataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<RelatedUniqueData>(
       rows,
@@ -445,6 +456,7 @@ class RelatedUniqueDataRepository {
       updateColumns: updateColumns?.call(RelatedUniqueData.t),
       updateWhere: updateWhere?.call(RelatedUniqueData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -483,16 +495,22 @@ class RelatedUniqueDataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> update(
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
     _i1.ColumnSelections<RelatedUniqueDataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<RelatedUniqueData>(
       rows,
       columns: columns?.call(RelatedUniqueData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -530,6 +548,10 @@ class RelatedUniqueDataRepository {
 
   /// Updates all [RelatedUniqueData]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<RelatedUniqueDataUpdateTable>
@@ -542,6 +564,7 @@ class RelatedUniqueDataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<RelatedUniqueData>(
       columnValues: columnValues(RelatedUniqueData.t.updateTable),
@@ -553,6 +576,7 @@ class RelatedUniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -563,6 +587,10 @@ class RelatedUniqueDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> delete(
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
@@ -571,6 +599,7 @@ class RelatedUniqueDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<RelatedUniqueData>(
       rows,
@@ -579,6 +608,7 @@ class RelatedUniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -598,6 +628,10 @@ class RelatedUniqueDataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelatedUniqueDataTable> where,
@@ -606,6 +640,7 @@ class RelatedUniqueDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<RelatedUniqueData>(
       where: where(RelatedUniqueData.t),
@@ -614,6 +649,7 @@ class RelatedUniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/required/model_with_required_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/required/model_with_required_field.dart
@@ -358,16 +358,22 @@ class ModelWithRequiredFieldRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> insert(
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ModelWithRequiredField>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -401,6 +407,10 @@ class ModelWithRequiredFieldRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> upsert(
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
@@ -408,6 +418,7 @@ class ModelWithRequiredFieldRepository {
     _i1.ColumnSelections<ModelWithRequiredFieldTable>? updateColumns,
     _i1.WhereExpressionBuilder<ModelWithRequiredFieldTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ModelWithRequiredField>(
       rows,
@@ -415,6 +426,7 @@ class ModelWithRequiredFieldRepository {
       updateColumns: updateColumns?.call(ModelWithRequiredField.t),
       updateWhere: updateWhere?.call(ModelWithRequiredField.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -453,16 +465,22 @@ class ModelWithRequiredFieldRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> update(
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
     _i1.ColumnSelections<ModelWithRequiredFieldTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ModelWithRequiredField>(
       rows,
       columns: columns?.call(ModelWithRequiredField.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -500,6 +518,10 @@ class ModelWithRequiredFieldRepository {
 
   /// Updates all [ModelWithRequiredField]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ModelWithRequiredFieldUpdateTable>
@@ -512,6 +534,7 @@ class ModelWithRequiredFieldRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ModelWithRequiredField>(
       columnValues: columnValues(ModelWithRequiredField.t.updateTable),
@@ -523,6 +546,7 @@ class ModelWithRequiredFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -533,6 +557,10 @@ class ModelWithRequiredFieldRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> delete(
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
@@ -541,6 +569,7 @@ class ModelWithRequiredFieldRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ModelWithRequiredField>(
       rows,
@@ -549,6 +578,7 @@ class ModelWithRequiredFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -568,6 +598,10 @@ class ModelWithRequiredFieldRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ModelWithRequiredFieldTable> where,
@@ -576,6 +610,7 @@ class ModelWithRequiredFieldRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ModelWithRequiredField>(
       where: where(ModelWithRequiredField.t),
@@ -584,6 +619,7 @@ class ModelWithRequiredFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
@@ -344,16 +344,22 @@ class ScopeNoneFieldsRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ScopeNoneFields>> insert(
     _i1.DatabaseSession session,
     List<ScopeNoneFields> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ScopeNoneFields>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -387,6 +393,10 @@ class ScopeNoneFieldsRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ScopeNoneFields>> upsert(
     _i1.DatabaseSession session,
     List<ScopeNoneFields> rows, {
@@ -394,6 +404,7 @@ class ScopeNoneFieldsRepository {
     _i1.ColumnSelections<ScopeNoneFieldsTable>? updateColumns,
     _i1.WhereExpressionBuilder<ScopeNoneFieldsTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ScopeNoneFields>(
       rows,
@@ -401,6 +412,7 @@ class ScopeNoneFieldsRepository {
       updateColumns: updateColumns?.call(ScopeNoneFields.t),
       updateWhere: updateWhere?.call(ScopeNoneFields.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -439,16 +451,22 @@ class ScopeNoneFieldsRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ScopeNoneFields>> update(
     _i1.DatabaseSession session,
     List<ScopeNoneFields> rows, {
     _i1.ColumnSelections<ScopeNoneFieldsTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ScopeNoneFields>(
       rows,
       columns: columns?.call(ScopeNoneFields.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,6 +504,10 @@ class ScopeNoneFieldsRepository {
 
   /// Updates all [ScopeNoneFields]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ScopeNoneFields>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ScopeNoneFieldsUpdateTable>
@@ -498,6 +520,7 @@ class ScopeNoneFieldsRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ScopeNoneFields>(
       columnValues: columnValues(ScopeNoneFields.t.updateTable),
@@ -509,6 +532,7 @@ class ScopeNoneFieldsRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -519,6 +543,10 @@ class ScopeNoneFieldsRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ScopeNoneFields>> delete(
     _i1.DatabaseSession session,
     List<ScopeNoneFields> rows, {
@@ -527,6 +555,7 @@ class ScopeNoneFieldsRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ScopeNoneFieldsTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ScopeNoneFields>(
       rows,
@@ -535,6 +564,7 @@ class ScopeNoneFieldsRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -554,6 +584,10 @@ class ScopeNoneFieldsRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ScopeNoneFields>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ScopeNoneFieldsTable> where,
@@ -562,6 +596,7 @@ class ScopeNoneFieldsRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ScopeNoneFieldsTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ScopeNoneFields>(
       where: where(ScopeNoneFields.t),
@@ -570,6 +605,7 @@ class ScopeNoneFieldsRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/shared_model_container.dart
+++ b/tests/serverpod_test_server/lib/src/generated/shared_model_container.dart
@@ -1062,16 +1062,22 @@ class SharedModelContainerRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SharedModelContainer>> insert(
     _i1.DatabaseSession session,
     List<SharedModelContainer> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<SharedModelContainer>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -1105,6 +1111,10 @@ class SharedModelContainerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SharedModelContainer>> upsert(
     _i1.DatabaseSession session,
     List<SharedModelContainer> rows, {
@@ -1112,6 +1122,7 @@ class SharedModelContainerRepository {
     _i1.ColumnSelections<SharedModelContainerTable>? updateColumns,
     _i1.WhereExpressionBuilder<SharedModelContainerTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<SharedModelContainer>(
       rows,
@@ -1119,6 +1130,7 @@ class SharedModelContainerRepository {
       updateColumns: updateColumns?.call(SharedModelContainer.t),
       updateWhere: updateWhere?.call(SharedModelContainer.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -1157,16 +1169,22 @@ class SharedModelContainerRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SharedModelContainer>> update(
     _i1.DatabaseSession session,
     List<SharedModelContainer> rows, {
     _i1.ColumnSelections<SharedModelContainerTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<SharedModelContainer>(
       rows,
       columns: columns?.call(SharedModelContainer.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -1204,6 +1222,10 @@ class SharedModelContainerRepository {
 
   /// Updates all [SharedModelContainer]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SharedModelContainer>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<SharedModelContainerUpdateTable>
@@ -1216,6 +1238,7 @@ class SharedModelContainerRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<SharedModelContainer>(
       columnValues: columnValues(SharedModelContainer.t.updateTable),
@@ -1227,6 +1250,7 @@ class SharedModelContainerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -1237,6 +1261,10 @@ class SharedModelContainerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SharedModelContainer>> delete(
     _i1.DatabaseSession session,
     List<SharedModelContainer> rows, {
@@ -1245,6 +1273,7 @@ class SharedModelContainerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SharedModelContainerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<SharedModelContainer>(
       rows,
@@ -1253,6 +1282,7 @@ class SharedModelContainerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -1272,6 +1302,10 @@ class SharedModelContainerRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SharedModelContainer>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SharedModelContainerTable> where,
@@ -1280,6 +1314,7 @@ class SharedModelContainerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SharedModelContainerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<SharedModelContainer>(
       where: where(SharedModelContainer.t),
@@ -1288,6 +1323,7 @@ class SharedModelContainerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -313,16 +313,22 @@ class SimpleDataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> insert(
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<SimpleData>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -356,6 +362,10 @@ class SimpleDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> upsert(
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
@@ -363,6 +373,7 @@ class SimpleDataRepository {
     _i1.ColumnSelections<SimpleDataTable>? updateColumns,
     _i1.WhereExpressionBuilder<SimpleDataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<SimpleData>(
       rows,
@@ -370,6 +381,7 @@ class SimpleDataRepository {
       updateColumns: updateColumns?.call(SimpleData.t),
       updateWhere: updateWhere?.call(SimpleData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -408,16 +420,22 @@ class SimpleDataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> update(
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
     _i1.ColumnSelections<SimpleDataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<SimpleData>(
       rows,
       columns: columns?.call(SimpleData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -454,6 +472,10 @@ class SimpleDataRepository {
 
   /// Updates all [SimpleData]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<SimpleDataUpdateTable> columnValues,
@@ -465,6 +487,7 @@ class SimpleDataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<SimpleData>(
       columnValues: columnValues(SimpleData.t.updateTable),
@@ -476,6 +499,7 @@ class SimpleDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,6 +510,10 @@ class SimpleDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> delete(
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
@@ -494,6 +522,7 @@ class SimpleDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<SimpleData>(
       rows,
@@ -502,6 +531,7 @@ class SimpleDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -521,6 +551,10 @@ class SimpleDataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SimpleDataTable> where,
@@ -529,6 +563,7 @@ class SimpleDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<SimpleData>(
       where: where(SimpleData.t),
@@ -537,6 +572,7 @@ class SimpleDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -313,16 +313,22 @@ class SimpleDateTimeRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> insert(
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<SimpleDateTime>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -356,6 +362,10 @@ class SimpleDateTimeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> upsert(
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
@@ -363,6 +373,7 @@ class SimpleDateTimeRepository {
     _i1.ColumnSelections<SimpleDateTimeTable>? updateColumns,
     _i1.WhereExpressionBuilder<SimpleDateTimeTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<SimpleDateTime>(
       rows,
@@ -370,6 +381,7 @@ class SimpleDateTimeRepository {
       updateColumns: updateColumns?.call(SimpleDateTime.t),
       updateWhere: updateWhere?.call(SimpleDateTime.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -408,16 +420,22 @@ class SimpleDateTimeRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> update(
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
     _i1.ColumnSelections<SimpleDateTimeTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<SimpleDateTime>(
       rows,
       columns: columns?.call(SimpleDateTime.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -454,6 +472,10 @@ class SimpleDateTimeRepository {
 
   /// Updates all [SimpleDateTime]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<SimpleDateTimeUpdateTable> columnValues,
@@ -465,6 +487,7 @@ class SimpleDateTimeRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<SimpleDateTime>(
       columnValues: columnValues(SimpleDateTime.t.updateTable),
@@ -476,6 +499,7 @@ class SimpleDateTimeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,6 +510,10 @@ class SimpleDateTimeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> delete(
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
@@ -494,6 +522,7 @@ class SimpleDateTimeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<SimpleDateTime>(
       rows,
@@ -502,6 +531,7 @@ class SimpleDateTimeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -521,6 +551,10 @@ class SimpleDateTimeRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SimpleDateTimeTable> where,
@@ -529,6 +563,7 @@ class SimpleDateTimeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<SimpleDateTime>(
       where: where(SimpleDateTime.t),
@@ -537,6 +572,7 @@ class SimpleDateTimeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -857,16 +857,22 @@ class TypesRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> insert(
     _i1.DatabaseSession session,
     List<Types> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Types>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -900,6 +906,10 @@ class TypesRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> upsert(
     _i1.DatabaseSession session,
     List<Types> rows, {
@@ -907,6 +917,7 @@ class TypesRepository {
     _i1.ColumnSelections<TypesTable>? updateColumns,
     _i1.WhereExpressionBuilder<TypesTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Types>(
       rows,
@@ -914,6 +925,7 @@ class TypesRepository {
       updateColumns: updateColumns?.call(Types.t),
       updateWhere: updateWhere?.call(Types.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -952,16 +964,22 @@ class TypesRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> update(
     _i1.DatabaseSession session,
     List<Types> rows, {
     _i1.ColumnSelections<TypesTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Types>(
       rows,
       columns: columns?.call(Types.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -998,6 +1016,10 @@ class TypesRepository {
 
   /// Updates all [Types]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TypesUpdateTable> columnValues,
@@ -1009,6 +1031,7 @@ class TypesRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Types>(
       columnValues: columnValues(Types.t.updateTable),
@@ -1020,6 +1043,7 @@ class TypesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -1030,6 +1054,10 @@ class TypesRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> delete(
     _i1.DatabaseSession session,
     List<Types> rows, {
@@ -1038,6 +1066,7 @@ class TypesRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Types>(
       rows,
@@ -1046,6 +1075,7 @@ class TypesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -1065,6 +1095,10 @@ class TypesRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TypesTable> where,
@@ -1073,6 +1107,7 @@ class TypesRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Types>(
       where: where(Types.t),
@@ -1081,6 +1116,7 @@ class TypesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -330,16 +330,22 @@ class UniqueDataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> insert(
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UniqueData>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -373,6 +379,10 @@ class UniqueDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> upsert(
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
@@ -380,6 +390,7 @@ class UniqueDataRepository {
     _i1.ColumnSelections<UniqueDataTable>? updateColumns,
     _i1.WhereExpressionBuilder<UniqueDataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UniqueData>(
       rows,
@@ -387,6 +398,7 @@ class UniqueDataRepository {
       updateColumns: updateColumns?.call(UniqueData.t),
       updateWhere: updateWhere?.call(UniqueData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -425,16 +437,22 @@ class UniqueDataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> update(
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
     _i1.ColumnSelections<UniqueDataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UniqueData>(
       rows,
       columns: columns?.call(UniqueData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -471,6 +489,10 @@ class UniqueDataRepository {
 
   /// Updates all [UniqueData]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UniqueDataUpdateTable> columnValues,
@@ -482,6 +504,7 @@ class UniqueDataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UniqueData>(
       columnValues: columnValues(UniqueData.t.updateTable),
@@ -493,6 +516,7 @@ class UniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -503,6 +527,10 @@ class UniqueDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> delete(
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
@@ -511,6 +539,7 @@ class UniqueDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UniqueData>(
       rows,
@@ -519,6 +548,7 @@ class UniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -538,6 +568,10 @@ class UniqueDataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UniqueDataTable> where,
@@ -546,6 +580,7 @@ class UniqueDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UniqueData>(
       where: where(UniqueData.t),
@@ -554,6 +589,7 @@ class UniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/unique_data_with_non_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data_with_non_persist.dart
@@ -346,16 +346,22 @@ class UniqueDataWithNonPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> insert(
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UniqueDataWithNonPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -389,6 +395,10 @@ class UniqueDataWithNonPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> upsert(
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
@@ -397,6 +407,7 @@ class UniqueDataWithNonPersistRepository {
     _i1.ColumnSelections<UniqueDataWithNonPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<UniqueDataWithNonPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UniqueDataWithNonPersist>(
       rows,
@@ -404,6 +415,7 @@ class UniqueDataWithNonPersistRepository {
       updateColumns: updateColumns?.call(UniqueDataWithNonPersist.t),
       updateWhere: updateWhere?.call(UniqueDataWithNonPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -443,16 +455,22 @@ class UniqueDataWithNonPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> update(
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
     _i1.ColumnSelections<UniqueDataWithNonPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UniqueDataWithNonPersist>(
       rows,
       columns: columns?.call(UniqueDataWithNonPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -490,6 +508,10 @@ class UniqueDataWithNonPersistRepository {
 
   /// Updates all [UniqueDataWithNonPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UniqueDataWithNonPersistUpdateTable>
@@ -502,6 +524,7 @@ class UniqueDataWithNonPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UniqueDataWithNonPersist>(
       columnValues: columnValues(UniqueDataWithNonPersist.t.updateTable),
@@ -513,6 +536,7 @@ class UniqueDataWithNonPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -523,6 +547,10 @@ class UniqueDataWithNonPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> delete(
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
@@ -531,6 +559,7 @@ class UniqueDataWithNonPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UniqueDataWithNonPersist>(
       rows,
@@ -539,6 +568,7 @@ class UniqueDataWithNonPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -558,6 +588,10 @@ class UniqueDataWithNonPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UniqueDataWithNonPersistTable> where,
@@ -566,6 +600,7 @@ class UniqueDataWithNonPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UniqueDataWithNonPersist>(
       where: where(UniqueDataWithNonPersist.t),
@@ -574,6 +609,7 @@ class UniqueDataWithNonPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/upsert_test_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/upsert_test_model.dart
@@ -355,16 +355,22 @@ class UpsertTestModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UpsertTestModel>> insert(
     _i1.DatabaseSession session,
     List<UpsertTestModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UpsertTestModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -398,6 +404,10 @@ class UpsertTestModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UpsertTestModel>> upsert(
     _i1.DatabaseSession session,
     List<UpsertTestModel> rows, {
@@ -405,6 +415,7 @@ class UpsertTestModelRepository {
     _i1.ColumnSelections<UpsertTestModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<UpsertTestModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UpsertTestModel>(
       rows,
@@ -412,6 +423,7 @@ class UpsertTestModelRepository {
       updateColumns: updateColumns?.call(UpsertTestModel.t),
       updateWhere: updateWhere?.call(UpsertTestModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -450,16 +462,22 @@ class UpsertTestModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UpsertTestModel>> update(
     _i1.DatabaseSession session,
     List<UpsertTestModel> rows, {
     _i1.ColumnSelections<UpsertTestModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UpsertTestModel>(
       rows,
       columns: columns?.call(UpsertTestModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -497,6 +515,10 @@ class UpsertTestModelRepository {
 
   /// Updates all [UpsertTestModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UpsertTestModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UpsertTestModelUpdateTable>
@@ -509,6 +531,7 @@ class UpsertTestModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UpsertTestModel>(
       columnValues: columnValues(UpsertTestModel.t.updateTable),
@@ -520,6 +543,7 @@ class UpsertTestModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -530,6 +554,10 @@ class UpsertTestModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UpsertTestModel>> delete(
     _i1.DatabaseSession session,
     List<UpsertTestModel> rows, {
@@ -538,6 +566,7 @@ class UpsertTestModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UpsertTestModel>(
       rows,
@@ -546,6 +575,7 @@ class UpsertTestModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -565,6 +595,10 @@ class UpsertTestModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UpsertTestModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UpsertTestModelTable> where,
@@ -573,6 +607,7 @@ class UpsertTestModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UpsertTestModel>(
       where: where(UpsertTestModel.t),
@@ -581,6 +616,7 @@ class UpsertTestModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/create_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/create_test.dart
@@ -113,6 +113,42 @@ void main() async {
         expect(second.number, 20);
       },
     );
+
+    test(
+      'when batch inserting with noReturn set to true '
+      'then an empty list is returned but the rows are persisted.',
+      () async {
+        var result = await UniqueData.db.insert(
+          session,
+          [
+            UniqueData(number: 1, email: 'a@serverpod.dev'),
+            UniqueData(number: 2, email: 'b@serverpod.dev'),
+          ],
+          noReturn: true,
+        );
+
+        expect(result, isEmpty);
+        expect(await UniqueData.db.find(session), hasLength(2));
+      },
+    );
+
+    test(
+      'when batch inserting with mixed ids and noReturn set to true '
+      'then an empty list is returned but all rows are persisted.',
+      () async {
+        var result = await UniqueData.db.insert(
+          session,
+          [
+            UniqueData(id: 1000, number: 1, email: 'a@serverpod.dev'),
+            UniqueData(number: 2, email: 'b@serverpod.dev'),
+          ],
+          noReturn: true,
+        );
+
+        expect(result, isEmpty);
+        expect(await UniqueData.db.find(session), hasLength(2));
+      },
+    );
   });
 
   group('Given an object data without an id when calling insertRow', () {

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/delete_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/delete_test.dart
@@ -424,5 +424,46 @@ void main() async {
         expect(deleted.first.id!, inserted.first.id);
       },
     );
+
+    test(
+      'Given an inserted entry '
+      'when batch deleting with noReturn set to true '
+      'then an empty list is returned but the rows are removed.',
+      () async {
+        var inserted = (await UniqueData.db.insert(session, [
+          UniqueData(number: 1, email: 'a@serverpod.dev'),
+        ])).first;
+
+        var result = await UniqueData.db.delete(
+          session,
+          [inserted],
+          noReturn: true,
+        );
+
+        expect(result, isEmpty);
+        expect(await UniqueData.db.find(session), isEmpty);
+      },
+    );
+
+    test(
+      'Given two inserted entries '
+      'when deleting rows matching a where expression with noReturn set to true '
+      'then an empty list is returned but the matching rows are removed.',
+      () async {
+        await UniqueData.db.insert(session, [
+          UniqueData(number: 1, email: 'a@serverpod.dev'),
+          UniqueData(number: 2, email: 'b@serverpod.dev'),
+        ]);
+
+        var result = await UniqueData.db.deleteWhere(
+          session,
+          where: (t) => Constant.bool(true),
+          noReturn: true,
+        );
+
+        expect(result, isEmpty);
+        expect(await UniqueData.db.find(session), isEmpty);
+      },
+    );
   });
 }

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/update_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/update_test.dart
@@ -13,6 +13,27 @@ void main() async {
   });
 
   test(
+    'Given an inserted entry '
+    'when batch updating with noReturn set to true '
+    'then an empty list is returned but the change is persisted.',
+    () async {
+      var inserted = (await UniqueData.db.insert(session, [
+        UniqueData(number: 1, email: 'a@serverpod.dev'),
+      ])).first;
+
+      var result = await UniqueData.db.update(
+        session,
+        [UniqueData(id: inserted.id, number: 99, email: 'a@serverpod.dev')],
+        noReturn: true,
+      );
+
+      expect(result, isEmpty);
+      var found = await UniqueData.db.findById(session, inserted.id!);
+      expect(found?.number, 99);
+    },
+  );
+
+  test(
     'Given a list of entries when batch updating only a single column then no other data is updated.',
     () async {
       var expectedFirstEmail = 'info@serverpod.dev';

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/update_where_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/update_where_test.dart
@@ -763,4 +763,44 @@ void main() {
       });
     },
   );
+
+  withServerpod(
+    'Given an inserted entry,',
+    (sessionBuilder, endpoints) {
+      var session = sessionBuilder.build();
+
+      setUp(() async {
+        await UniqueData.db.insert(session, [
+          UniqueData(number: 1, email: 'a@serverpod.dev'),
+        ]);
+      });
+
+      tearDown(() async {
+        await UniqueData.db.deleteWhere(
+          session,
+          where: (t) => Constant.bool(true),
+        );
+      });
+
+      test(
+        'when updating rows matching a where expression with noReturn set to true '
+        'then an empty list is returned but the matching rows are updated.',
+        () async {
+          var result = await UniqueData.db.updateWhere(
+            session,
+            columnValues: (t) => [t.number(42)],
+            where: (t) => t.email.equals('a@serverpod.dev'),
+            noReturn: true,
+          );
+
+          expect(result, isEmpty);
+          var found = await UniqueData.db.findFirstRow(
+            session,
+            where: (t) => t.email.equals('a@serverpod.dev'),
+          );
+          expect(found?.number, 42);
+        },
+      );
+    },
+  );
 }

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/upsert_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/upsert_test.dart
@@ -131,6 +131,22 @@ void main() async {
     );
 
     test(
+      'when batch upserting with noReturn set to true '
+      'then an empty list is returned but the rows are persisted.',
+      () async {
+        var result = await UniqueData.db.upsert(
+          session,
+          [UniqueData(number: 1, email: 'a@serverpod.dev')],
+          conflictColumns: (t) => [t.email],
+          noReturn: true,
+        );
+
+        expect(result, isEmpty);
+        expect(await UniqueData.db.find(session), hasLength(1));
+      },
+    );
+
+    test(
       'when upserting a single row with upsertRow then the row is inserted.',
       () async {
         var result = (await UniqueData.db.upsertRow(

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/empty_model_relation_item.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/empty_model_relation_item.dart
@@ -359,16 +359,22 @@ class EmptyModelRelationItemRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> insert(
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EmptyModelRelationItem>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -402,6 +408,10 @@ class EmptyModelRelationItemRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> upsert(
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
@@ -409,6 +419,7 @@ class EmptyModelRelationItemRepository {
     _i1.ColumnSelections<EmptyModelRelationItemTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmptyModelRelationItemTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EmptyModelRelationItem>(
       rows,
@@ -416,6 +427,7 @@ class EmptyModelRelationItemRepository {
       updateColumns: updateColumns?.call(EmptyModelRelationItem.t),
       updateWhere: updateWhere?.call(EmptyModelRelationItem.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -454,16 +466,22 @@ class EmptyModelRelationItemRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> update(
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
     _i1.ColumnSelections<EmptyModelRelationItemTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EmptyModelRelationItem>(
       rows,
       columns: columns?.call(EmptyModelRelationItem.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -501,6 +519,10 @@ class EmptyModelRelationItemRepository {
 
   /// Updates all [EmptyModelRelationItem]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmptyModelRelationItemUpdateTable>
@@ -513,6 +535,7 @@ class EmptyModelRelationItemRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EmptyModelRelationItem>(
       columnValues: columnValues(EmptyModelRelationItem.t.updateTable),
@@ -524,6 +547,7 @@ class EmptyModelRelationItemRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -534,6 +558,10 @@ class EmptyModelRelationItemRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> delete(
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
@@ -542,6 +570,7 @@ class EmptyModelRelationItemRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EmptyModelRelationItem>(
       rows,
@@ -550,6 +579,7 @@ class EmptyModelRelationItemRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -569,6 +599,10 @@ class EmptyModelRelationItemRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmptyModelRelationItemTable> where,
@@ -577,6 +611,7 @@ class EmptyModelRelationItemRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EmptyModelRelationItem>(
       where: where(EmptyModelRelationItem.t),
@@ -585,6 +620,7 @@ class EmptyModelRelationItemRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/empty_model_with_table.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/empty_model_with_table.dart
@@ -258,16 +258,22 @@ class EmptyModelWithTableRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> insert(
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EmptyModelWithTable>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -301,6 +307,10 @@ class EmptyModelWithTableRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> upsert(
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
@@ -308,6 +318,7 @@ class EmptyModelWithTableRepository {
     _i1.ColumnSelections<EmptyModelWithTableTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmptyModelWithTableTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EmptyModelWithTable>(
       rows,
@@ -315,6 +326,7 @@ class EmptyModelWithTableRepository {
       updateColumns: updateColumns?.call(EmptyModelWithTable.t),
       updateWhere: updateWhere?.call(EmptyModelWithTable.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -353,16 +365,22 @@ class EmptyModelWithTableRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> update(
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
     _i1.ColumnSelections<EmptyModelWithTableTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EmptyModelWithTable>(
       rows,
       columns: columns?.call(EmptyModelWithTable.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -400,6 +418,10 @@ class EmptyModelWithTableRepository {
 
   /// Updates all [EmptyModelWithTable]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmptyModelWithTableUpdateTable>
@@ -412,6 +434,7 @@ class EmptyModelWithTableRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EmptyModelWithTable>(
       columnValues: columnValues(EmptyModelWithTable.t.updateTable),
@@ -423,6 +446,7 @@ class EmptyModelWithTableRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -433,6 +457,10 @@ class EmptyModelWithTableRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> delete(
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
@@ -441,6 +469,7 @@ class EmptyModelWithTableRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EmptyModelWithTable>(
       rows,
@@ -449,6 +478,7 @@ class EmptyModelWithTableRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -468,6 +498,10 @@ class EmptyModelWithTableRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmptyModelWithTableTable> where,
@@ -476,6 +510,7 @@ class EmptyModelWithTableRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EmptyModelWithTable>(
       where: where(EmptyModelWithTable.t),
@@ -484,6 +519,7 @@ class EmptyModelWithTableRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/relation_empy_model.dart
@@ -364,16 +364,22 @@ class RelationEmptyModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> insert(
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<RelationEmptyModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -407,6 +413,10 @@ class RelationEmptyModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> upsert(
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
@@ -414,6 +424,7 @@ class RelationEmptyModelRepository {
     _i1.ColumnSelections<RelationEmptyModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<RelationEmptyModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<RelationEmptyModel>(
       rows,
@@ -421,6 +432,7 @@ class RelationEmptyModelRepository {
       updateColumns: updateColumns?.call(RelationEmptyModel.t),
       updateWhere: updateWhere?.call(RelationEmptyModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -459,16 +471,22 @@ class RelationEmptyModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> update(
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
     _i1.ColumnSelections<RelationEmptyModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<RelationEmptyModel>(
       rows,
       columns: columns?.call(RelationEmptyModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -506,6 +524,10 @@ class RelationEmptyModelRepository {
 
   /// Updates all [RelationEmptyModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<RelationEmptyModelUpdateTable>
@@ -518,6 +540,7 @@ class RelationEmptyModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<RelationEmptyModel>(
       columnValues: columnValues(RelationEmptyModel.t.updateTable),
@@ -529,6 +552,7 @@ class RelationEmptyModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -539,6 +563,10 @@ class RelationEmptyModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> delete(
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
@@ -547,6 +575,7 @@ class RelationEmptyModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<RelationEmptyModel>(
       rows,
@@ -555,6 +584,7 @@ class RelationEmptyModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -574,6 +604,10 @@ class RelationEmptyModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelationEmptyModelTable> where,
@@ -582,6 +616,7 @@ class RelationEmptyModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<RelationEmptyModel>(
       where: where(RelationEmptyModel.t),
@@ -590,6 +625,7 @@ class RelationEmptyModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/city.dart
@@ -453,16 +453,22 @@ class CityRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> insert(
     _i1.DatabaseSession session,
     List<City> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<City>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -496,6 +502,10 @@ class CityRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> upsert(
     _i1.DatabaseSession session,
     List<City> rows, {
@@ -503,6 +513,7 @@ class CityRepository {
     _i1.ColumnSelections<CityTable>? updateColumns,
     _i1.WhereExpressionBuilder<CityTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<City>(
       rows,
@@ -510,6 +521,7 @@ class CityRepository {
       updateColumns: updateColumns?.call(City.t),
       updateWhere: updateWhere?.call(City.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -548,16 +560,22 @@ class CityRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> update(
     _i1.DatabaseSession session,
     List<City> rows, {
     _i1.ColumnSelections<CityTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<City>(
       rows,
       columns: columns?.call(City.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -594,6 +612,10 @@ class CityRepository {
 
   /// Updates all [City]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CityUpdateTable> columnValues,
@@ -605,6 +627,7 @@ class CityRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<City>(
       columnValues: columnValues(City.t.updateTable),
@@ -616,6 +639,7 @@ class CityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -626,6 +650,10 @@ class CityRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> delete(
     _i1.DatabaseSession session,
     List<City> rows, {
@@ -634,6 +662,7 @@ class CityRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<City>(
       rows,
@@ -642,6 +671,7 @@ class CityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -661,6 +691,10 @@ class CityRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CityTable> where,
@@ -669,6 +703,7 @@ class CityRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<City>(
       where: where(City.t),
@@ -677,6 +712,7 @@ class CityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/organization.dart
@@ -450,16 +450,22 @@ class OrganizationRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> insert(
     _i1.DatabaseSession session,
     List<Organization> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Organization>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -493,6 +499,10 @@ class OrganizationRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> upsert(
     _i1.DatabaseSession session,
     List<Organization> rows, {
@@ -500,6 +510,7 @@ class OrganizationRepository {
     _i1.ColumnSelections<OrganizationTable>? updateColumns,
     _i1.WhereExpressionBuilder<OrganizationTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Organization>(
       rows,
@@ -507,6 +518,7 @@ class OrganizationRepository {
       updateColumns: updateColumns?.call(Organization.t),
       updateWhere: updateWhere?.call(Organization.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -545,16 +557,22 @@ class OrganizationRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> update(
     _i1.DatabaseSession session,
     List<Organization> rows, {
     _i1.ColumnSelections<OrganizationTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Organization>(
       rows,
       columns: columns?.call(Organization.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +609,10 @@ class OrganizationRepository {
 
   /// Updates all [Organization]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<OrganizationUpdateTable> columnValues,
@@ -602,6 +624,7 @@ class OrganizationRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Organization>(
       columnValues: columnValues(Organization.t.updateTable),
@@ -613,6 +636,7 @@ class OrganizationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -623,6 +647,10 @@ class OrganizationRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> delete(
     _i1.DatabaseSession session,
     List<Organization> rows, {
@@ -631,6 +659,7 @@ class OrganizationRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Organization>(
       rows,
@@ -639,6 +668,7 @@ class OrganizationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -658,6 +688,10 @@ class OrganizationRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrganizationTable> where,
@@ -666,6 +700,7 @@ class OrganizationRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Organization>(
       where: where(Organization.t),
@@ -674,6 +709,7 @@ class OrganizationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/person.dart
@@ -436,16 +436,22 @@ class PersonRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> insert(
     _i1.DatabaseSession session,
     List<Person> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Person>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -479,6 +485,10 @@ class PersonRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> upsert(
     _i1.DatabaseSession session,
     List<Person> rows, {
@@ -486,6 +496,7 @@ class PersonRepository {
     _i1.ColumnSelections<PersonTable>? updateColumns,
     _i1.WhereExpressionBuilder<PersonTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Person>(
       rows,
@@ -493,6 +504,7 @@ class PersonRepository {
       updateColumns: updateColumns?.call(Person.t),
       updateWhere: updateWhere?.call(Person.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,16 +543,22 @@ class PersonRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> update(
     _i1.DatabaseSession session,
     List<Person> rows, {
     _i1.ColumnSelections<PersonTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Person>(
       rows,
       columns: columns?.call(Person.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -577,6 +595,10 @@ class PersonRepository {
 
   /// Updates all [Person]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PersonUpdateTable> columnValues,
@@ -588,6 +610,7 @@ class PersonRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Person>(
       columnValues: columnValues(Person.t.updateTable),
@@ -599,6 +622,7 @@ class PersonRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -609,6 +633,10 @@ class PersonRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> delete(
     _i1.DatabaseSession session,
     List<Person> rows, {
@@ -617,6 +645,7 @@ class PersonRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Person>(
       rows,
@@ -625,6 +654,7 @@ class PersonRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -644,6 +674,10 @@ class PersonRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PersonTable> where,
@@ -652,6 +686,7 @@ class PersonRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Person>(
       where: where(Person.t),
@@ -660,6 +695,7 @@ class PersonRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
@@ -380,16 +380,22 @@ class CourseRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> insert(
     _i1.DatabaseSession session,
     List<Course> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Course>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -423,6 +429,10 @@ class CourseRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> upsert(
     _i1.DatabaseSession session,
     List<Course> rows, {
@@ -430,6 +440,7 @@ class CourseRepository {
     _i1.ColumnSelections<CourseTable>? updateColumns,
     _i1.WhereExpressionBuilder<CourseTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Course>(
       rows,
@@ -437,6 +448,7 @@ class CourseRepository {
       updateColumns: updateColumns?.call(Course.t),
       updateWhere: updateWhere?.call(Course.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -475,16 +487,22 @@ class CourseRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> update(
     _i1.DatabaseSession session,
     List<Course> rows, {
     _i1.ColumnSelections<CourseTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Course>(
       rows,
       columns: columns?.call(Course.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -521,6 +539,10 @@ class CourseRepository {
 
   /// Updates all [Course]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CourseUpdateTable> columnValues,
@@ -532,6 +554,7 @@ class CourseRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Course>(
       columnValues: columnValues(Course.t.updateTable),
@@ -543,6 +566,7 @@ class CourseRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -553,6 +577,10 @@ class CourseRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> delete(
     _i1.DatabaseSession session,
     List<Course> rows, {
@@ -561,6 +589,7 @@ class CourseRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Course>(
       rows,
@@ -569,6 +598,7 @@ class CourseRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -588,6 +618,10 @@ class CourseRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CourseTable> where,
@@ -596,6 +630,7 @@ class CourseRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Course>(
       where: where(Course.t),
@@ -604,6 +639,7 @@ class CourseRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/enrollment.dart
@@ -420,16 +420,22 @@ class EnrollmentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> insert(
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Enrollment>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -463,6 +469,10 @@ class EnrollmentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> upsert(
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
@@ -470,6 +480,7 @@ class EnrollmentRepository {
     _i1.ColumnSelections<EnrollmentTable>? updateColumns,
     _i1.WhereExpressionBuilder<EnrollmentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Enrollment>(
       rows,
@@ -477,6 +488,7 @@ class EnrollmentRepository {
       updateColumns: updateColumns?.call(Enrollment.t),
       updateWhere: updateWhere?.call(Enrollment.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -515,16 +527,22 @@ class EnrollmentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> update(
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
     _i1.ColumnSelections<EnrollmentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Enrollment>(
       rows,
       columns: columns?.call(Enrollment.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -561,6 +579,10 @@ class EnrollmentRepository {
 
   /// Updates all [Enrollment]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnrollmentUpdateTable> columnValues,
@@ -572,6 +594,7 @@ class EnrollmentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Enrollment>(
       columnValues: columnValues(Enrollment.t.updateTable),
@@ -583,6 +606,7 @@ class EnrollmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -593,6 +617,10 @@ class EnrollmentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> delete(
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
@@ -601,6 +629,7 @@ class EnrollmentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Enrollment>(
       rows,
@@ -609,6 +638,7 @@ class EnrollmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -628,6 +658,10 @@ class EnrollmentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnrollmentTable> where,
@@ -636,6 +670,7 @@ class EnrollmentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Enrollment>(
       where: where(Enrollment.t),
@@ -644,6 +679,7 @@ class EnrollmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
@@ -376,16 +376,22 @@ class StudentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> insert(
     _i1.DatabaseSession session,
     List<Student> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Student>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -419,6 +425,10 @@ class StudentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> upsert(
     _i1.DatabaseSession session,
     List<Student> rows, {
@@ -426,6 +436,7 @@ class StudentRepository {
     _i1.ColumnSelections<StudentTable>? updateColumns,
     _i1.WhereExpressionBuilder<StudentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Student>(
       rows,
@@ -433,6 +444,7 @@ class StudentRepository {
       updateColumns: updateColumns?.call(Student.t),
       updateWhere: updateWhere?.call(Student.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -471,16 +483,22 @@ class StudentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> update(
     _i1.DatabaseSession session,
     List<Student> rows, {
     _i1.ColumnSelections<StudentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Student>(
       rows,
       columns: columns?.call(Student.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -517,6 +535,10 @@ class StudentRepository {
 
   /// Updates all [Student]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<StudentUpdateTable> columnValues,
@@ -528,6 +550,7 @@ class StudentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Student>(
       columnValues: columnValues(Student.t.updateTable),
@@ -539,6 +562,7 @@ class StudentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,6 +573,10 @@ class StudentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> delete(
     _i1.DatabaseSession session,
     List<Student> rows, {
@@ -557,6 +585,7 @@ class StudentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Student>(
       rows,
@@ -565,6 +594,7 @@ class StudentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -584,6 +614,10 @@ class StudentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StudentTable> where,
@@ -592,6 +626,7 @@ class StudentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Student>(
       where: where(Student.t),
@@ -600,6 +635,7 @@ class StudentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/arena.dart
@@ -350,16 +350,22 @@ class ArenaRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> insert(
     _i1.DatabaseSession session,
     List<Arena> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Arena>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -393,6 +399,10 @@ class ArenaRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> upsert(
     _i1.DatabaseSession session,
     List<Arena> rows, {
@@ -400,6 +410,7 @@ class ArenaRepository {
     _i1.ColumnSelections<ArenaTable>? updateColumns,
     _i1.WhereExpressionBuilder<ArenaTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Arena>(
       rows,
@@ -407,6 +418,7 @@ class ArenaRepository {
       updateColumns: updateColumns?.call(Arena.t),
       updateWhere: updateWhere?.call(Arena.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -445,16 +457,22 @@ class ArenaRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> update(
     _i1.DatabaseSession session,
     List<Arena> rows, {
     _i1.ColumnSelections<ArenaTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Arena>(
       rows,
       columns: columns?.call(Arena.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -491,6 +509,10 @@ class ArenaRepository {
 
   /// Updates all [Arena]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ArenaUpdateTable> columnValues,
@@ -502,6 +524,7 @@ class ArenaRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Arena>(
       columnValues: columnValues(Arena.t.updateTable),
@@ -513,6 +536,7 @@ class ArenaRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -523,6 +547,10 @@ class ArenaRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> delete(
     _i1.DatabaseSession session,
     List<Arena> rows, {
@@ -531,6 +559,7 @@ class ArenaRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Arena>(
       rows,
@@ -539,6 +568,7 @@ class ArenaRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -558,6 +588,10 @@ class ArenaRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ArenaTable> where,
@@ -566,6 +600,7 @@ class ArenaRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Arena>(
       where: where(Arena.t),
@@ -574,6 +609,7 @@ class ArenaRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/player.dart
@@ -373,16 +373,22 @@ class PlayerRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> insert(
     _i1.DatabaseSession session,
     List<Player> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Player>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -416,6 +422,10 @@ class PlayerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> upsert(
     _i1.DatabaseSession session,
     List<Player> rows, {
@@ -423,6 +433,7 @@ class PlayerRepository {
     _i1.ColumnSelections<PlayerTable>? updateColumns,
     _i1.WhereExpressionBuilder<PlayerTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Player>(
       rows,
@@ -430,6 +441,7 @@ class PlayerRepository {
       updateColumns: updateColumns?.call(Player.t),
       updateWhere: updateWhere?.call(Player.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -468,16 +480,22 @@ class PlayerRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> update(
     _i1.DatabaseSession session,
     List<Player> rows, {
     _i1.ColumnSelections<PlayerTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Player>(
       rows,
       columns: columns?.call(Player.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -514,6 +532,10 @@ class PlayerRepository {
 
   /// Updates all [Player]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PlayerUpdateTable> columnValues,
@@ -525,6 +547,7 @@ class PlayerRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Player>(
       columnValues: columnValues(Player.t.updateTable),
@@ -536,6 +559,7 @@ class PlayerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -546,6 +570,10 @@ class PlayerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> delete(
     _i1.DatabaseSession session,
     List<Player> rows, {
@@ -554,6 +582,7 @@ class PlayerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Player>(
       rows,
@@ -562,6 +591,7 @@ class PlayerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -581,6 +611,10 @@ class PlayerRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PlayerTable> where,
@@ -589,6 +623,7 @@ class PlayerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Player>(
       where: where(Player.t),
@@ -597,6 +632,7 @@ class PlayerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
@@ -450,16 +450,22 @@ class TeamRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> insert(
     _i1.DatabaseSession session,
     List<Team> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Team>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -493,6 +499,10 @@ class TeamRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> upsert(
     _i1.DatabaseSession session,
     List<Team> rows, {
@@ -500,6 +510,7 @@ class TeamRepository {
     _i1.ColumnSelections<TeamTable>? updateColumns,
     _i1.WhereExpressionBuilder<TeamTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Team>(
       rows,
@@ -507,6 +518,7 @@ class TeamRepository {
       updateColumns: updateColumns?.call(Team.t),
       updateWhere: updateWhere?.call(Team.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -545,16 +557,22 @@ class TeamRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> update(
     _i1.DatabaseSession session,
     List<Team> rows, {
     _i1.ColumnSelections<TeamTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Team>(
       rows,
       columns: columns?.call(Team.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +609,10 @@ class TeamRepository {
 
   /// Updates all [Team]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TeamUpdateTable> columnValues,
@@ -602,6 +624,7 @@ class TeamRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Team>(
       columnValues: columnValues(Team.t.updateTable),
@@ -613,6 +636,7 @@ class TeamRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -623,6 +647,10 @@ class TeamRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> delete(
     _i1.DatabaseSession session,
     List<Team> rows, {
@@ -631,6 +659,7 @@ class TeamRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Team>(
       rows,
@@ -639,6 +668,7 @@ class TeamRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -658,6 +688,10 @@ class TeamRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TeamTable> where,
@@ -666,6 +700,7 @@ class TeamRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Team>(
       where: where(Team.t),
@@ -674,6 +709,7 @@ class TeamRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/comment.dart
@@ -371,16 +371,22 @@ class CommentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> insert(
     _i1.DatabaseSession session,
     List<Comment> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Comment>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -414,6 +420,10 @@ class CommentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> upsert(
     _i1.DatabaseSession session,
     List<Comment> rows, {
@@ -421,6 +431,7 @@ class CommentRepository {
     _i1.ColumnSelections<CommentTable>? updateColumns,
     _i1.WhereExpressionBuilder<CommentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Comment>(
       rows,
@@ -428,6 +439,7 @@ class CommentRepository {
       updateColumns: updateColumns?.call(Comment.t),
       updateWhere: updateWhere?.call(Comment.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -466,16 +478,22 @@ class CommentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> update(
     _i1.DatabaseSession session,
     List<Comment> rows, {
     _i1.ColumnSelections<CommentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Comment>(
       rows,
       columns: columns?.call(Comment.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +530,10 @@ class CommentRepository {
 
   /// Updates all [Comment]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CommentUpdateTable> columnValues,
@@ -523,6 +545,7 @@ class CommentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Comment>(
       columnValues: columnValues(Comment.t.updateTable),
@@ -534,6 +557,7 @@ class CommentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -544,6 +568,10 @@ class CommentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> delete(
     _i1.DatabaseSession session,
     List<Comment> rows, {
@@ -552,6 +580,7 @@ class CommentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Comment>(
       rows,
@@ -560,6 +589,7 @@ class CommentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -579,6 +609,10 @@ class CommentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CommentTable> where,
@@ -587,6 +621,7 @@ class CommentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Comment>(
       where: where(Comment.t),
@@ -595,6 +630,7 @@ class CommentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
@@ -380,16 +380,22 @@ class CustomerRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> insert(
     _i1.DatabaseSession session,
     List<Customer> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Customer>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -423,6 +429,10 @@ class CustomerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> upsert(
     _i1.DatabaseSession session,
     List<Customer> rows, {
@@ -430,6 +440,7 @@ class CustomerRepository {
     _i1.ColumnSelections<CustomerTable>? updateColumns,
     _i1.WhereExpressionBuilder<CustomerTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Customer>(
       rows,
@@ -437,6 +448,7 @@ class CustomerRepository {
       updateColumns: updateColumns?.call(Customer.t),
       updateWhere: updateWhere?.call(Customer.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -475,16 +487,22 @@ class CustomerRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> update(
     _i1.DatabaseSession session,
     List<Customer> rows, {
     _i1.ColumnSelections<CustomerTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Customer>(
       rows,
       columns: columns?.call(Customer.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -521,6 +539,10 @@ class CustomerRepository {
 
   /// Updates all [Customer]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CustomerUpdateTable> columnValues,
@@ -532,6 +554,7 @@ class CustomerRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Customer>(
       columnValues: columnValues(Customer.t.updateTable),
@@ -543,6 +566,7 @@ class CustomerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -553,6 +577,10 @@ class CustomerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> delete(
     _i1.DatabaseSession session,
     List<Customer> rows, {
@@ -561,6 +589,7 @@ class CustomerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Customer>(
       rows,
@@ -569,6 +598,7 @@ class CustomerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -588,6 +618,10 @@ class CustomerRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CustomerTable> where,
@@ -596,6 +630,7 @@ class CustomerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Customer>(
       where: where(Customer.t),
@@ -604,6 +639,7 @@ class CustomerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/implicit/book.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/implicit/book.dart
@@ -381,16 +381,22 @@ class BookRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> insert(
     _i1.DatabaseSession session,
     List<Book> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Book>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -424,6 +430,10 @@ class BookRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> upsert(
     _i1.DatabaseSession session,
     List<Book> rows, {
@@ -431,6 +441,7 @@ class BookRepository {
     _i1.ColumnSelections<BookTable>? updateColumns,
     _i1.WhereExpressionBuilder<BookTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Book>(
       rows,
@@ -438,6 +449,7 @@ class BookRepository {
       updateColumns: updateColumns?.call(Book.t),
       updateWhere: updateWhere?.call(Book.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -476,16 +488,22 @@ class BookRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> update(
     _i1.DatabaseSession session,
     List<Book> rows, {
     _i1.ColumnSelections<BookTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Book>(
       rows,
       columns: columns?.call(Book.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -522,6 +540,10 @@ class BookRepository {
 
   /// Updates all [Book]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BookUpdateTable> columnValues,
@@ -533,6 +555,7 @@ class BookRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Book>(
       columnValues: columnValues(Book.t.updateTable),
@@ -544,6 +567,7 @@ class BookRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -554,6 +578,10 @@ class BookRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> delete(
     _i1.DatabaseSession session,
     List<Book> rows, {
@@ -562,6 +590,7 @@ class BookRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Book>(
       rows,
@@ -570,6 +599,7 @@ class BookRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -589,6 +619,10 @@ class BookRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BookTable> where,
@@ -597,6 +631,7 @@ class BookRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Book>(
       where: where(Book.t),
@@ -605,6 +640,7 @@ class BookRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/implicit/chapter.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/implicit/chapter.dart
@@ -347,16 +347,22 @@ class ChapterRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> insert(
     _i1.DatabaseSession session,
     List<Chapter> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Chapter>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -390,6 +396,10 @@ class ChapterRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> upsert(
     _i1.DatabaseSession session,
     List<Chapter> rows, {
@@ -397,6 +407,7 @@ class ChapterRepository {
     _i1.ColumnSelections<ChapterTable>? updateColumns,
     _i1.WhereExpressionBuilder<ChapterTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Chapter>(
       rows,
@@ -404,6 +415,7 @@ class ChapterRepository {
       updateColumns: updateColumns?.call(Chapter.t),
       updateWhere: updateWhere?.call(Chapter.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -442,16 +454,22 @@ class ChapterRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> update(
     _i1.DatabaseSession session,
     List<Chapter> rows, {
     _i1.ColumnSelections<ChapterTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Chapter>(
       rows,
       columns: columns?.call(Chapter.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -488,6 +506,10 @@ class ChapterRepository {
 
   /// Updates all [Chapter]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ChapterUpdateTable> columnValues,
@@ -499,6 +521,7 @@ class ChapterRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Chapter>(
       columnValues: columnValues(Chapter.t.updateTable),
@@ -510,6 +533,7 @@ class ChapterRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -520,6 +544,10 @@ class ChapterRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> delete(
     _i1.DatabaseSession session,
     List<Chapter> rows, {
@@ -528,6 +556,7 @@ class ChapterRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Chapter>(
       rows,
@@ -536,6 +565,7 @@ class ChapterRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -555,6 +585,10 @@ class ChapterRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChapterTable> where,
@@ -563,6 +597,7 @@ class ChapterRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Chapter>(
       where: where(Chapter.t),
@@ -571,6 +606,7 @@ class ChapterRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
@@ -450,16 +450,22 @@ class OrderRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> insert(
     _i1.DatabaseSession session,
     List<Order> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Order>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -493,6 +499,10 @@ class OrderRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> upsert(
     _i1.DatabaseSession session,
     List<Order> rows, {
@@ -500,6 +510,7 @@ class OrderRepository {
     _i1.ColumnSelections<OrderTable>? updateColumns,
     _i1.WhereExpressionBuilder<OrderTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Order>(
       rows,
@@ -507,6 +518,7 @@ class OrderRepository {
       updateColumns: updateColumns?.call(Order.t),
       updateWhere: updateWhere?.call(Order.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -545,16 +557,22 @@ class OrderRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> update(
     _i1.DatabaseSession session,
     List<Order> rows, {
     _i1.ColumnSelections<OrderTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Order>(
       rows,
       columns: columns?.call(Order.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +609,10 @@ class OrderRepository {
 
   /// Updates all [Order]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<OrderUpdateTable> columnValues,
@@ -602,6 +624,7 @@ class OrderRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Order>(
       columnValues: columnValues(Order.t.updateTable),
@@ -613,6 +636,7 @@ class OrderRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -623,6 +647,10 @@ class OrderRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> delete(
     _i1.DatabaseSession session,
     List<Order> rows, {
@@ -631,6 +659,7 @@ class OrderRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Order>(
       rows,
@@ -639,6 +668,7 @@ class OrderRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -658,6 +688,10 @@ class OrderRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrderTable> where,
@@ -666,6 +700,7 @@ class OrderRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Order>(
       where: where(Order.t),
@@ -674,6 +709,7 @@ class OrderRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/address.dart
@@ -377,16 +377,22 @@ class AddressRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> insert(
     _i1.DatabaseSession session,
     List<Address> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Address>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -420,6 +426,10 @@ class AddressRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> upsert(
     _i1.DatabaseSession session,
     List<Address> rows, {
@@ -427,6 +437,7 @@ class AddressRepository {
     _i1.ColumnSelections<AddressTable>? updateColumns,
     _i1.WhereExpressionBuilder<AddressTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Address>(
       rows,
@@ -434,6 +445,7 @@ class AddressRepository {
       updateColumns: updateColumns?.call(Address.t),
       updateWhere: updateWhere?.call(Address.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -472,16 +484,22 @@ class AddressRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> update(
     _i1.DatabaseSession session,
     List<Address> rows, {
     _i1.ColumnSelections<AddressTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Address>(
       rows,
       columns: columns?.call(Address.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -518,6 +536,10 @@ class AddressRepository {
 
   /// Updates all [Address]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<AddressUpdateTable> columnValues,
@@ -529,6 +551,7 @@ class AddressRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Address>(
       columnValues: columnValues(Address.t.updateTable),
@@ -540,6 +563,7 @@ class AddressRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -550,6 +574,10 @@ class AddressRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> delete(
     _i1.DatabaseSession session,
     List<Address> rows, {
@@ -558,6 +586,7 @@ class AddressRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Address>(
       rows,
@@ -566,6 +595,7 @@ class AddressRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -585,6 +615,10 @@ class AddressRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AddressTable> where,
@@ -593,6 +627,7 @@ class AddressRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Address>(
       where: where(Address.t),
@@ -601,6 +636,7 @@ class AddressRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/citizen.dart
@@ -489,16 +489,22 @@ class CitizenRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> insert(
     _i1.DatabaseSession session,
     List<Citizen> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Citizen>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -532,6 +538,10 @@ class CitizenRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> upsert(
     _i1.DatabaseSession session,
     List<Citizen> rows, {
@@ -539,6 +549,7 @@ class CitizenRepository {
     _i1.ColumnSelections<CitizenTable>? updateColumns,
     _i1.WhereExpressionBuilder<CitizenTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Citizen>(
       rows,
@@ -546,6 +557,7 @@ class CitizenRepository {
       updateColumns: updateColumns?.call(Citizen.t),
       updateWhere: updateWhere?.call(Citizen.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -584,16 +596,22 @@ class CitizenRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> update(
     _i1.DatabaseSession session,
     List<Citizen> rows, {
     _i1.ColumnSelections<CitizenTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Citizen>(
       rows,
       columns: columns?.call(Citizen.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -630,6 +648,10 @@ class CitizenRepository {
 
   /// Updates all [Citizen]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CitizenUpdateTable> columnValues,
@@ -641,6 +663,7 @@ class CitizenRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Citizen>(
       columnValues: columnValues(Citizen.t.updateTable),
@@ -652,6 +675,7 @@ class CitizenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -662,6 +686,10 @@ class CitizenRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> delete(
     _i1.DatabaseSession session,
     List<Citizen> rows, {
@@ -670,6 +698,7 @@ class CitizenRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Citizen>(
       rows,
@@ -678,6 +707,7 @@ class CitizenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -697,6 +727,10 @@ class CitizenRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CitizenTable> where,
@@ -705,6 +739,7 @@ class CitizenRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Citizen>(
       where: where(Citizen.t),
@@ -713,6 +748,7 @@ class CitizenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/company.dart
@@ -371,16 +371,22 @@ class CompanyRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> insert(
     _i1.DatabaseSession session,
     List<Company> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Company>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -414,6 +420,10 @@ class CompanyRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> upsert(
     _i1.DatabaseSession session,
     List<Company> rows, {
@@ -421,6 +431,7 @@ class CompanyRepository {
     _i1.ColumnSelections<CompanyTable>? updateColumns,
     _i1.WhereExpressionBuilder<CompanyTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Company>(
       rows,
@@ -428,6 +439,7 @@ class CompanyRepository {
       updateColumns: updateColumns?.call(Company.t),
       updateWhere: updateWhere?.call(Company.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -466,16 +478,22 @@ class CompanyRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> update(
     _i1.DatabaseSession session,
     List<Company> rows, {
     _i1.ColumnSelections<CompanyTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Company>(
       rows,
       columns: columns?.call(Company.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +530,10 @@ class CompanyRepository {
 
   /// Updates all [Company]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CompanyUpdateTable> columnValues,
@@ -523,6 +545,7 @@ class CompanyRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Company>(
       columnValues: columnValues(Company.t.updateTable),
@@ -534,6 +557,7 @@ class CompanyRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -544,6 +568,10 @@ class CompanyRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> delete(
     _i1.DatabaseSession session,
     List<Company> rows, {
@@ -552,6 +580,7 @@ class CompanyRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Company>(
       rows,
@@ -560,6 +589,7 @@ class CompanyRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -579,6 +609,10 @@ class CompanyRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CompanyTable> where,
@@ -587,6 +621,7 @@ class CompanyRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Company>(
       where: where(Company.t),
@@ -595,6 +630,7 @@ class CompanyRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/town.dart
@@ -373,16 +373,22 @@ class TownRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> insert(
     _i1.DatabaseSession session,
     List<Town> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Town>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -416,6 +422,10 @@ class TownRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> upsert(
     _i1.DatabaseSession session,
     List<Town> rows, {
@@ -423,6 +433,7 @@ class TownRepository {
     _i1.ColumnSelections<TownTable>? updateColumns,
     _i1.WhereExpressionBuilder<TownTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Town>(
       rows,
@@ -430,6 +441,7 @@ class TownRepository {
       updateColumns: updateColumns?.call(Town.t),
       updateWhere: updateWhere?.call(Town.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -468,16 +480,22 @@ class TownRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> update(
     _i1.DatabaseSession session,
     List<Town> rows, {
     _i1.ColumnSelections<TownTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Town>(
       rows,
       columns: columns?.call(Town.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -514,6 +532,10 @@ class TownRepository {
 
   /// Updates all [Town]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TownUpdateTable> columnValues,
@@ -525,6 +547,7 @@ class TownRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Town>(
       columnValues: columnValues(Town.t.updateTable),
@@ -536,6 +559,7 @@ class TownRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -546,6 +570,10 @@ class TownRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> delete(
     _i1.DatabaseSession session,
     List<Town> rows, {
@@ -554,6 +582,7 @@ class TownRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Town>(
       rows,
@@ -562,6 +591,7 @@ class TownRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -581,6 +611,10 @@ class TownRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TownTable> where,
@@ -589,6 +623,7 @@ class TownRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Town>(
       where: where(Town.t),
@@ -597,6 +632,7 @@ class TownRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -424,16 +424,22 @@ class BlockingRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> insert(
     _i1.DatabaseSession session,
     List<Blocking> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Blocking>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -467,6 +473,10 @@ class BlockingRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> upsert(
     _i1.DatabaseSession session,
     List<Blocking> rows, {
@@ -474,6 +484,7 @@ class BlockingRepository {
     _i1.ColumnSelections<BlockingTable>? updateColumns,
     _i1.WhereExpressionBuilder<BlockingTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Blocking>(
       rows,
@@ -481,6 +492,7 @@ class BlockingRepository {
       updateColumns: updateColumns?.call(Blocking.t),
       updateWhere: updateWhere?.call(Blocking.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -519,16 +531,22 @@ class BlockingRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> update(
     _i1.DatabaseSession session,
     List<Blocking> rows, {
     _i1.ColumnSelections<BlockingTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Blocking>(
       rows,
       columns: columns?.call(Blocking.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -565,6 +583,10 @@ class BlockingRepository {
 
   /// Updates all [Blocking]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BlockingUpdateTable> columnValues,
@@ -576,6 +598,7 @@ class BlockingRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Blocking>(
       columnValues: columnValues(Blocking.t.updateTable),
@@ -587,6 +610,7 @@ class BlockingRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -597,6 +621,10 @@ class BlockingRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> delete(
     _i1.DatabaseSession session,
     List<Blocking> rows, {
@@ -605,6 +633,7 @@ class BlockingRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Blocking>(
       rows,
@@ -613,6 +642,7 @@ class BlockingRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -632,6 +662,10 @@ class BlockingRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BlockingTable> where,
@@ -640,6 +674,7 @@ class BlockingRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Blocking>(
       where: where(Blocking.t),
@@ -648,6 +683,7 @@ class BlockingRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
@@ -449,16 +449,22 @@ class MemberRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> insert(
     _i1.DatabaseSession session,
     List<Member> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Member>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -492,6 +498,10 @@ class MemberRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> upsert(
     _i1.DatabaseSession session,
     List<Member> rows, {
@@ -499,6 +509,7 @@ class MemberRepository {
     _i1.ColumnSelections<MemberTable>? updateColumns,
     _i1.WhereExpressionBuilder<MemberTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Member>(
       rows,
@@ -506,6 +517,7 @@ class MemberRepository {
       updateColumns: updateColumns?.call(Member.t),
       updateWhere: updateWhere?.call(Member.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -544,16 +556,22 @@ class MemberRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> update(
     _i1.DatabaseSession session,
     List<Member> rows, {
     _i1.ColumnSelections<MemberTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Member>(
       rows,
       columns: columns?.call(Member.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -590,6 +608,10 @@ class MemberRepository {
 
   /// Updates all [Member]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<MemberUpdateTable> columnValues,
@@ -601,6 +623,7 @@ class MemberRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Member>(
       columnValues: columnValues(Member.t.updateTable),
@@ -612,6 +635,7 @@ class MemberRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -622,6 +646,10 @@ class MemberRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> delete(
     _i1.DatabaseSession session,
     List<Member> rows, {
@@ -630,6 +658,7 @@ class MemberRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Member>(
       rows,
@@ -638,6 +667,7 @@ class MemberRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -657,6 +687,10 @@ class MemberRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MemberTable> where,
@@ -665,6 +699,7 @@ class MemberRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Member>(
       where: where(Member.t),
@@ -673,6 +708,7 @@ class MemberRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
@@ -450,16 +450,22 @@ class CatRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> insert(
     _i1.DatabaseSession session,
     List<Cat> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Cat>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -493,6 +499,10 @@ class CatRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> upsert(
     _i1.DatabaseSession session,
     List<Cat> rows, {
@@ -500,6 +510,7 @@ class CatRepository {
     _i1.ColumnSelections<CatTable>? updateColumns,
     _i1.WhereExpressionBuilder<CatTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Cat>(
       rows,
@@ -507,6 +518,7 @@ class CatRepository {
       updateColumns: updateColumns?.call(Cat.t),
       updateWhere: updateWhere?.call(Cat.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -545,16 +557,22 @@ class CatRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> update(
     _i1.DatabaseSession session,
     List<Cat> rows, {
     _i1.ColumnSelections<CatTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Cat>(
       rows,
       columns: columns?.call(Cat.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +609,10 @@ class CatRepository {
 
   /// Updates all [Cat]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CatUpdateTable> columnValues,
@@ -602,6 +624,7 @@ class CatRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Cat>(
       columnValues: columnValues(Cat.t.updateTable),
@@ -613,6 +636,7 @@ class CatRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -623,6 +647,10 @@ class CatRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> delete(
     _i1.DatabaseSession session,
     List<Cat> rows, {
@@ -631,6 +659,7 @@ class CatRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Cat>(
       rows,
@@ -639,6 +668,7 @@ class CatRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -658,6 +688,10 @@ class CatRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CatTable> where,
@@ -666,6 +700,7 @@ class CatRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Cat>(
       where: where(Cat.t),
@@ -674,6 +709,7 @@ class CatRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/one_to_one/post.dart
@@ -420,16 +420,22 @@ class PostRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> insert(
     _i1.DatabaseSession session,
     List<Post> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Post>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -463,6 +469,10 @@ class PostRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> upsert(
     _i1.DatabaseSession session,
     List<Post> rows, {
@@ -470,6 +480,7 @@ class PostRepository {
     _i1.ColumnSelections<PostTable>? updateColumns,
     _i1.WhereExpressionBuilder<PostTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Post>(
       rows,
@@ -477,6 +488,7 @@ class PostRepository {
       updateColumns: updateColumns?.call(Post.t),
       updateWhere: updateWhere?.call(Post.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -515,16 +527,22 @@ class PostRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> update(
     _i1.DatabaseSession session,
     List<Post> rows, {
     _i1.ColumnSelections<PostTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Post>(
       rows,
       columns: columns?.call(Post.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -561,6 +579,10 @@ class PostRepository {
 
   /// Updates all [Post]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PostUpdateTable> columnValues,
@@ -572,6 +594,7 @@ class PostRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Post>(
       columnValues: columnValues(Post.t.updateTable),
@@ -583,6 +606,7 @@ class PostRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -593,6 +617,10 @@ class PostRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> delete(
     _i1.DatabaseSession session,
     List<Post> rows, {
@@ -601,6 +629,7 @@ class PostRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Post>(
       rows,
@@ -609,6 +638,7 @@ class PostRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -628,6 +658,10 @@ class PostRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PostTable> where,
@@ -636,6 +670,7 @@ class PostRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Post>(
       where: where(Post.t),
@@ -644,6 +679,7 @@ class PostRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/object_field_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/object_field_persist.dart
@@ -327,16 +327,22 @@ class ObjectFieldPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> insert(
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectFieldPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -370,6 +376,10 @@ class ObjectFieldPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> upsert(
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
@@ -377,6 +387,7 @@ class ObjectFieldPersistRepository {
     _i1.ColumnSelections<ObjectFieldPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectFieldPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectFieldPersist>(
       rows,
@@ -384,6 +395,7 @@ class ObjectFieldPersistRepository {
       updateColumns: updateColumns?.call(ObjectFieldPersist.t),
       updateWhere: updateWhere?.call(ObjectFieldPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -422,16 +434,22 @@ class ObjectFieldPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> update(
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
     _i1.ColumnSelections<ObjectFieldPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectFieldPersist>(
       rows,
       columns: columns?.call(ObjectFieldPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -469,6 +487,10 @@ class ObjectFieldPersistRepository {
 
   /// Updates all [ObjectFieldPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectFieldPersistUpdateTable>
@@ -481,6 +503,7 @@ class ObjectFieldPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectFieldPersist>(
       columnValues: columnValues(ObjectFieldPersist.t.updateTable),
@@ -492,6 +515,7 @@ class ObjectFieldPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -502,6 +526,10 @@ class ObjectFieldPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> delete(
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
@@ -510,6 +538,7 @@ class ObjectFieldPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectFieldPersist>(
       rows,
@@ -518,6 +547,7 @@ class ObjectFieldPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -537,6 +567,10 @@ class ObjectFieldPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectFieldPersistTable> where,
@@ -545,6 +579,7 @@ class ObjectFieldPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectFieldPersist>(
       where: where(ObjectFieldPersist.t),
@@ -553,6 +588,7 @@ class ObjectFieldPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/related_unique_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/related_unique_data.dart
@@ -377,16 +377,22 @@ class RelatedUniqueDataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> insert(
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<RelatedUniqueData>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -420,6 +426,10 @@ class RelatedUniqueDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> upsert(
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
@@ -427,6 +437,7 @@ class RelatedUniqueDataRepository {
     _i1.ColumnSelections<RelatedUniqueDataTable>? updateColumns,
     _i1.WhereExpressionBuilder<RelatedUniqueDataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<RelatedUniqueData>(
       rows,
@@ -434,6 +445,7 @@ class RelatedUniqueDataRepository {
       updateColumns: updateColumns?.call(RelatedUniqueData.t),
       updateWhere: updateWhere?.call(RelatedUniqueData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -472,16 +484,22 @@ class RelatedUniqueDataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> update(
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
     _i1.ColumnSelections<RelatedUniqueDataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<RelatedUniqueData>(
       rows,
       columns: columns?.call(RelatedUniqueData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -519,6 +537,10 @@ class RelatedUniqueDataRepository {
 
   /// Updates all [RelatedUniqueData]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<RelatedUniqueDataUpdateTable>
@@ -531,6 +553,7 @@ class RelatedUniqueDataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<RelatedUniqueData>(
       columnValues: columnValues(RelatedUniqueData.t.updateTable),
@@ -542,6 +565,7 @@ class RelatedUniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -552,6 +576,10 @@ class RelatedUniqueDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> delete(
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
@@ -560,6 +588,7 @@ class RelatedUniqueDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<RelatedUniqueData>(
       rows,
@@ -568,6 +597,7 @@ class RelatedUniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -587,6 +617,10 @@ class RelatedUniqueDataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelatedUniqueDataTable> where,
@@ -595,6 +629,7 @@ class RelatedUniqueDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<RelatedUniqueData>(
       where: where(RelatedUniqueData.t),
@@ -603,6 +638,7 @@ class RelatedUniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/required/model_with_required_field.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/required/model_with_required_field.dart
@@ -347,16 +347,22 @@ class ModelWithRequiredFieldRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> insert(
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ModelWithRequiredField>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -390,6 +396,10 @@ class ModelWithRequiredFieldRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> upsert(
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
@@ -397,6 +407,7 @@ class ModelWithRequiredFieldRepository {
     _i1.ColumnSelections<ModelWithRequiredFieldTable>? updateColumns,
     _i1.WhereExpressionBuilder<ModelWithRequiredFieldTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ModelWithRequiredField>(
       rows,
@@ -404,6 +415,7 @@ class ModelWithRequiredFieldRepository {
       updateColumns: updateColumns?.call(ModelWithRequiredField.t),
       updateWhere: updateWhere?.call(ModelWithRequiredField.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -442,16 +454,22 @@ class ModelWithRequiredFieldRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> update(
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
     _i1.ColumnSelections<ModelWithRequiredFieldTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ModelWithRequiredField>(
       rows,
       columns: columns?.call(ModelWithRequiredField.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -489,6 +507,10 @@ class ModelWithRequiredFieldRepository {
 
   /// Updates all [ModelWithRequiredField]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ModelWithRequiredFieldUpdateTable>
@@ -501,6 +523,7 @@ class ModelWithRequiredFieldRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ModelWithRequiredField>(
       columnValues: columnValues(ModelWithRequiredField.t.updateTable),
@@ -512,6 +535,7 @@ class ModelWithRequiredFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -522,6 +546,10 @@ class ModelWithRequiredFieldRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> delete(
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
@@ -530,6 +558,7 @@ class ModelWithRequiredFieldRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ModelWithRequiredField>(
       rows,
@@ -538,6 +567,7 @@ class ModelWithRequiredFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -557,6 +587,10 @@ class ModelWithRequiredFieldRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ModelWithRequiredFieldTable> where,
@@ -565,6 +599,7 @@ class ModelWithRequiredFieldRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ModelWithRequiredField>(
       where: where(ModelWithRequiredField.t),
@@ -573,6 +608,7 @@ class ModelWithRequiredFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/simple_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/simple_data.dart
@@ -304,16 +304,22 @@ class SimpleDataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> insert(
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<SimpleData>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -347,6 +353,10 @@ class SimpleDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> upsert(
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
@@ -354,6 +364,7 @@ class SimpleDataRepository {
     _i1.ColumnSelections<SimpleDataTable>? updateColumns,
     _i1.WhereExpressionBuilder<SimpleDataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<SimpleData>(
       rows,
@@ -361,6 +372,7 @@ class SimpleDataRepository {
       updateColumns: updateColumns?.call(SimpleData.t),
       updateWhere: updateWhere?.call(SimpleData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -399,16 +411,22 @@ class SimpleDataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> update(
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
     _i1.ColumnSelections<SimpleDataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<SimpleData>(
       rows,
       columns: columns?.call(SimpleData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -445,6 +463,10 @@ class SimpleDataRepository {
 
   /// Updates all [SimpleData]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<SimpleDataUpdateTable> columnValues,
@@ -456,6 +478,7 @@ class SimpleDataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<SimpleData>(
       columnValues: columnValues(SimpleData.t.updateTable),
@@ -467,6 +490,7 @@ class SimpleDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -477,6 +501,10 @@ class SimpleDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> delete(
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
@@ -485,6 +513,7 @@ class SimpleDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<SimpleData>(
       rows,
@@ -493,6 +522,7 @@ class SimpleDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +542,10 @@ class SimpleDataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SimpleDataTable> where,
@@ -520,6 +554,7 @@ class SimpleDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<SimpleData>(
       where: where(SimpleData.t),
@@ -528,6 +563,7 @@ class SimpleDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/simple_date_time.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/simple_date_time.dart
@@ -304,16 +304,22 @@ class SimpleDateTimeRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> insert(
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<SimpleDateTime>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -347,6 +353,10 @@ class SimpleDateTimeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> upsert(
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
@@ -354,6 +364,7 @@ class SimpleDateTimeRepository {
     _i1.ColumnSelections<SimpleDateTimeTable>? updateColumns,
     _i1.WhereExpressionBuilder<SimpleDateTimeTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<SimpleDateTime>(
       rows,
@@ -361,6 +372,7 @@ class SimpleDateTimeRepository {
       updateColumns: updateColumns?.call(SimpleDateTime.t),
       updateWhere: updateWhere?.call(SimpleDateTime.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -399,16 +411,22 @@ class SimpleDateTimeRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> update(
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
     _i1.ColumnSelections<SimpleDateTimeTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<SimpleDateTime>(
       rows,
       columns: columns?.call(SimpleDateTime.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -445,6 +463,10 @@ class SimpleDateTimeRepository {
 
   /// Updates all [SimpleDateTime]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<SimpleDateTimeUpdateTable> columnValues,
@@ -456,6 +478,7 @@ class SimpleDateTimeRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<SimpleDateTime>(
       columnValues: columnValues(SimpleDateTime.t.updateTable),
@@ -467,6 +490,7 @@ class SimpleDateTimeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -477,6 +501,10 @@ class SimpleDateTimeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> delete(
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
@@ -485,6 +513,7 @@ class SimpleDateTimeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<SimpleDateTime>(
       rows,
@@ -493,6 +522,7 @@ class SimpleDateTimeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +542,10 @@ class SimpleDateTimeRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SimpleDateTimeTable> where,
@@ -520,6 +554,7 @@ class SimpleDateTimeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<SimpleDateTime>(
       where: where(SimpleDateTime.t),
@@ -528,6 +563,7 @@ class SimpleDateTimeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/types.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/types.dart
@@ -829,16 +829,22 @@ class TypesRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> insert(
     _i1.DatabaseSession session,
     List<Types> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Types>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -872,6 +878,10 @@ class TypesRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> upsert(
     _i1.DatabaseSession session,
     List<Types> rows, {
@@ -879,6 +889,7 @@ class TypesRepository {
     _i1.ColumnSelections<TypesTable>? updateColumns,
     _i1.WhereExpressionBuilder<TypesTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Types>(
       rows,
@@ -886,6 +897,7 @@ class TypesRepository {
       updateColumns: updateColumns?.call(Types.t),
       updateWhere: updateWhere?.call(Types.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -924,16 +936,22 @@ class TypesRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> update(
     _i1.DatabaseSession session,
     List<Types> rows, {
     _i1.ColumnSelections<TypesTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Types>(
       rows,
       columns: columns?.call(Types.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -970,6 +988,10 @@ class TypesRepository {
 
   /// Updates all [Types]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TypesUpdateTable> columnValues,
@@ -981,6 +1003,7 @@ class TypesRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Types>(
       columnValues: columnValues(Types.t.updateTable),
@@ -992,6 +1015,7 @@ class TypesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -1002,6 +1026,10 @@ class TypesRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> delete(
     _i1.DatabaseSession session,
     List<Types> rows, {
@@ -1010,6 +1038,7 @@ class TypesRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Types>(
       rows,
@@ -1018,6 +1047,7 @@ class TypesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -1037,6 +1067,10 @@ class TypesRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TypesTable> where,
@@ -1045,6 +1079,7 @@ class TypesRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Types>(
       where: where(Types.t),
@@ -1053,6 +1088,7 @@ class TypesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/unique_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/unique_data.dart
@@ -320,16 +320,22 @@ class UniqueDataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> insert(
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UniqueData>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -363,6 +369,10 @@ class UniqueDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> upsert(
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
@@ -370,6 +380,7 @@ class UniqueDataRepository {
     _i1.ColumnSelections<UniqueDataTable>? updateColumns,
     _i1.WhereExpressionBuilder<UniqueDataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UniqueData>(
       rows,
@@ -377,6 +388,7 @@ class UniqueDataRepository {
       updateColumns: updateColumns?.call(UniqueData.t),
       updateWhere: updateWhere?.call(UniqueData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -415,16 +427,22 @@ class UniqueDataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> update(
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
     _i1.ColumnSelections<UniqueDataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UniqueData>(
       rows,
       columns: columns?.call(UniqueData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -461,6 +479,10 @@ class UniqueDataRepository {
 
   /// Updates all [UniqueData]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UniqueDataUpdateTable> columnValues,
@@ -472,6 +494,7 @@ class UniqueDataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UniqueData>(
       columnValues: columnValues(UniqueData.t.updateTable),
@@ -483,6 +506,7 @@ class UniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -493,6 +517,10 @@ class UniqueDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> delete(
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
@@ -501,6 +529,7 @@ class UniqueDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UniqueData>(
       rows,
@@ -509,6 +538,7 @@ class UniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -528,6 +558,10 @@ class UniqueDataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UniqueDataTable> where,
@@ -536,6 +570,7 @@ class UniqueDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UniqueData>(
       where: where(UniqueData.t),
@@ -544,6 +579,7 @@ class UniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/unique_data_with_non_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/unique_data_with_non_persist.dart
@@ -335,16 +335,22 @@ class UniqueDataWithNonPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> insert(
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UniqueDataWithNonPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -378,6 +384,10 @@ class UniqueDataWithNonPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> upsert(
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
@@ -386,6 +396,7 @@ class UniqueDataWithNonPersistRepository {
     _i1.ColumnSelections<UniqueDataWithNonPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<UniqueDataWithNonPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UniqueDataWithNonPersist>(
       rows,
@@ -393,6 +404,7 @@ class UniqueDataWithNonPersistRepository {
       updateColumns: updateColumns?.call(UniqueDataWithNonPersist.t),
       updateWhere: updateWhere?.call(UniqueDataWithNonPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -432,16 +444,22 @@ class UniqueDataWithNonPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> update(
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
     _i1.ColumnSelections<UniqueDataWithNonPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UniqueDataWithNonPersist>(
       rows,
       columns: columns?.call(UniqueDataWithNonPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -479,6 +497,10 @@ class UniqueDataWithNonPersistRepository {
 
   /// Updates all [UniqueDataWithNonPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UniqueDataWithNonPersistUpdateTable>
@@ -491,6 +513,7 @@ class UniqueDataWithNonPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UniqueDataWithNonPersist>(
       columnValues: columnValues(UniqueDataWithNonPersist.t.updateTable),
@@ -502,6 +525,7 @@ class UniqueDataWithNonPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +536,10 @@ class UniqueDataWithNonPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> delete(
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
@@ -520,6 +548,7 @@ class UniqueDataWithNonPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UniqueDataWithNonPersist>(
       rows,
@@ -528,6 +557,7 @@ class UniqueDataWithNonPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -547,6 +577,10 @@ class UniqueDataWithNonPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UniqueDataWithNonPersistTable> where,
@@ -555,6 +589,7 @@ class UniqueDataWithNonPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UniqueDataWithNonPersist>(
       where: where(UniqueDataWithNonPersist.t),
@@ -563,6 +598,7 @@ class UniqueDataWithNonPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/course.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/course.dart
@@ -398,16 +398,22 @@ class CourseUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CourseUuid>> insert(
     _i1.DatabaseSession session,
     List<CourseUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CourseUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -441,6 +447,10 @@ class CourseUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CourseUuid>> upsert(
     _i1.DatabaseSession session,
     List<CourseUuid> rows, {
@@ -448,6 +458,7 @@ class CourseUuidRepository {
     _i1.ColumnSelections<CourseUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<CourseUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CourseUuid>(
       rows,
@@ -455,6 +466,7 @@ class CourseUuidRepository {
       updateColumns: updateColumns?.call(CourseUuid.t),
       updateWhere: updateWhere?.call(CourseUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -493,16 +505,22 @@ class CourseUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CourseUuid>> update(
     _i1.DatabaseSession session,
     List<CourseUuid> rows, {
     _i1.ColumnSelections<CourseUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CourseUuid>(
       rows,
       columns: columns?.call(CourseUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -539,6 +557,10 @@ class CourseUuidRepository {
 
   /// Updates all [CourseUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CourseUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CourseUuidUpdateTable> columnValues,
@@ -550,6 +572,7 @@ class CourseUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CourseUuid>(
       columnValues: columnValues(CourseUuid.t.updateTable),
@@ -561,6 +584,7 @@ class CourseUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -571,6 +595,10 @@ class CourseUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CourseUuid>> delete(
     _i1.DatabaseSession session,
     List<CourseUuid> rows, {
@@ -579,6 +607,7 @@ class CourseUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CourseUuid>(
       rows,
@@ -587,6 +616,7 @@ class CourseUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -606,6 +636,10 @@ class CourseUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CourseUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CourseUuidTable> where,
@@ -614,6 +648,7 @@ class CourseUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CourseUuid>(
       where: where(CourseUuid.t),
@@ -622,6 +657,7 @@ class CourseUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/enrollment.dart
@@ -443,16 +443,22 @@ class EnrollmentIntRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnrollmentInt>> insert(
     _i1.DatabaseSession session,
     List<EnrollmentInt> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EnrollmentInt>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -486,6 +492,10 @@ class EnrollmentIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnrollmentInt>> upsert(
     _i1.DatabaseSession session,
     List<EnrollmentInt> rows, {
@@ -493,6 +503,7 @@ class EnrollmentIntRepository {
     _i1.ColumnSelections<EnrollmentIntTable>? updateColumns,
     _i1.WhereExpressionBuilder<EnrollmentIntTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EnrollmentInt>(
       rows,
@@ -500,6 +511,7 @@ class EnrollmentIntRepository {
       updateColumns: updateColumns?.call(EnrollmentInt.t),
       updateWhere: updateWhere?.call(EnrollmentInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -538,16 +550,22 @@ class EnrollmentIntRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnrollmentInt>> update(
     _i1.DatabaseSession session,
     List<EnrollmentInt> rows, {
     _i1.ColumnSelections<EnrollmentIntTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EnrollmentInt>(
       rows,
       columns: columns?.call(EnrollmentInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -584,6 +602,10 @@ class EnrollmentIntRepository {
 
   /// Updates all [EnrollmentInt]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnrollmentInt>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnrollmentIntUpdateTable> columnValues,
@@ -595,6 +617,7 @@ class EnrollmentIntRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EnrollmentInt>(
       columnValues: columnValues(EnrollmentInt.t.updateTable),
@@ -606,6 +629,7 @@ class EnrollmentIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -616,6 +640,10 @@ class EnrollmentIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnrollmentInt>> delete(
     _i1.DatabaseSession session,
     List<EnrollmentInt> rows, {
@@ -624,6 +652,7 @@ class EnrollmentIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EnrollmentInt>(
       rows,
@@ -632,6 +661,7 @@ class EnrollmentIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -651,6 +681,10 @@ class EnrollmentIntRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnrollmentInt>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnrollmentIntTable> where,
@@ -659,6 +693,7 @@ class EnrollmentIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EnrollmentInt>(
       where: where(EnrollmentInt.t),
@@ -667,6 +702,7 @@ class EnrollmentIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/student.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/student.dart
@@ -394,16 +394,22 @@ class StudentUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StudentUuid>> insert(
     _i1.DatabaseSession session,
     List<StudentUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<StudentUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -437,6 +443,10 @@ class StudentUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StudentUuid>> upsert(
     _i1.DatabaseSession session,
     List<StudentUuid> rows, {
@@ -444,6 +454,7 @@ class StudentUuidRepository {
     _i1.ColumnSelections<StudentUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<StudentUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<StudentUuid>(
       rows,
@@ -451,6 +462,7 @@ class StudentUuidRepository {
       updateColumns: updateColumns?.call(StudentUuid.t),
       updateWhere: updateWhere?.call(StudentUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -489,16 +501,22 @@ class StudentUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StudentUuid>> update(
     _i1.DatabaseSession session,
     List<StudentUuid> rows, {
     _i1.ColumnSelections<StudentUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<StudentUuid>(
       rows,
       columns: columns?.call(StudentUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -535,6 +553,10 @@ class StudentUuidRepository {
 
   /// Updates all [StudentUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StudentUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<StudentUuidUpdateTable> columnValues,
@@ -546,6 +568,7 @@ class StudentUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<StudentUuid>(
       columnValues: columnValues(StudentUuid.t.updateTable),
@@ -557,6 +580,7 @@ class StudentUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -567,6 +591,10 @@ class StudentUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StudentUuid>> delete(
     _i1.DatabaseSession session,
     List<StudentUuid> rows, {
@@ -575,6 +603,7 @@ class StudentUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<StudentUuid>(
       rows,
@@ -583,6 +612,7 @@ class StudentUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -602,6 +632,10 @@ class StudentUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StudentUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StudentUuidTable> where,
@@ -610,6 +644,7 @@ class StudentUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<StudentUuid>(
       where: where(StudentUuid.t),
@@ -618,6 +653,7 @@ class StudentUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/arena.dart
@@ -363,16 +363,22 @@ class ArenaUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ArenaUuid>> insert(
     _i1.DatabaseSession session,
     List<ArenaUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ArenaUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -406,6 +412,10 @@ class ArenaUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ArenaUuid>> upsert(
     _i1.DatabaseSession session,
     List<ArenaUuid> rows, {
@@ -413,6 +423,7 @@ class ArenaUuidRepository {
     _i1.ColumnSelections<ArenaUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<ArenaUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ArenaUuid>(
       rows,
@@ -420,6 +431,7 @@ class ArenaUuidRepository {
       updateColumns: updateColumns?.call(ArenaUuid.t),
       updateWhere: updateWhere?.call(ArenaUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -458,16 +470,22 @@ class ArenaUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ArenaUuid>> update(
     _i1.DatabaseSession session,
     List<ArenaUuid> rows, {
     _i1.ColumnSelections<ArenaUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ArenaUuid>(
       rows,
       columns: columns?.call(ArenaUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -504,6 +522,10 @@ class ArenaUuidRepository {
 
   /// Updates all [ArenaUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ArenaUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ArenaUuidUpdateTable> columnValues,
@@ -515,6 +537,7 @@ class ArenaUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ArenaUuid>(
       columnValues: columnValues(ArenaUuid.t.updateTable),
@@ -526,6 +549,7 @@ class ArenaUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -536,6 +560,10 @@ class ArenaUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ArenaUuid>> delete(
     _i1.DatabaseSession session,
     List<ArenaUuid> rows, {
@@ -544,6 +572,7 @@ class ArenaUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ArenaUuid>(
       rows,
@@ -552,6 +581,7 @@ class ArenaUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -571,6 +601,10 @@ class ArenaUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ArenaUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ArenaUuidTable> where,
@@ -579,6 +613,7 @@ class ArenaUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ArenaUuid>(
       where: where(ArenaUuid.t),
@@ -587,6 +622,7 @@ class ArenaUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
@@ -387,16 +387,22 @@ class PlayerUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PlayerUuid>> insert(
     _i1.DatabaseSession session,
     List<PlayerUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<PlayerUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -430,6 +436,10 @@ class PlayerUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PlayerUuid>> upsert(
     _i1.DatabaseSession session,
     List<PlayerUuid> rows, {
@@ -437,6 +447,7 @@ class PlayerUuidRepository {
     _i1.ColumnSelections<PlayerUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<PlayerUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<PlayerUuid>(
       rows,
@@ -444,6 +455,7 @@ class PlayerUuidRepository {
       updateColumns: updateColumns?.call(PlayerUuid.t),
       updateWhere: updateWhere?.call(PlayerUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -482,16 +494,22 @@ class PlayerUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PlayerUuid>> update(
     _i1.DatabaseSession session,
     List<PlayerUuid> rows, {
     _i1.ColumnSelections<PlayerUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<PlayerUuid>(
       rows,
       columns: columns?.call(PlayerUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -528,6 +546,10 @@ class PlayerUuidRepository {
 
   /// Updates all [PlayerUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PlayerUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PlayerUuidUpdateTable> columnValues,
@@ -539,6 +561,7 @@ class PlayerUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<PlayerUuid>(
       columnValues: columnValues(PlayerUuid.t.updateTable),
@@ -550,6 +573,7 @@ class PlayerUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -560,6 +584,10 @@ class PlayerUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PlayerUuid>> delete(
     _i1.DatabaseSession session,
     List<PlayerUuid> rows, {
@@ -568,6 +596,7 @@ class PlayerUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<PlayerUuid>(
       rows,
@@ -576,6 +605,7 @@ class PlayerUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -595,6 +625,10 @@ class PlayerUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PlayerUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PlayerUuidTable> where,
@@ -603,6 +637,7 @@ class PlayerUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<PlayerUuid>(
       where: where(PlayerUuid.t),
@@ -611,6 +646,7 @@ class PlayerUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/team.dart
@@ -469,16 +469,22 @@ class TeamIntRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TeamInt>> insert(
     _i1.DatabaseSession session,
     List<TeamInt> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<TeamInt>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +518,10 @@ class TeamIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TeamInt>> upsert(
     _i1.DatabaseSession session,
     List<TeamInt> rows, {
@@ -519,6 +529,7 @@ class TeamIntRepository {
     _i1.ColumnSelections<TeamIntTable>? updateColumns,
     _i1.WhereExpressionBuilder<TeamIntTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<TeamInt>(
       rows,
@@ -526,6 +537,7 @@ class TeamIntRepository {
       updateColumns: updateColumns?.call(TeamInt.t),
       updateWhere: updateWhere?.call(TeamInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,16 +576,22 @@ class TeamIntRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TeamInt>> update(
     _i1.DatabaseSession session,
     List<TeamInt> rows, {
     _i1.ColumnSelections<TeamIntTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<TeamInt>(
       rows,
       columns: columns?.call(TeamInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -610,6 +628,10 @@ class TeamIntRepository {
 
   /// Updates all [TeamInt]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TeamInt>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TeamIntUpdateTable> columnValues,
@@ -621,6 +643,7 @@ class TeamIntRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<TeamInt>(
       columnValues: columnValues(TeamInt.t.updateTable),
@@ -632,6 +655,7 @@ class TeamIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -642,6 +666,10 @@ class TeamIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TeamInt>> delete(
     _i1.DatabaseSession session,
     List<TeamInt> rows, {
@@ -650,6 +678,7 @@ class TeamIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<TeamInt>(
       rows,
@@ -658,6 +687,7 @@ class TeamIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -677,6 +707,10 @@ class TeamIntRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TeamInt>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TeamIntTable> where,
@@ -685,6 +719,7 @@ class TeamIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<TeamInt>(
       where: where(TeamInt.t),
@@ -693,6 +728,7 @@ class TeamIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/comment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/comment.dart
@@ -388,16 +388,22 @@ class CommentIntRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CommentInt>> insert(
     _i1.DatabaseSession session,
     List<CommentInt> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CommentInt>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -431,6 +437,10 @@ class CommentIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CommentInt>> upsert(
     _i1.DatabaseSession session,
     List<CommentInt> rows, {
@@ -438,6 +448,7 @@ class CommentIntRepository {
     _i1.ColumnSelections<CommentIntTable>? updateColumns,
     _i1.WhereExpressionBuilder<CommentIntTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CommentInt>(
       rows,
@@ -445,6 +456,7 @@ class CommentIntRepository {
       updateColumns: updateColumns?.call(CommentInt.t),
       updateWhere: updateWhere?.call(CommentInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -483,16 +495,22 @@ class CommentIntRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CommentInt>> update(
     _i1.DatabaseSession session,
     List<CommentInt> rows, {
     _i1.ColumnSelections<CommentIntTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CommentInt>(
       rows,
       columns: columns?.call(CommentInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -529,6 +547,10 @@ class CommentIntRepository {
 
   /// Updates all [CommentInt]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CommentInt>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CommentIntUpdateTable> columnValues,
@@ -540,6 +562,7 @@ class CommentIntRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CommentInt>(
       columnValues: columnValues(CommentInt.t.updateTable),
@@ -551,6 +574,7 @@ class CommentIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -561,6 +585,10 @@ class CommentIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CommentInt>> delete(
     _i1.DatabaseSession session,
     List<CommentInt> rows, {
@@ -569,6 +597,7 @@ class CommentIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CommentInt>(
       rows,
@@ -577,6 +606,7 @@ class CommentIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -596,6 +626,10 @@ class CommentIntRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CommentInt>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CommentIntTable> where,
@@ -604,6 +638,7 @@ class CommentIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CommentInt>(
       where: where(CommentInt.t),
@@ -612,6 +647,7 @@ class CommentIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
@@ -392,16 +392,22 @@ class CustomerIntRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CustomerInt>> insert(
     _i1.DatabaseSession session,
     List<CustomerInt> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CustomerInt>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -435,6 +441,10 @@ class CustomerIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CustomerInt>> upsert(
     _i1.DatabaseSession session,
     List<CustomerInt> rows, {
@@ -442,6 +452,7 @@ class CustomerIntRepository {
     _i1.ColumnSelections<CustomerIntTable>? updateColumns,
     _i1.WhereExpressionBuilder<CustomerIntTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CustomerInt>(
       rows,
@@ -449,6 +460,7 @@ class CustomerIntRepository {
       updateColumns: updateColumns?.call(CustomerInt.t),
       updateWhere: updateWhere?.call(CustomerInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -487,16 +499,22 @@ class CustomerIntRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CustomerInt>> update(
     _i1.DatabaseSession session,
     List<CustomerInt> rows, {
     _i1.ColumnSelections<CustomerIntTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CustomerInt>(
       rows,
       columns: columns?.call(CustomerInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -533,6 +551,10 @@ class CustomerIntRepository {
 
   /// Updates all [CustomerInt]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CustomerInt>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CustomerIntUpdateTable> columnValues,
@@ -544,6 +566,7 @@ class CustomerIntRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CustomerInt>(
       columnValues: columnValues(CustomerInt.t.updateTable),
@@ -555,6 +578,7 @@ class CustomerIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -565,6 +589,10 @@ class CustomerIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CustomerInt>> delete(
     _i1.DatabaseSession session,
     List<CustomerInt> rows, {
@@ -573,6 +601,7 @@ class CustomerIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CustomerInt>(
       rows,
@@ -581,6 +610,7 @@ class CustomerIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -600,6 +630,10 @@ class CustomerIntRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CustomerInt>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CustomerIntTable> where,
@@ -608,6 +642,7 @@ class CustomerIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CustomerInt>(
       where: where(CustomerInt.t),
@@ -616,6 +651,7 @@ class CustomerIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/order.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/order.dart
@@ -466,16 +466,22 @@ class OrderUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrderUuid>> insert(
     _i1.DatabaseSession session,
     List<OrderUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<OrderUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -509,6 +515,10 @@ class OrderUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrderUuid>> upsert(
     _i1.DatabaseSession session,
     List<OrderUuid> rows, {
@@ -516,6 +526,7 @@ class OrderUuidRepository {
     _i1.ColumnSelections<OrderUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<OrderUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<OrderUuid>(
       rows,
@@ -523,6 +534,7 @@ class OrderUuidRepository {
       updateColumns: updateColumns?.call(OrderUuid.t),
       updateWhere: updateWhere?.call(OrderUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -561,16 +573,22 @@ class OrderUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrderUuid>> update(
     _i1.DatabaseSession session,
     List<OrderUuid> rows, {
     _i1.ColumnSelections<OrderUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<OrderUuid>(
       rows,
       columns: columns?.call(OrderUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -607,6 +625,10 @@ class OrderUuidRepository {
 
   /// Updates all [OrderUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrderUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<OrderUuidUpdateTable> columnValues,
@@ -618,6 +640,7 @@ class OrderUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<OrderUuid>(
       columnValues: columnValues(OrderUuid.t.updateTable),
@@ -629,6 +652,7 @@ class OrderUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -639,6 +663,10 @@ class OrderUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrderUuid>> delete(
     _i1.DatabaseSession session,
     List<OrderUuid> rows, {
@@ -647,6 +675,7 @@ class OrderUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<OrderUuid>(
       rows,
@@ -655,6 +684,7 @@ class OrderUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -674,6 +704,10 @@ class OrderUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrderUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrderUuidTable> where,
@@ -682,6 +716,7 @@ class OrderUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<OrderUuid>(
       where: where(OrderUuid.t),
@@ -690,6 +725,7 @@ class OrderUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/address.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/address.dart
@@ -391,16 +391,22 @@ class AddressUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AddressUuid>> insert(
     _i1.DatabaseSession session,
     List<AddressUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<AddressUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -434,6 +440,10 @@ class AddressUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AddressUuid>> upsert(
     _i1.DatabaseSession session,
     List<AddressUuid> rows, {
@@ -441,6 +451,7 @@ class AddressUuidRepository {
     _i1.ColumnSelections<AddressUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<AddressUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<AddressUuid>(
       rows,
@@ -448,6 +459,7 @@ class AddressUuidRepository {
       updateColumns: updateColumns?.call(AddressUuid.t),
       updateWhere: updateWhere?.call(AddressUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,16 +498,22 @@ class AddressUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AddressUuid>> update(
     _i1.DatabaseSession session,
     List<AddressUuid> rows, {
     _i1.ColumnSelections<AddressUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<AddressUuid>(
       rows,
       columns: columns?.call(AddressUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -532,6 +550,10 @@ class AddressUuidRepository {
 
   /// Updates all [AddressUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AddressUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<AddressUuidUpdateTable> columnValues,
@@ -543,6 +565,7 @@ class AddressUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<AddressUuid>(
       columnValues: columnValues(AddressUuid.t.updateTable),
@@ -554,6 +577,7 @@ class AddressUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,6 +588,10 @@ class AddressUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AddressUuid>> delete(
     _i1.DatabaseSession session,
     List<AddressUuid> rows, {
@@ -572,6 +600,7 @@ class AddressUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<AddressUuid>(
       rows,
@@ -580,6 +609,7 @@ class AddressUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -599,6 +629,10 @@ class AddressUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<AddressUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AddressUuidTable> where,
@@ -607,6 +641,7 @@ class AddressUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<AddressUuid>(
       where: where(AddressUuid.t),
@@ -615,6 +650,7 @@ class AddressUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/citizen.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/citizen.dart
@@ -516,16 +516,22 @@ class CitizenIntRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CitizenInt>> insert(
     _i1.DatabaseSession session,
     List<CitizenInt> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CitizenInt>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -559,6 +565,10 @@ class CitizenIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CitizenInt>> upsert(
     _i1.DatabaseSession session,
     List<CitizenInt> rows, {
@@ -566,6 +576,7 @@ class CitizenIntRepository {
     _i1.ColumnSelections<CitizenIntTable>? updateColumns,
     _i1.WhereExpressionBuilder<CitizenIntTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CitizenInt>(
       rows,
@@ -573,6 +584,7 @@ class CitizenIntRepository {
       updateColumns: updateColumns?.call(CitizenInt.t),
       updateWhere: updateWhere?.call(CitizenInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -611,16 +623,22 @@ class CitizenIntRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CitizenInt>> update(
     _i1.DatabaseSession session,
     List<CitizenInt> rows, {
     _i1.ColumnSelections<CitizenIntTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CitizenInt>(
       rows,
       columns: columns?.call(CitizenInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -657,6 +675,10 @@ class CitizenIntRepository {
 
   /// Updates all [CitizenInt]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CitizenInt>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CitizenIntUpdateTable> columnValues,
@@ -668,6 +690,7 @@ class CitizenIntRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CitizenInt>(
       columnValues: columnValues(CitizenInt.t.updateTable),
@@ -679,6 +702,7 @@ class CitizenIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -689,6 +713,10 @@ class CitizenIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CitizenInt>> delete(
     _i1.DatabaseSession session,
     List<CitizenInt> rows, {
@@ -697,6 +725,7 @@ class CitizenIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CitizenInt>(
       rows,
@@ -705,6 +734,7 @@ class CitizenIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -724,6 +754,10 @@ class CitizenIntRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CitizenInt>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CitizenIntTable> where,
@@ -732,6 +766,7 @@ class CitizenIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CitizenInt>(
       where: where(CitizenInt.t),
@@ -740,6 +775,7 @@ class CitizenIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/company.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/company.dart
@@ -385,16 +385,22 @@ class CompanyUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CompanyUuid>> insert(
     _i1.DatabaseSession session,
     List<CompanyUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CompanyUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -428,6 +434,10 @@ class CompanyUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CompanyUuid>> upsert(
     _i1.DatabaseSession session,
     List<CompanyUuid> rows, {
@@ -435,6 +445,7 @@ class CompanyUuidRepository {
     _i1.ColumnSelections<CompanyUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<CompanyUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CompanyUuid>(
       rows,
@@ -442,6 +453,7 @@ class CompanyUuidRepository {
       updateColumns: updateColumns?.call(CompanyUuid.t),
       updateWhere: updateWhere?.call(CompanyUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -480,16 +492,22 @@ class CompanyUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CompanyUuid>> update(
     _i1.DatabaseSession session,
     List<CompanyUuid> rows, {
     _i1.ColumnSelections<CompanyUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CompanyUuid>(
       rows,
       columns: columns?.call(CompanyUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -526,6 +544,10 @@ class CompanyUuidRepository {
 
   /// Updates all [CompanyUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CompanyUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CompanyUuidUpdateTable> columnValues,
@@ -537,6 +559,7 @@ class CompanyUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CompanyUuid>(
       columnValues: columnValues(CompanyUuid.t.updateTable),
@@ -548,6 +571,7 @@ class CompanyUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -558,6 +582,10 @@ class CompanyUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CompanyUuid>> delete(
     _i1.DatabaseSession session,
     List<CompanyUuid> rows, {
@@ -566,6 +594,7 @@ class CompanyUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CompanyUuid>(
       rows,
@@ -574,6 +603,7 @@ class CompanyUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -593,6 +623,10 @@ class CompanyUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CompanyUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CompanyUuidTable> where,
@@ -601,6 +635,7 @@ class CompanyUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CompanyUuid>(
       where: where(CompanyUuid.t),
@@ -609,6 +644,7 @@ class CompanyUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/town.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/town.dart
@@ -387,16 +387,22 @@ class TownIntRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TownInt>> insert(
     _i1.DatabaseSession session,
     List<TownInt> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<TownInt>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -430,6 +436,10 @@ class TownIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TownInt>> upsert(
     _i1.DatabaseSession session,
     List<TownInt> rows, {
@@ -437,6 +447,7 @@ class TownIntRepository {
     _i1.ColumnSelections<TownIntTable>? updateColumns,
     _i1.WhereExpressionBuilder<TownIntTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<TownInt>(
       rows,
@@ -444,6 +455,7 @@ class TownIntRepository {
       updateColumns: updateColumns?.call(TownInt.t),
       updateWhere: updateWhere?.call(TownInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -482,16 +494,22 @@ class TownIntRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TownInt>> update(
     _i1.DatabaseSession session,
     List<TownInt> rows, {
     _i1.ColumnSelections<TownIntTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<TownInt>(
       rows,
       columns: columns?.call(TownInt.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -528,6 +546,10 @@ class TownIntRepository {
 
   /// Updates all [TownInt]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TownInt>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TownIntUpdateTable> columnValues,
@@ -539,6 +561,7 @@ class TownIntRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<TownInt>(
       columnValues: columnValues(TownInt.t.updateTable),
@@ -550,6 +573,7 @@ class TownIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -560,6 +584,10 @@ class TownIntRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TownInt>> delete(
     _i1.DatabaseSession session,
     List<TownInt> rows, {
@@ -568,6 +596,7 @@ class TownIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<TownInt>(
       rows,
@@ -576,6 +605,7 @@ class TownIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -595,6 +625,10 @@ class TownIntRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TownInt>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TownIntTable> where,
@@ -603,6 +637,7 @@ class TownIntRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<TownInt>(
       where: where(TownInt.t),
@@ -611,6 +646,7 @@ class TownIntRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/self.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/self.dart
@@ -586,16 +586,22 @@ class ChangedIdTypeSelfRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChangedIdTypeSelf>> insert(
     _i1.DatabaseSession session,
     List<ChangedIdTypeSelf> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ChangedIdTypeSelf>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -629,6 +635,10 @@ class ChangedIdTypeSelfRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChangedIdTypeSelf>> upsert(
     _i1.DatabaseSession session,
     List<ChangedIdTypeSelf> rows, {
@@ -636,6 +646,7 @@ class ChangedIdTypeSelfRepository {
     _i1.ColumnSelections<ChangedIdTypeSelfTable>? updateColumns,
     _i1.WhereExpressionBuilder<ChangedIdTypeSelfTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ChangedIdTypeSelf>(
       rows,
@@ -643,6 +654,7 @@ class ChangedIdTypeSelfRepository {
       updateColumns: updateColumns?.call(ChangedIdTypeSelf.t),
       updateWhere: updateWhere?.call(ChangedIdTypeSelf.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -681,16 +693,22 @@ class ChangedIdTypeSelfRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChangedIdTypeSelf>> update(
     _i1.DatabaseSession session,
     List<ChangedIdTypeSelf> rows, {
     _i1.ColumnSelections<ChangedIdTypeSelfTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ChangedIdTypeSelf>(
       rows,
       columns: columns?.call(ChangedIdTypeSelf.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -728,6 +746,10 @@ class ChangedIdTypeSelfRepository {
 
   /// Updates all [ChangedIdTypeSelf]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChangedIdTypeSelf>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ChangedIdTypeSelfUpdateTable>
@@ -740,6 +762,7 @@ class ChangedIdTypeSelfRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ChangedIdTypeSelf>(
       columnValues: columnValues(ChangedIdTypeSelf.t.updateTable),
@@ -751,6 +774,7 @@ class ChangedIdTypeSelfRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -761,6 +785,10 @@ class ChangedIdTypeSelfRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChangedIdTypeSelf>> delete(
     _i1.DatabaseSession session,
     List<ChangedIdTypeSelf> rows, {
@@ -769,6 +797,7 @@ class ChangedIdTypeSelfRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ChangedIdTypeSelf>(
       rows,
@@ -777,6 +806,7 @@ class ChangedIdTypeSelfRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -796,6 +826,10 @@ class ChangedIdTypeSelfRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChangedIdTypeSelf>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChangedIdTypeSelfTable> where,
@@ -804,6 +838,7 @@ class ChangedIdTypeSelfRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ChangedIdTypeSelf>(
       where: where(ChangedIdTypeSelf.t),
@@ -812,6 +847,7 @@ class ChangedIdTypeSelfRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/server_only.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/server_only.dart
@@ -272,16 +272,22 @@ class ServerOnlyChangedIdFieldClassRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerOnlyChangedIdFieldClass>> insert(
     _i1.DatabaseSession session,
     List<ServerOnlyChangedIdFieldClass> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ServerOnlyChangedIdFieldClass>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -315,6 +321,10 @@ class ServerOnlyChangedIdFieldClassRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerOnlyChangedIdFieldClass>> upsert(
     _i1.DatabaseSession session,
     List<ServerOnlyChangedIdFieldClass> rows, {
@@ -323,6 +333,7 @@ class ServerOnlyChangedIdFieldClassRepository {
     _i1.ColumnSelections<ServerOnlyChangedIdFieldClassTable>? updateColumns,
     _i1.WhereExpressionBuilder<ServerOnlyChangedIdFieldClassTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ServerOnlyChangedIdFieldClass>(
       rows,
@@ -330,6 +341,7 @@ class ServerOnlyChangedIdFieldClassRepository {
       updateColumns: updateColumns?.call(ServerOnlyChangedIdFieldClass.t),
       updateWhere: updateWhere?.call(ServerOnlyChangedIdFieldClass.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -369,16 +381,22 @@ class ServerOnlyChangedIdFieldClassRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerOnlyChangedIdFieldClass>> update(
     _i1.DatabaseSession session,
     List<ServerOnlyChangedIdFieldClass> rows, {
     _i1.ColumnSelections<ServerOnlyChangedIdFieldClassTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ServerOnlyChangedIdFieldClass>(
       rows,
       columns: columns?.call(ServerOnlyChangedIdFieldClass.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -418,6 +436,10 @@ class ServerOnlyChangedIdFieldClassRepository {
 
   /// Updates all [ServerOnlyChangedIdFieldClass]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerOnlyChangedIdFieldClass>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<
@@ -433,6 +455,7 @@ class ServerOnlyChangedIdFieldClassRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ServerOnlyChangedIdFieldClass>(
       columnValues: columnValues(ServerOnlyChangedIdFieldClass.t.updateTable),
@@ -444,6 +467,7 @@ class ServerOnlyChangedIdFieldClassRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -454,6 +478,10 @@ class ServerOnlyChangedIdFieldClassRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerOnlyChangedIdFieldClass>> delete(
     _i1.DatabaseSession session,
     List<ServerOnlyChangedIdFieldClass> rows, {
@@ -462,6 +490,7 @@ class ServerOnlyChangedIdFieldClassRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ServerOnlyChangedIdFieldClass>(
       rows,
@@ -470,6 +499,7 @@ class ServerOnlyChangedIdFieldClassRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -489,6 +519,10 @@ class ServerOnlyChangedIdFieldClassRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ServerOnlyChangedIdFieldClass>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ServerOnlyChangedIdFieldClassTable>
@@ -498,6 +532,7 @@ class ServerOnlyChangedIdFieldClassRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ServerOnlyChangedIdFieldClass>(
       where: where(ServerOnlyChangedIdFieldClass.t),
@@ -506,6 +541,7 @@ class ServerOnlyChangedIdFieldClassRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default.dart
@@ -350,16 +350,22 @@ class BigIntDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefault>> insert(
     _i1.DatabaseSession session,
     List<BigIntDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BigIntDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -393,6 +399,10 @@ class BigIntDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefault>> upsert(
     _i1.DatabaseSession session,
     List<BigIntDefault> rows, {
@@ -400,6 +410,7 @@ class BigIntDefaultRepository {
     _i1.ColumnSelections<BigIntDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<BigIntDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BigIntDefault>(
       rows,
@@ -407,6 +418,7 @@ class BigIntDefaultRepository {
       updateColumns: updateColumns?.call(BigIntDefault.t),
       updateWhere: updateWhere?.call(BigIntDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -445,16 +457,22 @@ class BigIntDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefault>> update(
     _i1.DatabaseSession session,
     List<BigIntDefault> rows, {
     _i1.ColumnSelections<BigIntDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BigIntDefault>(
       rows,
       columns: columns?.call(BigIntDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -491,6 +509,10 @@ class BigIntDefaultRepository {
 
   /// Updates all [BigIntDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BigIntDefaultUpdateTable> columnValues,
@@ -502,6 +524,7 @@ class BigIntDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BigIntDefault>(
       columnValues: columnValues(BigIntDefault.t.updateTable),
@@ -513,6 +536,7 @@ class BigIntDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -523,6 +547,10 @@ class BigIntDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefault>> delete(
     _i1.DatabaseSession session,
     List<BigIntDefault> rows, {
@@ -531,6 +559,7 @@ class BigIntDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BigIntDefault>(
       rows,
@@ -539,6 +568,7 @@ class BigIntDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -558,6 +588,10 @@ class BigIntDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultTable> where,
@@ -566,6 +600,7 @@ class BigIntDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BigIntDefault>(
       where: where(BigIntDefault.t),
@@ -574,6 +609,7 @@ class BigIntDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default_mix.dart
@@ -393,16 +393,22 @@ class BigIntDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<BigIntDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BigIntDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -436,6 +442,10 @@ class BigIntDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<BigIntDefaultMix> rows, {
@@ -443,6 +453,7 @@ class BigIntDefaultMixRepository {
     _i1.ColumnSelections<BigIntDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<BigIntDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BigIntDefaultMix>(
       rows,
@@ -450,6 +461,7 @@ class BigIntDefaultMixRepository {
       updateColumns: updateColumns?.call(BigIntDefaultMix.t),
       updateWhere: updateWhere?.call(BigIntDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -488,16 +500,22 @@ class BigIntDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultMix>> update(
     _i1.DatabaseSession session,
     List<BigIntDefaultMix> rows, {
     _i1.ColumnSelections<BigIntDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BigIntDefaultMix>(
       rows,
       columns: columns?.call(BigIntDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -535,6 +553,10 @@ class BigIntDefaultMixRepository {
 
   /// Updates all [BigIntDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BigIntDefaultMixUpdateTable>
@@ -547,6 +569,7 @@ class BigIntDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BigIntDefaultMix>(
       columnValues: columnValues(BigIntDefaultMix.t.updateTable),
@@ -558,6 +581,7 @@ class BigIntDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -568,6 +592,10 @@ class BigIntDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<BigIntDefaultMix> rows, {
@@ -576,6 +604,7 @@ class BigIntDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BigIntDefaultMix>(
       rows,
@@ -584,6 +613,7 @@ class BigIntDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -603,6 +633,10 @@ class BigIntDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultMixTable> where,
@@ -611,6 +645,7 @@ class BigIntDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BigIntDefaultMix>(
       where: where(BigIntDefaultMix.t),
@@ -619,6 +654,7 @@ class BigIntDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default_model.dart
@@ -353,16 +353,22 @@ class BigIntDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<BigIntDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BigIntDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -396,6 +402,10 @@ class BigIntDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<BigIntDefaultModel> rows, {
@@ -403,6 +413,7 @@ class BigIntDefaultModelRepository {
     _i1.ColumnSelections<BigIntDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<BigIntDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BigIntDefaultModel>(
       rows,
@@ -410,6 +421,7 @@ class BigIntDefaultModelRepository {
       updateColumns: updateColumns?.call(BigIntDefaultModel.t),
       updateWhere: updateWhere?.call(BigIntDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -448,16 +460,22 @@ class BigIntDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultModel>> update(
     _i1.DatabaseSession session,
     List<BigIntDefaultModel> rows, {
     _i1.ColumnSelections<BigIntDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BigIntDefaultModel>(
       rows,
       columns: columns?.call(BigIntDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -495,6 +513,10 @@ class BigIntDefaultModelRepository {
 
   /// Updates all [BigIntDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BigIntDefaultModelUpdateTable>
@@ -507,6 +529,7 @@ class BigIntDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BigIntDefaultModel>(
       columnValues: columnValues(BigIntDefaultModel.t.updateTable),
@@ -518,6 +541,7 @@ class BigIntDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -528,6 +552,10 @@ class BigIntDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<BigIntDefaultModel> rows, {
@@ -536,6 +564,7 @@ class BigIntDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BigIntDefaultModel>(
       rows,
@@ -544,6 +573,7 @@ class BigIntDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -563,6 +593,10 @@ class BigIntDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultModelTable> where,
@@ -571,6 +605,7 @@ class BigIntDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BigIntDefaultModel>(
       where: where(BigIntDefaultModel.t),
@@ -579,6 +614,7 @@ class BigIntDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default_persist.dart
@@ -321,16 +321,22 @@ class BigIntDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<BigIntDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BigIntDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -364,6 +370,10 @@ class BigIntDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<BigIntDefaultPersist> rows, {
@@ -371,6 +381,7 @@ class BigIntDefaultPersistRepository {
     _i1.ColumnSelections<BigIntDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<BigIntDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BigIntDefaultPersist>(
       rows,
@@ -378,6 +389,7 @@ class BigIntDefaultPersistRepository {
       updateColumns: updateColumns?.call(BigIntDefaultPersist.t),
       updateWhere: updateWhere?.call(BigIntDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -416,16 +428,22 @@ class BigIntDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<BigIntDefaultPersist> rows, {
     _i1.ColumnSelections<BigIntDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BigIntDefaultPersist>(
       rows,
       columns: columns?.call(BigIntDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -463,6 +481,10 @@ class BigIntDefaultPersistRepository {
 
   /// Updates all [BigIntDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BigIntDefaultPersistUpdateTable>
@@ -475,6 +497,7 @@ class BigIntDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BigIntDefaultPersist>(
       columnValues: columnValues(BigIntDefaultPersist.t.updateTable),
@@ -486,6 +509,7 @@ class BigIntDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -496,6 +520,10 @@ class BigIntDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<BigIntDefaultPersist> rows, {
@@ -504,6 +532,7 @@ class BigIntDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BigIntDefaultPersist>(
       rows,
@@ -512,6 +541,7 @@ class BigIntDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +561,10 @@ class BigIntDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BigIntDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultPersistTable> where,
@@ -539,6 +573,7 @@ class BigIntDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BigIntDefaultPersist>(
       where: where(BigIntDefaultPersist.t),
@@ -547,6 +582,7 @@ class BigIntDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default.dart
@@ -376,16 +376,22 @@ class BoolDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefault>> insert(
     _i1.DatabaseSession session,
     List<BoolDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BoolDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -419,6 +425,10 @@ class BoolDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefault>> upsert(
     _i1.DatabaseSession session,
     List<BoolDefault> rows, {
@@ -426,6 +436,7 @@ class BoolDefaultRepository {
     _i1.ColumnSelections<BoolDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<BoolDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BoolDefault>(
       rows,
@@ -433,6 +444,7 @@ class BoolDefaultRepository {
       updateColumns: updateColumns?.call(BoolDefault.t),
       updateWhere: updateWhere?.call(BoolDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -471,16 +483,22 @@ class BoolDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefault>> update(
     _i1.DatabaseSession session,
     List<BoolDefault> rows, {
     _i1.ColumnSelections<BoolDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BoolDefault>(
       rows,
       columns: columns?.call(BoolDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -517,6 +535,10 @@ class BoolDefaultRepository {
 
   /// Updates all [BoolDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BoolDefaultUpdateTable> columnValues,
@@ -528,6 +550,7 @@ class BoolDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BoolDefault>(
       columnValues: columnValues(BoolDefault.t.updateTable),
@@ -539,6 +562,7 @@ class BoolDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,6 +573,10 @@ class BoolDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefault>> delete(
     _i1.DatabaseSession session,
     List<BoolDefault> rows, {
@@ -557,6 +585,7 @@ class BoolDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BoolDefault>(
       rows,
@@ -565,6 +594,7 @@ class BoolDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -584,6 +614,10 @@ class BoolDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultTable> where,
@@ -592,6 +626,7 @@ class BoolDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BoolDefault>(
       where: where(BoolDefault.t),
@@ -600,6 +635,7 @@ class BoolDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
@@ -383,16 +383,22 @@ class BoolDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<BoolDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BoolDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -426,6 +432,10 @@ class BoolDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<BoolDefaultMix> rows, {
@@ -433,6 +443,7 @@ class BoolDefaultMixRepository {
     _i1.ColumnSelections<BoolDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<BoolDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BoolDefaultMix>(
       rows,
@@ -440,6 +451,7 @@ class BoolDefaultMixRepository {
       updateColumns: updateColumns?.call(BoolDefaultMix.t),
       updateWhere: updateWhere?.call(BoolDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -478,16 +490,22 @@ class BoolDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultMix>> update(
     _i1.DatabaseSession session,
     List<BoolDefaultMix> rows, {
     _i1.ColumnSelections<BoolDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BoolDefaultMix>(
       rows,
       columns: columns?.call(BoolDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -524,6 +542,10 @@ class BoolDefaultMixRepository {
 
   /// Updates all [BoolDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BoolDefaultMixUpdateTable> columnValues,
@@ -535,6 +557,7 @@ class BoolDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BoolDefaultMix>(
       columnValues: columnValues(BoolDefaultMix.t.updateTable),
@@ -546,6 +569,7 @@ class BoolDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -556,6 +580,10 @@ class BoolDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<BoolDefaultMix> rows, {
@@ -564,6 +592,7 @@ class BoolDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BoolDefaultMix>(
       rows,
@@ -572,6 +601,7 @@ class BoolDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +621,10 @@ class BoolDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultMixTable> where,
@@ -599,6 +633,7 @@ class BoolDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BoolDefaultMix>(
       where: where(BoolDefaultMix.t),
@@ -607,6 +642,7 @@ class BoolDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default_model.dart
@@ -376,16 +376,22 @@ class BoolDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<BoolDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BoolDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -419,6 +425,10 @@ class BoolDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<BoolDefaultModel> rows, {
@@ -426,6 +436,7 @@ class BoolDefaultModelRepository {
     _i1.ColumnSelections<BoolDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<BoolDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BoolDefaultModel>(
       rows,
@@ -433,6 +444,7 @@ class BoolDefaultModelRepository {
       updateColumns: updateColumns?.call(BoolDefaultModel.t),
       updateWhere: updateWhere?.call(BoolDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -471,16 +483,22 @@ class BoolDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultModel>> update(
     _i1.DatabaseSession session,
     List<BoolDefaultModel> rows, {
     _i1.ColumnSelections<BoolDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BoolDefaultModel>(
       rows,
       columns: columns?.call(BoolDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -518,6 +536,10 @@ class BoolDefaultModelRepository {
 
   /// Updates all [BoolDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BoolDefaultModelUpdateTable>
@@ -530,6 +552,7 @@ class BoolDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BoolDefaultModel>(
       columnValues: columnValues(BoolDefaultModel.t.updateTable),
@@ -541,6 +564,7 @@ class BoolDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -551,6 +575,10 @@ class BoolDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<BoolDefaultModel> rows, {
@@ -559,6 +587,7 @@ class BoolDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BoolDefaultModel>(
       rows,
@@ -567,6 +596,7 @@ class BoolDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -586,6 +616,10 @@ class BoolDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultModelTable> where,
@@ -594,6 +628,7 @@ class BoolDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BoolDefaultModel>(
       where: where(BoolDefaultModel.t),
@@ -602,6 +637,7 @@ class BoolDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
@@ -354,16 +354,22 @@ class BoolDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<BoolDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<BoolDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -397,6 +403,10 @@ class BoolDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<BoolDefaultPersist> rows, {
@@ -404,6 +414,7 @@ class BoolDefaultPersistRepository {
     _i1.ColumnSelections<BoolDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<BoolDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<BoolDefaultPersist>(
       rows,
@@ -411,6 +422,7 @@ class BoolDefaultPersistRepository {
       updateColumns: updateColumns?.call(BoolDefaultPersist.t),
       updateWhere: updateWhere?.call(BoolDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -449,16 +461,22 @@ class BoolDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<BoolDefaultPersist> rows, {
     _i1.ColumnSelections<BoolDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<BoolDefaultPersist>(
       rows,
       columns: columns?.call(BoolDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -496,6 +514,10 @@ class BoolDefaultPersistRepository {
 
   /// Updates all [BoolDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BoolDefaultPersistUpdateTable>
@@ -508,6 +530,7 @@ class BoolDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<BoolDefaultPersist>(
       columnValues: columnValues(BoolDefaultPersist.t.updateTable),
@@ -519,6 +542,7 @@ class BoolDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -529,6 +553,10 @@ class BoolDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<BoolDefaultPersist> rows, {
@@ -537,6 +565,7 @@ class BoolDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<BoolDefaultPersist>(
       rows,
@@ -545,6 +574,7 @@ class BoolDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,6 +594,10 @@ class BoolDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<BoolDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultPersistTable> where,
@@ -572,6 +606,7 @@ class BoolDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<BoolDefaultPersist>(
       where: where(BoolDefaultPersist.t),
@@ -580,6 +615,7 @@ class BoolDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default.dart
@@ -382,16 +382,22 @@ class DateTimeDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefault>> insert(
     _i1.DatabaseSession session,
     List<DateTimeDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DateTimeDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -425,6 +431,10 @@ class DateTimeDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefault>> upsert(
     _i1.DatabaseSession session,
     List<DateTimeDefault> rows, {
@@ -432,6 +442,7 @@ class DateTimeDefaultRepository {
     _i1.ColumnSelections<DateTimeDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<DateTimeDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DateTimeDefault>(
       rows,
@@ -439,6 +450,7 @@ class DateTimeDefaultRepository {
       updateColumns: updateColumns?.call(DateTimeDefault.t),
       updateWhere: updateWhere?.call(DateTimeDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -477,16 +489,22 @@ class DateTimeDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefault>> update(
     _i1.DatabaseSession session,
     List<DateTimeDefault> rows, {
     _i1.ColumnSelections<DateTimeDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DateTimeDefault>(
       rows,
       columns: columns?.call(DateTimeDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -524,6 +542,10 @@ class DateTimeDefaultRepository {
 
   /// Updates all [DateTimeDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DateTimeDefaultUpdateTable>
@@ -536,6 +558,7 @@ class DateTimeDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DateTimeDefault>(
       columnValues: columnValues(DateTimeDefault.t.updateTable),
@@ -547,6 +570,7 @@ class DateTimeDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -557,6 +581,10 @@ class DateTimeDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefault>> delete(
     _i1.DatabaseSession session,
     List<DateTimeDefault> rows, {
@@ -565,6 +593,7 @@ class DateTimeDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DateTimeDefault>(
       rows,
@@ -573,6 +602,7 @@ class DateTimeDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -592,6 +622,10 @@ class DateTimeDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultTable> where,
@@ -600,6 +634,7 @@ class DateTimeDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DateTimeDefault>(
       where: where(DateTimeDefault.t),
@@ -608,6 +643,7 @@ class DateTimeDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
@@ -398,16 +398,22 @@ class DateTimeDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<DateTimeDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DateTimeDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -441,6 +447,10 @@ class DateTimeDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<DateTimeDefaultMix> rows, {
@@ -448,6 +458,7 @@ class DateTimeDefaultMixRepository {
     _i1.ColumnSelections<DateTimeDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<DateTimeDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DateTimeDefaultMix>(
       rows,
@@ -455,6 +466,7 @@ class DateTimeDefaultMixRepository {
       updateColumns: updateColumns?.call(DateTimeDefaultMix.t),
       updateWhere: updateWhere?.call(DateTimeDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -493,16 +505,22 @@ class DateTimeDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultMix>> update(
     _i1.DatabaseSession session,
     List<DateTimeDefaultMix> rows, {
     _i1.ColumnSelections<DateTimeDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DateTimeDefaultMix>(
       rows,
       columns: columns?.call(DateTimeDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -540,6 +558,10 @@ class DateTimeDefaultMixRepository {
 
   /// Updates all [DateTimeDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DateTimeDefaultMixUpdateTable>
@@ -552,6 +574,7 @@ class DateTimeDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DateTimeDefaultMix>(
       columnValues: columnValues(DateTimeDefaultMix.t.updateTable),
@@ -563,6 +586,7 @@ class DateTimeDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -573,6 +597,10 @@ class DateTimeDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<DateTimeDefaultMix> rows, {
@@ -581,6 +609,7 @@ class DateTimeDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DateTimeDefaultMix>(
       rows,
@@ -589,6 +618,7 @@ class DateTimeDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -608,6 +638,10 @@ class DateTimeDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultMixTable> where,
@@ -616,6 +650,7 @@ class DateTimeDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DateTimeDefaultMix>(
       where: where(DateTimeDefaultMix.t),
@@ -624,6 +659,7 @@ class DateTimeDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
@@ -389,16 +389,22 @@ class DateTimeDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<DateTimeDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DateTimeDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -432,6 +438,10 @@ class DateTimeDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<DateTimeDefaultModel> rows, {
@@ -439,6 +449,7 @@ class DateTimeDefaultModelRepository {
     _i1.ColumnSelections<DateTimeDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<DateTimeDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DateTimeDefaultModel>(
       rows,
@@ -446,6 +457,7 @@ class DateTimeDefaultModelRepository {
       updateColumns: updateColumns?.call(DateTimeDefaultModel.t),
       updateWhere: updateWhere?.call(DateTimeDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -484,16 +496,22 @@ class DateTimeDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultModel>> update(
     _i1.DatabaseSession session,
     List<DateTimeDefaultModel> rows, {
     _i1.ColumnSelections<DateTimeDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DateTimeDefaultModel>(
       rows,
       columns: columns?.call(DateTimeDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +549,10 @@ class DateTimeDefaultModelRepository {
 
   /// Updates all [DateTimeDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DateTimeDefaultModelUpdateTable>
@@ -543,6 +565,7 @@ class DateTimeDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DateTimeDefaultModel>(
       columnValues: columnValues(DateTimeDefaultModel.t.updateTable),
@@ -554,6 +577,7 @@ class DateTimeDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,6 +588,10 @@ class DateTimeDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<DateTimeDefaultModel> rows, {
@@ -572,6 +600,7 @@ class DateTimeDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DateTimeDefaultModel>(
       rows,
@@ -580,6 +609,7 @@ class DateTimeDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -599,6 +629,10 @@ class DateTimeDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultModelTable> where,
@@ -607,6 +641,7 @@ class DateTimeDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DateTimeDefaultModel>(
       where: where(DateTimeDefaultModel.t),
@@ -615,6 +650,7 @@ class DateTimeDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
@@ -358,16 +358,22 @@ class DateTimeDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<DateTimeDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DateTimeDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -401,6 +407,10 @@ class DateTimeDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<DateTimeDefaultPersist> rows, {
@@ -408,6 +418,7 @@ class DateTimeDefaultPersistRepository {
     _i1.ColumnSelections<DateTimeDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<DateTimeDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DateTimeDefaultPersist>(
       rows,
@@ -415,6 +426,7 @@ class DateTimeDefaultPersistRepository {
       updateColumns: updateColumns?.call(DateTimeDefaultPersist.t),
       updateWhere: updateWhere?.call(DateTimeDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -453,16 +465,22 @@ class DateTimeDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<DateTimeDefaultPersist> rows, {
     _i1.ColumnSelections<DateTimeDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DateTimeDefaultPersist>(
       rows,
       columns: columns?.call(DateTimeDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -500,6 +518,10 @@ class DateTimeDefaultPersistRepository {
 
   /// Updates all [DateTimeDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DateTimeDefaultPersistUpdateTable>
@@ -512,6 +534,7 @@ class DateTimeDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DateTimeDefaultPersist>(
       columnValues: columnValues(DateTimeDefaultPersist.t.updateTable),
@@ -523,6 +546,7 @@ class DateTimeDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -533,6 +557,10 @@ class DateTimeDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<DateTimeDefaultPersist> rows, {
@@ -541,6 +569,7 @@ class DateTimeDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DateTimeDefaultPersist>(
       rows,
@@ -549,6 +578,7 @@ class DateTimeDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -568,6 +598,10 @@ class DateTimeDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DateTimeDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultPersistTable> where,
@@ -576,6 +610,7 @@ class DateTimeDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DateTimeDefaultPersist>(
       where: where(DateTimeDefaultPersist.t),
@@ -584,6 +619,7 @@ class DateTimeDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default.dart
@@ -339,16 +339,22 @@ class DoubleDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefault>> insert(
     _i1.DatabaseSession session,
     List<DoubleDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DoubleDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -382,6 +388,10 @@ class DoubleDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefault>> upsert(
     _i1.DatabaseSession session,
     List<DoubleDefault> rows, {
@@ -389,6 +399,7 @@ class DoubleDefaultRepository {
     _i1.ColumnSelections<DoubleDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<DoubleDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DoubleDefault>(
       rows,
@@ -396,6 +407,7 @@ class DoubleDefaultRepository {
       updateColumns: updateColumns?.call(DoubleDefault.t),
       updateWhere: updateWhere?.call(DoubleDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -434,16 +446,22 @@ class DoubleDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefault>> update(
     _i1.DatabaseSession session,
     List<DoubleDefault> rows, {
     _i1.ColumnSelections<DoubleDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DoubleDefault>(
       rows,
       columns: columns?.call(DoubleDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -480,6 +498,10 @@ class DoubleDefaultRepository {
 
   /// Updates all [DoubleDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DoubleDefaultUpdateTable> columnValues,
@@ -491,6 +513,7 @@ class DoubleDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DoubleDefault>(
       columnValues: columnValues(DoubleDefault.t.updateTable),
@@ -502,6 +525,7 @@ class DoubleDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +536,10 @@ class DoubleDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefault>> delete(
     _i1.DatabaseSession session,
     List<DoubleDefault> rows, {
@@ -520,6 +548,7 @@ class DoubleDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DoubleDefault>(
       rows,
@@ -528,6 +557,7 @@ class DoubleDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -547,6 +577,10 @@ class DoubleDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultTable> where,
@@ -555,6 +589,7 @@ class DoubleDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DoubleDefault>(
       where: where(DoubleDefault.t),
@@ -563,6 +598,7 @@ class DoubleDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default_mix.dart
@@ -380,16 +380,22 @@ class DoubleDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<DoubleDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DoubleDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -423,6 +429,10 @@ class DoubleDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<DoubleDefaultMix> rows, {
@@ -430,6 +440,7 @@ class DoubleDefaultMixRepository {
     _i1.ColumnSelections<DoubleDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<DoubleDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DoubleDefaultMix>(
       rows,
@@ -437,6 +448,7 @@ class DoubleDefaultMixRepository {
       updateColumns: updateColumns?.call(DoubleDefaultMix.t),
       updateWhere: updateWhere?.call(DoubleDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -475,16 +487,22 @@ class DoubleDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultMix>> update(
     _i1.DatabaseSession session,
     List<DoubleDefaultMix> rows, {
     _i1.ColumnSelections<DoubleDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DoubleDefaultMix>(
       rows,
       columns: columns?.call(DoubleDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -522,6 +540,10 @@ class DoubleDefaultMixRepository {
 
   /// Updates all [DoubleDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DoubleDefaultMixUpdateTable>
@@ -534,6 +556,7 @@ class DoubleDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DoubleDefaultMix>(
       columnValues: columnValues(DoubleDefaultMix.t.updateTable),
@@ -545,6 +568,7 @@ class DoubleDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -555,6 +579,10 @@ class DoubleDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<DoubleDefaultMix> rows, {
@@ -563,6 +591,7 @@ class DoubleDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DoubleDefaultMix>(
       rows,
@@ -571,6 +600,7 @@ class DoubleDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -590,6 +620,10 @@ class DoubleDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultMixTable> where,
@@ -598,6 +632,7 @@ class DoubleDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DoubleDefaultMix>(
       where: where(DoubleDefaultMix.t),
@@ -606,6 +641,7 @@ class DoubleDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default_model.dart
@@ -338,16 +338,22 @@ class DoubleDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<DoubleDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DoubleDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -381,6 +387,10 @@ class DoubleDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<DoubleDefaultModel> rows, {
@@ -388,6 +398,7 @@ class DoubleDefaultModelRepository {
     _i1.ColumnSelections<DoubleDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<DoubleDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DoubleDefaultModel>(
       rows,
@@ -395,6 +406,7 @@ class DoubleDefaultModelRepository {
       updateColumns: updateColumns?.call(DoubleDefaultModel.t),
       updateWhere: updateWhere?.call(DoubleDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -433,16 +445,22 @@ class DoubleDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultModel>> update(
     _i1.DatabaseSession session,
     List<DoubleDefaultModel> rows, {
     _i1.ColumnSelections<DoubleDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DoubleDefaultModel>(
       rows,
       columns: columns?.call(DoubleDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -480,6 +498,10 @@ class DoubleDefaultModelRepository {
 
   /// Updates all [DoubleDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DoubleDefaultModelUpdateTable>
@@ -492,6 +514,7 @@ class DoubleDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DoubleDefaultModel>(
       columnValues: columnValues(DoubleDefaultModel.t.updateTable),
@@ -503,6 +526,7 @@ class DoubleDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -513,6 +537,10 @@ class DoubleDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<DoubleDefaultModel> rows, {
@@ -521,6 +549,7 @@ class DoubleDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DoubleDefaultModel>(
       rows,
@@ -529,6 +558,7 @@ class DoubleDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -548,6 +578,10 @@ class DoubleDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultModelTable> where,
@@ -556,6 +590,7 @@ class DoubleDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DoubleDefaultModel>(
       where: where(DoubleDefaultModel.t),
@@ -564,6 +599,7 @@ class DoubleDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default_persist.dart
@@ -317,16 +317,22 @@ class DoubleDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<DoubleDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DoubleDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -360,6 +366,10 @@ class DoubleDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<DoubleDefaultPersist> rows, {
@@ -367,6 +377,7 @@ class DoubleDefaultPersistRepository {
     _i1.ColumnSelections<DoubleDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<DoubleDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DoubleDefaultPersist>(
       rows,
@@ -374,6 +385,7 @@ class DoubleDefaultPersistRepository {
       updateColumns: updateColumns?.call(DoubleDefaultPersist.t),
       updateWhere: updateWhere?.call(DoubleDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -412,16 +424,22 @@ class DoubleDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<DoubleDefaultPersist> rows, {
     _i1.ColumnSelections<DoubleDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DoubleDefaultPersist>(
       rows,
       columns: columns?.call(DoubleDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -459,6 +477,10 @@ class DoubleDefaultPersistRepository {
 
   /// Updates all [DoubleDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DoubleDefaultPersistUpdateTable>
@@ -471,6 +493,7 @@ class DoubleDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DoubleDefaultPersist>(
       columnValues: columnValues(DoubleDefaultPersist.t.updateTable),
@@ -482,6 +505,7 @@ class DoubleDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -492,6 +516,10 @@ class DoubleDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<DoubleDefaultPersist> rows, {
@@ -500,6 +528,7 @@ class DoubleDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DoubleDefaultPersist>(
       rows,
@@ -508,6 +537,7 @@ class DoubleDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -527,6 +557,10 @@ class DoubleDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DoubleDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultPersistTable> where,
@@ -535,6 +569,7 @@ class DoubleDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DoubleDefaultPersist>(
       where: where(DoubleDefaultPersist.t),
@@ -543,6 +578,7 @@ class DoubleDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default.dart
@@ -364,16 +364,22 @@ class DurationDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefault>> insert(
     _i1.DatabaseSession session,
     List<DurationDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DurationDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -407,6 +413,10 @@ class DurationDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefault>> upsert(
     _i1.DatabaseSession session,
     List<DurationDefault> rows, {
@@ -414,6 +424,7 @@ class DurationDefaultRepository {
     _i1.ColumnSelections<DurationDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<DurationDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DurationDefault>(
       rows,
@@ -421,6 +432,7 @@ class DurationDefaultRepository {
       updateColumns: updateColumns?.call(DurationDefault.t),
       updateWhere: updateWhere?.call(DurationDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -459,16 +471,22 @@ class DurationDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefault>> update(
     _i1.DatabaseSession session,
     List<DurationDefault> rows, {
     _i1.ColumnSelections<DurationDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DurationDefault>(
       rows,
       columns: columns?.call(DurationDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -506,6 +524,10 @@ class DurationDefaultRepository {
 
   /// Updates all [DurationDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DurationDefaultUpdateTable>
@@ -518,6 +540,7 @@ class DurationDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DurationDefault>(
       columnValues: columnValues(DurationDefault.t.updateTable),
@@ -529,6 +552,7 @@ class DurationDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -539,6 +563,10 @@ class DurationDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefault>> delete(
     _i1.DatabaseSession session,
     List<DurationDefault> rows, {
@@ -547,6 +575,7 @@ class DurationDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DurationDefault>(
       rows,
@@ -555,6 +584,7 @@ class DurationDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -574,6 +604,10 @@ class DurationDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultTable> where,
@@ -582,6 +616,7 @@ class DurationDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DurationDefault>(
       where: where(DurationDefault.t),
@@ -590,6 +625,7 @@ class DurationDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default_mix.dart
@@ -416,16 +416,22 @@ class DurationDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<DurationDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DurationDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -459,6 +465,10 @@ class DurationDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<DurationDefaultMix> rows, {
@@ -466,6 +476,7 @@ class DurationDefaultMixRepository {
     _i1.ColumnSelections<DurationDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<DurationDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DurationDefaultMix>(
       rows,
@@ -473,6 +484,7 @@ class DurationDefaultMixRepository {
       updateColumns: updateColumns?.call(DurationDefaultMix.t),
       updateWhere: updateWhere?.call(DurationDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -511,16 +523,22 @@ class DurationDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultMix>> update(
     _i1.DatabaseSession session,
     List<DurationDefaultMix> rows, {
     _i1.ColumnSelections<DurationDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DurationDefaultMix>(
       rows,
       columns: columns?.call(DurationDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -558,6 +576,10 @@ class DurationDefaultMixRepository {
 
   /// Updates all [DurationDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DurationDefaultMixUpdateTable>
@@ -570,6 +592,7 @@ class DurationDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DurationDefaultMix>(
       columnValues: columnValues(DurationDefaultMix.t.updateTable),
@@ -581,6 +604,7 @@ class DurationDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +615,10 @@ class DurationDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<DurationDefaultMix> rows, {
@@ -599,6 +627,7 @@ class DurationDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DurationDefaultMix>(
       rows,
@@ -607,6 +636,7 @@ class DurationDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -626,6 +656,10 @@ class DurationDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultMixTable> where,
@@ -634,6 +668,7 @@ class DurationDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DurationDefaultMix>(
       where: where(DurationDefaultMix.t),
@@ -642,6 +677,7 @@ class DurationDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default_model.dart
@@ -367,16 +367,22 @@ class DurationDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<DurationDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DurationDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -410,6 +416,10 @@ class DurationDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<DurationDefaultModel> rows, {
@@ -417,6 +427,7 @@ class DurationDefaultModelRepository {
     _i1.ColumnSelections<DurationDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<DurationDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DurationDefaultModel>(
       rows,
@@ -424,6 +435,7 @@ class DurationDefaultModelRepository {
       updateColumns: updateColumns?.call(DurationDefaultModel.t),
       updateWhere: updateWhere?.call(DurationDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -462,16 +474,22 @@ class DurationDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultModel>> update(
     _i1.DatabaseSession session,
     List<DurationDefaultModel> rows, {
     _i1.ColumnSelections<DurationDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DurationDefaultModel>(
       rows,
       columns: columns?.call(DurationDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -509,6 +527,10 @@ class DurationDefaultModelRepository {
 
   /// Updates all [DurationDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DurationDefaultModelUpdateTable>
@@ -521,6 +543,7 @@ class DurationDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DurationDefaultModel>(
       columnValues: columnValues(DurationDefaultModel.t.updateTable),
@@ -532,6 +555,7 @@ class DurationDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -542,6 +566,10 @@ class DurationDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<DurationDefaultModel> rows, {
@@ -550,6 +578,7 @@ class DurationDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DurationDefaultModel>(
       rows,
@@ -558,6 +587,7 @@ class DurationDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -577,6 +607,10 @@ class DurationDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultModelTable> where,
@@ -585,6 +619,7 @@ class DurationDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DurationDefaultModel>(
       where: where(DurationDefaultModel.t),
@@ -593,6 +628,7 @@ class DurationDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default_persist.dart
@@ -321,16 +321,22 @@ class DurationDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<DurationDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<DurationDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -364,6 +370,10 @@ class DurationDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<DurationDefaultPersist> rows, {
@@ -371,6 +381,7 @@ class DurationDefaultPersistRepository {
     _i1.ColumnSelections<DurationDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<DurationDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<DurationDefaultPersist>(
       rows,
@@ -378,6 +389,7 @@ class DurationDefaultPersistRepository {
       updateColumns: updateColumns?.call(DurationDefaultPersist.t),
       updateWhere: updateWhere?.call(DurationDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -416,16 +428,22 @@ class DurationDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<DurationDefaultPersist> rows, {
     _i1.ColumnSelections<DurationDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<DurationDefaultPersist>(
       rows,
       columns: columns?.call(DurationDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -463,6 +481,10 @@ class DurationDefaultPersistRepository {
 
   /// Updates all [DurationDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DurationDefaultPersistUpdateTable>
@@ -475,6 +497,7 @@ class DurationDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<DurationDefaultPersist>(
       columnValues: columnValues(DurationDefaultPersist.t.updateTable),
@@ -486,6 +509,7 @@ class DurationDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -496,6 +520,10 @@ class DurationDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<DurationDefaultPersist> rows, {
@@ -504,6 +532,7 @@ class DurationDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<DurationDefaultPersist>(
       rows,
@@ -512,6 +541,7 @@ class DurationDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +561,10 @@ class DurationDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<DurationDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultPersistTable> where,
@@ -539,6 +573,7 @@ class DurationDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<DurationDefaultPersist>(
       where: where(DurationDefaultPersist.t),
@@ -547,6 +582,7 @@ class DurationDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default.dart
@@ -425,16 +425,22 @@ class EnumDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefault>> insert(
     _i1.DatabaseSession session,
     List<EnumDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EnumDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -468,6 +474,10 @@ class EnumDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefault>> upsert(
     _i1.DatabaseSession session,
     List<EnumDefault> rows, {
@@ -475,6 +485,7 @@ class EnumDefaultRepository {
     _i1.ColumnSelections<EnumDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<EnumDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EnumDefault>(
       rows,
@@ -482,6 +493,7 @@ class EnumDefaultRepository {
       updateColumns: updateColumns?.call(EnumDefault.t),
       updateWhere: updateWhere?.call(EnumDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -520,16 +532,22 @@ class EnumDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefault>> update(
     _i1.DatabaseSession session,
     List<EnumDefault> rows, {
     _i1.ColumnSelections<EnumDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EnumDefault>(
       rows,
       columns: columns?.call(EnumDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -566,6 +584,10 @@ class EnumDefaultRepository {
 
   /// Updates all [EnumDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnumDefaultUpdateTable> columnValues,
@@ -577,6 +599,7 @@ class EnumDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EnumDefault>(
       columnValues: columnValues(EnumDefault.t.updateTable),
@@ -588,6 +611,7 @@ class EnumDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -598,6 +622,10 @@ class EnumDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefault>> delete(
     _i1.DatabaseSession session,
     List<EnumDefault> rows, {
@@ -606,6 +634,7 @@ class EnumDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EnumDefault>(
       rows,
@@ -614,6 +643,7 @@ class EnumDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -633,6 +663,10 @@ class EnumDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultTable> where,
@@ -641,6 +675,7 @@ class EnumDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EnumDefault>(
       where: where(EnumDefault.t),
@@ -649,6 +684,7 @@ class EnumDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default_mix.dart
@@ -402,16 +402,22 @@ class EnumDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<EnumDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EnumDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -445,6 +451,10 @@ class EnumDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<EnumDefaultMix> rows, {
@@ -452,6 +462,7 @@ class EnumDefaultMixRepository {
     _i1.ColumnSelections<EnumDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<EnumDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EnumDefaultMix>(
       rows,
@@ -459,6 +470,7 @@ class EnumDefaultMixRepository {
       updateColumns: updateColumns?.call(EnumDefaultMix.t),
       updateWhere: updateWhere?.call(EnumDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -497,16 +509,22 @@ class EnumDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultMix>> update(
     _i1.DatabaseSession session,
     List<EnumDefaultMix> rows, {
     _i1.ColumnSelections<EnumDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EnumDefaultMix>(
       rows,
       columns: columns?.call(EnumDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -543,6 +561,10 @@ class EnumDefaultMixRepository {
 
   /// Updates all [EnumDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnumDefaultMixUpdateTable> columnValues,
@@ -554,6 +576,7 @@ class EnumDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EnumDefaultMix>(
       columnValues: columnValues(EnumDefaultMix.t.updateTable),
@@ -565,6 +588,7 @@ class EnumDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -575,6 +599,10 @@ class EnumDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<EnumDefaultMix> rows, {
@@ -583,6 +611,7 @@ class EnumDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EnumDefaultMix>(
       rows,
@@ -591,6 +620,7 @@ class EnumDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -610,6 +640,10 @@ class EnumDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultMixTable> where,
@@ -618,6 +652,7 @@ class EnumDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EnumDefaultMix>(
       where: where(EnumDefaultMix.t),
@@ -626,6 +661,7 @@ class EnumDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default_model.dart
@@ -432,16 +432,22 @@ class EnumDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<EnumDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EnumDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -475,6 +481,10 @@ class EnumDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<EnumDefaultModel> rows, {
@@ -482,6 +492,7 @@ class EnumDefaultModelRepository {
     _i1.ColumnSelections<EnumDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<EnumDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EnumDefaultModel>(
       rows,
@@ -489,6 +500,7 @@ class EnumDefaultModelRepository {
       updateColumns: updateColumns?.call(EnumDefaultModel.t),
       updateWhere: updateWhere?.call(EnumDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -527,16 +539,22 @@ class EnumDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultModel>> update(
     _i1.DatabaseSession session,
     List<EnumDefaultModel> rows, {
     _i1.ColumnSelections<EnumDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EnumDefaultModel>(
       rows,
       columns: columns?.call(EnumDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -574,6 +592,10 @@ class EnumDefaultModelRepository {
 
   /// Updates all [EnumDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnumDefaultModelUpdateTable>
@@ -586,6 +608,7 @@ class EnumDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EnumDefaultModel>(
       columnValues: columnValues(EnumDefaultModel.t.updateTable),
@@ -597,6 +620,7 @@ class EnumDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -607,6 +631,10 @@ class EnumDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<EnumDefaultModel> rows, {
@@ -615,6 +643,7 @@ class EnumDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EnumDefaultModel>(
       rows,
@@ -623,6 +652,7 @@ class EnumDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -642,6 +672,10 @@ class EnumDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultModelTable> where,
@@ -650,6 +684,7 @@ class EnumDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EnumDefaultModel>(
       where: where(EnumDefaultModel.t),
@@ -658,6 +693,7 @@ class EnumDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default_persist.dart
@@ -360,16 +360,22 @@ class EnumDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<EnumDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EnumDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -403,6 +409,10 @@ class EnumDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<EnumDefaultPersist> rows, {
@@ -410,6 +420,7 @@ class EnumDefaultPersistRepository {
     _i1.ColumnSelections<EnumDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<EnumDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EnumDefaultPersist>(
       rows,
@@ -417,6 +428,7 @@ class EnumDefaultPersistRepository {
       updateColumns: updateColumns?.call(EnumDefaultPersist.t),
       updateWhere: updateWhere?.call(EnumDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -455,16 +467,22 @@ class EnumDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<EnumDefaultPersist> rows, {
     _i1.ColumnSelections<EnumDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EnumDefaultPersist>(
       rows,
       columns: columns?.call(EnumDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -502,6 +520,10 @@ class EnumDefaultPersistRepository {
 
   /// Updates all [EnumDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnumDefaultPersistUpdateTable>
@@ -514,6 +536,7 @@ class EnumDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EnumDefaultPersist>(
       columnValues: columnValues(EnumDefaultPersist.t.updateTable),
@@ -525,6 +548,7 @@ class EnumDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -535,6 +559,10 @@ class EnumDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<EnumDefaultPersist> rows, {
@@ -543,6 +571,7 @@ class EnumDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EnumDefaultPersist>(
       rows,
@@ -551,6 +580,7 @@ class EnumDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -570,6 +600,10 @@ class EnumDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EnumDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultPersistTable> where,
@@ -578,6 +612,7 @@ class EnumDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EnumDefaultPersist>(
       where: where(EnumDefaultPersist.t),
@@ -586,6 +621,7 @@ class EnumDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default.dart
@@ -335,16 +335,22 @@ class IntDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefault>> insert(
     _i1.DatabaseSession session,
     List<IntDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<IntDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -378,6 +384,10 @@ class IntDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefault>> upsert(
     _i1.DatabaseSession session,
     List<IntDefault> rows, {
@@ -385,6 +395,7 @@ class IntDefaultRepository {
     _i1.ColumnSelections<IntDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<IntDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<IntDefault>(
       rows,
@@ -392,6 +403,7 @@ class IntDefaultRepository {
       updateColumns: updateColumns?.call(IntDefault.t),
       updateWhere: updateWhere?.call(IntDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -430,16 +442,22 @@ class IntDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefault>> update(
     _i1.DatabaseSession session,
     List<IntDefault> rows, {
     _i1.ColumnSelections<IntDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<IntDefault>(
       rows,
       columns: columns?.call(IntDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -476,6 +494,10 @@ class IntDefaultRepository {
 
   /// Updates all [IntDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<IntDefaultUpdateTable> columnValues,
@@ -487,6 +509,7 @@ class IntDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<IntDefault>(
       columnValues: columnValues(IntDefault.t.updateTable),
@@ -498,6 +521,7 @@ class IntDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -508,6 +532,10 @@ class IntDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefault>> delete(
     _i1.DatabaseSession session,
     List<IntDefault> rows, {
@@ -516,6 +544,7 @@ class IntDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<IntDefault>(
       rows,
@@ -524,6 +553,7 @@ class IntDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -543,6 +573,10 @@ class IntDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultTable> where,
@@ -551,6 +585,7 @@ class IntDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<IntDefault>(
       where: where(IntDefault.t),
@@ -559,6 +594,7 @@ class IntDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default_mix.dart
@@ -371,16 +371,22 @@ class IntDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<IntDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<IntDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -414,6 +420,10 @@ class IntDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<IntDefaultMix> rows, {
@@ -421,6 +431,7 @@ class IntDefaultMixRepository {
     _i1.ColumnSelections<IntDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<IntDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<IntDefaultMix>(
       rows,
@@ -428,6 +439,7 @@ class IntDefaultMixRepository {
       updateColumns: updateColumns?.call(IntDefaultMix.t),
       updateWhere: updateWhere?.call(IntDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -466,16 +478,22 @@ class IntDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultMix>> update(
     _i1.DatabaseSession session,
     List<IntDefaultMix> rows, {
     _i1.ColumnSelections<IntDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<IntDefaultMix>(
       rows,
       columns: columns?.call(IntDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +530,10 @@ class IntDefaultMixRepository {
 
   /// Updates all [IntDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<IntDefaultMixUpdateTable> columnValues,
@@ -523,6 +545,7 @@ class IntDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<IntDefaultMix>(
       columnValues: columnValues(IntDefaultMix.t.updateTable),
@@ -534,6 +557,7 @@ class IntDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -544,6 +568,10 @@ class IntDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<IntDefaultMix> rows, {
@@ -552,6 +580,7 @@ class IntDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<IntDefaultMix>(
       rows,
@@ -560,6 +589,7 @@ class IntDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -579,6 +609,10 @@ class IntDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultMixTable> where,
@@ -587,6 +621,7 @@ class IntDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<IntDefaultMix>(
       where: where(IntDefaultMix.t),
@@ -595,6 +630,7 @@ class IntDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default_model.dart
@@ -332,16 +332,22 @@ class IntDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<IntDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<IntDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -375,6 +381,10 @@ class IntDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<IntDefaultModel> rows, {
@@ -382,6 +392,7 @@ class IntDefaultModelRepository {
     _i1.ColumnSelections<IntDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<IntDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<IntDefaultModel>(
       rows,
@@ -389,6 +400,7 @@ class IntDefaultModelRepository {
       updateColumns: updateColumns?.call(IntDefaultModel.t),
       updateWhere: updateWhere?.call(IntDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -427,16 +439,22 @@ class IntDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultModel>> update(
     _i1.DatabaseSession session,
     List<IntDefaultModel> rows, {
     _i1.ColumnSelections<IntDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<IntDefaultModel>(
       rows,
       columns: columns?.call(IntDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -474,6 +492,10 @@ class IntDefaultModelRepository {
 
   /// Updates all [IntDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<IntDefaultModelUpdateTable>
@@ -486,6 +508,7 @@ class IntDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<IntDefaultModel>(
       columnValues: columnValues(IntDefaultModel.t.updateTable),
@@ -497,6 +520,7 @@ class IntDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -507,6 +531,10 @@ class IntDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<IntDefaultModel> rows, {
@@ -515,6 +543,7 @@ class IntDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<IntDefaultModel>(
       rows,
@@ -523,6 +552,7 @@ class IntDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -542,6 +572,10 @@ class IntDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultModelTable> where,
@@ -550,6 +584,7 @@ class IntDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<IntDefaultModel>(
       where: where(IntDefaultModel.t),
@@ -558,6 +593,7 @@ class IntDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default_persist.dart
@@ -311,16 +311,22 @@ class IntDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<IntDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<IntDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -354,6 +360,10 @@ class IntDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<IntDefaultPersist> rows, {
@@ -361,6 +371,7 @@ class IntDefaultPersistRepository {
     _i1.ColumnSelections<IntDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<IntDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<IntDefaultPersist>(
       rows,
@@ -368,6 +379,7 @@ class IntDefaultPersistRepository {
       updateColumns: updateColumns?.call(IntDefaultPersist.t),
       updateWhere: updateWhere?.call(IntDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -406,16 +418,22 @@ class IntDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<IntDefaultPersist> rows, {
     _i1.ColumnSelections<IntDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<IntDefaultPersist>(
       rows,
       columns: columns?.call(IntDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -453,6 +471,10 @@ class IntDefaultPersistRepository {
 
   /// Updates all [IntDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<IntDefaultPersistUpdateTable>
@@ -465,6 +487,7 @@ class IntDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<IntDefaultPersist>(
       columnValues: columnValues(IntDefaultPersist.t.updateTable),
@@ -476,6 +499,7 @@ class IntDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,6 +510,10 @@ class IntDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<IntDefaultPersist> rows, {
@@ -494,6 +522,7 @@ class IntDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<IntDefaultPersist>(
       rows,
@@ -502,6 +531,7 @@ class IntDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -521,6 +551,10 @@ class IntDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<IntDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultPersistTable> where,
@@ -529,6 +563,7 @@ class IntDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<IntDefaultPersist>(
       where: where(IntDefaultPersist.t),
@@ -537,6 +572,7 @@ class IntDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default.dart
@@ -338,16 +338,22 @@ class StringDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefault>> insert(
     _i1.DatabaseSession session,
     List<StringDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<StringDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -381,6 +387,10 @@ class StringDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefault>> upsert(
     _i1.DatabaseSession session,
     List<StringDefault> rows, {
@@ -388,6 +398,7 @@ class StringDefaultRepository {
     _i1.ColumnSelections<StringDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<StringDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<StringDefault>(
       rows,
@@ -395,6 +406,7 @@ class StringDefaultRepository {
       updateColumns: updateColumns?.call(StringDefault.t),
       updateWhere: updateWhere?.call(StringDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -433,16 +445,22 @@ class StringDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefault>> update(
     _i1.DatabaseSession session,
     List<StringDefault> rows, {
     _i1.ColumnSelections<StringDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<StringDefault>(
       rows,
       columns: columns?.call(StringDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -479,6 +497,10 @@ class StringDefaultRepository {
 
   /// Updates all [StringDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<StringDefaultUpdateTable> columnValues,
@@ -490,6 +512,7 @@ class StringDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<StringDefault>(
       columnValues: columnValues(StringDefault.t.updateTable),
@@ -501,6 +524,7 @@ class StringDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -511,6 +535,10 @@ class StringDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefault>> delete(
     _i1.DatabaseSession session,
     List<StringDefault> rows, {
@@ -519,6 +547,7 @@ class StringDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<StringDefault>(
       rows,
@@ -527,6 +556,7 @@ class StringDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -546,6 +576,10 @@ class StringDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultTable> where,
@@ -554,6 +588,7 @@ class StringDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<StringDefault>(
       where: where(StringDefault.t),
@@ -562,6 +597,7 @@ class StringDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default_mix.dart
@@ -379,16 +379,22 @@ class StringDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<StringDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<StringDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -422,6 +428,10 @@ class StringDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<StringDefaultMix> rows, {
@@ -429,6 +439,7 @@ class StringDefaultMixRepository {
     _i1.ColumnSelections<StringDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<StringDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<StringDefaultMix>(
       rows,
@@ -436,6 +447,7 @@ class StringDefaultMixRepository {
       updateColumns: updateColumns?.call(StringDefaultMix.t),
       updateWhere: updateWhere?.call(StringDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -474,16 +486,22 @@ class StringDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultMix>> update(
     _i1.DatabaseSession session,
     List<StringDefaultMix> rows, {
     _i1.ColumnSelections<StringDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<StringDefaultMix>(
       rows,
       columns: columns?.call(StringDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -521,6 +539,10 @@ class StringDefaultMixRepository {
 
   /// Updates all [StringDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<StringDefaultMixUpdateTable>
@@ -533,6 +555,7 @@ class StringDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<StringDefaultMix>(
       columnValues: columnValues(StringDefaultMix.t.updateTable),
@@ -544,6 +567,7 @@ class StringDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -554,6 +578,10 @@ class StringDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<StringDefaultMix> rows, {
@@ -562,6 +590,7 @@ class StringDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<StringDefaultMix>(
       rows,
@@ -570,6 +599,7 @@ class StringDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -589,6 +619,10 @@ class StringDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultMixTable> where,
@@ -597,6 +631,7 @@ class StringDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<StringDefaultMix>(
       where: where(StringDefaultMix.t),
@@ -605,6 +640,7 @@ class StringDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default_model.dart
@@ -339,16 +339,22 @@ class StringDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<StringDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<StringDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -382,6 +388,10 @@ class StringDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<StringDefaultModel> rows, {
@@ -389,6 +399,7 @@ class StringDefaultModelRepository {
     _i1.ColumnSelections<StringDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<StringDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<StringDefaultModel>(
       rows,
@@ -396,6 +407,7 @@ class StringDefaultModelRepository {
       updateColumns: updateColumns?.call(StringDefaultModel.t),
       updateWhere: updateWhere?.call(StringDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -434,16 +446,22 @@ class StringDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultModel>> update(
     _i1.DatabaseSession session,
     List<StringDefaultModel> rows, {
     _i1.ColumnSelections<StringDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<StringDefaultModel>(
       rows,
       columns: columns?.call(StringDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,6 +499,10 @@ class StringDefaultModelRepository {
 
   /// Updates all [StringDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<StringDefaultModelUpdateTable>
@@ -493,6 +515,7 @@ class StringDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<StringDefaultModel>(
       columnValues: columnValues(StringDefaultModel.t.updateTable),
@@ -504,6 +527,7 @@ class StringDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -514,6 +538,10 @@ class StringDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<StringDefaultModel> rows, {
@@ -522,6 +550,7 @@ class StringDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<StringDefaultModel>(
       rows,
@@ -530,6 +559,7 @@ class StringDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,6 +579,10 @@ class StringDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultModelTable> where,
@@ -557,6 +591,7 @@ class StringDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<StringDefaultModel>(
       where: where(StringDefaultModel.t),
@@ -565,6 +600,7 @@ class StringDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default_persist.dart
@@ -621,16 +621,22 @@ class StringDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<StringDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<StringDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -664,6 +670,10 @@ class StringDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<StringDefaultPersist> rows, {
@@ -671,6 +681,7 @@ class StringDefaultPersistRepository {
     _i1.ColumnSelections<StringDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<StringDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<StringDefaultPersist>(
       rows,
@@ -678,6 +689,7 @@ class StringDefaultPersistRepository {
       updateColumns: updateColumns?.call(StringDefaultPersist.t),
       updateWhere: updateWhere?.call(StringDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -716,16 +728,22 @@ class StringDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<StringDefaultPersist> rows, {
     _i1.ColumnSelections<StringDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<StringDefaultPersist>(
       rows,
       columns: columns?.call(StringDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -763,6 +781,10 @@ class StringDefaultPersistRepository {
 
   /// Updates all [StringDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<StringDefaultPersistUpdateTable>
@@ -775,6 +797,7 @@ class StringDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<StringDefaultPersist>(
       columnValues: columnValues(StringDefaultPersist.t.updateTable),
@@ -786,6 +809,7 @@ class StringDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -796,6 +820,10 @@ class StringDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<StringDefaultPersist> rows, {
@@ -804,6 +832,7 @@ class StringDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<StringDefaultPersist>(
       rows,
@@ -812,6 +841,7 @@ class StringDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -831,6 +861,10 @@ class StringDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<StringDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultPersistTable> where,
@@ -839,6 +873,7 @@ class StringDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<StringDefaultPersist>(
       where: where(StringDefaultPersist.t),
@@ -847,6 +882,7 @@ class StringDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default.dart
@@ -340,16 +340,22 @@ class UriDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefault>> insert(
     _i1.DatabaseSession session,
     List<UriDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UriDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -383,6 +389,10 @@ class UriDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefault>> upsert(
     _i1.DatabaseSession session,
     List<UriDefault> rows, {
@@ -390,6 +400,7 @@ class UriDefaultRepository {
     _i1.ColumnSelections<UriDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<UriDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UriDefault>(
       rows,
@@ -397,6 +408,7 @@ class UriDefaultRepository {
       updateColumns: updateColumns?.call(UriDefault.t),
       updateWhere: updateWhere?.call(UriDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -435,16 +447,22 @@ class UriDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefault>> update(
     _i1.DatabaseSession session,
     List<UriDefault> rows, {
     _i1.ColumnSelections<UriDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UriDefault>(
       rows,
       columns: columns?.call(UriDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,6 +499,10 @@ class UriDefaultRepository {
 
   /// Updates all [UriDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UriDefaultUpdateTable> columnValues,
@@ -492,6 +514,7 @@ class UriDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UriDefault>(
       columnValues: columnValues(UriDefault.t.updateTable),
@@ -503,6 +526,7 @@ class UriDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -513,6 +537,10 @@ class UriDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefault>> delete(
     _i1.DatabaseSession session,
     List<UriDefault> rows, {
@@ -521,6 +549,7 @@ class UriDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UriDefault>(
       rows,
@@ -529,6 +558,7 @@ class UriDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -548,6 +578,10 @@ class UriDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultTable> where,
@@ -556,6 +590,7 @@ class UriDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UriDefault>(
       where: where(UriDefault.t),
@@ -564,6 +599,7 @@ class UriDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default_mix.dart
@@ -390,16 +390,22 @@ class UriDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<UriDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UriDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -433,6 +439,10 @@ class UriDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<UriDefaultMix> rows, {
@@ -440,6 +450,7 @@ class UriDefaultMixRepository {
     _i1.ColumnSelections<UriDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<UriDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UriDefaultMix>(
       rows,
@@ -447,6 +458,7 @@ class UriDefaultMixRepository {
       updateColumns: updateColumns?.call(UriDefaultMix.t),
       updateWhere: updateWhere?.call(UriDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -485,16 +497,22 @@ class UriDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultMix>> update(
     _i1.DatabaseSession session,
     List<UriDefaultMix> rows, {
     _i1.ColumnSelections<UriDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UriDefaultMix>(
       rows,
       columns: columns?.call(UriDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +549,10 @@ class UriDefaultMixRepository {
 
   /// Updates all [UriDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UriDefaultMixUpdateTable> columnValues,
@@ -542,6 +564,7 @@ class UriDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UriDefaultMix>(
       columnValues: columnValues(UriDefaultMix.t.updateTable),
@@ -553,6 +576,7 @@ class UriDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -563,6 +587,10 @@ class UriDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<UriDefaultMix> rows, {
@@ -571,6 +599,7 @@ class UriDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UriDefaultMix>(
       rows,
@@ -579,6 +608,7 @@ class UriDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -598,6 +628,10 @@ class UriDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultMixTable> where,
@@ -606,6 +640,7 @@ class UriDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UriDefaultMix>(
       where: where(UriDefaultMix.t),
@@ -614,6 +649,7 @@ class UriDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default_model.dart
@@ -345,16 +345,22 @@ class UriDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<UriDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UriDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -388,6 +394,10 @@ class UriDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<UriDefaultModel> rows, {
@@ -395,6 +405,7 @@ class UriDefaultModelRepository {
     _i1.ColumnSelections<UriDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<UriDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UriDefaultModel>(
       rows,
@@ -402,6 +413,7 @@ class UriDefaultModelRepository {
       updateColumns: updateColumns?.call(UriDefaultModel.t),
       updateWhere: updateWhere?.call(UriDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -440,16 +452,22 @@ class UriDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultModel>> update(
     _i1.DatabaseSession session,
     List<UriDefaultModel> rows, {
     _i1.ColumnSelections<UriDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UriDefaultModel>(
       rows,
       columns: columns?.call(UriDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -487,6 +505,10 @@ class UriDefaultModelRepository {
 
   /// Updates all [UriDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UriDefaultModelUpdateTable>
@@ -499,6 +521,7 @@ class UriDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UriDefaultModel>(
       columnValues: columnValues(UriDefaultModel.t.updateTable),
@@ -510,6 +533,7 @@ class UriDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -520,6 +544,10 @@ class UriDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<UriDefaultModel> rows, {
@@ -528,6 +556,7 @@ class UriDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UriDefaultModel>(
       rows,
@@ -536,6 +565,7 @@ class UriDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -555,6 +585,10 @@ class UriDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultModelTable> where,
@@ -563,6 +597,7 @@ class UriDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UriDefaultModel>(
       where: where(UriDefaultModel.t),
@@ -571,6 +606,7 @@ class UriDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default_persist.dart
@@ -317,16 +317,22 @@ class UriDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<UriDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UriDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -360,6 +366,10 @@ class UriDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<UriDefaultPersist> rows, {
@@ -367,6 +377,7 @@ class UriDefaultPersistRepository {
     _i1.ColumnSelections<UriDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<UriDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UriDefaultPersist>(
       rows,
@@ -374,6 +385,7 @@ class UriDefaultPersistRepository {
       updateColumns: updateColumns?.call(UriDefaultPersist.t),
       updateWhere: updateWhere?.call(UriDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -412,16 +424,22 @@ class UriDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<UriDefaultPersist> rows, {
     _i1.ColumnSelections<UriDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UriDefaultPersist>(
       rows,
       columns: columns?.call(UriDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -459,6 +477,10 @@ class UriDefaultPersistRepository {
 
   /// Updates all [UriDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UriDefaultPersistUpdateTable>
@@ -471,6 +493,7 @@ class UriDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UriDefaultPersist>(
       columnValues: columnValues(UriDefaultPersist.t.updateTable),
@@ -482,6 +505,7 @@ class UriDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -492,6 +516,10 @@ class UriDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<UriDefaultPersist> rows, {
@@ -500,6 +528,7 @@ class UriDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UriDefaultPersist>(
       rows,
@@ -508,6 +537,7 @@ class UriDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -527,6 +557,10 @@ class UriDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UriDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultPersistTable> where,
@@ -535,6 +569,7 @@ class UriDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UriDefaultPersist>(
       where: where(UriDefaultPersist.t),
@@ -543,6 +578,7 @@ class UriDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default.dart
@@ -454,16 +454,22 @@ class UuidDefaultRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefault>> insert(
     _i1.DatabaseSession session,
     List<UuidDefault> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UuidDefault>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -497,6 +503,10 @@ class UuidDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefault>> upsert(
     _i1.DatabaseSession session,
     List<UuidDefault> rows, {
@@ -504,6 +514,7 @@ class UuidDefaultRepository {
     _i1.ColumnSelections<UuidDefaultTable>? updateColumns,
     _i1.WhereExpressionBuilder<UuidDefaultTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UuidDefault>(
       rows,
@@ -511,6 +522,7 @@ class UuidDefaultRepository {
       updateColumns: updateColumns?.call(UuidDefault.t),
       updateWhere: updateWhere?.call(UuidDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,16 +561,22 @@ class UuidDefaultRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefault>> update(
     _i1.DatabaseSession session,
     List<UuidDefault> rows, {
     _i1.ColumnSelections<UuidDefaultTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UuidDefault>(
       rows,
       columns: columns?.call(UuidDefault.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -595,6 +613,10 @@ class UuidDefaultRepository {
 
   /// Updates all [UuidDefault]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefault>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UuidDefaultUpdateTable> columnValues,
@@ -606,6 +628,7 @@ class UuidDefaultRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UuidDefault>(
       columnValues: columnValues(UuidDefault.t.updateTable),
@@ -617,6 +640,7 @@ class UuidDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -627,6 +651,10 @@ class UuidDefaultRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefault>> delete(
     _i1.DatabaseSession session,
     List<UuidDefault> rows, {
@@ -635,6 +663,7 @@ class UuidDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UuidDefault>(
       rows,
@@ -643,6 +672,7 @@ class UuidDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -662,6 +692,10 @@ class UuidDefaultRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefault>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultTable> where,
@@ -670,6 +704,7 @@ class UuidDefaultRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UuidDefault>(
       where: where(UuidDefault.t),
@@ -678,6 +713,7 @@ class UuidDefaultRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
@@ -392,16 +392,22 @@ class UuidDefaultMixRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultMix>> insert(
     _i1.DatabaseSession session,
     List<UuidDefaultMix> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UuidDefaultMix>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -435,6 +441,10 @@ class UuidDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultMix>> upsert(
     _i1.DatabaseSession session,
     List<UuidDefaultMix> rows, {
@@ -442,6 +452,7 @@ class UuidDefaultMixRepository {
     _i1.ColumnSelections<UuidDefaultMixTable>? updateColumns,
     _i1.WhereExpressionBuilder<UuidDefaultMixTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UuidDefaultMix>(
       rows,
@@ -449,6 +460,7 @@ class UuidDefaultMixRepository {
       updateColumns: updateColumns?.call(UuidDefaultMix.t),
       updateWhere: updateWhere?.call(UuidDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -487,16 +499,22 @@ class UuidDefaultMixRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultMix>> update(
     _i1.DatabaseSession session,
     List<UuidDefaultMix> rows, {
     _i1.ColumnSelections<UuidDefaultMixTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UuidDefaultMix>(
       rows,
       columns: columns?.call(UuidDefaultMix.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -533,6 +551,10 @@ class UuidDefaultMixRepository {
 
   /// Updates all [UuidDefaultMix]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultMix>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UuidDefaultMixUpdateTable> columnValues,
@@ -544,6 +566,7 @@ class UuidDefaultMixRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UuidDefaultMix>(
       columnValues: columnValues(UuidDefaultMix.t.updateTable),
@@ -555,6 +578,7 @@ class UuidDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -565,6 +589,10 @@ class UuidDefaultMixRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultMix>> delete(
     _i1.DatabaseSession session,
     List<UuidDefaultMix> rows, {
@@ -573,6 +601,7 @@ class UuidDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UuidDefaultMix>(
       rows,
@@ -581,6 +610,7 @@ class UuidDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -600,6 +630,10 @@ class UuidDefaultMixRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultMix>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultMixTable> where,
@@ -608,6 +642,7 @@ class UuidDefaultMixRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UuidDefaultMix>(
       where: where(UuidDefaultMix.t),
@@ -616,6 +651,7 @@ class UuidDefaultMixRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
@@ -459,16 +459,22 @@ class UuidDefaultModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultModel>> insert(
     _i1.DatabaseSession session,
     List<UuidDefaultModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UuidDefaultModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -502,6 +508,10 @@ class UuidDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultModel>> upsert(
     _i1.DatabaseSession session,
     List<UuidDefaultModel> rows, {
@@ -509,6 +519,7 @@ class UuidDefaultModelRepository {
     _i1.ColumnSelections<UuidDefaultModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<UuidDefaultModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UuidDefaultModel>(
       rows,
@@ -516,6 +527,7 @@ class UuidDefaultModelRepository {
       updateColumns: updateColumns?.call(UuidDefaultModel.t),
       updateWhere: updateWhere?.call(UuidDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -554,16 +566,22 @@ class UuidDefaultModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultModel>> update(
     _i1.DatabaseSession session,
     List<UuidDefaultModel> rows, {
     _i1.ColumnSelections<UuidDefaultModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UuidDefaultModel>(
       rows,
       columns: columns?.call(UuidDefaultModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -601,6 +619,10 @@ class UuidDefaultModelRepository {
 
   /// Updates all [UuidDefaultModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UuidDefaultModelUpdateTable>
@@ -613,6 +635,7 @@ class UuidDefaultModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UuidDefaultModel>(
       columnValues: columnValues(UuidDefaultModel.t.updateTable),
@@ -624,6 +647,7 @@ class UuidDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -634,6 +658,10 @@ class UuidDefaultModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultModel>> delete(
     _i1.DatabaseSession session,
     List<UuidDefaultModel> rows, {
@@ -642,6 +670,7 @@ class UuidDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UuidDefaultModel>(
       rows,
@@ -650,6 +679,7 @@ class UuidDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -669,6 +699,10 @@ class UuidDefaultModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultModelTable> where,
@@ -677,6 +711,7 @@ class UuidDefaultModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UuidDefaultModel>(
       where: where(UuidDefaultModel.t),
@@ -685,6 +720,7 @@ class UuidDefaultModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
@@ -391,16 +391,22 @@ class UuidDefaultPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultPersist>> insert(
     _i1.DatabaseSession session,
     List<UuidDefaultPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UuidDefaultPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -434,6 +440,10 @@ class UuidDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultPersist>> upsert(
     _i1.DatabaseSession session,
     List<UuidDefaultPersist> rows, {
@@ -441,6 +451,7 @@ class UuidDefaultPersistRepository {
     _i1.ColumnSelections<UuidDefaultPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<UuidDefaultPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UuidDefaultPersist>(
       rows,
@@ -448,6 +459,7 @@ class UuidDefaultPersistRepository {
       updateColumns: updateColumns?.call(UuidDefaultPersist.t),
       updateWhere: updateWhere?.call(UuidDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,16 +498,22 @@ class UuidDefaultPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultPersist>> update(
     _i1.DatabaseSession session,
     List<UuidDefaultPersist> rows, {
     _i1.ColumnSelections<UuidDefaultPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UuidDefaultPersist>(
       rows,
       columns: columns?.call(UuidDefaultPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -533,6 +551,10 @@ class UuidDefaultPersistRepository {
 
   /// Updates all [UuidDefaultPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UuidDefaultPersistUpdateTable>
@@ -545,6 +567,7 @@ class UuidDefaultPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UuidDefaultPersist>(
       columnValues: columnValues(UuidDefaultPersist.t.updateTable),
@@ -556,6 +579,7 @@ class UuidDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -566,6 +590,10 @@ class UuidDefaultPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultPersist>> delete(
     _i1.DatabaseSession session,
     List<UuidDefaultPersist> rows, {
@@ -574,6 +602,7 @@ class UuidDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UuidDefaultPersist>(
       rows,
@@ -582,6 +611,7 @@ class UuidDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -601,6 +631,10 @@ class UuidDefaultPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UuidDefaultPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultPersistTable> where,
@@ -609,6 +643,7 @@ class UuidDefaultPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UuidDefaultPersist>(
       where: where(UuidDefaultPersist.t),
@@ -617,6 +652,7 @@ class UuidDefaultPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/empty_model_relation_item.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/empty_model_relation_item.dart
@@ -368,16 +368,22 @@ class EmptyModelRelationItemRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> insert(
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EmptyModelRelationItem>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -411,6 +417,10 @@ class EmptyModelRelationItemRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> upsert(
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
@@ -418,6 +428,7 @@ class EmptyModelRelationItemRepository {
     _i1.ColumnSelections<EmptyModelRelationItemTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmptyModelRelationItemTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EmptyModelRelationItem>(
       rows,
@@ -425,6 +436,7 @@ class EmptyModelRelationItemRepository {
       updateColumns: updateColumns?.call(EmptyModelRelationItem.t),
       updateWhere: updateWhere?.call(EmptyModelRelationItem.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -463,16 +475,22 @@ class EmptyModelRelationItemRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> update(
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
     _i1.ColumnSelections<EmptyModelRelationItemTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EmptyModelRelationItem>(
       rows,
       columns: columns?.call(EmptyModelRelationItem.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -510,6 +528,10 @@ class EmptyModelRelationItemRepository {
 
   /// Updates all [EmptyModelRelationItem]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmptyModelRelationItemUpdateTable>
@@ -522,6 +544,7 @@ class EmptyModelRelationItemRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EmptyModelRelationItem>(
       columnValues: columnValues(EmptyModelRelationItem.t.updateTable),
@@ -533,6 +556,7 @@ class EmptyModelRelationItemRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -543,6 +567,10 @@ class EmptyModelRelationItemRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> delete(
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
@@ -551,6 +579,7 @@ class EmptyModelRelationItemRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EmptyModelRelationItem>(
       rows,
@@ -559,6 +588,7 @@ class EmptyModelRelationItemRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -578,6 +608,10 @@ class EmptyModelRelationItemRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelRelationItem>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmptyModelRelationItemTable> where,
@@ -586,6 +620,7 @@ class EmptyModelRelationItemRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EmptyModelRelationItem>(
       where: where(EmptyModelRelationItem.t),
@@ -594,6 +629,7 @@ class EmptyModelRelationItemRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/empty_model_with_table.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/empty_model_with_table.dart
@@ -266,16 +266,22 @@ class EmptyModelWithTableRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> insert(
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<EmptyModelWithTable>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -309,6 +315,10 @@ class EmptyModelWithTableRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> upsert(
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
@@ -316,6 +326,7 @@ class EmptyModelWithTableRepository {
     _i1.ColumnSelections<EmptyModelWithTableTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmptyModelWithTableTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<EmptyModelWithTable>(
       rows,
@@ -323,6 +334,7 @@ class EmptyModelWithTableRepository {
       updateColumns: updateColumns?.call(EmptyModelWithTable.t),
       updateWhere: updateWhere?.call(EmptyModelWithTable.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -361,16 +373,22 @@ class EmptyModelWithTableRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> update(
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
     _i1.ColumnSelections<EmptyModelWithTableTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<EmptyModelWithTable>(
       rows,
       columns: columns?.call(EmptyModelWithTable.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -408,6 +426,10 @@ class EmptyModelWithTableRepository {
 
   /// Updates all [EmptyModelWithTable]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmptyModelWithTableUpdateTable>
@@ -420,6 +442,7 @@ class EmptyModelWithTableRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<EmptyModelWithTable>(
       columnValues: columnValues(EmptyModelWithTable.t.updateTable),
@@ -431,6 +454,7 @@ class EmptyModelWithTableRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -441,6 +465,10 @@ class EmptyModelWithTableRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> delete(
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
@@ -449,6 +477,7 @@ class EmptyModelWithTableRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<EmptyModelWithTable>(
       rows,
@@ -457,6 +486,7 @@ class EmptyModelWithTableRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -476,6 +506,10 @@ class EmptyModelWithTableRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<EmptyModelWithTable>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmptyModelWithTableTable> where,
@@ -484,6 +518,7 @@ class EmptyModelWithTableRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<EmptyModelWithTable>(
       where: where(EmptyModelWithTable.t),
@@ -492,6 +527,7 @@ class EmptyModelWithTableRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/relation_empy_model.dart
@@ -375,16 +375,22 @@ class RelationEmptyModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> insert(
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<RelationEmptyModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -418,6 +424,10 @@ class RelationEmptyModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> upsert(
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
@@ -425,6 +435,7 @@ class RelationEmptyModelRepository {
     _i1.ColumnSelections<RelationEmptyModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<RelationEmptyModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<RelationEmptyModel>(
       rows,
@@ -432,6 +443,7 @@ class RelationEmptyModelRepository {
       updateColumns: updateColumns?.call(RelationEmptyModel.t),
       updateWhere: updateWhere?.call(RelationEmptyModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -470,16 +482,22 @@ class RelationEmptyModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> update(
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
     _i1.ColumnSelections<RelationEmptyModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<RelationEmptyModel>(
       rows,
       columns: columns?.call(RelationEmptyModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -517,6 +535,10 @@ class RelationEmptyModelRepository {
 
   /// Updates all [RelationEmptyModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<RelationEmptyModelUpdateTable>
@@ -529,6 +551,7 @@ class RelationEmptyModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<RelationEmptyModel>(
       columnValues: columnValues(RelationEmptyModel.t.updateTable),
@@ -540,6 +563,7 @@ class RelationEmptyModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -550,6 +574,10 @@ class RelationEmptyModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> delete(
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
@@ -558,6 +586,7 @@ class RelationEmptyModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<RelationEmptyModel>(
       rows,
@@ -566,6 +595,7 @@ class RelationEmptyModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -585,6 +615,10 @@ class RelationEmptyModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationEmptyModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelationEmptyModelTable> where,
@@ -593,6 +627,7 @@ class RelationEmptyModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<RelationEmptyModel>(
       where: where(RelationEmptyModel.t),
@@ -601,6 +636,7 @@ class RelationEmptyModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/inheritance/child_class_explicit_column.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/inheritance/child_class_explicit_column.dart
@@ -337,16 +337,22 @@ class ChildClassExplicitColumnRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassExplicitColumn>> insert(
     _i2.DatabaseSession session,
     List<ChildClassExplicitColumn> rows, {
     _i2.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ChildClassExplicitColumn>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -380,6 +386,10 @@ class ChildClassExplicitColumnRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassExplicitColumn>> upsert(
     _i2.DatabaseSession session,
     List<ChildClassExplicitColumn> rows, {
@@ -388,6 +398,7 @@ class ChildClassExplicitColumnRepository {
     _i2.ColumnSelections<ChildClassExplicitColumnTable>? updateColumns,
     _i2.WhereExpressionBuilder<ChildClassExplicitColumnTable>? updateWhere,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ChildClassExplicitColumn>(
       rows,
@@ -395,6 +406,7 @@ class ChildClassExplicitColumnRepository {
       updateColumns: updateColumns?.call(ChildClassExplicitColumn.t),
       updateWhere: updateWhere?.call(ChildClassExplicitColumn.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -434,16 +446,22 @@ class ChildClassExplicitColumnRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassExplicitColumn>> update(
     _i2.DatabaseSession session,
     List<ChildClassExplicitColumn> rows, {
     _i2.ColumnSelections<ChildClassExplicitColumnTable>? columns,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ChildClassExplicitColumn>(
       rows,
       columns: columns?.call(ChildClassExplicitColumn.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,6 +499,10 @@ class ChildClassExplicitColumnRepository {
 
   /// Updates all [ChildClassExplicitColumn]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassExplicitColumn>> updateWhere(
     _i2.DatabaseSession session, {
     required _i2.ColumnValueListBuilder<ChildClassExplicitColumnUpdateTable>
@@ -493,6 +515,7 @@ class ChildClassExplicitColumnRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ChildClassExplicitColumn>(
       columnValues: columnValues(ChildClassExplicitColumn.t.updateTable),
@@ -504,6 +527,7 @@ class ChildClassExplicitColumnRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -514,6 +538,10 @@ class ChildClassExplicitColumnRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassExplicitColumn>> delete(
     _i2.DatabaseSession session,
     List<ChildClassExplicitColumn> rows, {
@@ -522,6 +550,7 @@ class ChildClassExplicitColumnRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ChildClassExplicitColumn>(
       rows,
@@ -530,6 +559,7 @@ class ChildClassExplicitColumnRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,6 +579,10 @@ class ChildClassExplicitColumnRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ChildClassExplicitColumn>> deleteWhere(
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<ChildClassExplicitColumnTable> where,
@@ -557,6 +591,7 @@ class ChildClassExplicitColumnRepository {
     bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     _i2.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ChildClassExplicitColumn>(
       where: where(ChildClassExplicitColumn.t),
@@ -565,6 +600,7 @@ class ChildClassExplicitColumnRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/modified_column_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/modified_column_name.dart
@@ -335,16 +335,22 @@ class ModifiedColumnNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModifiedColumnName>> insert(
     _i1.DatabaseSession session,
     List<ModifiedColumnName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ModifiedColumnName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -378,6 +384,10 @@ class ModifiedColumnNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModifiedColumnName>> upsert(
     _i1.DatabaseSession session,
     List<ModifiedColumnName> rows, {
@@ -385,6 +395,7 @@ class ModifiedColumnNameRepository {
     _i1.ColumnSelections<ModifiedColumnNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<ModifiedColumnNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ModifiedColumnName>(
       rows,
@@ -392,6 +403,7 @@ class ModifiedColumnNameRepository {
       updateColumns: updateColumns?.call(ModifiedColumnName.t),
       updateWhere: updateWhere?.call(ModifiedColumnName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -430,16 +442,22 @@ class ModifiedColumnNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModifiedColumnName>> update(
     _i1.DatabaseSession session,
     List<ModifiedColumnName> rows, {
     _i1.ColumnSelections<ModifiedColumnNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ModifiedColumnName>(
       rows,
       columns: columns?.call(ModifiedColumnName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -477,6 +495,10 @@ class ModifiedColumnNameRepository {
 
   /// Updates all [ModifiedColumnName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModifiedColumnName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ModifiedColumnNameUpdateTable>
@@ -489,6 +511,7 @@ class ModifiedColumnNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ModifiedColumnName>(
       columnValues: columnValues(ModifiedColumnName.t.updateTable),
@@ -500,6 +523,7 @@ class ModifiedColumnNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -510,6 +534,10 @@ class ModifiedColumnNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModifiedColumnName>> delete(
     _i1.DatabaseSession session,
     List<ModifiedColumnName> rows, {
@@ -518,6 +546,7 @@ class ModifiedColumnNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ModifiedColumnName>(
       rows,
@@ -526,6 +555,7 @@ class ModifiedColumnNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -545,6 +575,10 @@ class ModifiedColumnNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModifiedColumnName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ModifiedColumnNameTable> where,
@@ -553,6 +587,7 @@ class ModifiedColumnNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ModifiedColumnName>(
       where: where(ModifiedColumnName.t),
@@ -561,6 +596,7 @@ class ModifiedColumnNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_many/department.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_many/department.dart
@@ -391,16 +391,22 @@ class DepartmentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Department>> insert(
     _i1.DatabaseSession session,
     List<Department> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Department>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -434,6 +440,10 @@ class DepartmentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Department>> upsert(
     _i1.DatabaseSession session,
     List<Department> rows, {
@@ -441,6 +451,7 @@ class DepartmentRepository {
     _i1.ColumnSelections<DepartmentTable>? updateColumns,
     _i1.WhereExpressionBuilder<DepartmentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Department>(
       rows,
@@ -448,6 +459,7 @@ class DepartmentRepository {
       updateColumns: updateColumns?.call(Department.t),
       updateWhere: updateWhere?.call(Department.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,16 +498,22 @@ class DepartmentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Department>> update(
     _i1.DatabaseSession session,
     List<Department> rows, {
     _i1.ColumnSelections<DepartmentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Department>(
       rows,
       columns: columns?.call(Department.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -532,6 +550,10 @@ class DepartmentRepository {
 
   /// Updates all [Department]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Department>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<DepartmentUpdateTable> columnValues,
@@ -543,6 +565,7 @@ class DepartmentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Department>(
       columnValues: columnValues(Department.t.updateTable),
@@ -554,6 +577,7 @@ class DepartmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,6 +588,10 @@ class DepartmentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Department>> delete(
     _i1.DatabaseSession session,
     List<Department> rows, {
@@ -572,6 +600,7 @@ class DepartmentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Department>(
       rows,
@@ -580,6 +609,7 @@ class DepartmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -599,6 +629,10 @@ class DepartmentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Department>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DepartmentTable> where,
@@ -607,6 +641,7 @@ class DepartmentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Department>(
       where: where(Department.t),
@@ -615,6 +650,7 @@ class DepartmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_many/employee.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_many/employee.dart
@@ -331,16 +331,22 @@ class EmployeeRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Employee>> insert(
     _i1.DatabaseSession session,
     List<Employee> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Employee>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -374,6 +380,10 @@ class EmployeeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Employee>> upsert(
     _i1.DatabaseSession session,
     List<Employee> rows, {
@@ -381,6 +391,7 @@ class EmployeeRepository {
     _i1.ColumnSelections<EmployeeTable>? updateColumns,
     _i1.WhereExpressionBuilder<EmployeeTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Employee>(
       rows,
@@ -388,6 +399,7 @@ class EmployeeRepository {
       updateColumns: updateColumns?.call(Employee.t),
       updateWhere: updateWhere?.call(Employee.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -426,16 +438,22 @@ class EmployeeRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Employee>> update(
     _i1.DatabaseSession session,
     List<Employee> rows, {
     _i1.ColumnSelections<EmployeeTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Employee>(
       rows,
       columns: columns?.call(Employee.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -472,6 +490,10 @@ class EmployeeRepository {
 
   /// Updates all [Employee]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Employee>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EmployeeUpdateTable> columnValues,
@@ -483,6 +505,7 @@ class EmployeeRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Employee>(
       columnValues: columnValues(Employee.t.updateTable),
@@ -494,6 +517,7 @@ class EmployeeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -504,6 +528,10 @@ class EmployeeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Employee>> delete(
     _i1.DatabaseSession session,
     List<Employee> rows, {
@@ -512,6 +540,7 @@ class EmployeeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Employee>(
       rows,
@@ -520,6 +549,7 @@ class EmployeeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -539,6 +569,10 @@ class EmployeeRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Employee>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmployeeTable> where,
@@ -547,6 +581,7 @@ class EmployeeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Employee>(
       where: where(Employee.t),
@@ -555,6 +590,7 @@ class EmployeeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_one/contractor.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_one/contractor.dart
@@ -390,16 +390,22 @@ class ContractorRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Contractor>> insert(
     _i1.DatabaseSession session,
     List<Contractor> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Contractor>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -433,6 +439,10 @@ class ContractorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Contractor>> upsert(
     _i1.DatabaseSession session,
     List<Contractor> rows, {
@@ -440,6 +450,7 @@ class ContractorRepository {
     _i1.ColumnSelections<ContractorTable>? updateColumns,
     _i1.WhereExpressionBuilder<ContractorTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Contractor>(
       rows,
@@ -447,6 +458,7 @@ class ContractorRepository {
       updateColumns: updateColumns?.call(Contractor.t),
       updateWhere: updateWhere?.call(Contractor.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -485,16 +497,22 @@ class ContractorRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Contractor>> update(
     _i1.DatabaseSession session,
     List<Contractor> rows, {
     _i1.ColumnSelections<ContractorTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Contractor>(
       rows,
       columns: columns?.call(Contractor.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +549,10 @@ class ContractorRepository {
 
   /// Updates all [Contractor]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Contractor>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ContractorUpdateTable> columnValues,
@@ -542,6 +564,7 @@ class ContractorRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Contractor>(
       columnValues: columnValues(Contractor.t.updateTable),
@@ -553,6 +576,7 @@ class ContractorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -563,6 +587,10 @@ class ContractorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Contractor>> delete(
     _i1.DatabaseSession session,
     List<Contractor> rows, {
@@ -571,6 +599,7 @@ class ContractorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Contractor>(
       rows,
@@ -579,6 +608,7 @@ class ContractorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -598,6 +628,10 @@ class ContractorRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Contractor>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ContractorTable> where,
@@ -606,6 +640,7 @@ class ContractorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Contractor>(
       where: where(Contractor.t),
@@ -614,6 +649,7 @@ class ContractorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_one/service.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_one/service.dart
@@ -330,16 +330,22 @@ class ServiceRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Service>> insert(
     _i1.DatabaseSession session,
     List<Service> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Service>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -373,6 +379,10 @@ class ServiceRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Service>> upsert(
     _i1.DatabaseSession session,
     List<Service> rows, {
@@ -380,6 +390,7 @@ class ServiceRepository {
     _i1.ColumnSelections<ServiceTable>? updateColumns,
     _i1.WhereExpressionBuilder<ServiceTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Service>(
       rows,
@@ -387,6 +398,7 @@ class ServiceRepository {
       updateColumns: updateColumns?.call(Service.t),
       updateWhere: updateWhere?.call(Service.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -425,16 +437,22 @@ class ServiceRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Service>> update(
     _i1.DatabaseSession session,
     List<Service> rows, {
     _i1.ColumnSelections<ServiceTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Service>(
       rows,
       columns: columns?.call(Service.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -471,6 +489,10 @@ class ServiceRepository {
 
   /// Updates all [Service]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Service>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ServiceUpdateTable> columnValues,
@@ -482,6 +504,7 @@ class ServiceRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Service>(
       columnValues: columnValues(Service.t.updateTable),
@@ -493,6 +516,7 @@ class ServiceRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -503,6 +527,10 @@ class ServiceRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Service>> delete(
     _i1.DatabaseSession session,
     List<Service> rows, {
@@ -511,6 +539,7 @@ class ServiceRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Service>(
       rows,
@@ -519,6 +548,7 @@ class ServiceRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -538,6 +568,10 @@ class ServiceRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Service>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ServiceTable> where,
@@ -546,6 +580,7 @@ class ServiceRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Service>(
       where: where(Service.t),
@@ -554,6 +589,7 @@ class ServiceRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/table_with_explicit_column_names.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/table_with_explicit_column_names.dart
@@ -337,16 +337,22 @@ class TableWithExplicitColumnNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TableWithExplicitColumnName>> insert(
     _i1.DatabaseSession session,
     List<TableWithExplicitColumnName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<TableWithExplicitColumnName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -380,6 +386,10 @@ class TableWithExplicitColumnNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TableWithExplicitColumnName>> upsert(
     _i1.DatabaseSession session,
     List<TableWithExplicitColumnName> rows, {
@@ -388,6 +398,7 @@ class TableWithExplicitColumnNameRepository {
     _i1.ColumnSelections<TableWithExplicitColumnNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<TableWithExplicitColumnNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<TableWithExplicitColumnName>(
       rows,
@@ -395,6 +406,7 @@ class TableWithExplicitColumnNameRepository {
       updateColumns: updateColumns?.call(TableWithExplicitColumnName.t),
       updateWhere: updateWhere?.call(TableWithExplicitColumnName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -434,16 +446,22 @@ class TableWithExplicitColumnNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TableWithExplicitColumnName>> update(
     _i1.DatabaseSession session,
     List<TableWithExplicitColumnName> rows, {
     _i1.ColumnSelections<TableWithExplicitColumnNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<TableWithExplicitColumnName>(
       rows,
       columns: columns?.call(TableWithExplicitColumnName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,6 +499,10 @@ class TableWithExplicitColumnNameRepository {
 
   /// Updates all [TableWithExplicitColumnName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TableWithExplicitColumnName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TableWithExplicitColumnNameUpdateTable>
@@ -493,6 +515,7 @@ class TableWithExplicitColumnNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<TableWithExplicitColumnName>(
       columnValues: columnValues(TableWithExplicitColumnName.t.updateTable),
@@ -504,6 +527,7 @@ class TableWithExplicitColumnNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -514,6 +538,10 @@ class TableWithExplicitColumnNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TableWithExplicitColumnName>> delete(
     _i1.DatabaseSession session,
     List<TableWithExplicitColumnName> rows, {
@@ -522,6 +550,7 @@ class TableWithExplicitColumnNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<TableWithExplicitColumnName>(
       rows,
@@ -530,6 +559,7 @@ class TableWithExplicitColumnNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,6 +579,10 @@ class TableWithExplicitColumnNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<TableWithExplicitColumnName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TableWithExplicitColumnNameTable> where,
@@ -557,6 +591,7 @@ class TableWithExplicitColumnNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<TableWithExplicitColumnName>(
       where: where(TableWithExplicitColumnName.t),
@@ -565,6 +600,7 @@ class TableWithExplicitColumnNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -485,16 +485,22 @@ class CityWithLongTableNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CityWithLongTableName>> insert(
     _i1.DatabaseSession session,
     List<CityWithLongTableName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<CityWithLongTableName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -528,6 +534,10 @@ class CityWithLongTableNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CityWithLongTableName>> upsert(
     _i1.DatabaseSession session,
     List<CityWithLongTableName> rows, {
@@ -535,6 +545,7 @@ class CityWithLongTableNameRepository {
     _i1.ColumnSelections<CityWithLongTableNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<CityWithLongTableNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<CityWithLongTableName>(
       rows,
@@ -542,6 +553,7 @@ class CityWithLongTableNameRepository {
       updateColumns: updateColumns?.call(CityWithLongTableName.t),
       updateWhere: updateWhere?.call(CityWithLongTableName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -580,16 +592,22 @@ class CityWithLongTableNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CityWithLongTableName>> update(
     _i1.DatabaseSession session,
     List<CityWithLongTableName> rows, {
     _i1.ColumnSelections<CityWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<CityWithLongTableName>(
       rows,
       columns: columns?.call(CityWithLongTableName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -627,6 +645,10 @@ class CityWithLongTableNameRepository {
 
   /// Updates all [CityWithLongTableName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CityWithLongTableName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CityWithLongTableNameUpdateTable>
@@ -639,6 +661,7 @@ class CityWithLongTableNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<CityWithLongTableName>(
       columnValues: columnValues(CityWithLongTableName.t.updateTable),
@@ -650,6 +673,7 @@ class CityWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -660,6 +684,10 @@ class CityWithLongTableNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CityWithLongTableName>> delete(
     _i1.DatabaseSession session,
     List<CityWithLongTableName> rows, {
@@ -668,6 +696,7 @@ class CityWithLongTableNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<CityWithLongTableName>(
       rows,
@@ -676,6 +705,7 @@ class CityWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -695,6 +725,10 @@ class CityWithLongTableNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<CityWithLongTableName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CityWithLongTableNameTable> where,
@@ -703,6 +737,7 @@ class CityWithLongTableNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<CityWithLongTableName>(
       where: where(CityWithLongTableName.t),
@@ -711,6 +746,7 @@ class CityWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -474,16 +474,22 @@ class OrganizationWithLongTableNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrganizationWithLongTableName>> insert(
     _i1.DatabaseSession session,
     List<OrganizationWithLongTableName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<OrganizationWithLongTableName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -517,6 +523,10 @@ class OrganizationWithLongTableNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrganizationWithLongTableName>> upsert(
     _i1.DatabaseSession session,
     List<OrganizationWithLongTableName> rows, {
@@ -525,6 +535,7 @@ class OrganizationWithLongTableNameRepository {
     _i1.ColumnSelections<OrganizationWithLongTableNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<OrganizationWithLongTableNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<OrganizationWithLongTableName>(
       rows,
@@ -532,6 +543,7 @@ class OrganizationWithLongTableNameRepository {
       updateColumns: updateColumns?.call(OrganizationWithLongTableName.t),
       updateWhere: updateWhere?.call(OrganizationWithLongTableName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -571,16 +583,22 @@ class OrganizationWithLongTableNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrganizationWithLongTableName>> update(
     _i1.DatabaseSession session,
     List<OrganizationWithLongTableName> rows, {
     _i1.ColumnSelections<OrganizationWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<OrganizationWithLongTableName>(
       rows,
       columns: columns?.call(OrganizationWithLongTableName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -620,6 +638,10 @@ class OrganizationWithLongTableNameRepository {
 
   /// Updates all [OrganizationWithLongTableName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrganizationWithLongTableName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<
@@ -635,6 +657,7 @@ class OrganizationWithLongTableNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<OrganizationWithLongTableName>(
       columnValues: columnValues(OrganizationWithLongTableName.t.updateTable),
@@ -646,6 +669,7 @@ class OrganizationWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -656,6 +680,10 @@ class OrganizationWithLongTableNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrganizationWithLongTableName>> delete(
     _i1.DatabaseSession session,
     List<OrganizationWithLongTableName> rows, {
@@ -664,6 +692,7 @@ class OrganizationWithLongTableNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<OrganizationWithLongTableName>(
       rows,
@@ -672,6 +701,7 @@ class OrganizationWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -691,6 +721,10 @@ class OrganizationWithLongTableNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<OrganizationWithLongTableName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrganizationWithLongTableNameTable>
@@ -700,6 +734,7 @@ class OrganizationWithLongTableNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<OrganizationWithLongTableName>(
       where: where(OrganizationWithLongTableName.t),
@@ -708,6 +743,7 @@ class OrganizationWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -472,16 +472,22 @@ class PersonWithLongTableNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PersonWithLongTableName>> insert(
     _i1.DatabaseSession session,
     List<PersonWithLongTableName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<PersonWithLongTableName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -515,6 +521,10 @@ class PersonWithLongTableNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PersonWithLongTableName>> upsert(
     _i1.DatabaseSession session,
     List<PersonWithLongTableName> rows, {
@@ -522,6 +532,7 @@ class PersonWithLongTableNameRepository {
     _i1.ColumnSelections<PersonWithLongTableNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<PersonWithLongTableNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<PersonWithLongTableName>(
       rows,
@@ -529,6 +540,7 @@ class PersonWithLongTableNameRepository {
       updateColumns: updateColumns?.call(PersonWithLongTableName.t),
       updateWhere: updateWhere?.call(PersonWithLongTableName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -567,16 +579,22 @@ class PersonWithLongTableNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PersonWithLongTableName>> update(
     _i1.DatabaseSession session,
     List<PersonWithLongTableName> rows, {
     _i1.ColumnSelections<PersonWithLongTableNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<PersonWithLongTableName>(
       rows,
       columns: columns?.call(PersonWithLongTableName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -614,6 +632,10 @@ class PersonWithLongTableNameRepository {
 
   /// Updates all [PersonWithLongTableName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PersonWithLongTableName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PersonWithLongTableNameUpdateTable>
@@ -626,6 +648,7 @@ class PersonWithLongTableNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<PersonWithLongTableName>(
       columnValues: columnValues(PersonWithLongTableName.t.updateTable),
@@ -637,6 +660,7 @@ class PersonWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -647,6 +671,10 @@ class PersonWithLongTableNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PersonWithLongTableName>> delete(
     _i1.DatabaseSession session,
     List<PersonWithLongTableName> rows, {
@@ -655,6 +683,7 @@ class PersonWithLongTableNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<PersonWithLongTableName>(
       rows,
@@ -663,6 +692,7 @@ class PersonWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -682,6 +712,10 @@ class PersonWithLongTableNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<PersonWithLongTableName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PersonWithLongTableNameTable> where,
@@ -690,6 +724,7 @@ class PersonWithLongTableNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<PersonWithLongTableName>(
       where: where(PersonWithLongTableName.t),
@@ -698,6 +733,7 @@ class PersonWithLongTableNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/max_field_name.dart
@@ -320,16 +320,22 @@ class MaxFieldNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MaxFieldName>> insert(
     _i1.DatabaseSession session,
     List<MaxFieldName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<MaxFieldName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -363,6 +369,10 @@ class MaxFieldNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MaxFieldName>> upsert(
     _i1.DatabaseSession session,
     List<MaxFieldName> rows, {
@@ -370,6 +380,7 @@ class MaxFieldNameRepository {
     _i1.ColumnSelections<MaxFieldNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<MaxFieldNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<MaxFieldName>(
       rows,
@@ -377,6 +388,7 @@ class MaxFieldNameRepository {
       updateColumns: updateColumns?.call(MaxFieldName.t),
       updateWhere: updateWhere?.call(MaxFieldName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -415,16 +427,22 @@ class MaxFieldNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MaxFieldName>> update(
     _i1.DatabaseSession session,
     List<MaxFieldName> rows, {
     _i1.ColumnSelections<MaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<MaxFieldName>(
       rows,
       columns: columns?.call(MaxFieldName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -461,6 +479,10 @@ class MaxFieldNameRepository {
 
   /// Updates all [MaxFieldName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MaxFieldName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<MaxFieldNameUpdateTable> columnValues,
@@ -472,6 +494,7 @@ class MaxFieldNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<MaxFieldName>(
       columnValues: columnValues(MaxFieldName.t.updateTable),
@@ -483,6 +506,7 @@ class MaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -493,6 +517,10 @@ class MaxFieldNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MaxFieldName>> delete(
     _i1.DatabaseSession session,
     List<MaxFieldName> rows, {
@@ -501,6 +529,7 @@ class MaxFieldNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<MaxFieldName>(
       rows,
@@ -509,6 +538,7 @@ class MaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -528,6 +558,10 @@ class MaxFieldNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MaxFieldName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MaxFieldNameTable> where,
@@ -536,6 +570,7 @@ class MaxFieldNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<MaxFieldName>(
       where: where(MaxFieldName.t),
@@ -544,6 +579,7 @@ class MaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -370,16 +370,22 @@ class LongImplicitIdFieldRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdField>> insert(
     _i1.DatabaseSession session,
     List<LongImplicitIdField> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<LongImplicitIdField>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -413,6 +419,10 @@ class LongImplicitIdFieldRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdField>> upsert(
     _i1.DatabaseSession session,
     List<LongImplicitIdField> rows, {
@@ -420,6 +430,7 @@ class LongImplicitIdFieldRepository {
     _i1.ColumnSelections<LongImplicitIdFieldTable>? updateColumns,
     _i1.WhereExpressionBuilder<LongImplicitIdFieldTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<LongImplicitIdField>(
       rows,
@@ -427,6 +438,7 @@ class LongImplicitIdFieldRepository {
       updateColumns: updateColumns?.call(LongImplicitIdField.t),
       updateWhere: updateWhere?.call(LongImplicitIdField.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -465,16 +477,22 @@ class LongImplicitIdFieldRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdField>> update(
     _i1.DatabaseSession session,
     List<LongImplicitIdField> rows, {
     _i1.ColumnSelections<LongImplicitIdFieldTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<LongImplicitIdField>(
       rows,
       columns: columns?.call(LongImplicitIdField.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -512,6 +530,10 @@ class LongImplicitIdFieldRepository {
 
   /// Updates all [LongImplicitIdField]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdField>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<LongImplicitIdFieldUpdateTable>
@@ -524,6 +546,7 @@ class LongImplicitIdFieldRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<LongImplicitIdField>(
       columnValues: columnValues(LongImplicitIdField.t.updateTable),
@@ -535,6 +558,7 @@ class LongImplicitIdFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -545,6 +569,10 @@ class LongImplicitIdFieldRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdField>> delete(
     _i1.DatabaseSession session,
     List<LongImplicitIdField> rows, {
@@ -553,6 +581,7 @@ class LongImplicitIdFieldRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<LongImplicitIdField>(
       rows,
@@ -561,6 +590,7 @@ class LongImplicitIdFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -580,6 +610,10 @@ class LongImplicitIdFieldRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdField>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<LongImplicitIdFieldTable> where,
@@ -588,6 +622,7 @@ class LongImplicitIdFieldRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<LongImplicitIdField>(
       where: where(LongImplicitIdField.t),
@@ -596,6 +631,7 @@ class LongImplicitIdFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -445,16 +445,22 @@ class LongImplicitIdFieldCollectionRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdFieldCollection>> insert(
     _i1.DatabaseSession session,
     List<LongImplicitIdFieldCollection> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<LongImplicitIdFieldCollection>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -488,6 +494,10 @@ class LongImplicitIdFieldCollectionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdFieldCollection>> upsert(
     _i1.DatabaseSession session,
     List<LongImplicitIdFieldCollection> rows, {
@@ -496,6 +506,7 @@ class LongImplicitIdFieldCollectionRepository {
     _i1.ColumnSelections<LongImplicitIdFieldCollectionTable>? updateColumns,
     _i1.WhereExpressionBuilder<LongImplicitIdFieldCollectionTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<LongImplicitIdFieldCollection>(
       rows,
@@ -503,6 +514,7 @@ class LongImplicitIdFieldCollectionRepository {
       updateColumns: updateColumns?.call(LongImplicitIdFieldCollection.t),
       updateWhere: updateWhere?.call(LongImplicitIdFieldCollection.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -542,16 +554,22 @@ class LongImplicitIdFieldCollectionRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdFieldCollection>> update(
     _i1.DatabaseSession session,
     List<LongImplicitIdFieldCollection> rows, {
     _i1.ColumnSelections<LongImplicitIdFieldCollectionTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<LongImplicitIdFieldCollection>(
       rows,
       columns: columns?.call(LongImplicitIdFieldCollection.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +609,10 @@ class LongImplicitIdFieldCollectionRepository {
 
   /// Updates all [LongImplicitIdFieldCollection]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdFieldCollection>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<
@@ -606,6 +628,7 @@ class LongImplicitIdFieldCollectionRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<LongImplicitIdFieldCollection>(
       columnValues: columnValues(LongImplicitIdFieldCollection.t.updateTable),
@@ -617,6 +640,7 @@ class LongImplicitIdFieldCollectionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -627,6 +651,10 @@ class LongImplicitIdFieldCollectionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdFieldCollection>> delete(
     _i1.DatabaseSession session,
     List<LongImplicitIdFieldCollection> rows, {
@@ -635,6 +663,7 @@ class LongImplicitIdFieldCollectionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<LongImplicitIdFieldCollection>(
       rows,
@@ -643,6 +672,7 @@ class LongImplicitIdFieldCollectionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -662,6 +692,10 @@ class LongImplicitIdFieldCollectionRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<LongImplicitIdFieldCollection>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<LongImplicitIdFieldCollectionTable>
@@ -671,6 +705,7 @@ class LongImplicitIdFieldCollectionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<LongImplicitIdFieldCollection>(
       where: where(LongImplicitIdFieldCollection.t),
@@ -679,6 +714,7 @@ class LongImplicitIdFieldCollectionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -416,16 +416,22 @@ class RelationToMultipleMaxFieldNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationToMultipleMaxFieldName>> insert(
     _i1.DatabaseSession session,
     List<RelationToMultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<RelationToMultipleMaxFieldName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -459,6 +465,10 @@ class RelationToMultipleMaxFieldNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationToMultipleMaxFieldName>> upsert(
     _i1.DatabaseSession session,
     List<RelationToMultipleMaxFieldName> rows, {
@@ -468,6 +478,7 @@ class RelationToMultipleMaxFieldNameRepository {
     _i1.WhereExpressionBuilder<RelationToMultipleMaxFieldNameTable>?
     updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<RelationToMultipleMaxFieldName>(
       rows,
@@ -475,6 +486,7 @@ class RelationToMultipleMaxFieldNameRepository {
       updateColumns: updateColumns?.call(RelationToMultipleMaxFieldName.t),
       updateWhere: updateWhere?.call(RelationToMultipleMaxFieldName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -515,16 +527,22 @@ class RelationToMultipleMaxFieldNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationToMultipleMaxFieldName>> update(
     _i1.DatabaseSession session,
     List<RelationToMultipleMaxFieldName> rows, {
     _i1.ColumnSelections<RelationToMultipleMaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<RelationToMultipleMaxFieldName>(
       rows,
       columns: columns?.call(RelationToMultipleMaxFieldName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,6 +582,10 @@ class RelationToMultipleMaxFieldNameRepository {
 
   /// Updates all [RelationToMultipleMaxFieldName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationToMultipleMaxFieldName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<
@@ -579,6 +601,7 @@ class RelationToMultipleMaxFieldNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<RelationToMultipleMaxFieldName>(
       columnValues: columnValues(RelationToMultipleMaxFieldName.t.updateTable),
@@ -590,6 +613,7 @@ class RelationToMultipleMaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -600,6 +624,10 @@ class RelationToMultipleMaxFieldNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationToMultipleMaxFieldName>> delete(
     _i1.DatabaseSession session,
     List<RelationToMultipleMaxFieldName> rows, {
@@ -608,6 +636,7 @@ class RelationToMultipleMaxFieldNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<RelationToMultipleMaxFieldName>(
       rows,
@@ -616,6 +645,7 @@ class RelationToMultipleMaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -635,6 +665,10 @@ class RelationToMultipleMaxFieldNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelationToMultipleMaxFieldName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelationToMultipleMaxFieldNameTable>
@@ -644,6 +678,7 @@ class RelationToMultipleMaxFieldNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<RelationToMultipleMaxFieldName>(
       where: where(RelationToMultipleMaxFieldName.t),
@@ -652,6 +687,7 @@ class RelationToMultipleMaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
@@ -367,16 +367,22 @@ class UserNoteRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNote>> insert(
     _i1.DatabaseSession session,
     List<UserNote> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UserNote>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -410,6 +416,10 @@ class UserNoteRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNote>> upsert(
     _i1.DatabaseSession session,
     List<UserNote> rows, {
@@ -417,6 +427,7 @@ class UserNoteRepository {
     _i1.ColumnSelections<UserNoteTable>? updateColumns,
     _i1.WhereExpressionBuilder<UserNoteTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UserNote>(
       rows,
@@ -424,6 +435,7 @@ class UserNoteRepository {
       updateColumns: updateColumns?.call(UserNote.t),
       updateWhere: updateWhere?.call(UserNote.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -462,16 +474,22 @@ class UserNoteRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNote>> update(
     _i1.DatabaseSession session,
     List<UserNote> rows, {
     _i1.ColumnSelections<UserNoteTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UserNote>(
       rows,
       columns: columns?.call(UserNote.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -508,6 +526,10 @@ class UserNoteRepository {
 
   /// Updates all [UserNote]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNote>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UserNoteUpdateTable> columnValues,
@@ -519,6 +541,7 @@ class UserNoteRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UserNote>(
       columnValues: columnValues(UserNote.t.updateTable),
@@ -530,6 +553,7 @@ class UserNoteRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -540,6 +564,10 @@ class UserNoteRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNote>> delete(
     _i1.DatabaseSession session,
     List<UserNote> rows, {
@@ -548,6 +576,7 @@ class UserNoteRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UserNote>(
       rows,
@@ -556,6 +585,7 @@ class UserNoteRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -575,6 +605,10 @@ class UserNoteRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNote>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteTable> where,
@@ -583,6 +617,7 @@ class UserNoteRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UserNote>(
       where: where(UserNote.t),
@@ -591,6 +626,7 @@ class UserNoteRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -412,16 +412,22 @@ class UserNoteCollectionRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollection>> insert(
     _i1.DatabaseSession session,
     List<UserNoteCollection> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UserNoteCollection>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -455,6 +461,10 @@ class UserNoteCollectionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollection>> upsert(
     _i1.DatabaseSession session,
     List<UserNoteCollection> rows, {
@@ -462,6 +472,7 @@ class UserNoteCollectionRepository {
     _i1.ColumnSelections<UserNoteCollectionTable>? updateColumns,
     _i1.WhereExpressionBuilder<UserNoteCollectionTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UserNoteCollection>(
       rows,
@@ -469,6 +480,7 @@ class UserNoteCollectionRepository {
       updateColumns: updateColumns?.call(UserNoteCollection.t),
       updateWhere: updateWhere?.call(UserNoteCollection.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -507,16 +519,22 @@ class UserNoteCollectionRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollection>> update(
     _i1.DatabaseSession session,
     List<UserNoteCollection> rows, {
     _i1.ColumnSelections<UserNoteCollectionTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UserNoteCollection>(
       rows,
       columns: columns?.call(UserNoteCollection.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -554,6 +572,10 @@ class UserNoteCollectionRepository {
 
   /// Updates all [UserNoteCollection]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollection>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UserNoteCollectionUpdateTable>
@@ -566,6 +588,7 @@ class UserNoteCollectionRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UserNoteCollection>(
       columnValues: columnValues(UserNoteCollection.t.updateTable),
@@ -577,6 +600,7 @@ class UserNoteCollectionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -587,6 +611,10 @@ class UserNoteCollectionRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollection>> delete(
     _i1.DatabaseSession session,
     List<UserNoteCollection> rows, {
@@ -595,6 +623,7 @@ class UserNoteCollectionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UserNoteCollection>(
       rows,
@@ -603,6 +632,7 @@ class UserNoteCollectionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -622,6 +652,10 @@ class UserNoteCollectionRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollection>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteCollectionTable> where,
@@ -630,6 +664,7 @@ class UserNoteCollectionRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UserNoteCollection>(
       where: where(UserNoteCollection.t),
@@ -638,6 +673,7 @@ class UserNoteCollectionRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -409,16 +409,22 @@ class UserNoteCollectionWithALongNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollectionWithALongName>> insert(
     _i1.DatabaseSession session,
     List<UserNoteCollectionWithALongName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UserNoteCollectionWithALongName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -452,6 +458,10 @@ class UserNoteCollectionWithALongNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollectionWithALongName>> upsert(
     _i1.DatabaseSession session,
     List<UserNoteCollectionWithALongName> rows, {
@@ -461,6 +471,7 @@ class UserNoteCollectionWithALongNameRepository {
     _i1.WhereExpressionBuilder<UserNoteCollectionWithALongNameTable>?
     updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UserNoteCollectionWithALongName>(
       rows,
@@ -468,6 +479,7 @@ class UserNoteCollectionWithALongNameRepository {
       updateColumns: updateColumns?.call(UserNoteCollectionWithALongName.t),
       updateWhere: updateWhere?.call(UserNoteCollectionWithALongName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -508,16 +520,22 @@ class UserNoteCollectionWithALongNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollectionWithALongName>> update(
     _i1.DatabaseSession session,
     List<UserNoteCollectionWithALongName> rows, {
     _i1.ColumnSelections<UserNoteCollectionWithALongNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UserNoteCollectionWithALongName>(
       rows,
       columns: columns?.call(UserNoteCollectionWithALongName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -557,6 +575,10 @@ class UserNoteCollectionWithALongNameRepository {
 
   /// Updates all [UserNoteCollectionWithALongName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollectionWithALongName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<
@@ -572,6 +594,7 @@ class UserNoteCollectionWithALongNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UserNoteCollectionWithALongName>(
       columnValues: columnValues(UserNoteCollectionWithALongName.t.updateTable),
@@ -583,6 +606,7 @@ class UserNoteCollectionWithALongNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -593,6 +617,10 @@ class UserNoteCollectionWithALongNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollectionWithALongName>> delete(
     _i1.DatabaseSession session,
     List<UserNoteCollectionWithALongName> rows, {
@@ -601,6 +629,7 @@ class UserNoteCollectionWithALongNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UserNoteCollectionWithALongName>(
       rows,
@@ -609,6 +638,7 @@ class UserNoteCollectionWithALongNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -628,6 +658,10 @@ class UserNoteCollectionWithALongNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteCollectionWithALongName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteCollectionWithALongNameTable>
@@ -637,6 +671,7 @@ class UserNoteCollectionWithALongNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UserNoteCollectionWithALongName>(
       where: where(UserNoteCollectionWithALongName.t),
@@ -645,6 +680,7 @@ class UserNoteCollectionWithALongNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -372,16 +372,22 @@ class UserNoteWithALongNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteWithALongName>> insert(
     _i1.DatabaseSession session,
     List<UserNoteWithALongName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UserNoteWithALongName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -415,6 +421,10 @@ class UserNoteWithALongNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteWithALongName>> upsert(
     _i1.DatabaseSession session,
     List<UserNoteWithALongName> rows, {
@@ -422,6 +432,7 @@ class UserNoteWithALongNameRepository {
     _i1.ColumnSelections<UserNoteWithALongNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<UserNoteWithALongNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UserNoteWithALongName>(
       rows,
@@ -429,6 +440,7 @@ class UserNoteWithALongNameRepository {
       updateColumns: updateColumns?.call(UserNoteWithALongName.t),
       updateWhere: updateWhere?.call(UserNoteWithALongName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -467,16 +479,22 @@ class UserNoteWithALongNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteWithALongName>> update(
     _i1.DatabaseSession session,
     List<UserNoteWithALongName> rows, {
     _i1.ColumnSelections<UserNoteWithALongNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UserNoteWithALongName>(
       rows,
       columns: columns?.call(UserNoteWithALongName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -514,6 +532,10 @@ class UserNoteWithALongNameRepository {
 
   /// Updates all [UserNoteWithALongName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteWithALongName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UserNoteWithALongNameUpdateTable>
@@ -526,6 +548,7 @@ class UserNoteWithALongNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UserNoteWithALongName>(
       columnValues: columnValues(UserNoteWithALongName.t.updateTable),
@@ -537,6 +560,7 @@ class UserNoteWithALongNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -547,6 +571,10 @@ class UserNoteWithALongNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteWithALongName>> delete(
     _i1.DatabaseSession session,
     List<UserNoteWithALongName> rows, {
@@ -555,6 +583,7 @@ class UserNoteWithALongNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UserNoteWithALongName>(
       rows,
@@ -563,6 +592,7 @@ class UserNoteWithALongNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -582,6 +612,10 @@ class UserNoteWithALongNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UserNoteWithALongName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteWithALongNameTable> where,
@@ -590,6 +624,7 @@ class UserNoteWithALongNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UserNoteWithALongName>(
       where: where(UserNoteWithALongName.t),
@@ -598,6 +633,7 @@ class UserNoteWithALongNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
@@ -434,16 +434,22 @@ class MultipleMaxFieldNameRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MultipleMaxFieldName>> insert(
     _i1.DatabaseSession session,
     List<MultipleMaxFieldName> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<MultipleMaxFieldName>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -477,6 +483,10 @@ class MultipleMaxFieldNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MultipleMaxFieldName>> upsert(
     _i1.DatabaseSession session,
     List<MultipleMaxFieldName> rows, {
@@ -484,6 +494,7 @@ class MultipleMaxFieldNameRepository {
     _i1.ColumnSelections<MultipleMaxFieldNameTable>? updateColumns,
     _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<MultipleMaxFieldName>(
       rows,
@@ -491,6 +502,7 @@ class MultipleMaxFieldNameRepository {
       updateColumns: updateColumns?.call(MultipleMaxFieldName.t),
       updateWhere: updateWhere?.call(MultipleMaxFieldName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -529,16 +541,22 @@ class MultipleMaxFieldNameRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MultipleMaxFieldName>> update(
     _i1.DatabaseSession session,
     List<MultipleMaxFieldName> rows, {
     _i1.ColumnSelections<MultipleMaxFieldNameTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<MultipleMaxFieldName>(
       rows,
       columns: columns?.call(MultipleMaxFieldName.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -576,6 +594,10 @@ class MultipleMaxFieldNameRepository {
 
   /// Updates all [MultipleMaxFieldName]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MultipleMaxFieldName>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<MultipleMaxFieldNameUpdateTable>
@@ -588,6 +610,7 @@ class MultipleMaxFieldNameRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<MultipleMaxFieldName>(
       columnValues: columnValues(MultipleMaxFieldName.t.updateTable),
@@ -599,6 +622,7 @@ class MultipleMaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -609,6 +633,10 @@ class MultipleMaxFieldNameRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MultipleMaxFieldName>> delete(
     _i1.DatabaseSession session,
     List<MultipleMaxFieldName> rows, {
@@ -617,6 +645,7 @@ class MultipleMaxFieldNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<MultipleMaxFieldName>(
       rows,
@@ -625,6 +654,7 @@ class MultipleMaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -644,6 +674,10 @@ class MultipleMaxFieldNameRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<MultipleMaxFieldName>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable> where,
@@ -652,6 +686,7 @@ class MultipleMaxFieldNameRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<MultipleMaxFieldName>(
       where: where(MultipleMaxFieldName.t),
@@ -660,6 +695,7 @@ class MultipleMaxFieldNameRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/city.dart
@@ -468,16 +468,22 @@ class CityRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> insert(
     _i1.DatabaseSession session,
     List<City> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<City>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -511,6 +517,10 @@ class CityRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> upsert(
     _i1.DatabaseSession session,
     List<City> rows, {
@@ -518,6 +528,7 @@ class CityRepository {
     _i1.ColumnSelections<CityTable>? updateColumns,
     _i1.WhereExpressionBuilder<CityTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<City>(
       rows,
@@ -525,6 +536,7 @@ class CityRepository {
       updateColumns: updateColumns?.call(City.t),
       updateWhere: updateWhere?.call(City.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -563,16 +575,22 @@ class CityRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> update(
     _i1.DatabaseSession session,
     List<City> rows, {
     _i1.ColumnSelections<CityTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<City>(
       rows,
       columns: columns?.call(City.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -609,6 +627,10 @@ class CityRepository {
 
   /// Updates all [City]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CityUpdateTable> columnValues,
@@ -620,6 +642,7 @@ class CityRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<City>(
       columnValues: columnValues(City.t.updateTable),
@@ -631,6 +654,7 @@ class CityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -641,6 +665,10 @@ class CityRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> delete(
     _i1.DatabaseSession session,
     List<City> rows, {
@@ -649,6 +677,7 @@ class CityRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<City>(
       rows,
@@ -657,6 +686,7 @@ class CityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -676,6 +706,10 @@ class CityRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<City>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CityTable> where,
@@ -684,6 +718,7 @@ class CityRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<City>(
       where: where(City.t),
@@ -692,6 +727,7 @@ class CityRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -464,16 +464,22 @@ class OrganizationRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> insert(
     _i1.DatabaseSession session,
     List<Organization> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Organization>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -507,6 +513,10 @@ class OrganizationRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> upsert(
     _i1.DatabaseSession session,
     List<Organization> rows, {
@@ -514,6 +524,7 @@ class OrganizationRepository {
     _i1.ColumnSelections<OrganizationTable>? updateColumns,
     _i1.WhereExpressionBuilder<OrganizationTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Organization>(
       rows,
@@ -521,6 +532,7 @@ class OrganizationRepository {
       updateColumns: updateColumns?.call(Organization.t),
       updateWhere: updateWhere?.call(Organization.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -559,16 +571,22 @@ class OrganizationRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> update(
     _i1.DatabaseSession session,
     List<Organization> rows, {
     _i1.ColumnSelections<OrganizationTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Organization>(
       rows,
       columns: columns?.call(Organization.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -605,6 +623,10 @@ class OrganizationRepository {
 
   /// Updates all [Organization]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<OrganizationUpdateTable> columnValues,
@@ -616,6 +638,7 @@ class OrganizationRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Organization>(
       columnValues: columnValues(Organization.t.updateTable),
@@ -627,6 +650,7 @@ class OrganizationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -637,6 +661,10 @@ class OrganizationRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> delete(
     _i1.DatabaseSession session,
     List<Organization> rows, {
@@ -645,6 +673,7 @@ class OrganizationRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Organization>(
       rows,
@@ -653,6 +682,7 @@ class OrganizationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -672,6 +702,10 @@ class OrganizationRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Organization>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrganizationTable> where,
@@ -680,6 +714,7 @@ class OrganizationRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Organization>(
       where: where(Organization.t),
@@ -688,6 +723,7 @@ class OrganizationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/person.dart
@@ -448,16 +448,22 @@ class PersonRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> insert(
     _i1.DatabaseSession session,
     List<Person> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Person>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -491,6 +497,10 @@ class PersonRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> upsert(
     _i1.DatabaseSession session,
     List<Person> rows, {
@@ -498,6 +508,7 @@ class PersonRepository {
     _i1.ColumnSelections<PersonTable>? updateColumns,
     _i1.WhereExpressionBuilder<PersonTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Person>(
       rows,
@@ -505,6 +516,7 @@ class PersonRepository {
       updateColumns: updateColumns?.call(Person.t),
       updateWhere: updateWhere?.call(Person.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -543,16 +555,22 @@ class PersonRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> update(
     _i1.DatabaseSession session,
     List<Person> rows, {
     _i1.ColumnSelections<PersonTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Person>(
       rows,
       columns: columns?.call(Person.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -589,6 +607,10 @@ class PersonRepository {
 
   /// Updates all [Person]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PersonUpdateTable> columnValues,
@@ -600,6 +622,7 @@ class PersonRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Person>(
       columnValues: columnValues(Person.t.updateTable),
@@ -611,6 +634,7 @@ class PersonRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -621,6 +645,10 @@ class PersonRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> delete(
     _i1.DatabaseSession session,
     List<Person> rows, {
@@ -629,6 +657,7 @@ class PersonRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Person>(
       rows,
@@ -637,6 +666,7 @@ class PersonRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -656,6 +686,10 @@ class PersonRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Person>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PersonTable> where,
@@ -664,6 +698,7 @@ class PersonRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Person>(
       where: where(Person.t),
@@ -672,6 +707,7 @@ class PersonRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -393,16 +393,22 @@ class CourseRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> insert(
     _i1.DatabaseSession session,
     List<Course> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Course>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -436,6 +442,10 @@ class CourseRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> upsert(
     _i1.DatabaseSession session,
     List<Course> rows, {
@@ -443,6 +453,7 @@ class CourseRepository {
     _i1.ColumnSelections<CourseTable>? updateColumns,
     _i1.WhereExpressionBuilder<CourseTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Course>(
       rows,
@@ -450,6 +461,7 @@ class CourseRepository {
       updateColumns: updateColumns?.call(Course.t),
       updateWhere: updateWhere?.call(Course.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -488,16 +500,22 @@ class CourseRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> update(
     _i1.DatabaseSession session,
     List<Course> rows, {
     _i1.ColumnSelections<CourseTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Course>(
       rows,
       columns: columns?.call(Course.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -534,6 +552,10 @@ class CourseRepository {
 
   /// Updates all [Course]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CourseUpdateTable> columnValues,
@@ -545,6 +567,7 @@ class CourseRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Course>(
       columnValues: columnValues(Course.t.updateTable),
@@ -556,6 +579,7 @@ class CourseRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -566,6 +590,10 @@ class CourseRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> delete(
     _i1.DatabaseSession session,
     List<Course> rows, {
@@ -574,6 +602,7 @@ class CourseRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Course>(
       rows,
@@ -582,6 +611,7 @@ class CourseRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -601,6 +631,10 @@ class CourseRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Course>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CourseTable> where,
@@ -609,6 +643,7 @@ class CourseRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Course>(
       where: where(Course.t),
@@ -617,6 +652,7 @@ class CourseRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -433,16 +433,22 @@ class EnrollmentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> insert(
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Enrollment>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -476,6 +482,10 @@ class EnrollmentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> upsert(
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
@@ -483,6 +493,7 @@ class EnrollmentRepository {
     _i1.ColumnSelections<EnrollmentTable>? updateColumns,
     _i1.WhereExpressionBuilder<EnrollmentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Enrollment>(
       rows,
@@ -490,6 +501,7 @@ class EnrollmentRepository {
       updateColumns: updateColumns?.call(Enrollment.t),
       updateWhere: updateWhere?.call(Enrollment.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -528,16 +540,22 @@ class EnrollmentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> update(
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
     _i1.ColumnSelections<EnrollmentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Enrollment>(
       rows,
       columns: columns?.call(Enrollment.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -574,6 +592,10 @@ class EnrollmentRepository {
 
   /// Updates all [Enrollment]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<EnrollmentUpdateTable> columnValues,
@@ -585,6 +607,7 @@ class EnrollmentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Enrollment>(
       columnValues: columnValues(Enrollment.t.updateTable),
@@ -596,6 +619,7 @@ class EnrollmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -606,6 +630,10 @@ class EnrollmentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> delete(
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
@@ -614,6 +642,7 @@ class EnrollmentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Enrollment>(
       rows,
@@ -622,6 +651,7 @@ class EnrollmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -641,6 +671,10 @@ class EnrollmentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Enrollment>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnrollmentTable> where,
@@ -649,6 +683,7 @@ class EnrollmentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Enrollment>(
       where: where(Enrollment.t),
@@ -657,6 +692,7 @@ class EnrollmentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -390,16 +390,22 @@ class StudentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> insert(
     _i1.DatabaseSession session,
     List<Student> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Student>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -433,6 +439,10 @@ class StudentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> upsert(
     _i1.DatabaseSession session,
     List<Student> rows, {
@@ -440,6 +450,7 @@ class StudentRepository {
     _i1.ColumnSelections<StudentTable>? updateColumns,
     _i1.WhereExpressionBuilder<StudentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Student>(
       rows,
@@ -447,6 +458,7 @@ class StudentRepository {
       updateColumns: updateColumns?.call(Student.t),
       updateWhere: updateWhere?.call(Student.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -485,16 +497,22 @@ class StudentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> update(
     _i1.DatabaseSession session,
     List<Student> rows, {
     _i1.ColumnSelections<StudentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Student>(
       rows,
       columns: columns?.call(Student.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +549,10 @@ class StudentRepository {
 
   /// Updates all [Student]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<StudentUpdateTable> columnValues,
@@ -542,6 +564,7 @@ class StudentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Student>(
       columnValues: columnValues(Student.t.updateTable),
@@ -553,6 +576,7 @@ class StudentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -563,6 +587,10 @@ class StudentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> delete(
     _i1.DatabaseSession session,
     List<Student> rows, {
@@ -571,6 +599,7 @@ class StudentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Student>(
       rows,
@@ -579,6 +608,7 @@ class StudentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -598,6 +628,10 @@ class StudentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Student>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StudentTable> where,
@@ -606,6 +640,7 @@ class StudentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Student>(
       where: where(Student.t),
@@ -614,6 +649,7 @@ class StudentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -360,16 +360,22 @@ class ArenaRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> insert(
     _i1.DatabaseSession session,
     List<Arena> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Arena>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -403,6 +409,10 @@ class ArenaRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> upsert(
     _i1.DatabaseSession session,
     List<Arena> rows, {
@@ -410,6 +420,7 @@ class ArenaRepository {
     _i1.ColumnSelections<ArenaTable>? updateColumns,
     _i1.WhereExpressionBuilder<ArenaTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Arena>(
       rows,
@@ -417,6 +428,7 @@ class ArenaRepository {
       updateColumns: updateColumns?.call(Arena.t),
       updateWhere: updateWhere?.call(Arena.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -455,16 +467,22 @@ class ArenaRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> update(
     _i1.DatabaseSession session,
     List<Arena> rows, {
     _i1.ColumnSelections<ArenaTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Arena>(
       rows,
       columns: columns?.call(Arena.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -501,6 +519,10 @@ class ArenaRepository {
 
   /// Updates all [Arena]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ArenaUpdateTable> columnValues,
@@ -512,6 +534,7 @@ class ArenaRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Arena>(
       columnValues: columnValues(Arena.t.updateTable),
@@ -523,6 +546,7 @@ class ArenaRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -533,6 +557,10 @@ class ArenaRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> delete(
     _i1.DatabaseSession session,
     List<Arena> rows, {
@@ -541,6 +569,7 @@ class ArenaRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Arena>(
       rows,
@@ -549,6 +578,7 @@ class ArenaRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -568,6 +598,10 @@ class ArenaRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Arena>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ArenaTable> where,
@@ -576,6 +610,7 @@ class ArenaRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Arena>(
       where: where(Arena.t),
@@ -584,6 +619,7 @@ class ArenaRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -384,16 +384,22 @@ class PlayerRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> insert(
     _i1.DatabaseSession session,
     List<Player> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Player>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -427,6 +433,10 @@ class PlayerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> upsert(
     _i1.DatabaseSession session,
     List<Player> rows, {
@@ -434,6 +444,7 @@ class PlayerRepository {
     _i1.ColumnSelections<PlayerTable>? updateColumns,
     _i1.WhereExpressionBuilder<PlayerTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Player>(
       rows,
@@ -441,6 +452,7 @@ class PlayerRepository {
       updateColumns: updateColumns?.call(Player.t),
       updateWhere: updateWhere?.call(Player.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -479,16 +491,22 @@ class PlayerRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> update(
     _i1.DatabaseSession session,
     List<Player> rows, {
     _i1.ColumnSelections<PlayerTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Player>(
       rows,
       columns: columns?.call(Player.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -525,6 +543,10 @@ class PlayerRepository {
 
   /// Updates all [Player]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PlayerUpdateTable> columnValues,
@@ -536,6 +558,7 @@ class PlayerRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Player>(
       columnValues: columnValues(Player.t.updateTable),
@@ -547,6 +570,7 @@ class PlayerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -557,6 +581,10 @@ class PlayerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> delete(
     _i1.DatabaseSession session,
     List<Player> rows, {
@@ -565,6 +593,7 @@ class PlayerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Player>(
       rows,
@@ -573,6 +602,7 @@ class PlayerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -592,6 +622,10 @@ class PlayerRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Player>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PlayerTable> where,
@@ -600,6 +634,7 @@ class PlayerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Player>(
       where: where(Player.t),
@@ -608,6 +643,7 @@ class PlayerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -463,16 +463,22 @@ class TeamRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> insert(
     _i1.DatabaseSession session,
     List<Team> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Team>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -506,6 +512,10 @@ class TeamRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> upsert(
     _i1.DatabaseSession session,
     List<Team> rows, {
@@ -513,6 +523,7 @@ class TeamRepository {
     _i1.ColumnSelections<TeamTable>? updateColumns,
     _i1.WhereExpressionBuilder<TeamTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Team>(
       rows,
@@ -520,6 +531,7 @@ class TeamRepository {
       updateColumns: updateColumns?.call(Team.t),
       updateWhere: updateWhere?.call(Team.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -558,16 +570,22 @@ class TeamRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> update(
     _i1.DatabaseSession session,
     List<Team> rows, {
     _i1.ColumnSelections<TeamTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Team>(
       rows,
       columns: columns?.call(Team.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -604,6 +622,10 @@ class TeamRepository {
 
   /// Updates all [Team]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TeamUpdateTable> columnValues,
@@ -615,6 +637,7 @@ class TeamRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Team>(
       columnValues: columnValues(Team.t.updateTable),
@@ -626,6 +649,7 @@ class TeamRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -636,6 +660,10 @@ class TeamRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> delete(
     _i1.DatabaseSession session,
     List<Team> rows, {
@@ -644,6 +672,7 @@ class TeamRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Team>(
       rows,
@@ -652,6 +681,7 @@ class TeamRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -671,6 +701,10 @@ class TeamRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Team>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TeamTable> where,
@@ -679,6 +713,7 @@ class TeamRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Team>(
       where: where(Team.t),
@@ -687,6 +722,7 @@ class TeamRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -383,16 +383,22 @@ class CommentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> insert(
     _i1.DatabaseSession session,
     List<Comment> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Comment>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -426,6 +432,10 @@ class CommentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> upsert(
     _i1.DatabaseSession session,
     List<Comment> rows, {
@@ -433,6 +443,7 @@ class CommentRepository {
     _i1.ColumnSelections<CommentTable>? updateColumns,
     _i1.WhereExpressionBuilder<CommentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Comment>(
       rows,
@@ -440,6 +451,7 @@ class CommentRepository {
       updateColumns: updateColumns?.call(Comment.t),
       updateWhere: updateWhere?.call(Comment.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -478,16 +490,22 @@ class CommentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> update(
     _i1.DatabaseSession session,
     List<Comment> rows, {
     _i1.ColumnSelections<CommentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Comment>(
       rows,
       columns: columns?.call(Comment.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -524,6 +542,10 @@ class CommentRepository {
 
   /// Updates all [Comment]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CommentUpdateTable> columnValues,
@@ -535,6 +557,7 @@ class CommentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Comment>(
       columnValues: columnValues(Comment.t.updateTable),
@@ -546,6 +569,7 @@ class CommentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -556,6 +580,10 @@ class CommentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> delete(
     _i1.DatabaseSession session,
     List<Comment> rows, {
@@ -564,6 +592,7 @@ class CommentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Comment>(
       rows,
@@ -572,6 +601,7 @@ class CommentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +621,10 @@ class CommentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Comment>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CommentTable> where,
@@ -599,6 +633,7 @@ class CommentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Comment>(
       where: where(Comment.t),
@@ -607,6 +642,7 @@ class CommentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -392,16 +392,22 @@ class CustomerRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> insert(
     _i1.DatabaseSession session,
     List<Customer> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Customer>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -435,6 +441,10 @@ class CustomerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> upsert(
     _i1.DatabaseSession session,
     List<Customer> rows, {
@@ -442,6 +452,7 @@ class CustomerRepository {
     _i1.ColumnSelections<CustomerTable>? updateColumns,
     _i1.WhereExpressionBuilder<CustomerTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Customer>(
       rows,
@@ -449,6 +460,7 @@ class CustomerRepository {
       updateColumns: updateColumns?.call(Customer.t),
       updateWhere: updateWhere?.call(Customer.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -487,16 +499,22 @@ class CustomerRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> update(
     _i1.DatabaseSession session,
     List<Customer> rows, {
     _i1.ColumnSelections<CustomerTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Customer>(
       rows,
       columns: columns?.call(Customer.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -533,6 +551,10 @@ class CustomerRepository {
 
   /// Updates all [Customer]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CustomerUpdateTable> columnValues,
@@ -544,6 +566,7 @@ class CustomerRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Customer>(
       columnValues: columnValues(Customer.t.updateTable),
@@ -555,6 +578,7 @@ class CustomerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -565,6 +589,10 @@ class CustomerRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> delete(
     _i1.DatabaseSession session,
     List<Customer> rows, {
@@ -573,6 +601,7 @@ class CustomerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Customer>(
       rows,
@@ -581,6 +610,7 @@ class CustomerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -600,6 +630,10 @@ class CustomerRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Customer>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CustomerTable> where,
@@ -608,6 +642,7 @@ class CustomerRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Customer>(
       where: where(Customer.t),
@@ -616,6 +651,7 @@ class CustomerRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/implicit/book.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/implicit/book.dart
@@ -392,16 +392,22 @@ class BookRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> insert(
     _i1.DatabaseSession session,
     List<Book> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Book>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -435,6 +441,10 @@ class BookRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> upsert(
     _i1.DatabaseSession session,
     List<Book> rows, {
@@ -442,6 +452,7 @@ class BookRepository {
     _i1.ColumnSelections<BookTable>? updateColumns,
     _i1.WhereExpressionBuilder<BookTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Book>(
       rows,
@@ -449,6 +460,7 @@ class BookRepository {
       updateColumns: updateColumns?.call(Book.t),
       updateWhere: updateWhere?.call(Book.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -487,16 +499,22 @@ class BookRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> update(
     _i1.DatabaseSession session,
     List<Book> rows, {
     _i1.ColumnSelections<BookTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Book>(
       rows,
       columns: columns?.call(Book.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -533,6 +551,10 @@ class BookRepository {
 
   /// Updates all [Book]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BookUpdateTable> columnValues,
@@ -544,6 +566,7 @@ class BookRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Book>(
       columnValues: columnValues(Book.t.updateTable),
@@ -555,6 +578,7 @@ class BookRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -565,6 +589,10 @@ class BookRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> delete(
     _i1.DatabaseSession session,
     List<Book> rows, {
@@ -573,6 +601,7 @@ class BookRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Book>(
       rows,
@@ -581,6 +610,7 @@ class BookRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -600,6 +630,10 @@ class BookRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Book>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BookTable> where,
@@ -608,6 +642,7 @@ class BookRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Book>(
       where: where(Book.t),
@@ -616,6 +651,7 @@ class BookRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/implicit/chapter.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/implicit/chapter.dart
@@ -356,16 +356,22 @@ class ChapterRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> insert(
     _i1.DatabaseSession session,
     List<Chapter> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Chapter>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -399,6 +405,10 @@ class ChapterRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> upsert(
     _i1.DatabaseSession session,
     List<Chapter> rows, {
@@ -406,6 +416,7 @@ class ChapterRepository {
     _i1.ColumnSelections<ChapterTable>? updateColumns,
     _i1.WhereExpressionBuilder<ChapterTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Chapter>(
       rows,
@@ -413,6 +424,7 @@ class ChapterRepository {
       updateColumns: updateColumns?.call(Chapter.t),
       updateWhere: updateWhere?.call(Chapter.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -451,16 +463,22 @@ class ChapterRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> update(
     _i1.DatabaseSession session,
     List<Chapter> rows, {
     _i1.ColumnSelections<ChapterTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Chapter>(
       rows,
       columns: columns?.call(Chapter.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -497,6 +515,10 @@ class ChapterRepository {
 
   /// Updates all [Chapter]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ChapterUpdateTable> columnValues,
@@ -508,6 +530,7 @@ class ChapterRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Chapter>(
       columnValues: columnValues(Chapter.t.updateTable),
@@ -519,6 +542,7 @@ class ChapterRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -529,6 +553,10 @@ class ChapterRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> delete(
     _i1.DatabaseSession session,
     List<Chapter> rows, {
@@ -537,6 +565,7 @@ class ChapterRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Chapter>(
       rows,
@@ -545,6 +574,7 @@ class ChapterRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,6 +594,10 @@ class ChapterRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Chapter>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChapterTable> where,
@@ -572,6 +606,7 @@ class ChapterRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Chapter>(
       where: where(Chapter.t),
@@ -580,6 +615,7 @@ class ChapterRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -463,16 +463,22 @@ class OrderRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> insert(
     _i1.DatabaseSession session,
     List<Order> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Order>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -506,6 +512,10 @@ class OrderRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> upsert(
     _i1.DatabaseSession session,
     List<Order> rows, {
@@ -513,6 +523,7 @@ class OrderRepository {
     _i1.ColumnSelections<OrderTable>? updateColumns,
     _i1.WhereExpressionBuilder<OrderTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Order>(
       rows,
@@ -520,6 +531,7 @@ class OrderRepository {
       updateColumns: updateColumns?.call(Order.t),
       updateWhere: updateWhere?.call(Order.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -558,16 +570,22 @@ class OrderRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> update(
     _i1.DatabaseSession session,
     List<Order> rows, {
     _i1.ColumnSelections<OrderTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Order>(
       rows,
       columns: columns?.call(Order.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -604,6 +622,10 @@ class OrderRepository {
 
   /// Updates all [Order]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<OrderUpdateTable> columnValues,
@@ -615,6 +637,7 @@ class OrderRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Order>(
       columnValues: columnValues(Order.t.updateTable),
@@ -626,6 +649,7 @@ class OrderRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -636,6 +660,10 @@ class OrderRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> delete(
     _i1.DatabaseSession session,
     List<Order> rows, {
@@ -644,6 +672,7 @@ class OrderRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Order>(
       rows,
@@ -652,6 +681,7 @@ class OrderRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -671,6 +701,10 @@ class OrderRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Order>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrderTable> where,
@@ -679,6 +713,7 @@ class OrderRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Order>(
       where: where(Order.t),
@@ -687,6 +722,7 @@ class OrderRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -389,16 +389,22 @@ class AddressRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> insert(
     _i1.DatabaseSession session,
     List<Address> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Address>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -432,6 +438,10 @@ class AddressRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> upsert(
     _i1.DatabaseSession session,
     List<Address> rows, {
@@ -439,6 +449,7 @@ class AddressRepository {
     _i1.ColumnSelections<AddressTable>? updateColumns,
     _i1.WhereExpressionBuilder<AddressTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Address>(
       rows,
@@ -446,6 +457,7 @@ class AddressRepository {
       updateColumns: updateColumns?.call(Address.t),
       updateWhere: updateWhere?.call(Address.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -484,16 +496,22 @@ class AddressRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> update(
     _i1.DatabaseSession session,
     List<Address> rows, {
     _i1.ColumnSelections<AddressTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Address>(
       rows,
       columns: columns?.call(Address.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -530,6 +548,10 @@ class AddressRepository {
 
   /// Updates all [Address]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<AddressUpdateTable> columnValues,
@@ -541,6 +563,7 @@ class AddressRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Address>(
       columnValues: columnValues(Address.t.updateTable),
@@ -552,6 +575,7 @@ class AddressRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -562,6 +586,10 @@ class AddressRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> delete(
     _i1.DatabaseSession session,
     List<Address> rows, {
@@ -570,6 +598,7 @@ class AddressRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Address>(
       rows,
@@ -578,6 +607,7 @@ class AddressRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -597,6 +627,10 @@ class AddressRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Address>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AddressTable> where,
@@ -605,6 +639,7 @@ class AddressRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Address>(
       where: where(Address.t),
@@ -613,6 +648,7 @@ class AddressRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -504,16 +504,22 @@ class CitizenRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> insert(
     _i1.DatabaseSession session,
     List<Citizen> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Citizen>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -547,6 +553,10 @@ class CitizenRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> upsert(
     _i1.DatabaseSession session,
     List<Citizen> rows, {
@@ -554,6 +564,7 @@ class CitizenRepository {
     _i1.ColumnSelections<CitizenTable>? updateColumns,
     _i1.WhereExpressionBuilder<CitizenTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Citizen>(
       rows,
@@ -561,6 +572,7 @@ class CitizenRepository {
       updateColumns: updateColumns?.call(Citizen.t),
       updateWhere: updateWhere?.call(Citizen.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -599,16 +611,22 @@ class CitizenRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> update(
     _i1.DatabaseSession session,
     List<Citizen> rows, {
     _i1.ColumnSelections<CitizenTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Citizen>(
       rows,
       columns: columns?.call(Citizen.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -645,6 +663,10 @@ class CitizenRepository {
 
   /// Updates all [Citizen]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CitizenUpdateTable> columnValues,
@@ -656,6 +678,7 @@ class CitizenRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Citizen>(
       columnValues: columnValues(Citizen.t.updateTable),
@@ -667,6 +690,7 @@ class CitizenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -677,6 +701,10 @@ class CitizenRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> delete(
     _i1.DatabaseSession session,
     List<Citizen> rows, {
@@ -685,6 +713,7 @@ class CitizenRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Citizen>(
       rows,
@@ -693,6 +722,7 @@ class CitizenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -712,6 +742,10 @@ class CitizenRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Citizen>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CitizenTable> where,
@@ -720,6 +754,7 @@ class CitizenRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Citizen>(
       where: where(Citizen.t),
@@ -728,6 +763,7 @@ class CitizenRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -383,16 +383,22 @@ class CompanyRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> insert(
     _i1.DatabaseSession session,
     List<Company> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Company>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -426,6 +432,10 @@ class CompanyRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> upsert(
     _i1.DatabaseSession session,
     List<Company> rows, {
@@ -433,6 +443,7 @@ class CompanyRepository {
     _i1.ColumnSelections<CompanyTable>? updateColumns,
     _i1.WhereExpressionBuilder<CompanyTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Company>(
       rows,
@@ -440,6 +451,7 @@ class CompanyRepository {
       updateColumns: updateColumns?.call(Company.t),
       updateWhere: updateWhere?.call(Company.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -478,16 +490,22 @@ class CompanyRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> update(
     _i1.DatabaseSession session,
     List<Company> rows, {
     _i1.ColumnSelections<CompanyTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Company>(
       rows,
       columns: columns?.call(Company.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -524,6 +542,10 @@ class CompanyRepository {
 
   /// Updates all [Company]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CompanyUpdateTable> columnValues,
@@ -535,6 +557,7 @@ class CompanyRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Company>(
       columnValues: columnValues(Company.t.updateTable),
@@ -546,6 +569,7 @@ class CompanyRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -556,6 +580,10 @@ class CompanyRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> delete(
     _i1.DatabaseSession session,
     List<Company> rows, {
@@ -564,6 +592,7 @@ class CompanyRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Company>(
       rows,
@@ -572,6 +601,7 @@ class CompanyRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -591,6 +621,10 @@ class CompanyRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Company>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CompanyTable> where,
@@ -599,6 +633,7 @@ class CompanyRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Company>(
       where: where(Company.t),
@@ -607,6 +642,7 @@ class CompanyRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -384,16 +384,22 @@ class TownRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> insert(
     _i1.DatabaseSession session,
     List<Town> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Town>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -427,6 +433,10 @@ class TownRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> upsert(
     _i1.DatabaseSession session,
     List<Town> rows, {
@@ -434,6 +444,7 @@ class TownRepository {
     _i1.ColumnSelections<TownTable>? updateColumns,
     _i1.WhereExpressionBuilder<TownTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Town>(
       rows,
@@ -441,6 +452,7 @@ class TownRepository {
       updateColumns: updateColumns?.call(Town.t),
       updateWhere: updateWhere?.call(Town.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -479,16 +491,22 @@ class TownRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> update(
     _i1.DatabaseSession session,
     List<Town> rows, {
     _i1.ColumnSelections<TownTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Town>(
       rows,
       columns: columns?.call(Town.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -525,6 +543,10 @@ class TownRepository {
 
   /// Updates all [Town]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TownUpdateTable> columnValues,
@@ -536,6 +558,7 @@ class TownRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Town>(
       columnValues: columnValues(Town.t.updateTable),
@@ -547,6 +570,7 @@ class TownRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -557,6 +581,10 @@ class TownRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> delete(
     _i1.DatabaseSession session,
     List<Town> rows, {
@@ -565,6 +593,7 @@ class TownRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Town>(
       rows,
@@ -573,6 +602,7 @@ class TownRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -592,6 +622,10 @@ class TownRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Town>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TownTable> where,
@@ -600,6 +634,7 @@ class TownRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Town>(
       where: where(Town.t),
@@ -608,6 +643,7 @@ class TownRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -437,16 +437,22 @@ class BlockingRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> insert(
     _i1.DatabaseSession session,
     List<Blocking> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Blocking>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -480,6 +486,10 @@ class BlockingRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> upsert(
     _i1.DatabaseSession session,
     List<Blocking> rows, {
@@ -487,6 +497,7 @@ class BlockingRepository {
     _i1.ColumnSelections<BlockingTable>? updateColumns,
     _i1.WhereExpressionBuilder<BlockingTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Blocking>(
       rows,
@@ -494,6 +505,7 @@ class BlockingRepository {
       updateColumns: updateColumns?.call(Blocking.t),
       updateWhere: updateWhere?.call(Blocking.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -532,16 +544,22 @@ class BlockingRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> update(
     _i1.DatabaseSession session,
     List<Blocking> rows, {
     _i1.ColumnSelections<BlockingTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Blocking>(
       rows,
       columns: columns?.call(Blocking.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -578,6 +596,10 @@ class BlockingRepository {
 
   /// Updates all [Blocking]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<BlockingUpdateTable> columnValues,
@@ -589,6 +611,7 @@ class BlockingRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Blocking>(
       columnValues: columnValues(Blocking.t.updateTable),
@@ -600,6 +623,7 @@ class BlockingRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -610,6 +634,10 @@ class BlockingRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> delete(
     _i1.DatabaseSession session,
     List<Blocking> rows, {
@@ -618,6 +646,7 @@ class BlockingRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Blocking>(
       rows,
@@ -626,6 +655,7 @@ class BlockingRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -645,6 +675,10 @@ class BlockingRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Blocking>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BlockingTable> where,
@@ -653,6 +687,7 @@ class BlockingRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Blocking>(
       where: where(Blocking.t),
@@ -661,6 +696,7 @@ class BlockingRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -464,16 +464,22 @@ class MemberRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> insert(
     _i1.DatabaseSession session,
     List<Member> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Member>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -507,6 +513,10 @@ class MemberRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> upsert(
     _i1.DatabaseSession session,
     List<Member> rows, {
@@ -514,6 +524,7 @@ class MemberRepository {
     _i1.ColumnSelections<MemberTable>? updateColumns,
     _i1.WhereExpressionBuilder<MemberTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Member>(
       rows,
@@ -521,6 +532,7 @@ class MemberRepository {
       updateColumns: updateColumns?.call(Member.t),
       updateWhere: updateWhere?.call(Member.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -559,16 +571,22 @@ class MemberRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> update(
     _i1.DatabaseSession session,
     List<Member> rows, {
     _i1.ColumnSelections<MemberTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Member>(
       rows,
       columns: columns?.call(Member.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -605,6 +623,10 @@ class MemberRepository {
 
   /// Updates all [Member]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<MemberUpdateTable> columnValues,
@@ -616,6 +638,7 @@ class MemberRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Member>(
       columnValues: columnValues(Member.t.updateTable),
@@ -627,6 +650,7 @@ class MemberRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -637,6 +661,10 @@ class MemberRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> delete(
     _i1.DatabaseSession session,
     List<Member> rows, {
@@ -645,6 +673,7 @@ class MemberRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Member>(
       rows,
@@ -653,6 +682,7 @@ class MemberRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -672,6 +702,10 @@ class MemberRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Member>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MemberTable> where,
@@ -680,6 +714,7 @@ class MemberRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Member>(
       where: where(Member.t),
@@ -688,6 +723,7 @@ class MemberRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -463,16 +463,22 @@ class CatRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> insert(
     _i1.DatabaseSession session,
     List<Cat> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Cat>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -506,6 +512,10 @@ class CatRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> upsert(
     _i1.DatabaseSession session,
     List<Cat> rows, {
@@ -513,6 +523,7 @@ class CatRepository {
     _i1.ColumnSelections<CatTable>? updateColumns,
     _i1.WhereExpressionBuilder<CatTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Cat>(
       rows,
@@ -520,6 +531,7 @@ class CatRepository {
       updateColumns: updateColumns?.call(Cat.t),
       updateWhere: updateWhere?.call(Cat.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -558,16 +570,22 @@ class CatRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> update(
     _i1.DatabaseSession session,
     List<Cat> rows, {
     _i1.ColumnSelections<CatTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Cat>(
       rows,
       columns: columns?.call(Cat.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -604,6 +622,10 @@ class CatRepository {
 
   /// Updates all [Cat]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<CatUpdateTable> columnValues,
@@ -615,6 +637,7 @@ class CatRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Cat>(
       columnValues: columnValues(Cat.t.updateTable),
@@ -626,6 +649,7 @@ class CatRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -636,6 +660,10 @@ class CatRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> delete(
     _i1.DatabaseSession session,
     List<Cat> rows, {
@@ -644,6 +672,7 @@ class CatRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Cat>(
       rows,
@@ -652,6 +681,7 @@ class CatRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -671,6 +701,10 @@ class CatRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Cat>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CatTable> where,
@@ -679,6 +713,7 @@ class CatRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Cat>(
       where: where(Cat.t),
@@ -687,6 +722,7 @@ class CatRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -432,16 +432,22 @@ class PostRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> insert(
     _i1.DatabaseSession session,
     List<Post> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Post>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -475,6 +481,10 @@ class PostRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> upsert(
     _i1.DatabaseSession session,
     List<Post> rows, {
@@ -482,6 +492,7 @@ class PostRepository {
     _i1.ColumnSelections<PostTable>? updateColumns,
     _i1.WhereExpressionBuilder<PostTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Post>(
       rows,
@@ -489,6 +500,7 @@ class PostRepository {
       updateColumns: updateColumns?.call(Post.t),
       updateWhere: updateWhere?.call(Post.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -527,16 +539,22 @@ class PostRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> update(
     _i1.DatabaseSession session,
     List<Post> rows, {
     _i1.ColumnSelections<PostTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Post>(
       rows,
       columns: columns?.call(Post.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -573,6 +591,10 @@ class PostRepository {
 
   /// Updates all [Post]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<PostUpdateTable> columnValues,
@@ -584,6 +606,7 @@ class PostRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Post>(
       columnValues: columnValues(Post.t.updateTable),
@@ -595,6 +618,7 @@ class PostRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -605,6 +629,10 @@ class PostRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> delete(
     _i1.DatabaseSession session,
     List<Post> rows, {
@@ -613,6 +641,7 @@ class PostRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Post>(
       rows,
@@ -621,6 +650,7 @@ class PostRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -640,6 +670,10 @@ class PostRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Post>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PostTable> where,
@@ -648,6 +682,7 @@ class PostRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Post>(
       where: where(Post.t),
@@ -656,6 +691,7 @@ class PostRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_field_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_field_persist.dart
@@ -339,16 +339,22 @@ class ObjectFieldPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> insert(
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectFieldPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -382,6 +388,10 @@ class ObjectFieldPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> upsert(
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
@@ -389,6 +399,7 @@ class ObjectFieldPersistRepository {
     _i1.ColumnSelections<ObjectFieldPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectFieldPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectFieldPersist>(
       rows,
@@ -396,6 +407,7 @@ class ObjectFieldPersistRepository {
       updateColumns: updateColumns?.call(ObjectFieldPersist.t),
       updateWhere: updateWhere?.call(ObjectFieldPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -434,16 +446,22 @@ class ObjectFieldPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> update(
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
     _i1.ColumnSelections<ObjectFieldPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectFieldPersist>(
       rows,
       columns: columns?.call(ObjectFieldPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,6 +499,10 @@ class ObjectFieldPersistRepository {
 
   /// Updates all [ObjectFieldPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectFieldPersistUpdateTable>
@@ -493,6 +515,7 @@ class ObjectFieldPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectFieldPersist>(
       columnValues: columnValues(ObjectFieldPersist.t.updateTable),
@@ -504,6 +527,7 @@ class ObjectFieldPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -514,6 +538,10 @@ class ObjectFieldPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> delete(
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
@@ -522,6 +550,7 @@ class ObjectFieldPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectFieldPersist>(
       rows,
@@ -530,6 +559,7 @@ class ObjectFieldPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,6 +579,10 @@ class ObjectFieldPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectFieldPersistTable> where,
@@ -557,6 +591,7 @@ class ObjectFieldPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectFieldPersist>(
       where: where(ObjectFieldPersist.t),
@@ -565,6 +600,7 @@ class ObjectFieldPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_field_scopes.dart
@@ -343,16 +343,22 @@ class ObjectFieldScopesRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldScopes>> insert(
     _i1.DatabaseSession session,
     List<ObjectFieldScopes> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectFieldScopes>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -386,6 +392,10 @@ class ObjectFieldScopesRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldScopes>> upsert(
     _i1.DatabaseSession session,
     List<ObjectFieldScopes> rows, {
@@ -393,6 +403,7 @@ class ObjectFieldScopesRepository {
     _i1.ColumnSelections<ObjectFieldScopesTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectFieldScopesTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectFieldScopes>(
       rows,
@@ -400,6 +411,7 @@ class ObjectFieldScopesRepository {
       updateColumns: updateColumns?.call(ObjectFieldScopes.t),
       updateWhere: updateWhere?.call(ObjectFieldScopes.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -438,16 +450,22 @@ class ObjectFieldScopesRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldScopes>> update(
     _i1.DatabaseSession session,
     List<ObjectFieldScopes> rows, {
     _i1.ColumnSelections<ObjectFieldScopesTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectFieldScopes>(
       rows,
       columns: columns?.call(ObjectFieldScopes.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -485,6 +503,10 @@ class ObjectFieldScopesRepository {
 
   /// Updates all [ObjectFieldScopes]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldScopes>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectFieldScopesUpdateTable>
@@ -497,6 +519,7 @@ class ObjectFieldScopesRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectFieldScopes>(
       columnValues: columnValues(ObjectFieldScopes.t.updateTable),
@@ -508,6 +531,7 @@ class ObjectFieldScopesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -518,6 +542,10 @@ class ObjectFieldScopesRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldScopes>> delete(
     _i1.DatabaseSession session,
     List<ObjectFieldScopes> rows, {
@@ -526,6 +554,7 @@ class ObjectFieldScopesRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectFieldScopes>(
       rows,
@@ -534,6 +563,7 @@ class ObjectFieldScopesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -553,6 +583,10 @@ class ObjectFieldScopesRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectFieldScopes>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectFieldScopesTable> where,
@@ -561,6 +595,7 @@ class ObjectFieldScopesRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectFieldScopes>(
       where: where(ObjectFieldScopes.t),
@@ -569,6 +604,7 @@ class ObjectFieldScopesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_bit.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_bit.dart
@@ -454,16 +454,22 @@ class ObjectWithBitRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithBit>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithBit> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithBit>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -497,6 +503,10 @@ class ObjectWithBitRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithBit>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithBit> rows, {
@@ -504,6 +514,7 @@ class ObjectWithBitRepository {
     _i1.ColumnSelections<ObjectWithBitTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithBitTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithBit>(
       rows,
@@ -511,6 +522,7 @@ class ObjectWithBitRepository {
       updateColumns: updateColumns?.call(ObjectWithBit.t),
       updateWhere: updateWhere?.call(ObjectWithBit.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -549,16 +561,22 @@ class ObjectWithBitRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithBit>> update(
     _i1.DatabaseSession session,
     List<ObjectWithBit> rows, {
     _i1.ColumnSelections<ObjectWithBitTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithBit>(
       rows,
       columns: columns?.call(ObjectWithBit.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -595,6 +613,10 @@ class ObjectWithBitRepository {
 
   /// Updates all [ObjectWithBit]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithBit>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithBitUpdateTable> columnValues,
@@ -606,6 +628,7 @@ class ObjectWithBitRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithBit>(
       columnValues: columnValues(ObjectWithBit.t.updateTable),
@@ -617,6 +640,7 @@ class ObjectWithBitRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -627,6 +651,10 @@ class ObjectWithBitRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithBit>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithBit> rows, {
@@ -635,6 +663,7 @@ class ObjectWithBitRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithBit>(
       rows,
@@ -643,6 +672,7 @@ class ObjectWithBitRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -662,6 +692,10 @@ class ObjectWithBitRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithBit>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithBitTable> where,
@@ -670,6 +704,7 @@ class ObjectWithBitRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithBit>(
       where: where(ObjectWithBit.t),
@@ -678,6 +713,7 @@ class ObjectWithBitRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_bytedata.dart
@@ -312,16 +312,22 @@ class ObjectWithByteDataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithByteData>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithByteData> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithByteData>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -355,6 +361,10 @@ class ObjectWithByteDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithByteData>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithByteData> rows, {
@@ -362,6 +372,7 @@ class ObjectWithByteDataRepository {
     _i1.ColumnSelections<ObjectWithByteDataTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithByteDataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithByteData>(
       rows,
@@ -369,6 +380,7 @@ class ObjectWithByteDataRepository {
       updateColumns: updateColumns?.call(ObjectWithByteData.t),
       updateWhere: updateWhere?.call(ObjectWithByteData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -407,16 +419,22 @@ class ObjectWithByteDataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithByteData>> update(
     _i1.DatabaseSession session,
     List<ObjectWithByteData> rows, {
     _i1.ColumnSelections<ObjectWithByteDataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithByteData>(
       rows,
       columns: columns?.call(ObjectWithByteData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -454,6 +472,10 @@ class ObjectWithByteDataRepository {
 
   /// Updates all [ObjectWithByteData]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithByteData>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithByteDataUpdateTable>
@@ -466,6 +488,7 @@ class ObjectWithByteDataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithByteData>(
       columnValues: columnValues(ObjectWithByteData.t.updateTable),
@@ -477,6 +500,7 @@ class ObjectWithByteDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -487,6 +511,10 @@ class ObjectWithByteDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithByteData>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithByteData> rows, {
@@ -495,6 +523,7 @@ class ObjectWithByteDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithByteData>(
       rows,
@@ -503,6 +532,7 @@ class ObjectWithByteDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -522,6 +552,10 @@ class ObjectWithByteDataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithByteData>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithByteDataTable> where,
@@ -530,6 +564,7 @@ class ObjectWithByteDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithByteData>(
       where: where(ObjectWithByteData.t),
@@ -538,6 +573,7 @@ class ObjectWithByteDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_duration.dart
@@ -311,16 +311,22 @@ class ObjectWithDurationRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDuration>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithDuration> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithDuration>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -354,6 +360,10 @@ class ObjectWithDurationRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDuration>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithDuration> rows, {
@@ -361,6 +371,7 @@ class ObjectWithDurationRepository {
     _i1.ColumnSelections<ObjectWithDurationTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithDurationTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithDuration>(
       rows,
@@ -368,6 +379,7 @@ class ObjectWithDurationRepository {
       updateColumns: updateColumns?.call(ObjectWithDuration.t),
       updateWhere: updateWhere?.call(ObjectWithDuration.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -406,16 +418,22 @@ class ObjectWithDurationRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDuration>> update(
     _i1.DatabaseSession session,
     List<ObjectWithDuration> rows, {
     _i1.ColumnSelections<ObjectWithDurationTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithDuration>(
       rows,
       columns: columns?.call(ObjectWithDuration.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -453,6 +471,10 @@ class ObjectWithDurationRepository {
 
   /// Updates all [ObjectWithDuration]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDuration>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithDurationUpdateTable>
@@ -465,6 +487,7 @@ class ObjectWithDurationRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithDuration>(
       columnValues: columnValues(ObjectWithDuration.t.updateTable),
@@ -476,6 +499,7 @@ class ObjectWithDurationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,6 +510,10 @@ class ObjectWithDurationRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDuration>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithDuration> rows, {
@@ -494,6 +522,7 @@ class ObjectWithDurationRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithDuration>(
       rows,
@@ -502,6 +531,7 @@ class ObjectWithDurationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -521,6 +551,10 @@ class ObjectWithDurationRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDuration>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithDurationTable> where,
@@ -529,6 +563,7 @@ class ObjectWithDurationRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithDuration>(
       where: where(ObjectWithDuration.t),
@@ -537,6 +572,7 @@ class ObjectWithDurationRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_dynamic.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_dynamic.dart
@@ -512,16 +512,22 @@ class ObjectWithDynamicRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDynamic>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithDynamic> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithDynamic>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -555,6 +561,10 @@ class ObjectWithDynamicRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDynamic>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithDynamic> rows, {
@@ -562,6 +572,7 @@ class ObjectWithDynamicRepository {
     _i1.ColumnSelections<ObjectWithDynamicTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithDynamicTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithDynamic>(
       rows,
@@ -569,6 +580,7 @@ class ObjectWithDynamicRepository {
       updateColumns: updateColumns?.call(ObjectWithDynamic.t),
       updateWhere: updateWhere?.call(ObjectWithDynamic.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -607,16 +619,22 @@ class ObjectWithDynamicRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDynamic>> update(
     _i1.DatabaseSession session,
     List<ObjectWithDynamic> rows, {
     _i1.ColumnSelections<ObjectWithDynamicTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithDynamic>(
       rows,
       columns: columns?.call(ObjectWithDynamic.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -654,6 +672,10 @@ class ObjectWithDynamicRepository {
 
   /// Updates all [ObjectWithDynamic]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDynamic>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithDynamicUpdateTable>
@@ -666,6 +688,7 @@ class ObjectWithDynamicRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithDynamic>(
       columnValues: columnValues(ObjectWithDynamic.t.updateTable),
@@ -677,6 +700,7 @@ class ObjectWithDynamicRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -687,6 +711,10 @@ class ObjectWithDynamicRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDynamic>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithDynamic> rows, {
@@ -695,6 +723,7 @@ class ObjectWithDynamicRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithDynamic>(
       rows,
@@ -703,6 +732,7 @@ class ObjectWithDynamicRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -722,6 +752,10 @@ class ObjectWithDynamicRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithDynamic>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithDynamicTable> where,
@@ -730,6 +764,7 @@ class ObjectWithDynamicRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithDynamic>(
       where: where(ObjectWithDynamic.t),
@@ -738,6 +773,7 @@ class ObjectWithDynamicRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_enum.dart
@@ -437,16 +437,22 @@ class ObjectWithEnumRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnum>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithEnum> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithEnum>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -480,6 +486,10 @@ class ObjectWithEnumRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnum>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithEnum> rows, {
@@ -487,6 +497,7 @@ class ObjectWithEnumRepository {
     _i1.ColumnSelections<ObjectWithEnumTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithEnumTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithEnum>(
       rows,
@@ -494,6 +505,7 @@ class ObjectWithEnumRepository {
       updateColumns: updateColumns?.call(ObjectWithEnum.t),
       updateWhere: updateWhere?.call(ObjectWithEnum.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -532,16 +544,22 @@ class ObjectWithEnumRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnum>> update(
     _i1.DatabaseSession session,
     List<ObjectWithEnum> rows, {
     _i1.ColumnSelections<ObjectWithEnumTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithEnum>(
       rows,
       columns: columns?.call(ObjectWithEnum.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -578,6 +596,10 @@ class ObjectWithEnumRepository {
 
   /// Updates all [ObjectWithEnum]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnum>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithEnumUpdateTable> columnValues,
@@ -589,6 +611,7 @@ class ObjectWithEnumRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithEnum>(
       columnValues: columnValues(ObjectWithEnum.t.updateTable),
@@ -600,6 +623,7 @@ class ObjectWithEnumRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -610,6 +634,10 @@ class ObjectWithEnumRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnum>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithEnum> rows, {
@@ -618,6 +646,7 @@ class ObjectWithEnumRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithEnum>(
       rows,
@@ -626,6 +655,7 @@ class ObjectWithEnumRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -645,6 +675,10 @@ class ObjectWithEnumRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnum>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithEnumTable> where,
@@ -653,6 +687,7 @@ class ObjectWithEnumRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithEnum>(
       where: where(ObjectWithEnum.t),
@@ -661,6 +696,7 @@ class ObjectWithEnumRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_enum_enhanced.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_enum_enhanced.dart
@@ -470,16 +470,22 @@ class ObjectWithEnumEnhancedRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnumEnhanced>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithEnumEnhanced> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithEnumEnhanced>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -513,6 +519,10 @@ class ObjectWithEnumEnhancedRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnumEnhanced>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithEnumEnhanced> rows, {
@@ -520,6 +530,7 @@ class ObjectWithEnumEnhancedRepository {
     _i1.ColumnSelections<ObjectWithEnumEnhancedTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithEnumEnhancedTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithEnumEnhanced>(
       rows,
@@ -527,6 +538,7 @@ class ObjectWithEnumEnhancedRepository {
       updateColumns: updateColumns?.call(ObjectWithEnumEnhanced.t),
       updateWhere: updateWhere?.call(ObjectWithEnumEnhanced.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -565,16 +577,22 @@ class ObjectWithEnumEnhancedRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnumEnhanced>> update(
     _i1.DatabaseSession session,
     List<ObjectWithEnumEnhanced> rows, {
     _i1.ColumnSelections<ObjectWithEnumEnhancedTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithEnumEnhanced>(
       rows,
       columns: columns?.call(ObjectWithEnumEnhanced.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -612,6 +630,10 @@ class ObjectWithEnumEnhancedRepository {
 
   /// Updates all [ObjectWithEnumEnhanced]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnumEnhanced>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithEnumEnhancedUpdateTable>
@@ -624,6 +646,7 @@ class ObjectWithEnumEnhancedRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithEnumEnhanced>(
       columnValues: columnValues(ObjectWithEnumEnhanced.t.updateTable),
@@ -635,6 +658,7 @@ class ObjectWithEnumEnhancedRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -645,6 +669,10 @@ class ObjectWithEnumEnhancedRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnumEnhanced>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithEnumEnhanced> rows, {
@@ -653,6 +681,7 @@ class ObjectWithEnumEnhancedRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithEnumEnhanced>(
       rows,
@@ -661,6 +690,7 @@ class ObjectWithEnumEnhancedRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -680,6 +710,10 @@ class ObjectWithEnumEnhancedRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithEnumEnhanced>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithEnumEnhancedTable> where,
@@ -688,6 +722,7 @@ class ObjectWithEnumEnhancedRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithEnumEnhanced>(
       where: where(ObjectWithEnumEnhanced.t),
@@ -696,6 +731,7 @@ class ObjectWithEnumEnhancedRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_half_vector.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_half_vector.dart
@@ -474,16 +474,22 @@ class ObjectWithHalfVectorRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithHalfVector>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithHalfVector> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithHalfVector>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -517,6 +523,10 @@ class ObjectWithHalfVectorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithHalfVector>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithHalfVector> rows, {
@@ -524,6 +534,7 @@ class ObjectWithHalfVectorRepository {
     _i1.ColumnSelections<ObjectWithHalfVectorTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithHalfVectorTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithHalfVector>(
       rows,
@@ -531,6 +542,7 @@ class ObjectWithHalfVectorRepository {
       updateColumns: updateColumns?.call(ObjectWithHalfVector.t),
       updateWhere: updateWhere?.call(ObjectWithHalfVector.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -569,16 +581,22 @@ class ObjectWithHalfVectorRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithHalfVector>> update(
     _i1.DatabaseSession session,
     List<ObjectWithHalfVector> rows, {
     _i1.ColumnSelections<ObjectWithHalfVectorTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithHalfVector>(
       rows,
       columns: columns?.call(ObjectWithHalfVector.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -616,6 +634,10 @@ class ObjectWithHalfVectorRepository {
 
   /// Updates all [ObjectWithHalfVector]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithHalfVector>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithHalfVectorUpdateTable>
@@ -628,6 +650,7 @@ class ObjectWithHalfVectorRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithHalfVector>(
       columnValues: columnValues(ObjectWithHalfVector.t.updateTable),
@@ -639,6 +662,7 @@ class ObjectWithHalfVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -649,6 +673,10 @@ class ObjectWithHalfVectorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithHalfVector>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithHalfVector> rows, {
@@ -657,6 +685,7 @@ class ObjectWithHalfVectorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithHalfVector>(
       rows,
@@ -665,6 +694,7 @@ class ObjectWithHalfVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -684,6 +714,10 @@ class ObjectWithHalfVectorRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithHalfVector>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithHalfVectorTable> where,
@@ -692,6 +726,7 @@ class ObjectWithHalfVectorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithHalfVector>(
       where: where(ObjectWithHalfVector.t),
@@ -700,6 +735,7 @@ class ObjectWithHalfVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_index.dart
@@ -331,16 +331,22 @@ class ObjectWithIndexRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithIndex>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithIndex> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithIndex>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -374,6 +380,10 @@ class ObjectWithIndexRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithIndex>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithIndex> rows, {
@@ -381,6 +391,7 @@ class ObjectWithIndexRepository {
     _i1.ColumnSelections<ObjectWithIndexTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithIndexTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithIndex>(
       rows,
@@ -388,6 +399,7 @@ class ObjectWithIndexRepository {
       updateColumns: updateColumns?.call(ObjectWithIndex.t),
       updateWhere: updateWhere?.call(ObjectWithIndex.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -426,16 +438,22 @@ class ObjectWithIndexRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithIndex>> update(
     _i1.DatabaseSession session,
     List<ObjectWithIndex> rows, {
     _i1.ColumnSelections<ObjectWithIndexTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithIndex>(
       rows,
       columns: columns?.call(ObjectWithIndex.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -473,6 +491,10 @@ class ObjectWithIndexRepository {
 
   /// Updates all [ObjectWithIndex]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithIndex>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithIndexUpdateTable>
@@ -485,6 +507,7 @@ class ObjectWithIndexRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithIndex>(
       columnValues: columnValues(ObjectWithIndex.t.updateTable),
@@ -496,6 +519,7 @@ class ObjectWithIndexRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -506,6 +530,10 @@ class ObjectWithIndexRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithIndex>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithIndex> rows, {
@@ -514,6 +542,7 @@ class ObjectWithIndexRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithIndex>(
       rows,
@@ -522,6 +551,7 @@ class ObjectWithIndexRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -541,6 +571,10 @@ class ObjectWithIndexRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithIndex>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithIndexTable> where,
@@ -549,6 +583,7 @@ class ObjectWithIndexRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithIndex>(
       where: where(ObjectWithIndex.t),
@@ -557,6 +592,7 @@ class ObjectWithIndexRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_jsonb.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_jsonb.dart
@@ -555,16 +555,22 @@ class ObjectWithJsonbRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonb>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithJsonb> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithJsonb>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -598,6 +604,10 @@ class ObjectWithJsonbRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonb>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithJsonb> rows, {
@@ -605,6 +615,7 @@ class ObjectWithJsonbRepository {
     _i1.ColumnSelections<ObjectWithJsonbTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithJsonbTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithJsonb>(
       rows,
@@ -612,6 +623,7 @@ class ObjectWithJsonbRepository {
       updateColumns: updateColumns?.call(ObjectWithJsonb.t),
       updateWhere: updateWhere?.call(ObjectWithJsonb.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -650,16 +662,22 @@ class ObjectWithJsonbRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonb>> update(
     _i1.DatabaseSession session,
     List<ObjectWithJsonb> rows, {
     _i1.ColumnSelections<ObjectWithJsonbTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithJsonb>(
       rows,
       columns: columns?.call(ObjectWithJsonb.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -697,6 +715,10 @@ class ObjectWithJsonbRepository {
 
   /// Updates all [ObjectWithJsonb]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonb>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithJsonbUpdateTable>
@@ -709,6 +731,7 @@ class ObjectWithJsonbRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithJsonb>(
       columnValues: columnValues(ObjectWithJsonb.t.updateTable),
@@ -720,6 +743,7 @@ class ObjectWithJsonbRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -730,6 +754,10 @@ class ObjectWithJsonbRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonb>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithJsonb> rows, {
@@ -738,6 +766,7 @@ class ObjectWithJsonbRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithJsonb>(
       rows,
@@ -746,6 +775,7 @@ class ObjectWithJsonbRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -765,6 +795,10 @@ class ObjectWithJsonbRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonb>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithJsonbTable> where,
@@ -773,6 +807,7 @@ class ObjectWithJsonbRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithJsonb>(
       where: where(ObjectWithJsonb.t),
@@ -781,6 +816,7 @@ class ObjectWithJsonbRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_jsonb_class_level.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_jsonb_class_level.dart
@@ -371,16 +371,22 @@ class ObjectWithJsonbClassLevelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonbClassLevel>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithJsonbClassLevel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithJsonbClassLevel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -414,6 +420,10 @@ class ObjectWithJsonbClassLevelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonbClassLevel>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithJsonbClassLevel> rows, {
@@ -422,6 +432,7 @@ class ObjectWithJsonbClassLevelRepository {
     _i1.ColumnSelections<ObjectWithJsonbClassLevelTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithJsonbClassLevelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithJsonbClassLevel>(
       rows,
@@ -429,6 +440,7 @@ class ObjectWithJsonbClassLevelRepository {
       updateColumns: updateColumns?.call(ObjectWithJsonbClassLevel.t),
       updateWhere: updateWhere?.call(ObjectWithJsonbClassLevel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -468,16 +480,22 @@ class ObjectWithJsonbClassLevelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonbClassLevel>> update(
     _i1.DatabaseSession session,
     List<ObjectWithJsonbClassLevel> rows, {
     _i1.ColumnSelections<ObjectWithJsonbClassLevelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithJsonbClassLevel>(
       rows,
       columns: columns?.call(ObjectWithJsonbClassLevel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -515,6 +533,10 @@ class ObjectWithJsonbClassLevelRepository {
 
   /// Updates all [ObjectWithJsonbClassLevel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonbClassLevel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithJsonbClassLevelUpdateTable>
@@ -527,6 +549,7 @@ class ObjectWithJsonbClassLevelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithJsonbClassLevel>(
       columnValues: columnValues(ObjectWithJsonbClassLevel.t.updateTable),
@@ -538,6 +561,7 @@ class ObjectWithJsonbClassLevelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -548,6 +572,10 @@ class ObjectWithJsonbClassLevelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonbClassLevel>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithJsonbClassLevel> rows, {
@@ -556,6 +584,7 @@ class ObjectWithJsonbClassLevelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithJsonbClassLevel>(
       rows,
@@ -564,6 +593,7 @@ class ObjectWithJsonbClassLevelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -583,6 +613,10 @@ class ObjectWithJsonbClassLevelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithJsonbClassLevel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithJsonbClassLevelTable> where,
@@ -591,6 +625,7 @@ class ObjectWithJsonbClassLevelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithJsonbClassLevel>(
       where: where(ObjectWithJsonbClassLevel.t),
@@ -599,6 +634,7 @@ class ObjectWithJsonbClassLevelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_object.dart
@@ -672,16 +672,22 @@ class ObjectWithObjectRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithObject>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithObject> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithObject>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -715,6 +721,10 @@ class ObjectWithObjectRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithObject>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithObject> rows, {
@@ -722,6 +732,7 @@ class ObjectWithObjectRepository {
     _i1.ColumnSelections<ObjectWithObjectTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithObjectTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithObject>(
       rows,
@@ -729,6 +740,7 @@ class ObjectWithObjectRepository {
       updateColumns: updateColumns?.call(ObjectWithObject.t),
       updateWhere: updateWhere?.call(ObjectWithObject.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -767,16 +779,22 @@ class ObjectWithObjectRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithObject>> update(
     _i1.DatabaseSession session,
     List<ObjectWithObject> rows, {
     _i1.ColumnSelections<ObjectWithObjectTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithObject>(
       rows,
       columns: columns?.call(ObjectWithObject.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -814,6 +832,10 @@ class ObjectWithObjectRepository {
 
   /// Updates all [ObjectWithObject]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithObject>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithObjectUpdateTable>
@@ -826,6 +848,7 @@ class ObjectWithObjectRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithObject>(
       columnValues: columnValues(ObjectWithObject.t.updateTable),
@@ -837,6 +860,7 @@ class ObjectWithObjectRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -847,6 +871,10 @@ class ObjectWithObjectRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithObject>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithObject> rows, {
@@ -855,6 +883,7 @@ class ObjectWithObjectRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithObject>(
       rows,
@@ -863,6 +892,7 @@ class ObjectWithObjectRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -882,6 +912,10 @@ class ObjectWithObjectRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithObject>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithObjectTable> where,
@@ -890,6 +924,7 @@ class ObjectWithObjectRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithObject>(
       where: where(ObjectWithObject.t),
@@ -898,6 +933,7 @@ class ObjectWithObjectRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_parent.dart
@@ -308,16 +308,22 @@ class ObjectWithParentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithParent>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithParent> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithParent>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -351,6 +357,10 @@ class ObjectWithParentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithParent>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithParent> rows, {
@@ -358,6 +368,7 @@ class ObjectWithParentRepository {
     _i1.ColumnSelections<ObjectWithParentTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithParentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithParent>(
       rows,
@@ -365,6 +376,7 @@ class ObjectWithParentRepository {
       updateColumns: updateColumns?.call(ObjectWithParent.t),
       updateWhere: updateWhere?.call(ObjectWithParent.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -403,16 +415,22 @@ class ObjectWithParentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithParent>> update(
     _i1.DatabaseSession session,
     List<ObjectWithParent> rows, {
     _i1.ColumnSelections<ObjectWithParentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithParent>(
       rows,
       columns: columns?.call(ObjectWithParent.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -450,6 +468,10 @@ class ObjectWithParentRepository {
 
   /// Updates all [ObjectWithParent]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithParent>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithParentUpdateTable>
@@ -462,6 +484,7 @@ class ObjectWithParentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithParent>(
       columnValues: columnValues(ObjectWithParent.t.updateTable),
@@ -473,6 +496,7 @@ class ObjectWithParentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -483,6 +507,10 @@ class ObjectWithParentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithParent>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithParent> rows, {
@@ -491,6 +519,7 @@ class ObjectWithParentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithParent>(
       rows,
@@ -499,6 +528,7 @@ class ObjectWithParentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -518,6 +548,10 @@ class ObjectWithParentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithParent>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithParentTable> where,
@@ -526,6 +560,7 @@ class ObjectWithParentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithParent>(
       where: where(ObjectWithParent.t),
@@ -534,6 +569,7 @@ class ObjectWithParentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_self_parent.dart
@@ -310,16 +310,22 @@ class ObjectWithSelfParentRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSelfParent>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithSelfParent> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithSelfParent>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -353,6 +359,10 @@ class ObjectWithSelfParentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSelfParent>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithSelfParent> rows, {
@@ -360,6 +370,7 @@ class ObjectWithSelfParentRepository {
     _i1.ColumnSelections<ObjectWithSelfParentTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithSelfParentTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithSelfParent>(
       rows,
@@ -367,6 +378,7 @@ class ObjectWithSelfParentRepository {
       updateColumns: updateColumns?.call(ObjectWithSelfParent.t),
       updateWhere: updateWhere?.call(ObjectWithSelfParent.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -405,16 +417,22 @@ class ObjectWithSelfParentRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSelfParent>> update(
     _i1.DatabaseSession session,
     List<ObjectWithSelfParent> rows, {
     _i1.ColumnSelections<ObjectWithSelfParentTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithSelfParent>(
       rows,
       columns: columns?.call(ObjectWithSelfParent.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -452,6 +470,10 @@ class ObjectWithSelfParentRepository {
 
   /// Updates all [ObjectWithSelfParent]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSelfParent>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithSelfParentUpdateTable>
@@ -464,6 +486,7 @@ class ObjectWithSelfParentRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithSelfParent>(
       columnValues: columnValues(ObjectWithSelfParent.t.updateTable),
@@ -475,6 +498,7 @@ class ObjectWithSelfParentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -485,6 +509,10 @@ class ObjectWithSelfParentRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSelfParent>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithSelfParent> rows, {
@@ -493,6 +521,7 @@ class ObjectWithSelfParentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithSelfParent>(
       rows,
@@ -501,6 +530,7 @@ class ObjectWithSelfParentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -520,6 +550,10 @@ class ObjectWithSelfParentRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSelfParent>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithSelfParentTable> where,
@@ -528,6 +562,7 @@ class ObjectWithSelfParentRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithSelfParent>(
       where: where(ObjectWithSelfParent.t),
@@ -536,6 +571,7 @@ class ObjectWithSelfParentRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_sparse_vector.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_sparse_vector.dart
@@ -412,16 +412,22 @@ class ObjectWithSparseVectorRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSparseVector>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithSparseVector> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithSparseVector>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -455,6 +461,10 @@ class ObjectWithSparseVectorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSparseVector>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithSparseVector> rows, {
@@ -462,6 +472,7 @@ class ObjectWithSparseVectorRepository {
     _i1.ColumnSelections<ObjectWithSparseVectorTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithSparseVectorTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithSparseVector>(
       rows,
@@ -469,6 +480,7 @@ class ObjectWithSparseVectorRepository {
       updateColumns: updateColumns?.call(ObjectWithSparseVector.t),
       updateWhere: updateWhere?.call(ObjectWithSparseVector.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -507,16 +519,22 @@ class ObjectWithSparseVectorRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSparseVector>> update(
     _i1.DatabaseSession session,
     List<ObjectWithSparseVector> rows, {
     _i1.ColumnSelections<ObjectWithSparseVectorTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithSparseVector>(
       rows,
       columns: columns?.call(ObjectWithSparseVector.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -554,6 +572,10 @@ class ObjectWithSparseVectorRepository {
 
   /// Updates all [ObjectWithSparseVector]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSparseVector>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithSparseVectorUpdateTable>
@@ -566,6 +588,7 @@ class ObjectWithSparseVectorRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithSparseVector>(
       columnValues: columnValues(ObjectWithSparseVector.t.updateTable),
@@ -577,6 +600,7 @@ class ObjectWithSparseVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -587,6 +611,10 @@ class ObjectWithSparseVectorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSparseVector>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithSparseVector> rows, {
@@ -595,6 +623,7 @@ class ObjectWithSparseVectorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithSparseVector>(
       rows,
@@ -603,6 +632,7 @@ class ObjectWithSparseVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -622,6 +652,10 @@ class ObjectWithSparseVectorRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithSparseVector>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithSparseVectorTable> where,
@@ -630,6 +664,7 @@ class ObjectWithSparseVectorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithSparseVector>(
       where: where(ObjectWithSparseVector.t),
@@ -638,6 +673,7 @@ class ObjectWithSparseVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_uuid.dart
@@ -340,16 +340,22 @@ class ObjectWithUuidRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithUuid>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithUuid> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithUuid>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -383,6 +389,10 @@ class ObjectWithUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithUuid>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithUuid> rows, {
@@ -390,6 +400,7 @@ class ObjectWithUuidRepository {
     _i1.ColumnSelections<ObjectWithUuidTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithUuidTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithUuid>(
       rows,
@@ -397,6 +408,7 @@ class ObjectWithUuidRepository {
       updateColumns: updateColumns?.call(ObjectWithUuid.t),
       updateWhere: updateWhere?.call(ObjectWithUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -435,16 +447,22 @@ class ObjectWithUuidRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithUuid>> update(
     _i1.DatabaseSession session,
     List<ObjectWithUuid> rows, {
     _i1.ColumnSelections<ObjectWithUuidTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithUuid>(
       rows,
       columns: columns?.call(ObjectWithUuid.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -481,6 +499,10 @@ class ObjectWithUuidRepository {
 
   /// Updates all [ObjectWithUuid]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithUuid>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithUuidUpdateTable> columnValues,
@@ -492,6 +514,7 @@ class ObjectWithUuidRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithUuid>(
       columnValues: columnValues(ObjectWithUuid.t.updateTable),
@@ -503,6 +526,7 @@ class ObjectWithUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -513,6 +537,10 @@ class ObjectWithUuidRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithUuid>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithUuid> rows, {
@@ -521,6 +549,7 @@ class ObjectWithUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithUuid>(
       rows,
@@ -529,6 +558,7 @@ class ObjectWithUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -548,6 +578,10 @@ class ObjectWithUuidRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithUuid>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithUuidTable> where,
@@ -556,6 +590,7 @@ class ObjectWithUuidRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithUuid>(
       where: where(ObjectWithUuid.t),
@@ -564,6 +599,7 @@ class ObjectWithUuidRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_vector.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_vector.dart
@@ -462,16 +462,22 @@ class ObjectWithVectorRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithVector>> insert(
     _i1.DatabaseSession session,
     List<ObjectWithVector> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ObjectWithVector>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -505,6 +511,10 @@ class ObjectWithVectorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithVector>> upsert(
     _i1.DatabaseSession session,
     List<ObjectWithVector> rows, {
@@ -512,6 +522,7 @@ class ObjectWithVectorRepository {
     _i1.ColumnSelections<ObjectWithVectorTable>? updateColumns,
     _i1.WhereExpressionBuilder<ObjectWithVectorTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ObjectWithVector>(
       rows,
@@ -519,6 +530,7 @@ class ObjectWithVectorRepository {
       updateColumns: updateColumns?.call(ObjectWithVector.t),
       updateWhere: updateWhere?.call(ObjectWithVector.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -557,16 +569,22 @@ class ObjectWithVectorRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithVector>> update(
     _i1.DatabaseSession session,
     List<ObjectWithVector> rows, {
     _i1.ColumnSelections<ObjectWithVectorTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ObjectWithVector>(
       rows,
       columns: columns?.call(ObjectWithVector.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -604,6 +622,10 @@ class ObjectWithVectorRepository {
 
   /// Updates all [ObjectWithVector]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithVector>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ObjectWithVectorUpdateTable>
@@ -616,6 +638,7 @@ class ObjectWithVectorRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ObjectWithVector>(
       columnValues: columnValues(ObjectWithVector.t.updateTable),
@@ -627,6 +650,7 @@ class ObjectWithVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -637,6 +661,10 @@ class ObjectWithVectorRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithVector>> delete(
     _i1.DatabaseSession session,
     List<ObjectWithVector> rows, {
@@ -645,6 +673,7 @@ class ObjectWithVectorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ObjectWithVector>(
       rows,
@@ -653,6 +682,7 @@ class ObjectWithVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -672,6 +702,10 @@ class ObjectWithVectorRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ObjectWithVector>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithVectorTable> where,
@@ -680,6 +714,7 @@ class ObjectWithVectorRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ObjectWithVector>(
       where: where(ObjectWithVector.t),
@@ -688,6 +723,7 @@ class ObjectWithVectorRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/related_unique_data.dart
@@ -389,16 +389,22 @@ class RelatedUniqueDataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> insert(
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<RelatedUniqueData>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -432,6 +438,10 @@ class RelatedUniqueDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> upsert(
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
@@ -439,6 +449,7 @@ class RelatedUniqueDataRepository {
     _i1.ColumnSelections<RelatedUniqueDataTable>? updateColumns,
     _i1.WhereExpressionBuilder<RelatedUniqueDataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<RelatedUniqueData>(
       rows,
@@ -446,6 +457,7 @@ class RelatedUniqueDataRepository {
       updateColumns: updateColumns?.call(RelatedUniqueData.t),
       updateWhere: updateWhere?.call(RelatedUniqueData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -484,16 +496,22 @@ class RelatedUniqueDataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> update(
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
     _i1.ColumnSelections<RelatedUniqueDataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<RelatedUniqueData>(
       rows,
       columns: columns?.call(RelatedUniqueData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -531,6 +549,10 @@ class RelatedUniqueDataRepository {
 
   /// Updates all [RelatedUniqueData]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<RelatedUniqueDataUpdateTable>
@@ -543,6 +565,7 @@ class RelatedUniqueDataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<RelatedUniqueData>(
       columnValues: columnValues(RelatedUniqueData.t.updateTable),
@@ -554,6 +577,7 @@ class RelatedUniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -564,6 +588,10 @@ class RelatedUniqueDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> delete(
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
@@ -572,6 +600,7 @@ class RelatedUniqueDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<RelatedUniqueData>(
       rows,
@@ -580,6 +609,7 @@ class RelatedUniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -599,6 +629,10 @@ class RelatedUniqueDataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<RelatedUniqueData>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelatedUniqueDataTable> where,
@@ -607,6 +641,7 @@ class RelatedUniqueDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<RelatedUniqueData>(
       where: where(RelatedUniqueData.t),
@@ -615,6 +650,7 @@ class RelatedUniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/required/model_with_required_field.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/required/model_with_required_field.dart
@@ -358,16 +358,22 @@ class ModelWithRequiredFieldRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> insert(
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<ModelWithRequiredField>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -401,6 +407,10 @@ class ModelWithRequiredFieldRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> upsert(
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
@@ -408,6 +418,7 @@ class ModelWithRequiredFieldRepository {
     _i1.ColumnSelections<ModelWithRequiredFieldTable>? updateColumns,
     _i1.WhereExpressionBuilder<ModelWithRequiredFieldTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<ModelWithRequiredField>(
       rows,
@@ -415,6 +426,7 @@ class ModelWithRequiredFieldRepository {
       updateColumns: updateColumns?.call(ModelWithRequiredField.t),
       updateWhere: updateWhere?.call(ModelWithRequiredField.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -453,16 +465,22 @@ class ModelWithRequiredFieldRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> update(
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
     _i1.ColumnSelections<ModelWithRequiredFieldTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<ModelWithRequiredField>(
       rows,
       columns: columns?.call(ModelWithRequiredField.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -500,6 +518,10 @@ class ModelWithRequiredFieldRepository {
 
   /// Updates all [ModelWithRequiredField]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<ModelWithRequiredFieldUpdateTable>
@@ -512,6 +534,7 @@ class ModelWithRequiredFieldRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<ModelWithRequiredField>(
       columnValues: columnValues(ModelWithRequiredField.t.updateTable),
@@ -523,6 +546,7 @@ class ModelWithRequiredFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -533,6 +557,10 @@ class ModelWithRequiredFieldRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> delete(
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
@@ -541,6 +569,7 @@ class ModelWithRequiredFieldRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<ModelWithRequiredField>(
       rows,
@@ -549,6 +578,7 @@ class ModelWithRequiredFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -568,6 +598,10 @@ class ModelWithRequiredFieldRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<ModelWithRequiredField>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ModelWithRequiredFieldTable> where,
@@ -576,6 +610,7 @@ class ModelWithRequiredFieldRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<ModelWithRequiredField>(
       where: where(ModelWithRequiredField.t),
@@ -584,6 +619,7 @@ class ModelWithRequiredFieldRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/simple_data.dart
@@ -313,16 +313,22 @@ class SimpleDataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> insert(
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<SimpleData>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -356,6 +362,10 @@ class SimpleDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> upsert(
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
@@ -363,6 +373,7 @@ class SimpleDataRepository {
     _i1.ColumnSelections<SimpleDataTable>? updateColumns,
     _i1.WhereExpressionBuilder<SimpleDataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<SimpleData>(
       rows,
@@ -370,6 +381,7 @@ class SimpleDataRepository {
       updateColumns: updateColumns?.call(SimpleData.t),
       updateWhere: updateWhere?.call(SimpleData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -408,16 +420,22 @@ class SimpleDataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> update(
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
     _i1.ColumnSelections<SimpleDataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<SimpleData>(
       rows,
       columns: columns?.call(SimpleData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -454,6 +472,10 @@ class SimpleDataRepository {
 
   /// Updates all [SimpleData]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<SimpleDataUpdateTable> columnValues,
@@ -465,6 +487,7 @@ class SimpleDataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<SimpleData>(
       columnValues: columnValues(SimpleData.t.updateTable),
@@ -476,6 +499,7 @@ class SimpleDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,6 +510,10 @@ class SimpleDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> delete(
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
@@ -494,6 +522,7 @@ class SimpleDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<SimpleData>(
       rows,
@@ -502,6 +531,7 @@ class SimpleDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -521,6 +551,10 @@ class SimpleDataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleData>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SimpleDataTable> where,
@@ -529,6 +563,7 @@ class SimpleDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<SimpleData>(
       where: where(SimpleData.t),
@@ -537,6 +572,7 @@ class SimpleDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/simple_date_time.dart
@@ -313,16 +313,22 @@ class SimpleDateTimeRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> insert(
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<SimpleDateTime>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -356,6 +362,10 @@ class SimpleDateTimeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> upsert(
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
@@ -363,6 +373,7 @@ class SimpleDateTimeRepository {
     _i1.ColumnSelections<SimpleDateTimeTable>? updateColumns,
     _i1.WhereExpressionBuilder<SimpleDateTimeTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<SimpleDateTime>(
       rows,
@@ -370,6 +381,7 @@ class SimpleDateTimeRepository {
       updateColumns: updateColumns?.call(SimpleDateTime.t),
       updateWhere: updateWhere?.call(SimpleDateTime.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -408,16 +420,22 @@ class SimpleDateTimeRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> update(
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
     _i1.ColumnSelections<SimpleDateTimeTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<SimpleDateTime>(
       rows,
       columns: columns?.call(SimpleDateTime.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -454,6 +472,10 @@ class SimpleDateTimeRepository {
 
   /// Updates all [SimpleDateTime]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<SimpleDateTimeUpdateTable> columnValues,
@@ -465,6 +487,7 @@ class SimpleDateTimeRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<SimpleDateTime>(
       columnValues: columnValues(SimpleDateTime.t.updateTable),
@@ -476,6 +499,7 @@ class SimpleDateTimeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -486,6 +510,10 @@ class SimpleDateTimeRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> delete(
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
@@ -494,6 +522,7 @@ class SimpleDateTimeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<SimpleDateTime>(
       rows,
@@ -502,6 +531,7 @@ class SimpleDateTimeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -521,6 +551,10 @@ class SimpleDateTimeRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<SimpleDateTime>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SimpleDateTimeTable> where,
@@ -529,6 +563,7 @@ class SimpleDateTimeRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<SimpleDateTime>(
       where: where(SimpleDateTime.t),
@@ -537,6 +572,7 @@ class SimpleDateTimeRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/types.dart
@@ -858,16 +858,22 @@ class TypesRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> insert(
     _i1.DatabaseSession session,
     List<Types> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<Types>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -901,6 +907,10 @@ class TypesRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> upsert(
     _i1.DatabaseSession session,
     List<Types> rows, {
@@ -908,6 +918,7 @@ class TypesRepository {
     _i1.ColumnSelections<TypesTable>? updateColumns,
     _i1.WhereExpressionBuilder<TypesTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<Types>(
       rows,
@@ -915,6 +926,7 @@ class TypesRepository {
       updateColumns: updateColumns?.call(Types.t),
       updateWhere: updateWhere?.call(Types.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -953,16 +965,22 @@ class TypesRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> update(
     _i1.DatabaseSession session,
     List<Types> rows, {
     _i1.ColumnSelections<TypesTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<Types>(
       rows,
       columns: columns?.call(Types.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -999,6 +1017,10 @@ class TypesRepository {
 
   /// Updates all [Types]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<TypesUpdateTable> columnValues,
@@ -1010,6 +1032,7 @@ class TypesRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<Types>(
       columnValues: columnValues(Types.t.updateTable),
@@ -1021,6 +1044,7 @@ class TypesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -1031,6 +1055,10 @@ class TypesRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> delete(
     _i1.DatabaseSession session,
     List<Types> rows, {
@@ -1039,6 +1067,7 @@ class TypesRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<Types>(
       rows,
@@ -1047,6 +1076,7 @@ class TypesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -1066,6 +1096,10 @@ class TypesRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<Types>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TypesTable> where,
@@ -1074,6 +1108,7 @@ class TypesRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<Types>(
       where: where(Types.t),
@@ -1082,6 +1117,7 @@ class TypesRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/unique_data.dart
@@ -330,16 +330,22 @@ class UniqueDataRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> insert(
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UniqueData>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -373,6 +379,10 @@ class UniqueDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> upsert(
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
@@ -380,6 +390,7 @@ class UniqueDataRepository {
     _i1.ColumnSelections<UniqueDataTable>? updateColumns,
     _i1.WhereExpressionBuilder<UniqueDataTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UniqueData>(
       rows,
@@ -387,6 +398,7 @@ class UniqueDataRepository {
       updateColumns: updateColumns?.call(UniqueData.t),
       updateWhere: updateWhere?.call(UniqueData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -425,16 +437,22 @@ class UniqueDataRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> update(
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
     _i1.ColumnSelections<UniqueDataTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UniqueData>(
       rows,
       columns: columns?.call(UniqueData.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -471,6 +489,10 @@ class UniqueDataRepository {
 
   /// Updates all [UniqueData]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UniqueDataUpdateTable> columnValues,
@@ -482,6 +504,7 @@ class UniqueDataRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UniqueData>(
       columnValues: columnValues(UniqueData.t.updateTable),
@@ -493,6 +516,7 @@ class UniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -503,6 +527,10 @@ class UniqueDataRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> delete(
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
@@ -511,6 +539,7 @@ class UniqueDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UniqueData>(
       rows,
@@ -519,6 +548,7 @@ class UniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -538,6 +568,10 @@ class UniqueDataRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueData>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UniqueDataTable> where,
@@ -546,6 +580,7 @@ class UniqueDataRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UniqueData>(
       where: where(UniqueData.t),
@@ -554,6 +589,7 @@ class UniqueDataRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/unique_data_with_non_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/unique_data_with_non_persist.dart
@@ -346,16 +346,22 @@ class UniqueDataWithNonPersistRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> insert(
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UniqueDataWithNonPersist>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -389,6 +395,10 @@ class UniqueDataWithNonPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> upsert(
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
@@ -397,6 +407,7 @@ class UniqueDataWithNonPersistRepository {
     _i1.ColumnSelections<UniqueDataWithNonPersistTable>? updateColumns,
     _i1.WhereExpressionBuilder<UniqueDataWithNonPersistTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UniqueDataWithNonPersist>(
       rows,
@@ -404,6 +415,7 @@ class UniqueDataWithNonPersistRepository {
       updateColumns: updateColumns?.call(UniqueDataWithNonPersist.t),
       updateWhere: updateWhere?.call(UniqueDataWithNonPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -443,16 +455,22 @@ class UniqueDataWithNonPersistRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> update(
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
     _i1.ColumnSelections<UniqueDataWithNonPersistTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UniqueDataWithNonPersist>(
       rows,
       columns: columns?.call(UniqueDataWithNonPersist.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -490,6 +508,10 @@ class UniqueDataWithNonPersistRepository {
 
   /// Updates all [UniqueDataWithNonPersist]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UniqueDataWithNonPersistUpdateTable>
@@ -502,6 +524,7 @@ class UniqueDataWithNonPersistRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UniqueDataWithNonPersist>(
       columnValues: columnValues(UniqueDataWithNonPersist.t.updateTable),
@@ -513,6 +536,7 @@ class UniqueDataWithNonPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -523,6 +547,10 @@ class UniqueDataWithNonPersistRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> delete(
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
@@ -531,6 +559,7 @@ class UniqueDataWithNonPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UniqueDataWithNonPersist>(
       rows,
@@ -539,6 +568,7 @@ class UniqueDataWithNonPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -558,6 +588,10 @@ class UniqueDataWithNonPersistRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UniqueDataWithNonPersist>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UniqueDataWithNonPersistTable> where,
@@ -566,6 +600,7 @@ class UniqueDataWithNonPersistRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UniqueDataWithNonPersist>(
       where: where(UniqueDataWithNonPersist.t),
@@ -574,6 +609,7 @@ class UniqueDataWithNonPersistRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/upsert_test_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/upsert_test_model.dart
@@ -355,16 +355,22 @@ class UpsertTestModelRepository {
   /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
   /// rows are silently skipped, and only the successfully inserted rows are
   /// returned.
+  ///
+  /// If [noReturn] is set to `true`, the inserted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UpsertTestModel>> insert(
     _i1.DatabaseSession session,
     List<UpsertTestModel> rows, {
     _i1.Transaction? transaction,
     bool ignoreConflicts = false,
+    bool noReturn = false,
   }) async {
     return session.db.insert<UpsertTestModel>(
       rows,
       transaction: transaction,
       ignoreConflicts: ignoreConflicts,
+      noReturn: noReturn,
     );
   }
 
@@ -398,6 +404,10 @@ class UpsertTestModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fails,
   /// none of the rows will be affected.
+  ///
+  /// If [noReturn] is set to `true`, the resulting rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UpsertTestModel>> upsert(
     _i1.DatabaseSession session,
     List<UpsertTestModel> rows, {
@@ -405,6 +415,7 @@ class UpsertTestModelRepository {
     _i1.ColumnSelections<UpsertTestModelTable>? updateColumns,
     _i1.WhereExpressionBuilder<UpsertTestModelTable>? updateWhere,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.upsert<UpsertTestModel>(
       rows,
@@ -412,6 +423,7 @@ class UpsertTestModelRepository {
       updateColumns: updateColumns?.call(UpsertTestModel.t),
       updateWhere: updateWhere?.call(UpsertTestModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -450,16 +462,22 @@ class UpsertTestModelRepository {
   /// all columns.
   /// This is an atomic operation, meaning that if one of the rows fails to
   /// update, none of the rows will be updated.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UpsertTestModel>> update(
     _i1.DatabaseSession session,
     List<UpsertTestModel> rows, {
     _i1.ColumnSelections<UpsertTestModelTable>? columns,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.update<UpsertTestModel>(
       rows,
       columns: columns?.call(UpsertTestModel.t),
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -497,6 +515,10 @@ class UpsertTestModelRepository {
 
   /// Updates all [UpsertTestModel]s matching the [where] expression with the specified [columnValues].
   /// Returns the list of updated rows.
+  ///
+  /// If [noReturn] is set to `true`, the updated rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UpsertTestModel>> updateWhere(
     _i1.DatabaseSession session, {
     required _i1.ColumnValueListBuilder<UpsertTestModelUpdateTable>
@@ -509,6 +531,7 @@ class UpsertTestModelRepository {
     @Deprecated('Use desc() on the orderBy column instead.')
     bool orderDescending = false,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.updateWhere<UpsertTestModel>(
       columnValues: columnValues(UpsertTestModel.t.updateTable),
@@ -520,6 +543,7 @@ class UpsertTestModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -530,6 +554,10 @@ class UpsertTestModelRepository {
   ///
   /// This is an atomic operation, meaning that if one of the rows fail to
   /// be deleted, none of the rows will be deleted.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UpsertTestModel>> delete(
     _i1.DatabaseSession session,
     List<UpsertTestModel> rows, {
@@ -538,6 +566,7 @@ class UpsertTestModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.delete<UpsertTestModel>(
       rows,
@@ -546,6 +575,7 @@ class UpsertTestModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 
@@ -565,6 +595,10 @@ class UpsertTestModelRepository {
   ///
   /// To specify the order of the returned rows use [orderBy] or [orderByList]
   /// when sorting by multiple columns.
+  ///
+  /// If [noReturn] is set to `true`, the deleted rows are not read back from
+  /// the database and an empty list is returned. This avoids the overhead of
+  /// transferring and deserializing the rows when the result is not needed.
   Future<List<UpsertTestModel>> deleteWhere(
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UpsertTestModelTable> where,
@@ -573,6 +607,7 @@ class UpsertTestModelRepository {
     bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     _i1.Transaction? transaction,
+    bool noReturn = false,
   }) async {
     return session.db.deleteWhere<UpsertTestModel>(
       where: where(UpsertTestModel.t),
@@ -581,6 +616,7 @@ class UpsertTestModelRepository {
       orderDescending: // ignore: deprecated_member_use
           orderDescending,
       transaction: transaction,
+      noReturn: noReturn,
     );
   }
 

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/create_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/create_test.dart
@@ -113,6 +113,42 @@ void main() async {
         expect(second.number, 20);
       },
     );
+
+    test(
+      'when batch inserting with noReturn set to true '
+      'then an empty list is returned but the rows are persisted.',
+      () async {
+        var result = await UniqueData.db.insert(
+          session,
+          [
+            UniqueData(number: 1, email: 'a@serverpod.dev'),
+            UniqueData(number: 2, email: 'b@serverpod.dev'),
+          ],
+          noReturn: true,
+        );
+
+        expect(result, isEmpty);
+        expect(await UniqueData.db.find(session), hasLength(2));
+      },
+    );
+
+    test(
+      'when batch inserting with mixed ids and noReturn set to true '
+      'then an empty list is returned but all rows are persisted.',
+      () async {
+        var result = await UniqueData.db.insert(
+          session,
+          [
+            UniqueData(id: 1000, number: 1, email: 'a@serverpod.dev'),
+            UniqueData(number: 2, email: 'b@serverpod.dev'),
+          ],
+          noReturn: true,
+        );
+
+        expect(result, isEmpty);
+        expect(await UniqueData.db.find(session), hasLength(2));
+      },
+    );
   });
 
   group('Given an object data without an id when calling insertRow', () {

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/delete_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/delete_test.dart
@@ -425,5 +425,60 @@ void main() async {
         expect(deleted.first.id!, inserted.first.id);
       },
     );
+
+    test(
+      'Given an inserted entry '
+      'when batch deleting with noReturn set to true '
+      'then an empty list is returned but the rows are removed.',
+      () async {
+        var inserted = (await UniqueData.db.insert(session, [
+          UniqueData(number: 1, email: 'a@serverpod.dev'),
+        ])).first;
+
+        var result = await UniqueData.db.delete(
+          session,
+          [inserted],
+          noReturn: true,
+        );
+
+        expect(result, isEmpty);
+        expect(await UniqueData.db.find(session), isEmpty);
+      },
+    );
+
+    test(
+      'Given two inserted entries '
+      'when deleting rows matching a where expression with noReturn set to true '
+      'then an empty list is returned but the matching rows are removed.',
+      () async {
+        await UniqueData.db.insert(session, [
+          UniqueData(number: 1, email: 'a@serverpod.dev'),
+          UniqueData(number: 2, email: 'b@serverpod.dev'),
+        ]);
+
+        var result = await UniqueData.db.deleteWhere(
+          session,
+          where: (t) => t.number.equals(1),
+          noReturn: true,
+        );
+
+        expect(result, isEmpty);
+        expect(await UniqueData.db.find(session), hasLength(1));
+        expect(
+          await UniqueData.db.findFirstRow(
+            session,
+            where: (t) => t.number.equals(1),
+          ),
+          isNull,
+        );
+        expect(
+          await UniqueData.db.findFirstRow(
+            session,
+            where: (t) => t.number.equals(2),
+          ),
+          isNotNull,
+        );
+      },
+    );
   });
 }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_test.dart
@@ -13,6 +13,27 @@ void main() async {
   });
 
   test(
+    'Given an inserted entry '
+    'when batch updating with noReturn set to true '
+    'then an empty list is returned but the change is persisted.',
+    () async {
+      var inserted = (await UniqueData.db.insert(session, [
+        UniqueData(number: 1, email: 'a@serverpod.dev'),
+      ])).first;
+
+      var result = await UniqueData.db.update(
+        session,
+        [UniqueData(id: inserted.id, number: 99, email: 'a@serverpod.dev')],
+        noReturn: true,
+      );
+
+      expect(result, isEmpty);
+      var found = await UniqueData.db.findById(session, inserted.id!);
+      expect(found?.number, 99);
+    },
+  );
+
+  test(
     'Given a list of entries when batch updating only a single column then no other data is updated.',
     () async {
       var expectedFirstEmail = 'info@serverpod.dev';

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_where_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_where_test.dart
@@ -763,4 +763,44 @@ void main() {
       });
     },
   );
+
+  withServerpod(
+    'Given an inserted entry,',
+    (sessionBuilder, endpoints) {
+      var session = sessionBuilder.build();
+
+      setUp(() async {
+        await UniqueData.db.insert(session, [
+          UniqueData(number: 1, email: 'a@serverpod.dev'),
+        ]);
+      });
+
+      tearDown(() async {
+        await UniqueData.db.deleteWhere(
+          session,
+          where: (t) => Constant.bool(true),
+        );
+      });
+
+      test(
+        'when updating rows matching a where expression with noReturn set to true '
+        'then an empty list is returned but the matching rows are updated.',
+        () async {
+          var result = await UniqueData.db.updateWhere(
+            session,
+            columnValues: (t) => [t.number(42)],
+            where: (t) => t.email.equals('a@serverpod.dev'),
+            noReturn: true,
+          );
+
+          expect(result, isEmpty);
+          var found = await UniqueData.db.findFirstRow(
+            session,
+            where: (t) => t.email.equals('a@serverpod.dev'),
+          );
+          expect(found?.number, 42);
+        },
+      );
+    },
+  );
 }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/upsert_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/upsert_test.dart
@@ -142,6 +142,22 @@ void main() async {
     );
 
     test(
+      'when batch upserting with noReturn set to true '
+      'then an empty list is returned but the rows are persisted.',
+      () async {
+        var result = await UniqueData.db.upsert(
+          session,
+          [UniqueData(number: 1, email: 'a@serverpod.dev')],
+          conflictColumns: (t) => [t.email],
+          noReturn: true,
+        );
+
+        expect(result, isEmpty);
+        expect(await UniqueData.db.find(session), hasLength(1));
+      },
+    );
+
+    test(
       'when upserting a single row with upsertRow then the row is inserted.',
       () async {
         var result = (await UniqueData.db.upsertRow(

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
@@ -708,7 +708,11 @@ class BuildRepositoryClass {
 ///
 /// If [ignoreConflicts] is set to `true`, rows that conflict with existing
 /// rows are silently skipped, and only the successfully inserted rows are
-/// returned.''')
+/// returned.
+///
+/// If [noReturn] is set to `true`, the inserted rows are not read back from
+/// the database and an empty list is returned. This avoids the overhead of
+/// transferring and deserializing the rows when the result is not needed.''')
         ..name = 'insert'
         ..returns = TypeReference(
           (r) => r
@@ -746,6 +750,13 @@ class BuildRepositoryClass {
               ..named = true
               ..defaultTo = literalFalse.code,
           ),
+          Parameter(
+            (p) => p
+              ..type = refer('bool')
+              ..name = 'noReturn'
+              ..named = true
+              ..defaultTo = literalFalse.code,
+          ),
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
@@ -756,6 +767,7 @@ class BuildRepositoryClass {
               {
                 'transaction': refer('transaction'),
                 'ignoreConflicts': refer('ignoreConflicts'),
+                'noReturn': refer('noReturn'),
               },
               [refer(className)],
             )
@@ -837,7 +849,11 @@ class BuildRepositoryClass {
 /// The returned [$className]s will have their `id` fields set.
 ///
 /// This is an atomic operation, meaning that if one of the rows fails,
-/// none of the rows will be affected.''')
+/// none of the rows will be affected.
+///
+/// If [noReturn] is set to `true`, the resulting rows are not read back from
+/// the database and an empty list is returned. This avoids the overhead of
+/// transferring and deserializing the rows when the result is not needed.''')
         ..name = 'upsert'
         ..returns = TypeReference(
           (r) => r
@@ -896,6 +912,13 @@ class BuildRepositoryClass {
               ..name = 'transaction'
               ..named = true,
           ),
+          Parameter(
+            (p) => p
+              ..type = refer('bool')
+              ..name = 'noReturn'
+              ..named = true
+              ..defaultTo = literalFalse.code,
+          ),
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
@@ -914,6 +937,7 @@ class BuildRepositoryClass {
                     .nullSafeProperty('call')
                     .call([refer(className).property('t')]),
                 'transaction': refer('transaction'),
+                'noReturn': refer('noReturn'),
               },
               [refer(className)],
             )
@@ -1037,7 +1061,11 @@ class BuildRepositoryClass {
 /// [columns] is provided, only those columns will be updated. Defaults to
 /// all columns.
 /// This is an atomic operation, meaning that if one of the rows fails to
-/// update, none of the rows will be updated.''')
+/// update, none of the rows will be updated.
+///
+/// If [noReturn] is set to `true`, the updated rows are not read back from
+/// the database and an empty list is returned. This avoids the overhead of
+/// transferring and deserializing the rows when the result is not needed.''')
         ..name = 'update'
         ..returns = TypeReference(
           (r) => r
@@ -1079,6 +1107,13 @@ class BuildRepositoryClass {
               ..name = 'transaction'
               ..named = true,
           ),
+          Parameter(
+            (p) => p
+              ..type = refer('bool')
+              ..name = 'noReturn'
+              ..named = true
+              ..defaultTo = literalFalse.code,
+          ),
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
@@ -1091,6 +1126,7 @@ class BuildRepositoryClass {
                   refer(className).property('t'),
                 ]),
                 'transaction': refer('transaction'),
+                'noReturn': refer('noReturn'),
               },
               [refer(className)],
             )
@@ -1250,7 +1286,11 @@ class BuildRepositoryClass {
       methodBuilder
         ..docs.add('''
 /// Updates all [$className]s matching the [where] expression with the specified [columnValues].
-/// Returns the list of updated rows.''')
+/// Returns the list of updated rows.
+///
+/// If [noReturn] is set to `true`, the updated rows are not read back from
+/// the database and an empty list is returned. This avoids the overhead of
+/// transferring and deserializing the rows when the result is not needed.''')
         ..name = 'updateWhere'
         ..returns = TypeReference(
           (r) => r
@@ -1335,6 +1375,13 @@ class BuildRepositoryClass {
               ..name = 'transaction'
               ..named = true,
           ),
+          Parameter(
+            (p) => p
+              ..type = refer('bool')
+              ..name = 'noReturn'
+              ..named = true
+              ..defaultTo = literalFalse.code,
+          ),
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
@@ -1361,6 +1408,7 @@ class BuildRepositoryClass {
                   Code('// ignore: deprecated_member_use\norderDescending'),
                 ),
                 'transaction': refer('transaction'),
+                'noReturn': refer('noReturn'),
               },
               [refer(className)],
             )
@@ -1379,7 +1427,11 @@ class BuildRepositoryClass {
 /// when sorting by multiple columns.
 ///
 /// This is an atomic operation, meaning that if one of the rows fail to
-/// be deleted, none of the rows will be deleted.''')
+/// be deleted, none of the rows will be deleted.
+///
+/// If [noReturn] is set to `true`, the deleted rows are not read back from
+/// the database and an empty list is returned. This avoids the overhead of
+/// transferring and deserializing the rows when the result is not needed.''')
         ..name = 'delete'
         ..returns = TypeReference(
           (r) => r
@@ -1440,6 +1492,13 @@ class BuildRepositoryClass {
               ..name = 'transaction'
               ..named = true,
           ),
+          Parameter(
+            (p) => p
+              ..type = refer('bool')
+              ..name = 'noReturn'
+              ..named = true
+              ..defaultTo = literalFalse.code,
+          ),
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
@@ -1460,6 +1519,7 @@ class BuildRepositoryClass {
                   Code('// ignore: deprecated_member_use\norderDescending'),
                 ),
                 'transaction': refer('transaction'),
+                'noReturn': refer('noReturn'),
               },
               [refer(className)],
             )
@@ -1530,7 +1590,11 @@ class BuildRepositoryClass {
 /// Deletes all rows matching the [where] expression.
 ///
 /// To specify the order of the returned rows use [orderBy] or [orderByList]
-/// when sorting by multiple columns.''')
+/// when sorting by multiple columns.
+///
+/// If [noReturn] is set to `true`, the deleted rows are not read back from
+/// the database and an empty list is returned. This avoids the overhead of
+/// transferring and deserializing the rows when the result is not needed.''')
         ..name = 'deleteWhere'
         ..returns = TypeReference(
           (r) => r
@@ -1597,6 +1661,13 @@ class BuildRepositoryClass {
               ..name = 'transaction'
               ..named = true,
           ),
+          Parameter(
+            (p) => p
+              ..type = refer('bool')
+              ..name = 'noReturn'
+              ..named = true
+              ..defaultTo = literalFalse.code,
+          ),
         ])
         ..modifier = MethodModifier.async
         ..body = refer('session')
@@ -1618,6 +1689,7 @@ class BuildRepositoryClass {
                   Code('// ignore: deprecated_member_use\norderDescending'),
                 ),
                 'transaction': refer('transaction'),
+                'noReturn': refer('noReturn'),
               },
               [refer(className)],
             )

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_test.dart
@@ -445,6 +445,13 @@ void main() {
             contains('bool ignoreConflicts = false'),
           );
         });
+
+        test('that takes the noReturn bool as an optional param', () {
+          expect(
+            insertMethod?.parameters?.toSource(),
+            contains('bool noReturn = false'),
+          );
+        });
       });
 
       group('has an insert row method', () {
@@ -543,6 +550,13 @@ void main() {
           expect(
             updateMethod?.parameters?.toSource(),
             contains('Transaction? transaction'),
+          );
+        });
+
+        test('that takes the noReturn bool as an optional param', () {
+          expect(
+            updateMethod?.parameters?.toSource(),
+            contains('bool noReturn = false'),
           );
         });
       });
@@ -657,6 +671,13 @@ void main() {
           expect(
             deleteMethod?.parameters?.toSource(),
             contains('Transaction? transaction'),
+          );
+        });
+
+        test('that takes the noReturn bool as an optional param', () {
+          expect(
+            deleteMethod?.parameters?.toSource(),
+            contains('bool noReturn = false'),
           );
         });
       });
@@ -777,6 +798,13 @@ void main() {
           expect(
             deleteWhereMethod?.parameters?.toSource(),
             contains('Transaction? transaction'),
+          );
+        });
+
+        test('that takes the noReturn bool as an optional param', () {
+          expect(
+            deleteWhereMethod?.parameters?.toSource(),
+            contains('bool noReturn = false'),
           );
         });
       });
@@ -995,6 +1023,13 @@ void main() {
           expect(
             updateWhereMethod?.parameters?.toSource(),
             contains('Transaction? transaction'),
+          );
+        });
+
+        test('that takes the noReturn bool as an optional param', () {
+          expect(
+            updateWhereMethod?.parameters?.toSource(),
+            contains('bool noReturn = false'),
           );
         });
       });


### PR DESCRIPTION
Closes: #5118

Adds a `noReturn` parameter to all ORM methods that return a list of rows. When set to `true`, the rows are not read back from the database and an empty list is returned.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.