### PR TITLE
fix: Fix IDPs skipping `UserProfile` during first login

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/profile/business/user_profiles.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/profile/business/user_profiles.dart
@@ -26,6 +26,12 @@ class UserProfiles {
   });
 
   /// Creates a new user profile and stores it in the database.
+  ///
+  /// If an [imageSource] is provided, it will be set on the user profile.
+  /// Setting the image is a best-effort operation and may fail if the image
+  /// cannot be fetched or stored. In case of a failure, the user profile is
+  /// still created without an image. Failures can be handled inside the
+  /// [UserProfileConfig.onAfterUserProfileCreated] callback.
   Future<UserProfileModel> createUserProfile(
     final Session session,
     final UuidValue authUserId,
@@ -62,15 +68,25 @@ class UserProfiles {
           transaction: transaction,
         );
 
-        final createdProfileModel = switch (imageSource) {
-          null => createdProfile.toModel(),
-          _ => await _setUserImage(
-            session,
-            authUserId,
-            imageSource,
-            transaction: transaction,
-          ),
-        };
+        UserProfileModel? createdProfileModel;
+        if (imageSource != null) {
+          try {
+            createdProfileModel = await _setUserImage(
+              session,
+              authUserId,
+              imageSource,
+              transaction: transaction,
+            );
+          } catch (e, stackTrace) {
+            session.log(
+              'Failed to set user profile image during profile creation.',
+              level: LogLevel.error,
+              exception: e,
+              stackTrace: stackTrace,
+            );
+          }
+        }
+        createdProfileModel ??= createdProfile.toModel();
 
         await config.onAfterUserProfileCreated?.call(
           session,

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/profile/integration/user_profiles_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/profile/integration/user_profiles_test.dart
@@ -266,6 +266,43 @@ void main() {
           });
         },
       );
+
+      test(
+        'when creating a user profile with an image URL that fails to download, '
+        'then the profile is still created without an image.',
+        () async {
+          userProfiles = UserProfiles(
+            config: UserProfileConfig(
+              imageFetchFunc: (final _) {
+                throw Exception('Failed to download profile image');
+              },
+            ),
+          );
+
+          final createdUserProfile = await userProfiles.createUserProfile(
+            session,
+            authUserId,
+            UserProfileData(
+              userName: 'test_user',
+              email: 'test@example.com',
+            ),
+            imageSource: UserImageFromUrl.parse(
+              'https://serverpod.dev/external-profile-image.png',
+            ),
+          );
+
+          expect(createdUserProfile.userName, 'test_user');
+          expect(createdUserProfile.email, 'test@example.com');
+          expect(createdUserProfile.imageUrl, isNull);
+
+          final foundUserProfile = await userProfiles.findUserProfileByUserId(
+            session,
+            authUserId,
+          );
+
+          expect(foundUserProfile.imageUrl, isNull);
+        },
+      );
     },
   );
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/facebook/business/facebook_idp.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/facebook/business/facebook_idp.dart
@@ -83,25 +83,16 @@ class FacebookIdp {
 
         final image = account.details.image;
         if (account.newAccount) {
-          try {
-            await _userProfiles.createUserProfile(
-              session,
-              account.authUserId,
-              UserProfileData(
-                fullName: account.details.fullName?.trim(),
-                email: account.details.email,
-              ),
-              transaction: transaction,
-              imageSource: image != null ? UserImageFromUrl(image) : null,
-            );
-          } catch (e, stackTrace) {
-            session.log(
-              'Failed to create user profile for new Facebook user.',
-              level: LogLevel.error,
-              exception: e,
-              stackTrace: stackTrace,
-            );
-          }
+          await _userProfiles.createUserProfile(
+            session,
+            account.authUserId,
+            UserProfileData(
+              fullName: account.details.fullName?.trim(),
+              email: account.details.email,
+            ),
+            transaction: transaction,
+            imageSource: image != null ? UserImageFromUrl(image) : null,
+          );
         } else if (image != null) {
           try {
             final user = await UserProfile.db.findFirstRow(

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/firebase/business/firebase_idp.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/firebase/business/firebase_idp.dart
@@ -84,25 +84,16 @@ class FirebaseIdp {
 
         final image = account.details.image;
         if (account.newAccount) {
-          try {
-            await _userProfiles.createUserProfile(
-              session,
-              account.authUserId,
-              UserProfileData(
-                fullName: account.details.fullName?.trim(),
-                email: account.details.email,
-              ),
-              transaction: transaction,
-              imageSource: image != null ? UserImageFromUrl(image) : null,
-            );
-          } catch (e, stackTrace) {
-            session.log(
-              'Failed to create user profile for new Firebase user.',
-              level: LogLevel.error,
-              exception: e,
-              stackTrace: stackTrace,
-            );
-          }
+          await _userProfiles.createUserProfile(
+            session,
+            account.authUserId,
+            UserProfileData(
+              fullName: account.details.fullName?.trim(),
+              email: account.details.email,
+            ),
+            transaction: transaction,
+            imageSource: image != null ? UserImageFromUrl(image) : null,
+          );
         } else if (image != null) {
           try {
             final user = await UserProfile.db.findFirstRow(

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp.dart
@@ -92,25 +92,16 @@ class GitHubIdp {
 
         final image = account.details.image;
         if (account.newAccount) {
-          try {
-            await _userProfiles.createUserProfile(
-              session,
-              account.authUserId,
-              UserProfileData(
-                fullName: account.details.name?.trim(),
-                email: account.details.email,
-              ),
-              transaction: transaction,
-              imageSource: image != null ? UserImageFromUrl(image) : null,
-            );
-          } catch (e, stackTrace) {
-            session.log(
-              'Failed to create user profile for new GitHub user.',
-              level: LogLevel.error,
-              exception: e,
-              stackTrace: stackTrace,
-            );
-          }
+          await _userProfiles.createUserProfile(
+            session,
+            account.authUserId,
+            UserProfileData(
+              fullName: account.details.name?.trim(),
+              email: account.details.email,
+            ),
+            transaction: transaction,
+            imageSource: image != null ? UserImageFromUrl(image) : null,
+          );
         } else if (image != null) {
           try {
             final user = await UserProfile.db.findFirstRow(

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/google/business/google_idp.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/google/business/google_idp.dart
@@ -85,25 +85,16 @@ class GoogleIdp {
 
         final image = account.details.image;
         if (account.newAccount) {
-          try {
-            await _userProfiles.createUserProfile(
-              session,
-              account.authUserId,
-              UserProfileData(
-                fullName: account.details.fullName?.trim(),
-                email: account.details.email,
-              ),
-              transaction: transaction,
-              imageSource: image != null ? UserImageFromUrl(image) : null,
-            );
-          } catch (e, stackTrace) {
-            session.log(
-              'Failed to create user profile for new Google user.',
-              level: LogLevel.error,
-              exception: e,
-              stackTrace: stackTrace,
-            );
-          }
+          await _userProfiles.createUserProfile(
+            session,
+            account.authUserId,
+            UserProfileData(
+              fullName: account.details.fullName?.trim(),
+              email: account.details.email,
+            ),
+            transaction: transaction,
+            imageSource: image != null ? UserImageFromUrl(image) : null,
+          );
         } else if (image != null) {
           try {
             final user = await UserProfile.db.findFirstRow(

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/microsoft/business/microsoft_idp.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/microsoft/business/microsoft_idp.dart
@@ -94,27 +94,18 @@ class MicrosoftIdp {
 
         final imageBytes = account.details.imageBytes;
         if (account.newAccount) {
-          try {
-            await _userProfiles.createUserProfile(
-              session,
-              account.authUserId,
-              UserProfileData(
-                fullName: account.details.name?.trim(),
-                email: account.details.email,
-              ),
-              transaction: transaction,
-              imageSource: imageBytes != null
-                  ? UserImageFromBytes(imageBytes)
-                  : null,
-            );
-          } catch (e, stackTrace) {
-            session.log(
-              'Failed to create user profile for new Microsoft user.',
-              level: LogLevel.error,
-              exception: e,
-              stackTrace: stackTrace,
-            );
-          }
+          await _userProfiles.createUserProfile(
+            session,
+            account.authUserId,
+            UserProfileData(
+              fullName: account.details.name?.trim(),
+              email: account.details.email,
+            ),
+            transaction: transaction,
+            imageSource: imageBytes != null
+                ? UserImageFromBytes(imageBytes)
+                : null,
+          );
         } else if (imageBytes != null) {
           try {
             final user = await UserProfile.db.findFirstRow(


### PR DESCRIPTION
Fixes: #5365

The issue describes login with Google succeeding while no `UserProfile` is created. Given that the path to create the profile consists mostly of database calls + profile image fetch, the likely failure source is failing to fetch the image.

This PR fixes the issue in two ways: making profile creation lenient to image failures and removing the try/catch on each IDP login that would proceed in case of a failure. Since IDP logins always try to get the image if the user has none, in case the image was not set due to a transient network issue during profile creation, the next login will pick it up. For the remaining failure mode of failed database calls during the profile creation, we no longer proceed with the authentication.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.