### PR TITLE
fix: Export WebSocket event types

### DIFF
--- a/packages/serverpod/lib/serverpod.dart
+++ b/packages/serverpod/lib/serverpod.dart
@@ -16,6 +16,8 @@ export 'package:serverpod/server.dart';
 // Web server
 export 'package:serverpod/web_server.dart';
 export 'package:relic/relic.dart' hide QueryParameters;
+export 'package:web_socket/web_socket.dart'
+    show WebSocketEvent, TextDataReceived, BinaryDataReceived, CloseReceived;
 
 // Database
 export 'package:serverpod/database.dart';

--- a/packages/serverpod/test/web_server/web_socket_exports_test.dart
+++ b/packages/serverpod/test/web_server/web_socket_exports_test.dart
@@ -1,0 +1,24 @@
+import 'dart:typed_data';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given the main Serverpod library export', () {
+    String describe(WebSocketEvent event) => switch (event) {
+      TextDataReceived(text: var text) => text,
+      BinaryDataReceived(data: var data) => '${data.length} bytes',
+      CloseReceived(code: var code, reason: var reason) =>
+        'closed: $code $reason',
+    };
+
+    test('when handling web socket events then event types are available.', () {
+      expect(describe(TextDataReceived('hello')), 'hello');
+      expect(
+        describe(BinaryDataReceived(Uint8List.fromList([1, 2]))),
+        '2 bytes',
+      );
+      expect(describe(CloseReceived(1000, 'done')), 'closed: 1000 done');
+    });
+  });
+}


### PR DESCRIPTION
## What
- Re-export the web socket event types from `package:serverpod/serverpod.dart`.
- Add a small public API test covering `WebSocketEvent`, `TextDataReceived`, `BinaryDataReceived`, and `CloseReceived`.

## Why
Serverpod already exposes Relic web server APIs such as `WebSocketUpgrade`, but handling the resulting event stream still required users to import `package:web_socket/web_socket.dart` directly. This keeps the common WebSocket handler flow available from the main Serverpod import.

Fixes #5372.

## Testing
- `/Users/loopassembly/fvm/versions/3.38.5/bin/dart test test/web_server/web_socket_exports_test.dart`
- `/Users/loopassembly/fvm/versions/3.38.5/bin/dart analyze lib/serverpod.dart test/web_server/web_socket_exports_test.dart`
- `git diff --check -- packages/serverpod/lib/serverpod.dart packages/serverpod/test/web_server/web_socket_exports_test.dart`