### PR TITLE
chore: Upgrade nocterm to 0.8.0 and serverpod_tui to 0.5.0

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   logging: ^1.2.0
   lsp_server: ^0.4.0
   meta: ^1.15.0
-  nocterm: ^0.6.0
+  nocterm: ^0.8.0
   package_config: ^2.1.0
   path: ^1.8.3
   pub_api_client: '>=2.4.0 <4.0.0'
@@ -55,7 +55,7 @@ dependencies:
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_service_client: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
-  serverpod_tui: ^0.4.0
+  serverpod_tui: ^0.5.0
   skills: ^0.3.1
   source_span: ^1.10.0
   stream_channel: ^2.1.1

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -163,6 +163,7 @@ class MainScreen extends StatelessComponent {
         if (state.showHelp)
           HelpOverlay(
             bindings: _helpBindings,
+            closeKey: 'Esc',
             controller: helpScrollController,
           ),
         if (state.showLaunchPanel)

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   logging: ^1.2.0
   lsp_server: ^0.4.0
   meta: ^1.15.0
-  nocterm: ^0.6.0
+  nocterm: ^0.8.0
   package_config: ^2.1.0
   path: ^1.8.3
   pub_api_client: '>=2.4.0 <4.0.0'
@@ -56,7 +56,7 @@ dependencies:
   serverpod_serialization: 3.5.0-beta.10
   serverpod_service_client: 3.5.0-beta.10
   serverpod_shared: 3.5.0-beta.10
-  serverpod_tui: ^0.4.0
+  serverpod_tui: ^0.5.0
   skills: ^0.3.1
   source_span: ^1.10.0
   stream_channel: ^2.1.1


### PR DESCRIPTION
  Upgrades the `serverpod_cli` terminal UI stack to the latest published dependencies:

- **`nocterm` `^0.6.0` -> `^0.8.0`** - 0.8.0 folds in the Windows input/path fixes the CLI previously consumed via a local git override (now removed), plus IME and layout fixes. The breaking surface from 0.6→0.8 is minimal and does not touch any API the CLI uses directly.
- **`serverpod_tui` `^0.4.0` -> `^0.5.0`** - picks up the improved `HelpOverlay` and `TabBar`. 0.5.0 makes `HelpOverlay.closeKey` a required parameter, so the start TUI now passes `closeKey: 'Esc'`, matching its existing Escape-to-dismiss binding.

Fixes #5181
Fixes #5310 
Fixes #5171 


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None