### PR TITLE
feat: Reload flutter apps config from server pubspec on change

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/messages.dart
+++ b/tools/serverpod_cli/lib/src/commands/messages.dart
@@ -37,6 +37,8 @@ const flutterDependenciesChangedDart =
     'Flutter dependencies changed. Hot restarting the Flutter app...';
 const flutterAssetsFontsChanged =
     'Flutter assets or fonts changed. Relaunching the Flutter app...';
+const flutterAppsConfigChanged =
+    'Flutter apps configuration changed. Reloading apps.';
 const flutterPackageNotFound =
     'No Flutter package found; skipping --flutter. '
     'Pass --no-flutter to silence this notice.';

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -154,10 +154,11 @@ class StartCommand extends ServerpodCommand<StartOption> {
           GlobalOption.interactive,
         ),
       );
-      final flutterApps = _loadFlutterApps(config);
 
       // Bail before the TUI takes over the terminal
       if (await _detectExistingInstance(config)) return;
+
+      final flutterApps = _loadFlutterApps(config);
 
       final exitCode = await _runWithTui(
         commandConfig: commandConfig,
@@ -400,6 +401,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   Future<void> Function(ServerProcess server)? onServerStart,
   Future<void> Function(FlutterAppConfig app, FlutterProcess flutter)?
   onFlutterStart,
+  void Function(List<FlutterAppConfig>)? onFlutterAppsReloaded,
   List<Object> Function()? mcpGetLogHistory,
   List<String> Function()? mcpGetFlutterAppIds,
   List<String> Function(String appId)? mcpGetFlutterLogHistory,
@@ -594,10 +596,12 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   // IDE-facing Flutter VM-service proxies. Bound now so info files exist at
   // session start regardless of whether `--flutter` was passed.
   final runMode = runModeFromServerArgs(serverArgs.value);
+  final serverPubspecFile = File(p.join(serverDir, 'pubspec.yaml'));
   final flutterManager = FlutterAppManager(
     apps: flutterApps,
     serverpodToolDir: serverpodToolDir,
     runMode: runMode,
+    serverPubspecFile: serverPubspecFile,
     onProgress: (app, stage) => onFlutterProgress?.call(app, stage),
     onReady: (app, url) => onFlutterReady?.call(app, url),
     onStart: (app, process) async {
@@ -651,6 +655,45 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     log.warning(watch ? startBlockedByErrorsWatch : startBlockedByErrorsManual);
   }
 
+  StreamSubscription<void>? fileChangeSub;
+
+  /// Sets up single watcher across server/shared/client/web/flutter.
+  /// Changes serialize through session.handleFileChange via WatchSession._chain.
+  void setupFileWatcher() {
+    fileChangeSub?.cancel();
+    if (!watch) return;
+    final currentApps = flutterManager.apps.toList();
+    // One tracker per Flutter app that has a resolved dependency closure. Reused
+    // both to widen the watched directories and to pin the exact pub artifacts
+    // below.
+    final flutterDependencyTrackers = [
+      for (final app in currentApps)
+        ?flutterManager.dependencyTrackerFor(app.id),
+    ];
+    final watcher = FileWatcher(
+      watchPaths: buildWatchPaths(
+        config: config,
+        flutterApps: currentApps,
+        serverDartToolDir: serverDartToolDir,
+        flutterDependencyTrackers: flutterDependencyTrackers,
+      ),
+      // Exact files so a change to one resolution's artifact never triggers the
+      // other's action (matters only in a non-workspace layout). The server has
+      // a single package_config.json; each Flutter app contributes its own
+      // package_graph.json (they collapse to one entry in a workspace layout).
+      packageConfigPath: serverDartToolDir == null
+          ? null
+          : p.join(serverDartToolDir, 'package_config.json'),
+      packageGraphPaths: {
+        for (final tracker in flutterDependencyTrackers)
+          p.join(tracker.dartToolDir, 'package_graph.json'),
+      },
+    );
+    fileChangeSub = watcher.onFilesChanged
+        .asyncMapBuffer((events) => session.handleFileChange(events.merge()))
+        .listen((_) {});
+  }
+
   // Construct the watch session.
   session = WatchSession(
     compiler: compiler,
@@ -682,6 +725,16 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     generatedDirPaths: config.generatedDirPaths,
     serverDependencyTracker: serverDependencyTracker,
     flutterManager: flutterManager,
+    flutterAppsLoader: () async {
+      final apps = loadFlutterApps(
+        serverPubspecFile: serverPubspecFile,
+        serverPackageDirectoryPathParts: config.serverPackageDirectoryPathParts,
+        projectName: config.name,
+      );
+      await flutterManager.reloadApps(apps);
+      onFlutterAppsReloaded?.call(apps);
+      setupFileWatcher();
+    },
     applyMigrationsAction: () => _applyMigrationsForSession(
       serverDir: serverDir,
       runMode: runMode,
@@ -744,40 +797,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     mcpSocket = null;
   }
 
-  // Single watcher across server/shared/client/web/flutter. Changes
-  // serialize through session.handleFileChange via WatchSession._chain.
-  StreamSubscription<void>? fileChangeSub;
-  if (watch) {
-    // One tracker per Flutter app that has a resolved dependency closure. Reused
-    // both to widen the watched directories and to pin the exact pub artifacts
-    // below.
-    final flutterDependencyTrackers = [
-      for (final app in flutterApps)
-        ?flutterManager.dependencyTrackerFor(app.id),
-    ];
-    final watcher = FileWatcher(
-      watchPaths: buildWatchPaths(
-        config: config,
-        flutterApps: flutterApps,
-        serverDartToolDir: serverDartToolDir,
-        flutterDependencyTrackers: flutterDependencyTrackers,
-      ),
-      // Exact files so a change to one resolution's artifact never triggers the
-      // other's action (matters only in a non-workspace layout). The server has
-      // a single package_config.json; each Flutter app contributes its own
-      // package_graph.json (they collapse to one entry in a workspace layout).
-      packageConfigPath: serverDartToolDir == null
-          ? null
-          : p.join(serverDartToolDir, 'package_config.json'),
-      packageGraphPaths: {
-        for (final tracker in flutterDependencyTrackers)
-          p.join(tracker.dartToolDir, 'package_graph.json'),
-      },
-    );
-    fileChangeSub = watcher.onFilesChanged
-        .asyncMapBuffer((events) => session.handleFileChange(events.merge()))
-        .listen((_) {});
-  }
+  setupFileWatcher();
 
   return WatchLoopReady(
     WatchLoopContext(
@@ -785,8 +805,8 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       proxy: () => proxy,
       flutterManager: flutterManager,
       mcpSocket: mcpSocket,
-      fileChangeSub: fileChangeSub,
       closeAnalyzers: closeAnalyzers,
+      stopFileWatcher: () => fileChangeSub?.cancel(),
       stopDocker: startedDocker ? () => _stopDockerServices(serverDir) : null,
       vmServiceInfoFile: vmServiceInfoFile,
     ),
@@ -814,6 +834,10 @@ Set<String> buildWatchPaths({
     ...config.sharedModelsLibSourcePaths.map(p.absolute),
     p.absolute(p.joinAll([...config.clientPackagePathParts, 'lib'])),
     p.absolute(p.joinAll([...config.serverPackageDirectoryPathParts, 'web'])),
+    // The server's pubspec.yaml watched for changes to the flutter_apps config.
+    p.absolute(
+      p.joinAll([...config.serverPackageDirectoryPathParts, 'pubspec.yaml']),
+    ),
     for (final app in flutterApps) ...[
       p.absolute(p.joinAll([...app.pathParts, 'lib'])),
       // The app's pubspec.yaml, watched as an exact file (it lives in the app
@@ -1117,17 +1141,11 @@ Future<void> _runTuiBackend({
       serverStderrSink: stderrSink,
       flutterStdoutSinkFor: (app) => TuiLogSink(
         holder,
-        addLine: (line) => holder.state
-            .getOrCreateAppLogTab(appId: app.id, label: app.name)
-            .lines
-            .add(line),
+        addLine: (line) => holder.state.appLogTabFor(app.id)?.lines.add(line),
       ),
       flutterStderrSinkFor: (app) => TuiLogSink(
         holder,
-        addLine: (line) => holder.state
-            .getOrCreateAppLogTab(appId: app.id, label: app.name)
-            .lines
-            .add(line),
+        addLine: (line) => holder.state.appLogTabFor(app.id)?.lines.add(line),
       ),
       onEnsureFlutterAppTab: (app) {
         final tab = holder.state.getOrCreateAppLogTab(
@@ -1140,33 +1158,30 @@ Future<void> _runTuiBackend({
         holder.markDirty();
       },
       onFlutterProgress: (app, stage) {
-        final tab = holder.state.getOrCreateAppLogTab(
-          appId: app.id,
-          label: app.name,
-        );
-        tab.startupStage = stage;
-        holder.markDirty();
+        final tab = holder.state.appLogTabFor(app.id);
+        if (tab != null) {
+          tab.startupStage = stage;
+          holder.markDirty();
+        }
       },
       onFlutterReady: (app, url) {
-        final tab = holder.state.getOrCreateAppLogTab(
-          appId: app.id,
-          label: app.name,
-        );
-        tab.url = url;
-        tab.ready = true;
-        holder.markDirty();
+        final tab = holder.state.appLogTabFor(app.id);
+        if (tab != null) {
+          tab.url = url;
+          tab.ready = true;
+          holder.markDirty();
+        }
       },
       onFlutterLaunchFailed: (app) {
-        final tab = holder.state.getOrCreateAppLogTab(
-          appId: app.id,
-          label: app.name,
-        );
-        tab.ready = false;
-        tab.url = null;
-        // Replace the breadcrumb's spinner-y "connecting" with a terminal
-        // state so it doesn't hang; the build error is in the app's log.
-        tab.startupStage = 'launch failed - see log';
-        holder.markDirty();
+        final tab = holder.state.appLogTabFor(app.id);
+        if (tab != null) {
+          tab.ready = false;
+          tab.url = null;
+          // Replace the breadcrumb's spinner-y "connecting" with a terminal
+          // state so it doesn't hang; the build error is in the app's log.
+          tab.startupStage = 'launch failed — see log';
+          holder.markDirty();
+        }
       },
       onServerStart: (server) async {
         // Fires on every server boot - the initial start, a restart, and the
@@ -1189,6 +1204,22 @@ Future<void> _runTuiBackend({
         vmService.onExtensionEvent.listen(
           (event) => handleServerLogEvent(holder, event),
         );
+      },
+      onFlutterAppsReloaded: (newApps) {
+        // Remove tabs for gone apps and update state.
+        final oldApps = holder.state.launchableApps;
+        for (final app in oldApps) {
+          late final tab = holder.state.appLogTabFor(app.id);
+          if (!newApps.any((a) => a.id == app.id) && tab != null) {
+            holder.state.tabs.removeTab(tab);
+          }
+        }
+        holder.state.hasConfiguredApps = newApps.isNotEmpty;
+        holder.state.launchableApps = newApps;
+        holder.state.canLaunchApps =
+            flutterApps.isNotEmpty &&
+            runModeFromServerArgs(serverArgs) == 'development';
+        holder.markDirty();
       },
       mcpGetLogHistory: () => holder.state.logHistory.toList(),
       mcpGetFlutterAppIds: () => [for (final app in flutterApps) app.id],

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -385,7 +385,6 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   onFlutterStart,
   void Function(List<FlutterAppConfig>)? onFlutterAppsLoaded,
   List<Object> Function()? mcpGetLogHistory,
-  List<String> Function()? mcpGetFlutterAppIds,
   List<String> Function(String appId)? mcpGetFlutterLogHistory,
 }) async {
   log.info(watch ? 'Starting server in watch mode...' : 'Starting server...');
@@ -758,7 +757,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       onHotReload: session.forceReload,
       onHotRestart: session.forceRestart,
       getLogHistory: mcpGetLogHistory,
-      getFlutterAppIds: mcpGetFlutterAppIds,
+      getFlutterAppIds: () => [for (final app in flutterManager.apps) app.id],
       getFlutterLogHistory: mcpGetFlutterLogHistory,
       onSpawnFlutterApp: session.spawnFlutterApp,
       getVmServiceUri: () => proxy?.httpUri.toString(),
@@ -1191,10 +1190,6 @@ Future<void> _runTuiBackend({
         holder.markDirty();
       },
       mcpGetLogHistory: () => holder.state.logHistory.toList(),
-      mcpGetFlutterAppIds: () {
-        final apps = holder.state.launchableApps;
-        return [for (final app in apps) app.id];
-      },
       mcpGetFlutterLogHistory: (appId) =>
           holder.state.appLogTabFor(appId)?.lines.toList() ?? <String>[],
     );

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -158,15 +158,12 @@ class StartCommand extends ServerpodCommand<StartOption> {
       // Bail before the TUI takes over the terminal
       if (await _detectExistingInstance(config)) return;
 
-      final flutterApps = _loadFlutterApps(config);
-
       final exitCode = await _runWithTui(
         commandConfig: commandConfig,
         watch: watch,
         launchFlutterApp: launchFlutterApp,
         serverArgs: argResults?.rest ?? [],
         config: config,
-        flutterApps: flutterApps,
       );
       if (exitCode != 0) throw ExitException(exitCode);
       return;
@@ -197,7 +194,6 @@ class StartCommand extends ServerpodCommand<StartOption> {
     if (await _detectExistingInstance(config)) return;
 
     final serverDir = p.joinAll(config.serverPackageDirectoryPathParts);
-    final flutterApps = _loadFlutterApps(config);
     final docker = commandConfig.value(StartOption.docker);
 
     // Listen for termination signals before starting any services so that
@@ -213,7 +209,6 @@ class StartCommand extends ServerpodCommand<StartOption> {
 
       final result = await _setupWatchLoop(
         config: config,
-        flutterApps: flutterApps,
         serverDir: serverDir,
         serverArgs: serverArgs,
         watch: watch,
@@ -364,21 +359,8 @@ Future<void> _applyMigrationsForSession({
   }
 }
 
-/// Runs the unified watch-loop setup shared by the TUI and non-TUI flows.
-/// Loads the companion Flutter apps from the server pubspec for the resolved
-/// project. A `serverpod start`-only concern, kept off [GeneratorConfig].
-List<FlutterAppConfig> _loadFlutterApps(GeneratorConfig config) {
-  final serverDir = p.joinAll(config.serverPackageDirectoryPathParts);
-  return loadFlutterApps(
-    serverPubspecFile: File(p.join(serverDir, 'pubspec.yaml')),
-    serverPackageDirectoryPathParts: config.serverPackageDirectoryPathParts,
-    projectName: config.name,
-  );
-}
-
 Future<WatchLoopSetupResult> _setupWatchLoop({
   required GeneratorConfig config,
-  required List<FlutterAppConfig> flutterApps,
   required String serverDir,
   required ServerArgsRef serverArgs,
   required bool watch,
@@ -401,7 +383,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   Future<void> Function(ServerProcess server)? onServerStart,
   Future<void> Function(FlutterAppConfig app, FlutterProcess flutter)?
   onFlutterStart,
-  void Function(List<FlutterAppConfig>)? onFlutterAppsReloaded,
+  void Function(List<FlutterAppConfig>)? onFlutterAppsLoaded,
   List<Object> Function()? mcpGetLogHistory,
   List<String> Function()? mcpGetFlutterAppIds,
   List<String> Function(String appId)? mcpGetFlutterLogHistory,
@@ -598,10 +580,16 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   final runMode = runModeFromServerArgs(serverArgs.value);
   final serverPubspecFile = File(p.join(serverDir, 'pubspec.yaml'));
   final flutterManager = FlutterAppManager(
-    apps: flutterApps,
-    serverpodToolDir: serverpodToolDir,
     runMode: runMode,
+    projectName: config.name,
+    // Whether to auto-launch every app flagged with `auto_launch`
+    // (the synthesized default sibling app is flagged, preserving
+    // the historical single-app behavior). When no app opts in, none
+    // launch - the user starts them with Ctrl+R.
+    launchFlutterApp: launchFlutterApp,
+    serverpodToolDir: serverpodToolDir,
     serverPubspecFile: serverPubspecFile,
+    serverPackageDirectoryPathParts: config.serverPackageDirectoryPathParts,
     onProgress: (app, stage) => onFlutterProgress?.call(app, stage),
     onReady: (app, url) => onFlutterReady?.call(app, url),
     onStart: (app, process) async {
@@ -613,6 +601,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     stderrSinkFor: (app) => flutterStderrSinkFor?.call(app) ?? stderr,
   );
   await flutterManager.initialize();
+  onFlutterAppsLoaded?.call(flutterManager.apps.toList());
 
   // Server process factory. Invoked for the initial start and for each
   // subsequent restart driven by the WatchSession
@@ -726,13 +715,8 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     serverDependencyTracker: serverDependencyTracker,
     flutterManager: flutterManager,
     flutterAppsLoader: () async {
-      final apps = loadFlutterApps(
-        serverPubspecFile: serverPubspecFile,
-        serverPackageDirectoryPathParts: config.serverPackageDirectoryPathParts,
-        projectName: config.name,
-      );
-      await flutterManager.reloadApps(apps);
-      onFlutterAppsReloaded?.call(apps);
+      await flutterManager.loadApps();
+      onFlutterAppsLoaded?.call(flutterManager.apps.toList());
       setupFileWatcher();
     },
     applyMigrationsAction: () => _applyMigrationsForSession(
@@ -744,16 +728,6 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   // Route IDE attach auto-launch through the session so it serializes with
   // reload/restart cycles.
   flutterManager.launchOnWaitingClient = session.spawnFlutterApp;
-
-  // Auto-launch every app flagged with `auto_launch` (the synthesized default
-  // sibling app is flagged, preserving the historical single-app behavior).
-  // When no app opts in, none launch - the user starts them with Ctrl+R.
-  if (launchFlutterApp) {
-    await Future.wait([
-      for (final app in flutterApps.where((app) => app.autoLaunch))
-        session.spawnFlutterApp(app.id),
-    ]);
-  }
 
   // Forward server exit into the shutdown signal so the wait-for-exit
   // point only ever has to await [shutdown.future]
@@ -1020,11 +994,9 @@ Future<int> _runWithTui({
   required bool launchFlutterApp,
   required List<String> serverArgs,
   required GeneratorConfig config,
-  required List<FlutterAppConfig> flutterApps,
 }) async {
   final holder = StartAppStateHolder(
-    ServerWatchState(hasConfiguredApps: flutterApps.isNotEmpty)
-      ..watchModeEnabled = watch,
+    ServerWatchState()..watchModeEnabled = watch,
   );
   var backendStarted = false;
 
@@ -1058,7 +1030,6 @@ Future<int> _runWithTui({
       launchFlutterApp: launchFlutterApp,
       serverArgs: serverArgs,
       config: config,
-      flutterApps: flutterApps,
       shutdown: shutdown,
       onFatalError: recordFatalCrash,
     ).catchError((Object e, StackTrace st) => recordFatalCrash(e, st));
@@ -1107,7 +1078,6 @@ Future<void> _runTuiBackend({
   required bool launchFlutterApp,
   required List<String> serverArgs,
   required GeneratorConfig config,
-  required List<FlutterAppConfig> flutterApps,
   required _ShutdownSignal shutdown,
   required void Function(Object error, StackTrace stackTrace) onFatalError,
 }) async {
@@ -1127,7 +1097,6 @@ Future<void> _runTuiBackend({
 
     final result = await _setupWatchLoop(
       config: config,
-      flutterApps: flutterApps,
       serverDir: serverDir,
       serverArgs: argsRef,
       watch: watch,
@@ -1205,7 +1174,7 @@ Future<void> _runTuiBackend({
           (event) => handleServerLogEvent(holder, event),
         );
       },
-      onFlutterAppsReloaded: (newApps) {
+      onFlutterAppsLoaded: (newApps) {
         // Remove tabs for gone apps and update state.
         final oldApps = holder.state.launchableApps;
         for (final app in oldApps) {
@@ -1214,15 +1183,18 @@ Future<void> _runTuiBackend({
             holder.state.tabs.removeTab(tab);
           }
         }
-        holder.state.hasConfiguredApps = newApps.isNotEmpty;
+        holder.state.createAppsTabAreaIfNeeded();
         holder.state.launchableApps = newApps;
         holder.state.canLaunchApps =
-            flutterApps.isNotEmpty &&
+            newApps.isNotEmpty &&
             runModeFromServerArgs(serverArgs) == 'development';
         holder.markDirty();
       },
       mcpGetLogHistory: () => holder.state.logHistory.toList(),
-      mcpGetFlutterAppIds: () => [for (final app in flutterApps) app.id],
+      mcpGetFlutterAppIds: () {
+        final apps = holder.state.launchableApps;
+        return [for (final app in apps) app.id];
+      },
       mcpGetFlutterLogHistory: (appId) =>
           holder.state.appLogTabFor(appId)?.lines.toList() ?? <String>[],
     );
@@ -1234,15 +1206,17 @@ Future<void> _runTuiBackend({
       case WatchLoopReady(:final ctx):
         // Offer Ctrl+R whenever a Flutter app could run here - even after a
         // `--no-flutter` start, where it acts as a "launch the app" button.
+        final apps = ctx.flutterManager.apps.toList();
         holder.state.canLaunchApps =
-            flutterApps.isNotEmpty &&
+            apps.isNotEmpty &&
             runModeFromServerArgs(serverArgs) == 'development';
-        holder.state.launchableApps = flutterApps;
+        holder.state.launchableApps = apps;
         holder.state.isAppRunning = (appId) =>
             ctx.flutterManager.isRunning(appId);
         holder.state.isAppLaunching = (appId) =>
             ctx.flutterManager.isLaunching(appId);
         holder.onLaunchApp = (index) {
+          final flutterApps = ctx.flutterManager.apps.toList();
           if (index < 0 || index >= flutterApps.length) return;
           final app = flutterApps[index];
           // Selecting an already-running app relaunches it; a stopped one is
@@ -1255,6 +1229,7 @@ Future<void> _runTuiBackend({
           );
         };
         holder.onStopApp = (index) {
+          final flutterApps = ctx.flutterManager.apps.toList();
           if (index < 0 || index >= flutterApps.length) return;
           final app = flutterApps[index];
           if (!ctx.flutterManager.isRunning(app.id)) return;

--- a/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
@@ -24,10 +24,10 @@ class FileChangeEvent {
   /// comparing the dependency fingerprint (see `FlutterDependencyTracker`).
   final bool flutterDependenciesChanged;
 
-  /// Whether the Flutter app's `pubspec.yaml` was modified in this batch.
-  /// Assets and fonts declared in the `pubspec.yaml` are bundled at build
-  /// time, so any change requires a full process relaunch.
-  final bool flutterPubspecChanged;
+  /// Whether any `pubspec.yaml` was modified in this batch (any watched
+  /// pubspec, including the server's and each companion Flutter app's).
+  /// Consumers use fingerprinting to decide what action, if any, is needed.
+  final bool pubspecChanged;
 
   /// Whether non-dart, non-model files changed (e.g. HTML, JS, CSS).
   ///
@@ -39,7 +39,7 @@ class FileChangeEvent {
     this.modelFiles = const {},
     this.packageConfigChanged = false,
     this.flutterDependenciesChanged = false,
-    this.flutterPubspecChanged = false,
+    this.pubspecChanged = false,
     this.staticFilesChanged = false,
   });
 }
@@ -62,7 +62,7 @@ extension FileChangeEventMerge on List<FileChangeEvent> {
     final modelFiles = <String>{};
     var packageConfigChanged = false;
     var flutterDependenciesChanged = false;
-    var flutterPubspecChanged = false;
+    var pubspecChanged = false;
     var staticFilesChanged = false;
 
     for (final event in this) {
@@ -70,7 +70,7 @@ extension FileChangeEventMerge on List<FileChangeEvent> {
       modelFiles.addAll(event.modelFiles);
       packageConfigChanged |= event.packageConfigChanged;
       flutterDependenciesChanged |= event.flutterDependenciesChanged;
-      flutterPubspecChanged |= event.flutterPubspecChanged;
+      pubspecChanged |= event.pubspecChanged;
       staticFilesChanged |= event.staticFilesChanged;
     }
 
@@ -79,7 +79,7 @@ extension FileChangeEventMerge on List<FileChangeEvent> {
       modelFiles: modelFiles,
       packageConfigChanged: packageConfigChanged,
       flutterDependenciesChanged: flutterDependenciesChanged,
-      flutterPubspecChanged: flutterPubspecChanged,
+      pubspecChanged: pubspecChanged,
       staticFilesChanged: staticFilesChanged,
     );
   }
@@ -109,9 +109,9 @@ class FileWatcher {
 
   /// Creates a file watcher.
   ///
-  /// [watchPaths] is the set of directories to watch. [packageConfigPath] and
-  /// [packageGraphPaths] are the exact pub-artifact files whose changes map to
-  /// `packageConfigChanged` / `flutterDependenciesChanged`.
+  /// [watchPaths] is the set of directories or files to watch.
+  /// [packageConfigPath] and [packageGraphPaths] are the exact pub-artifact
+  /// files whose changes map to `packageConfigChanged` / `flutterDependenciesChanged`.
   FileWatcher({
     required Iterable<String> watchPaths,
     String? packageConfigPath,
@@ -158,7 +158,7 @@ class FileWatcher {
           final modelFiles = <String>{};
           var packageConfigChanged = false;
           var flutterDependenciesChanged = false;
-          var flutterPubspecChanged = false;
+          var pubspecChanged = false;
           var staticFilesChanged = false;
 
           for (final event in events) {
@@ -192,7 +192,7 @@ class FileWatcher {
             } else if (p.extension(filePath) == '.dart') {
               dartFiles.add(filePath);
             } else if (p.basename(filePath) == 'pubspec.yaml') {
-              flutterPubspecChanged = true;
+              pubspecChanged = true;
             } else {
               staticFilesChanged = true;
             }
@@ -203,7 +203,7 @@ class FileWatcher {
             modelFiles: modelFiles,
             packageConfigChanged: packageConfigChanged,
             flutterDependenciesChanged: flutterDependenciesChanged,
-            flutterPubspecChanged: flutterPubspecChanged,
+            pubspecChanged: pubspecChanged,
             staticFilesChanged: staticFilesChanged,
           );
         })
@@ -213,7 +213,7 @@ class FileWatcher {
               e.modelFiles.isNotEmpty ||
               e.packageConfigChanged ||
               e.flutterDependenciesChanged ||
-              e.flutterPubspecChanged ||
+              e.pubspecChanged ||
               e.staticFilesChanged,
         );
   }

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -46,6 +46,7 @@ class FlutterAppManager {
     required this.onEnsureAppTab,
     required this.stdoutSinkFor,
     required this.stderrSinkFor,
+    required this.serverPubspecFile,
     this.flutterExecutableForTesting,
     this.argsOverrideForTesting,
   }) : _apps = apps;
@@ -89,6 +90,12 @@ class FlutterAppManager {
   final void Function(FlutterAppConfig app) onEnsureAppTab;
   final IOSink Function(FlutterAppConfig app) stdoutSinkFor;
   final IOSink Function(FlutterAppConfig app) stderrSinkFor;
+
+  /// The server's `pubspec.yaml`, used to fingerprint the `flutter_apps`
+  /// config and detect changes without re-parsing on every file event.
+  final File serverPubspecFile;
+
+  String? _cachedFlutterAppsFingerprint;
 
   final List<FlutterAppConfig> _apps;
   final Map<String, _AppRuntime> _runtimes = {};
@@ -153,6 +160,16 @@ class FlutterAppManager {
         PackageDependencyChange.none;
   }
 
+  /// Checks whether the `serverpod: flutter_apps:` section of the server's
+  /// `pubspec.yaml` has changed since the last check. Returns `true` when the
+  /// fingerprint differs, meaning the Flutter app config should be reloaded.
+  bool hasServerFlutterAppsChanged() {
+    final fingerprint = computeFlutterAppsFingerprint(serverPubspecFile);
+    final changed = fingerprint != _cachedFlutterAppsFingerprint;
+    _cachedFlutterAppsFingerprint = fingerprint;
+    return changed;
+  }
+
   /// Returns running app ids whose `lib` directory contains any of [paths].
   ///
   /// When no app matches, returns every running app id so single-app behavior
@@ -181,6 +198,8 @@ class FlutterAppManager {
   Future<void> initialize() async {
     if (_initialized) return;
     _initialized = true;
+
+    _cacheFlutterAppsFingerprint();
 
     for (final app in _apps) {
       final infoFile = _infoFileFor(app.id);
@@ -290,6 +309,59 @@ class FlutterAppManager {
     runtime.process = null;
   }
 
+  /// Updates the list of configured apps to [newApps].
+  ///
+  /// Apps present in the old config but absent in the new one are stopped and
+  /// removed. Apps present in the new config but absent in the old one are
+  /// initialized (VM-service proxy bound, dependency tracker set up) and
+  /// launched if [FlutterAppConfig.autoLaunch] is true. Apps present in both
+  /// are kept running but their config is updated.
+  Future<void> reloadApps(List<FlutterAppConfig> newApps) async {
+    final oldIds = {for (final a in _apps) a.id};
+    final newIds = {for (final a in newApps) a.id};
+
+    // Stop and remove apps no longer configured.
+    for (final id in oldIds.difference(newIds)) {
+      await stop(id);
+      await _runtimes[id]?.proxy.close();
+      _runtimes.remove(id);
+    }
+
+    _apps
+      ..clear()
+      ..addAll(newApps);
+
+    _cacheFlutterAppsFingerprint();
+
+    // Add newly configured apps or update existing ones.
+    for (final app in newApps) {
+      final existing = _runtimes[app.id];
+      if (existing == null) {
+        final infoFile = _infoFileFor(app.id);
+        final proxy = await bindFlutterAppProxy(
+          infoFile: infoFile,
+          onWaitingClientArrived: () {
+            final launch = launchOnWaitingClient;
+            if (launch != null) return launch(app.id);
+            return this.launch(app.id);
+          },
+        );
+        _runtimes[app.id] = _AppRuntime(
+          app: app,
+          proxy: proxy,
+          infoFile: infoFile,
+        );
+      } else {
+        existing.app = app;
+      }
+
+      _setupDependencyTracker(app.id);
+      if (app.autoLaunch && runMode == 'development') {
+        await launch(app.id);
+      }
+    }
+  }
+
   /// Stops every running app and removes per-app VM-service info files.
   Future<void> stopAll() async {
     await _runtimes.values.map((runtime) async {
@@ -344,6 +416,12 @@ class FlutterAppManager {
         'not read the Flutter package name from $flutterPackageDir ($e).',
       );
     }
+  }
+
+  void _cacheFlutterAppsFingerprint() {
+    _cachedFlutterAppsFingerprint = computeFlutterAppsFingerprint(
+      serverPubspecFile,
+    );
   }
 
   Future<void> _connectAfterLaunch(
@@ -405,7 +483,7 @@ class _AppRuntime {
     required this.infoFile,
   });
 
-  final FlutterAppConfig app;
+  FlutterAppConfig app;
   final VmServiceProxy proxy;
   final String infoFile;
   FlutterProcess? process;

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -36,7 +36,6 @@ Future<VmServiceProxy> bindFlutterAppProxy({
 class FlutterAppManager {
   /// Creates a [FlutterAppManager].
   FlutterAppManager({
-    required List<FlutterAppConfig> apps,
     required this.serverpodToolDir,
     required this.runMode,
     required this.onProgress,
@@ -47,9 +46,12 @@ class FlutterAppManager {
     required this.stdoutSinkFor,
     required this.stderrSinkFor,
     required this.serverPubspecFile,
+    required this.serverPackageDirectoryPathParts,
+    required this.projectName,
+    required this.launchFlutterApp,
     this.flutterExecutableForTesting,
     this.argsOverrideForTesting,
-  }) : _apps = apps;
+  });
 
   /// Test-only override for the `flutter` executable path.
   final String? flutterExecutableForTesting;
@@ -94,10 +96,13 @@ class FlutterAppManager {
   /// The server's `pubspec.yaml`, used to fingerprint the `flutter_apps`
   /// config and detect changes without re-parsing on every file event.
   final File serverPubspecFile;
+  final List<String> serverPackageDirectoryPathParts;
+  final String projectName;
+  final bool launchFlutterApp;
 
   String? _cachedFlutterAppsFingerprint;
 
-  final List<FlutterAppConfig> _apps;
+  final List<FlutterAppConfig> _apps = [];
   final Map<String, _AppRuntime> _runtimes = {};
   bool _initialized = false;
 
@@ -198,26 +203,7 @@ class FlutterAppManager {
   Future<void> initialize() async {
     if (_initialized) return;
     _initialized = true;
-
-    _cacheFlutterAppsFingerprint();
-
-    for (final app in _apps) {
-      final infoFile = _infoFileFor(app.id);
-      final proxy = await bindFlutterAppProxy(
-        infoFile: infoFile,
-        onWaitingClientArrived: () {
-          final launch = launchOnWaitingClient;
-          if (launch != null) return launch(app.id);
-          return this.launch(app.id);
-        },
-      );
-      _runtimes[app.id] = _AppRuntime(
-        app: app,
-        proxy: proxy,
-        infoFile: infoFile,
-      );
-      _setupDependencyTracker(app.id);
-    }
+    await loadApps();
   }
 
   /// Launches [appId] when not already running. No-op in non-development mode
@@ -309,14 +295,20 @@ class FlutterAppManager {
     runtime.process = null;
   }
 
-  /// Updates the list of configured apps to [newApps].
+  /// Loads configured apps from [serverPubspecFile].
   ///
   /// Apps present in the old config but absent in the new one are stopped and
   /// removed. Apps present in the new config but absent in the old one are
   /// initialized (VM-service proxy bound, dependency tracker set up) and
   /// launched if [FlutterAppConfig.autoLaunch] is true. Apps present in both
   /// are kept running but their config is updated.
-  Future<void> reloadApps(List<FlutterAppConfig> newApps) async {
+  Future<void> loadApps() async {
+    final newApps = loadFlutterApps(
+      serverPubspecFile: serverPubspecFile,
+      serverPackageDirectoryPathParts: serverPackageDirectoryPathParts,
+      projectName: projectName,
+    );
+
     final oldIds = {for (final a in _apps) a.id};
     final newIds = {for (final a in newApps) a.id};
 
@@ -356,7 +348,7 @@ class FlutterAppManager {
       }
 
       _setupDependencyTracker(app.id);
-      if (app.autoLaunch && runMode == 'development') {
+      if (launchFlutterApp && app.autoLaunch) {
         await launch(app.id);
       }
     }

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -35,7 +35,7 @@ class ServerWatchState extends TuiState {
   final TabModel tabs;
 
   /// Whether this project declares at least one companion Flutter app.
-  final bool hasConfiguredApps;
+  bool hasConfiguredApps;
 
   /// Whether a Flutter app can be launched or restarted from here (the project
   /// has configured apps and we're in development mode).

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -6,14 +6,7 @@ import 'tab_model.dart';
 /// Central state for the TUI, mutated by the backend and rendered by nocterm.
 class ServerWatchState extends TuiState {
   /// Creates [ServerWatchState].
-  ///
-  /// When [hasConfiguredApps] is false the layout is a single full-width server
-  /// pane with no apps area.
-  ServerWatchState({this.hasConfiguredApps = true})
-    : tabs = TabModel([
-        TabArea(id: kMainArea, flex: 1),
-        if (hasConfiguredApps) TabArea(id: kAppsArea, flex: 1),
-      ]) {
+  ServerWatchState() : tabs = TabModel([TabArea(id: kMainArea, flex: 1)]) {
     tabs.addTab(ServerLogTab());
   }
 
@@ -35,7 +28,7 @@ class ServerWatchState extends TuiState {
   final TabModel tabs;
 
   /// Whether this project declares at least one companion Flutter app.
-  bool hasConfiguredApps;
+  bool get hasConfiguredApps => launchableApps.isNotEmpty;
 
   /// Whether a Flutter app can be launched or restarted from here (the project
   /// has configured apps and we're in development mode).
@@ -124,20 +117,34 @@ class ServerWatchState extends TuiState {
   /// The [launchableApps] index of the currently selected app tab, or 0 when
   /// none is open. Used to start the launch panel cursor on the active app.
   int get activeLaunchableIndex {
-    if (!hasConfiguredApps) return 0;
-    final selected = tabs.areaOf(kAppsArea).selected;
+    final tabArea = _appsTabArea;
+    if (tabArea == null) return 0;
+    final selected = tabArea.selected;
     if (selected is! AppLogTab) return 0;
     final index = launchableApps.indexWhere((a) => a.id == selected.appId);
     return index >= 0 ? index : 0;
   }
 
+  /// Returns tab area for apps if it exists.
+  TabArea? get _appsTabArea {
+    try {
+      return tabs.areaOf(kAppsArea);
+    } catch (_) {}
+    return null;
+  }
+
   /// Returns the [AppLogTab] for [appId], or null if it is not open.
   AppLogTab? appLogTabFor(String appId) {
-    if (!hasConfiguredApps) return null;
-    for (final tab in tabs.areaOf(kAppsArea).tabs) {
+    for (final tab in _appsTabArea?.tabs ?? []) {
       if (tab is AppLogTab && tab.appId == appId) return tab;
     }
     return null;
+  }
+
+  void createAppsTabAreaIfNeeded() {
+    if (_appsTabArea == null) {
+      tabs.addArea(TabArea(id: kAppsArea, flex: 1));
+    }
   }
 
   /// Returns an existing [AppLogTab] for [appId] or creates and adds one.
@@ -148,6 +155,7 @@ class ServerWatchState extends TuiState {
     final existing = appLogTabFor(appId);
     if (existing != null) return existing;
 
+    createAppsTabAreaIfNeeded();
     final tab = AppLogTab(appId: appId, label: label);
     tabs.addTab(tab);
     return tab;
@@ -160,8 +168,7 @@ class ServerWatchState extends TuiState {
   void clearLogs() {
     logHistory.clear();
     rawLines.clear();
-    if (!hasConfiguredApps) return;
-    for (final tab in tabs.areaOf(kAppsArea).tabs) {
+    for (final tab in _appsTabArea?.tabs ?? []) {
       if (tab is AppLogTab) {
         tab.lines.clear();
       }

--- a/tools/serverpod_cli/lib/src/commands/start/tui/tab_model.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/tab_model.dart
@@ -132,6 +132,11 @@ class TabModel {
     );
   }
 
+  /// Adds a tab area.
+  void addArea(TabArea area) {
+    areas.add(area);
+  }
+
   /// Adds [tab] to the area named by its [PaneTab.areaId].
   void addTab(PaneTab tab) {
     areaOf(tab.areaId).tabs.add(tab);

--- a/tools/serverpod_cli/lib/src/commands/start/watch_loop.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_loop.dart
@@ -39,9 +39,9 @@ class WatchLoopContext {
   final VmServiceProxy? Function() proxy;
   final FlutterAppManager flutterManager;
   final McpSocketServer? mcpSocket;
-  final StreamSubscription<void>? fileChangeSub;
   final Future<void> Function() closeAnalyzers;
   final Future<void> Function()? stopDocker;
+  final void Function() stopFileWatcher;
   final String vmServiceInfoFile;
   bool _disposed = false;
 
@@ -50,9 +50,9 @@ class WatchLoopContext {
     required this.proxy,
     required this.flutterManager,
     required this.mcpSocket,
-    required this.fileChangeSub,
     required this.closeAnalyzers,
     required this.stopDocker,
+    required this.stopFileWatcher,
     required this.vmServiceInfoFile,
   });
 
@@ -62,7 +62,7 @@ class WatchLoopContext {
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
-    await fileChangeSub?.cancel();
+    stopFileWatcher();
     await mcpSocket?.close();
     await closeAnalyzers();
     await session.dispose();

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -24,6 +24,9 @@ typedef GenerateAction =
       GenerationRequirements requirements,
     );
 
+/// Reloads the companion Flutter app configuration from the server's pubspec.
+typedef FlutterAppsLoader = Future<void> Function();
+
 /// Creates a new server process, starts it, connects VM service,
 /// and returns it ready for use.
 ///
@@ -127,6 +130,7 @@ class WatchSession {
   final PackageDependencyTracker? _serverDependencyTracker;
 
   final FlutterAppManager? _flutterManager;
+  final FlutterAppsLoader? _flutterAppsLoader;
 
   /// Whether a Flutter app process is currently running. Used e.g. to label
   /// the Ctrl+R action as a start or a restart.
@@ -199,6 +203,7 @@ class WatchSession {
     required ApplyMigrationsAction applyMigrationsAction,
     PackageDependencyTracker? serverDependencyTracker,
     FlutterAppManager? flutterManager,
+    FlutterAppsLoader? flutterAppsLoader,
   }) : _compiler = compiler,
        _nativeAssetsBuilder = nativeAssetsBuilder,
        _generate = generate,
@@ -209,7 +214,8 @@ class WatchSession {
        _classifyProtocolChange = classifyProtocolChange,
        _applyMigrationsAction = applyMigrationsAction,
        _serverDependencyTracker = serverDependencyTracker,
-       _flutterManager = flutterManager {
+       _flutterManager = flutterManager,
+       _flutterAppsLoader = flutterAppsLoader {
     assert(
       nativeAssetsBuilder == null || compiler != null,
       'nativeAssetsBuilder requires a compiler.',
@@ -264,12 +270,16 @@ class WatchSession {
         event.modelFiles.isNotEmpty ||
         serverDepsChanged;
 
+    // Pubspec changes could be for the server.
+    // In which case, the flutter apps should be reloaded if necessary.
+    if (event.pubspecChanged) await _reloadFlutterAppsIfChanged();
+
     // Static-only changes (HTML, JS, CSS, templates) and dependency-only
     // changes: no compilation needed. The browser refresh is tied to static
     // files specifically - a dependency-only change doesn't affect
     // server-rendered pages.
     if (!hasDartChanges) {
-      if (event.flutterDependenciesChanged || event.flutterPubspecChanged) {
+      if (event.flutterDependenciesChanged || event.pubspecChanged) {
         await _reloadOrRestartFlutterApps(changedPaths: const []);
       }
       if (event.staticFilesChanged) await _notifyBrowserRefresh();
@@ -369,6 +379,24 @@ class WatchSession {
     // changed, otherwise a hot reload).
     await _reloadOrRestartFlutterApps(changedPaths: allDartChanges);
     if (reloaded) await _notifyBrowserRefresh();
+  }
+
+  /// Reloads the companion Flutter app config from the server's `pubspec.yaml`
+  /// and applies the diff (adds/removes/updates app runtimes).
+  Future<void> _reloadFlutterAppsIfChanged() async {
+    final reloadApps = _flutterAppsLoader;
+    if (reloadApps == null) return;
+
+    final manager = _flutterManager;
+    if (manager == null) return;
+
+    try {
+      if (!manager.hasServerFlutterAppsChanged()) return;
+      await reloadApps();
+      log.info(flutterAppsConfigChanged);
+    } catch (e) {
+      log.warning('Failed to reload Flutter app config: $e');
+    }
   }
 
   /// Refreshes affected running Flutter apps after a file change.

--- a/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/watch_session.dart
@@ -381,8 +381,7 @@ class WatchSession {
     if (reloaded) await _notifyBrowserRefresh();
   }
 
-  /// Reloads the companion Flutter app config from the server's `pubspec.yaml`
-  /// and applies the diff (adds/removes/updates app runtimes).
+  /// Reloads the companion Flutter app config from the server's `pubspec.yaml`.
   Future<void> _reloadFlutterAppsIfChanged() async {
     final reloadApps = _flutterAppsLoader;
     if (reloadApps == null) return;

--- a/tools/serverpod_cli/lib/src/config/flutter_app_config.dart
+++ b/tools/serverpod_cli/lib/src/config/flutter_app_config.dart
@@ -67,6 +67,24 @@ class FlutterAppConfig {
   }
 }
 
+/// Computes a fingerprint of the `serverpod: flutter_apps:` section from
+/// [serverPubspecFile]. Consumers store the fingerprint and compare on
+/// subsequent file-change events to detect configuration changes.
+/// Returns `null` when the file cannot be read or parsed,
+/// or when flutter_apps section is not found in the pubspec.
+String? computeFlutterAppsFingerprint(File serverPubspecFile) {
+  try {
+    final pubspecYaml = loadYamlMap(serverPubspecFile.readAsStringSync());
+    final serverpodSection = pubspecYaml.nodes['serverpod'];
+    if (serverpodSection is! YamlMap) return null;
+    final flutterAppsNode = serverpodSection.nodes['flutter_apps'];
+    if (flutterAppsNode == null) return null;
+    return flutterAppsNode.value.toString();
+  } catch (_) {
+    return null;
+  }
+}
+
 /// Loads the companion Flutter apps from the server [serverPubspecFile].
 ///
 /// Apps are configured under `serverpod: flutter_apps:` (a sibling of

--- a/tools/serverpod_cli/test/commands/start/file_watcher_test.dart
+++ b/tools/serverpod_cli/test/commands/start/file_watcher_test.dart
@@ -390,7 +390,7 @@ void main() {
 
       test(
         'when the file changes, '
-        'then it emits a FileChangeEvent with only flutterPubspecChanged set',
+        'then it emits a FileChangeEvent with only pubspecChanged set',
         () async {
           final firstEvent = watcher.onFilesChanged.first;
           await watcher.ready;
@@ -399,7 +399,7 @@ void main() {
 
           final event = await firstEvent;
 
-          expect(event.flutterPubspecChanged, isTrue);
+          expect(event.pubspecChanged, isTrue);
           expect(event.flutterDependenciesChanged, isFalse);
           expect(event.packageConfigChanged, isFalse);
           expect(event.staticFilesChanged, isFalse);

--- a/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
@@ -104,10 +104,14 @@ dependencies:
         name: 'App B',
       );
 
+      final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
+      serverPubspecFile.writeAsStringSync('name: server');
+
       launchedAppId = '';
       manager = FlutterAppManager(
         apps: [appA, appB],
         serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
+        serverPubspecFile: serverPubspecFile,
         runMode: 'development',
         onProgress: (_, _) {},
         onReady: (_, _) {},
@@ -284,12 +288,16 @@ dependencies:
   });
 
   group('Given a FlutterAppManager wired with per-app log sinks', () {
+    late Directory tempDir;
     late FlutterAppConfig appA;
     late FlutterAppConfig appB;
     late Map<String, List<String>> sinkLines;
     late FlutterAppManager manager;
 
-    setUp(() {
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('flutter_mgr_test_');
+      final serverDir = Directory(p.join(tempDir.path, 'project_server'))
+        ..createSync(recursive: true);
       appA = const FlutterAppConfig(
         id: 'app-a',
         name: 'App A',
@@ -310,9 +318,13 @@ dependencies:
         return IOSink(controller.sink);
       }
 
+      final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
+      serverPubspecFile.writeAsStringSync('name: server');
+
       manager = FlutterAppManager(
         apps: [appA, appB],
         serverpodToolDir: 'unused',
+        serverPubspecFile: serverPubspecFile,
         runMode: 'development',
         onProgress: (_, _) {},
         onReady: (_, _) {},
@@ -322,6 +334,11 @@ dependencies:
         stdoutSinkFor: (app) => sinkFor(sinkLines[app.id]!),
         stderrSinkFor: (app) => sinkFor(sinkLines[app.id]!),
       );
+    });
+
+    tearDown(() async {
+      await manager.dispose();
+      await tempDir.delete(recursive: true);
     });
 
     test(
@@ -371,11 +388,14 @@ dependencies:
 
         final fake = await _startFakeVmService();
         addTearDown(() => fake.server.close(force: true));
+        final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
+        serverPubspecFile.writeAsStringSync('name: server');
 
         ready = Completer<String>();
         manager = FlutterAppManager(
           apps: [app],
           serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
+          serverPubspecFile: serverPubspecFile,
           runMode: 'development',
           onProgress: (_, _) {},
           onReady: (_, url) => ready.complete(url),
@@ -468,11 +488,15 @@ dependencies:
           name: 'Project',
         );
 
+        final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
+        serverPubspecFile.writeAsStringSync('name: server');
+
         readyCalls = 0;
         launchFailed = Completer<FlutterAppConfig>();
         manager = FlutterAppManager(
           apps: [app],
           serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
+          serverPubspecFile: serverPubspecFile,
           runMode: 'development',
           onProgress: (_, _) {},
           onReady: (_, _) => readyCalls++,
@@ -511,4 +535,125 @@ dependencies:
       );
     },
   );
+
+  group('Given an initialized FlutterAppManager', () {
+    late Directory tempDir;
+    late Directory serverDir;
+    late FlutterAppManager manager;
+    late FlutterAppConfig appA;
+    late FlutterAppConfig appB;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('flutter_mgr_reload_');
+      serverDir = Directory(p.join(tempDir.path, 'project_server'))
+        ..createSync(recursive: true);
+      final flutterDirA = Directory(p.join(tempDir.path, 'app_a_flutter'))
+        ..createSync(recursive: true);
+      final flutterDirB = Directory(p.join(tempDir.path, 'app_b_flutter'))
+        ..createSync(recursive: true);
+
+      for (final dir in [flutterDirA, flutterDirB]) {
+        File(p.join(dir.path, 'pubspec.yaml')).writeAsStringSync('''
+name: ${p.basename(dir.path)}
+dependencies:
+  flutter:
+    sdk: flutter
+''');
+      }
+
+      appA = _testApp(
+        serverDir: serverDir,
+        flutterDir: flutterDirA,
+        id: 'app-a',
+        name: 'App A',
+      );
+      appB = _testApp(
+        serverDir: serverDir,
+        flutterDir: flutterDirB,
+        id: 'app-b',
+        name: 'App B',
+      );
+
+      final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
+      serverPubspecFile.writeAsStringSync('name: server');
+
+      manager = FlutterAppManager(
+        apps: [appA, appB],
+        serverpodToolDir: p.join(tempDir.path, '.serverpod'),
+        serverPubspecFile: serverPubspecFile,
+        runMode: 'development',
+        onProgress: (_, _) {},
+        onReady: (_, _) {},
+        onStart: (_, _) async {},
+        onLaunchFailed: (_) {},
+        onEnsureAppTab: (_) {},
+        stdoutSinkFor: (_) => stdout,
+        stderrSinkFor: (_) => stderr,
+      );
+      await manager.initialize();
+    });
+
+    tearDown(() async {
+      await manager.dispose();
+      await tempDir.delete(recursive: true);
+    });
+
+    test(
+      'when reloadApps is called with a subset of apps, '
+      'then removed apps are stopped and new list is reflected',
+      () async {
+        expect(manager.apps.length, 2);
+
+        await manager.reloadApps([appA]);
+
+        expect(manager.isRunning(appB.id), isFalse);
+        expect(manager.apps.length, 1);
+        expect(manager.apps.first.id, 'app-a');
+      },
+    );
+
+    test(
+      'when reloadApps is called with additional apps, '
+      'then new apps are added and old ones remain',
+      () async {
+        final flutterDirC = Directory(p.join(tempDir.path, 'app_c_flutter'))
+          ..createSync(recursive: true);
+        File(p.join(flutterDirC.path, 'pubspec.yaml')).writeAsStringSync('''
+name: app_c
+dependencies:
+  flutter:
+    sdk: flutter
+''');
+        final appC = _testApp(
+          serverDir: serverDir,
+          flutterDir: flutterDirC,
+          id: 'app-c',
+          name: 'App C',
+        );
+
+        expect(manager.apps.length, 2);
+
+        await manager.reloadApps([appA, appB, appC]);
+
+        expect(manager.apps.length, 3);
+        expect(
+          manager.apps.map((a) => a.id),
+          containsAll(['app-a', 'app-b', 'app-c']),
+        );
+      },
+    );
+
+    test(
+      'when reloadApps is called with the same apps, '
+      'then the app list remains unchanged',
+      () async {
+        expect(manager.apps.length, 2);
+
+        await manager.reloadApps([appA, appB]);
+
+        expect(manager.apps.length, 2);
+        expect(manager.apps.map((a) => a.id), containsAll(['app-a', 'app-b']));
+      },
+    );
+  });
 }

--- a/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
@@ -105,13 +105,23 @@ dependencies:
       );
 
       final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
-      serverPubspecFile.writeAsStringSync('name: server');
+      serverPubspecFile.writeAsStringSync('''
+name: server
+serverpod:
+  flutter_apps:
+    app-a:
+      path: ../app_a_flutter
+    app-b:
+      path: ../app_b_flutter
+''');
 
       launchedAppId = '';
       manager = FlutterAppManager(
-        apps: [appA, appB],
-        serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
+        projectName: 'project',
+        launchFlutterApp: false,
         serverPubspecFile: serverPubspecFile,
+        serverPackageDirectoryPathParts: p.split(serverDir.path),
+        serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
         runMode: 'development',
         onProgress: (_, _) {},
         onReady: (_, _) {},
@@ -319,12 +329,22 @@ dependencies:
       }
 
       final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
-      serverPubspecFile.writeAsStringSync('name: server');
+      serverPubspecFile.writeAsStringSync('''
+name: server
+serverpod:
+  flutter_apps:
+    app-a:
+      path: ../app_a_flutter
+    app-b:
+      path: ../app_b_flutter
+''');
 
       manager = FlutterAppManager(
-        apps: [appA, appB],
+        projectName: 'project',
+        launchFlutterApp: false,
         serverpodToolDir: 'unused',
         serverPubspecFile: serverPubspecFile,
+        serverPackageDirectoryPathParts: p.split(serverDir.path),
         runMode: 'development',
         onProgress: (_, _) {},
         onReady: (_, _) {},
@@ -389,13 +409,21 @@ dependencies:
         final fake = await _startFakeVmService();
         addTearDown(() => fake.server.close(force: true));
         final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
-        serverPubspecFile.writeAsStringSync('name: server');
+        serverPubspecFile.writeAsStringSync('''
+name: project_server
+serverpod:
+  flutter_apps:
+    project:
+      path: ../project_flutter
+''');
 
         ready = Completer<String>();
         manager = FlutterAppManager(
-          apps: [app],
-          serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
+          projectName: 'project',
+          launchFlutterApp: false,
           serverPubspecFile: serverPubspecFile,
+          serverPackageDirectoryPathParts: p.split(serverDir.path),
+          serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
           runMode: 'development',
           onProgress: (_, _) {},
           onReady: (_, url) => ready.complete(url),
@@ -489,14 +517,22 @@ dependencies:
         );
 
         final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
-        serverPubspecFile.writeAsStringSync('name: server');
+        serverPubspecFile.writeAsStringSync('''
+name: project_server
+serverpod:
+  flutter_apps:
+    project:
+      path: ../project_flutter
+''');
 
         readyCalls = 0;
         launchFailed = Completer<FlutterAppConfig>();
         manager = FlutterAppManager(
-          apps: [app],
-          serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
+          projectName: 'project',
+          launchFlutterApp: false,
           serverPubspecFile: serverPubspecFile,
+          serverPackageDirectoryPathParts: p.split(serverDir.path),
+          serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
           runMode: 'development',
           onProgress: (_, _) {},
           onReady: (_, _) => readyCalls++,
@@ -540,8 +576,7 @@ dependencies:
     late Directory tempDir;
     late Directory serverDir;
     late FlutterAppManager manager;
-    late FlutterAppConfig appA;
-    late FlutterAppConfig appB;
+    late File serverPubspecFile;
 
     setUp(() async {
       tempDir = await Directory.systemTemp.createTemp('flutter_mgr_reload_');
@@ -561,26 +596,23 @@ dependencies:
 ''');
       }
 
-      appA = _testApp(
-        serverDir: serverDir,
-        flutterDir: flutterDirA,
-        id: 'app-a',
-        name: 'App A',
-      );
-      appB = _testApp(
-        serverDir: serverDir,
-        flutterDir: flutterDirB,
-        id: 'app-b',
-        name: 'App B',
-      );
-
-      final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
-      serverPubspecFile.writeAsStringSync('name: server');
+      serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
+      serverPubspecFile.writeAsStringSync('''
+name: server
+serverpod:
+  flutter_apps:
+    app-a:
+      path: ../app_a_flutter
+    app-b:
+      path: ../app_b_flutter
+''');
 
       manager = FlutterAppManager(
-        apps: [appA, appB],
-        serverpodToolDir: p.join(tempDir.path, '.serverpod'),
+        projectName: 'project',
+        launchFlutterApp: false,
         serverPubspecFile: serverPubspecFile,
+        serverpodToolDir: p.join(tempDir.path, '.serverpod'),
+        serverPackageDirectoryPathParts: p.split(serverDir.path),
         runMode: 'development',
         onProgress: (_, _) {},
         onReady: (_, _) {},
@@ -599,23 +631,41 @@ dependencies:
     });
 
     test(
-      'when reloadApps is called with a subset of apps, '
+      'when loadApps is called after removing apps from the config, '
       'then removed apps are stopped and new list is reflected',
       () async {
+        serverPubspecFile.writeAsStringSync('''
+name: server
+serverpod:
+  flutter_apps:
+    app-a:
+      path: ../app_a_flutter
+''');
+
         expect(manager.apps.length, 2);
-
-        await manager.reloadApps([appA]);
-
-        expect(manager.isRunning(appB.id), isFalse);
+        await manager.loadApps();
+        expect(manager.isRunning('app-b'), isFalse);
         expect(manager.apps.length, 1);
         expect(manager.apps.first.id, 'app-a');
       },
     );
 
     test(
-      'when reloadApps is called with additional apps, '
+      'when loadApps is called after adding additional apps to the config, '
       'then new apps are added and old ones remain',
       () async {
+        serverPubspecFile.writeAsStringSync('''
+name: server
+serverpod:
+  flutter_apps:
+    app-a:
+      path: ../app_a_flutter
+    app-b:
+      path: ../app_b_flutter
+    app-c:
+      path: ../app_c_flutter
+''');
+
         final flutterDirC = Directory(p.join(tempDir.path, 'app_c_flutter'))
           ..createSync(recursive: true);
         File(p.join(flutterDirC.path, 'pubspec.yaml')).writeAsStringSync('''
@@ -624,16 +674,9 @@ dependencies:
   flutter:
     sdk: flutter
 ''');
-        final appC = _testApp(
-          serverDir: serverDir,
-          flutterDir: flutterDirC,
-          id: 'app-c',
-          name: 'App C',
-        );
 
         expect(manager.apps.length, 2);
-
-        await manager.reloadApps([appA, appB, appC]);
+        await manager.loadApps();
 
         expect(manager.apps.length, 3);
         expect(
@@ -644,13 +687,11 @@ dependencies:
     );
 
     test(
-      'when reloadApps is called with the same apps, '
+      'when loadApps without changing the apps in the config, '
       'then the app list remains unchanged',
       () async {
         expect(manager.apps.length, 2);
-
-        await manager.reloadApps([appA, appB]);
-
+        await manager.loadApps();
         expect(manager.apps.length, 2);
         expect(manager.apps.map((a) => a.id), containsAll(['app-a', 'app-b']));
       },

--- a/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
@@ -24,6 +24,15 @@ Future<NoctermTester> _pumpAppsLayout(Size size) async {
       scope: LogScope.root('server'),
     ),
   );
+  state.launchableApps = [
+    for (final name in ['Admin', 'Portal'])
+      FlutterAppConfig(
+        id: name.toLowerCase(),
+        name: name,
+        relativePathParts: ['..', name.toLowerCase()],
+        serverPackageDirectoryPathParts: const [],
+      ),
+  ];
   final admin = state.getOrCreateAppLogTab(appId: 'admin', label: 'Admin');
   admin.lines.add('admin-log-line');
   state

--- a/tools/serverpod_cli/test/commands/start/tui/state_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/state_test.dart
@@ -75,8 +75,8 @@ void main() {
     'when created '
     'then only the main area exists',
     () {
-      final state = ServerWatchState(hasConfiguredApps: false);
-
+      final state = ServerWatchState();
+      expect(state.hasConfiguredApps, isFalse);
       expect(state.tabs.areas, hasLength(1));
       expect(state.tabs.areas.single.id, kMainArea);
     },

--- a/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
@@ -156,8 +156,7 @@ void main() {
     late _FakeMcpSocket mcp;
     late int closeAnalyzersCalls;
     late int stopDockerCalls;
-    late int fileSubCancelCalls;
-    late StreamSubscription<void> fileSub;
+    late int stopFileWatcherCalls;
     late Directory tempDir;
     late String vmServiceInfoFile;
     late FlutterAppManager flutterManager;
@@ -169,22 +168,17 @@ void main() {
       mcp = _FakeMcpSocket();
       closeAnalyzersCalls = 0;
       stopDockerCalls = 0;
-      fileSubCancelCalls = 0;
-
-      // A real StreamSubscription whose cancel we count via a wrapper
-      // controller; cancelling the inner sub increments the counter.
-      final controller = StreamController<void>();
-      fileSub = controller.stream.listen((_) {});
-      controller.onCancel = () {
-        fileSubCancelCalls++;
-      };
+      stopFileWatcherCalls = 0;
 
       tempDir = Directory.systemTemp.createTempSync('watch_loop_test_');
       vmServiceInfoFile = p.join(tempDir.path, 'vm-service-info.json');
       File(vmServiceInfoFile).writeAsStringSync('{}');
+      final serverPubspecFile = File(p.join(tempDir.path, 'pubspec.yaml'));
+      serverPubspecFile.writeAsStringSync('name: server');
       flutterManager = FlutterAppManager(
         apps: [],
         serverpodToolDir: tempDir.path,
+        serverPubspecFile: serverPubspecFile,
         runMode: 'development',
         onProgress: (_, _) {},
         onReady: (_, _) {},
@@ -211,7 +205,7 @@ void main() {
         proxy: () => proxy,
         flutterManager: flutterManager,
         mcpSocket: mcp,
-        fileChangeSub: fileSub,
+        stopFileWatcher: () => stopFileWatcherCalls++,
         closeAnalyzers: () async {
           closeAnalyzersCalls++;
         },
@@ -232,7 +226,6 @@ void main() {
 
         await ctx.dispose();
 
-        expect(fileSubCancelCalls, 1);
         expect(mcp.closeCalls, 1);
         expect(closeAnalyzersCalls, 1);
         expect(server.calls, contains('stop'));
@@ -240,6 +233,7 @@ void main() {
         expect(proxy.closeCalls, 1);
         expect(File(vmServiceInfoFile).existsSync(), isFalse);
         expect(stopDockerCalls, 1);
+        expect(stopFileWatcherCalls, 1);
         expect(ctx.isDisposed, isTrue);
       },
     );
@@ -253,7 +247,6 @@ void main() {
         await ctx.dispose();
         await ctx.dispose();
 
-        expect(fileSubCancelCalls, 1, reason: 'fileChangeSub.cancel');
         expect(mcp.closeCalls, 1, reason: 'mcpSocket.close');
         expect(closeAnalyzersCalls, 1, reason: 'closeAnalyzers');
         expect(
@@ -268,6 +261,7 @@ void main() {
         );
         expect(proxy.closeCalls, 1, reason: 'proxy.close');
         expect(stopDockerCalls, 1, reason: 'stopDocker');
+        expect(stopFileWatcherCalls, 1, reason: 'stopFileWatcher');
       },
     );
 
@@ -298,7 +292,7 @@ void main() {
     );
 
     test(
-      'when proxy and mcpSocket and fileChangeSub are null, '
+      'when proxy and mcpSocket are null, '
       'then dispose skips them and runs the rest',
       () async {
         final ctx = WatchLoopContext(
@@ -306,7 +300,7 @@ void main() {
           proxy: () => null,
           flutterManager: flutterManager,
           mcpSocket: null,
-          fileChangeSub: null,
+          stopFileWatcher: () => stopFileWatcherCalls++,
           closeAnalyzers: () async {
             closeAnalyzersCalls++;
           },
@@ -317,6 +311,7 @@ void main() {
         await ctx.dispose();
 
         expect(closeAnalyzersCalls, 1);
+        expect(stopFileWatcherCalls, 1);
         expect(server.calls, contains('stop'));
       },
     );

--- a/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
@@ -171,14 +171,18 @@ void main() {
       stopFileWatcherCalls = 0;
 
       tempDir = Directory.systemTemp.createTempSync('watch_loop_test_');
+      final serverDir = Directory(p.join(tempDir.path, 'project_server'))
+        ..createSync(recursive: true);
       vmServiceInfoFile = p.join(tempDir.path, 'vm-service-info.json');
       File(vmServiceInfoFile).writeAsStringSync('{}');
       final serverPubspecFile = File(p.join(tempDir.path, 'pubspec.yaml'));
       serverPubspecFile.writeAsStringSync('name: server');
       flutterManager = FlutterAppManager(
-        apps: [],
+        projectName: 'project',
+        launchFlutterApp: false,
         serverpodToolDir: tempDir.path,
         serverPubspecFile: serverPubspecFile,
+        serverPackageDirectoryPathParts: p.split(serverDir.path),
         runMode: 'development',
         onProgress: (_, _) {},
         onReady: (_, _) {},

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -227,10 +227,20 @@ dependencies:
     serverPackageDirectoryPathParts: p.split(serverDir.path),
   );
 
+  final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
+  serverPubspecFile.writeAsStringSync('''
+name: server
+serverpod:
+  flutter_apps:
+    app:
+      path: ../app_flutter
+''');
+
   final process = flutter ?? _FakeFlutter();
   final manager = FlutterAppManager(
     apps: [app],
     serverpodToolDir: p.join(tempDir.path, '.serverpod'),
+    serverPubspecFile: serverPubspecFile,
     runMode: 'development',
     onProgress: (_, _) {},
     onReady: (_, _) {},
@@ -277,11 +287,23 @@ _createTwoAppFlutterManagerHarness() async {
     serverPackageDirectoryPathParts: p.split(serverDir.path),
   );
 
+  final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
+  serverPubspecFile.writeAsStringSync('''
+name: server
+serverpod:
+  flutter_apps:
+    app-a:
+      path: ../app_a_flutter
+    app-b:
+      path: ../app_b_flutter
+''');
+
   final processA = _FakeFlutter();
   final processB = _FakeFlutter();
   final manager = FlutterAppManager(
     apps: [appConfig('app-a', flutterDirA), appConfig('app-b', flutterDirB)],
     serverpodToolDir: p.join(tempDir.path, '.serverpod'),
+    serverPubspecFile: serverPubspecFile,
     runMode: 'development',
     onProgress: (_, _) {},
     onReady: (_, _) {},
@@ -345,6 +367,7 @@ void main() {
     NativeAssetsApplier? nativeAssetsBuilder,
     PackageDependencyTracker? serverDependencyTracker,
     FlutterAppManager? flutterManager,
+    FlutterAppsLoader? flutterAppsLoader,
   }) {
     return WatchSession(
       compiler: compiler,
@@ -372,6 +395,7 @@ void main() {
       classifyProtocolChange:
           classifyProtocolChange ?? defaultProtocolChangeClassifier,
       flutterManager: flutterManager,
+      flutterAppsLoader: flutterAppsLoader,
     );
   }
 
@@ -2068,7 +2092,7 @@ void main() {
         () async {
           final event = FileChangeEvent(
             dartFiles: {},
-            flutterPubspecChanged: true,
+            pubspecChanged: true,
           );
 
           await session.handleFileChange(event);
@@ -2086,7 +2110,7 @@ void main() {
         () async {
           final event = FileChangeEvent(
             dartFiles: {'/lib/a.dart'},
-            flutterPubspecChanged: true,
+            pubspecChanged: true,
           );
 
           await session.handleFileChange(event);
@@ -2094,6 +2118,82 @@ void main() {
           expect(server.calls, contains('reload:/out.dill'));
           expect(restartActionCalls, 1);
           expect(flutter.calls, isEmpty);
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a watch session where the server pubspec flutter_apps section changed,',
+    () {
+      late int reloadAppsCalls;
+      late _FakeFlutter flutter;
+      late FlutterAppManager flutterManager;
+      late Directory tempDir;
+
+      setUp(() async {
+        reloadAppsCalls = 0;
+        flutter = _FakeFlutter();
+        final harness = await _createFlutterManagerHarness(
+          flutter: flutter,
+        );
+        flutterManager = harness.manager;
+        tempDir = harness.tempDir;
+
+        session = buildSession(
+          compiler: compiler,
+          initialServer: server,
+          flutterManager: flutterManager,
+          flutterAppsLoader: () async {
+            reloadAppsCalls++;
+          },
+        );
+
+        flutterManager.serverPubspecFile.writeAsStringSync('''
+name: server
+serverpod:
+  flutter_apps:
+    app:
+      path: ../app_flutter
+      device: chrome
+''');
+      });
+
+      tearDown(() {
+        tempDir.deleteSync(recursive: true);
+      });
+
+      test(
+        'when pubspecChanged is set without dart changes, '
+        'then the flutter apps reload callback is invoked and server is not recompiled.',
+        () async {
+          final event = FileChangeEvent(
+            dartFiles: {},
+            pubspecChanged: true,
+          );
+
+          await session.handleFileChange(event);
+
+          expect(reloadAppsCalls, 1);
+          expect(compiler.calls, isEmpty);
+          expect(testLogger.infoMessages, contains(flutterAppsConfigChanged));
+        },
+      );
+
+      test(
+        'when pubspecChanged and dart files change together, '
+        'then the flutter apps reload callback is invoked and the server is reloaded.',
+        () async {
+          final event = FileChangeEvent(
+            dartFiles: {'/lib/a.dart'},
+            pubspecChanged: true,
+          );
+
+          await session.handleFileChange(event);
+
+          expect(reloadAppsCalls, 1);
+          expect(server.calls, contains('reload:/out.dill'));
+          expect(testLogger.infoMessages, contains(flutterAppsConfigChanged));
         },
       );
     },

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -12,7 +12,6 @@ import 'package:serverpod_cli/src/commands/start/native_assets_builder.dart';
 import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart';
 import 'package:serverpod_cli/src/commands/start/watch_session.dart';
-import 'package:serverpod_cli/src/config/flutter_app_config.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vendored/frontend_server_client.dart';
 import 'package:test/fake.dart';
@@ -218,15 +217,6 @@ dependencies:
     sdk: flutter
 ''');
 
-  final app = FlutterAppConfig(
-    id: 'app',
-    name: 'App',
-    relativePathParts: p.split(
-      p.relative(flutterDir.path, from: serverDir.path),
-    ),
-    serverPackageDirectoryPathParts: p.split(serverDir.path),
-  );
-
   final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
   serverPubspecFile.writeAsStringSync('''
 name: server
@@ -238,9 +228,11 @@ serverpod:
 
   final process = flutter ?? _FakeFlutter();
   final manager = FlutterAppManager(
-    apps: [app],
-    serverpodToolDir: p.join(tempDir.path, '.serverpod'),
+    projectName: 'project',
+    launchFlutterApp: false,
     serverPubspecFile: serverPubspecFile,
+    serverPackageDirectoryPathParts: p.split(serverDir.path),
+    serverpodToolDir: p.join(tempDir.path, '.serverpod'),
     runMode: 'development',
     onProgress: (_, _) {},
     onReady: (_, _) {},
@@ -280,13 +272,6 @@ _createTwoAppFlutterManagerHarness() async {
   final flutterDirB = Directory(p.join(tempDir.path, 'app_b_flutter'))
     ..createSync(recursive: true);
 
-  FlutterAppConfig appConfig(String id, Directory dir) => FlutterAppConfig(
-    id: id,
-    name: id,
-    relativePathParts: p.split(p.relative(dir.path, from: serverDir.path)),
-    serverPackageDirectoryPathParts: p.split(serverDir.path),
-  );
-
   final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
   serverPubspecFile.writeAsStringSync('''
 name: server
@@ -301,10 +286,12 @@ serverpod:
   final processA = _FakeFlutter();
   final processB = _FakeFlutter();
   final manager = FlutterAppManager(
-    apps: [appConfig('app-a', flutterDirA), appConfig('app-b', flutterDirB)],
-    serverpodToolDir: p.join(tempDir.path, '.serverpod'),
-    serverPubspecFile: serverPubspecFile,
+    projectName: 'project',
+    launchFlutterApp: false,
     runMode: 'development',
+    serverPubspecFile: serverPubspecFile,
+    serverpodToolDir: p.join(tempDir.path, '.serverpod'),
+    serverPackageDirectoryPathParts: p.split(serverDir.path),
     onProgress: (_, _) {},
     onReady: (_, _) {},
     onStart: (_, _) async {},


### PR DESCRIPTION
`serverpod start` now watches the server's `pubspec.yaml` to reload configured Flutter apps when the `flutter_apps` section is updated.  

After the app configs are reloaded:
- Removed apps that are currently running are stopped and removed from the TUI. 
- New or existing apps with `auto_launch` set to true are automatically launched.
- The FileWatcher setup is re-initiated to watch pubspecs of the reloaded apps.

This PR also ensures that TUI tabs are only created once for apps using `getOrCreateAppLogTab` and subsequently retrieved using `appLogTabFor`.

Closes #5362 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None