### PR TITLE
ci: Add framework CLI reference docs sync bot

### DIFF
--- a/.github/workflows/sync-cli-docs.yml
+++ b/.github/workflows/sync-cli-docs.yml
@@ -1,0 +1,132 @@
+name: Sync CLI Docs to Serverpod Docs
+
+# After framework CLI changes land on main, regenerate the serverpod command
+# reference docs and open (or refresh) a single rolling PR in the serverpod_docs
+# repository.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "tools/serverpod_cli/lib/src/commands/**"
+      - "tools/serverpod_cli/lib/src/runner/**"
+      - "tools/serverpod_cli/bin/**"
+      - "tools/serverpod_cli/scripts/generate_command_usages.dart"
+      - ".github/workflows/sync-cli-docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Only one sync at a time so the rolling branch is never updated concurrently.
+concurrency:
+  group: sync-cli-docs
+  cancel-in-progress: false
+
+env:
+  DOCS_REPOSITORY: serverpod/serverpod_docs
+  # Distinct from the Cloud bot's `auto/cli-docs-sync` branch on the same repo.
+  SYNC_BRANCH: auto/framework-cli-docs-sync
+  CLI_DOCS_PATH: docs/06-concepts/cli
+
+jobs:
+  sync:
+    name: Sync CLI Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.DOCS_SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.DOCS_SYNC_APP_PRIVATE_KEY }}
+          owner: serverpod
+          repositories: serverpod_docs
+
+      - name: Checkout Serverpod Repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: src
+
+      # serverpod_cli is a pure Dart package, so the Dart SDK is all we need.
+      # (Most monorepo workflows pull Flutter only because their packages need
+      # it.)
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
+        with:
+          sdk: stable
+
+      - name: Resolve serverpod_cli dependencies
+        working-directory: src/tools/serverpod_cli
+        run: dart pub get
+
+      - name: Checkout Serverpod Docs Repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: target
+          ref: main
+          repository: ${{ env.DOCS_REPOSITORY }}
+          # persist-credentials (default true) embeds the app token so
+          # `git push` to the docs repo authenticates.
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Generate CLI docs
+        working-directory: src/tools/serverpod_cli
+        run: >
+          dart run scripts/generate_command_usages.dart
+          "${{ github.workspace }}/target/${{ env.CLI_DOCS_PATH }}"
+
+      - name: Detect changes in Serverpod Docs
+        id: check_changes
+        working-directory: target
+        run: |
+          git add -- "$CLI_DOCS_PATH"
+          git diff --cached --quiet || CHANGED=true
+          if [ "$CHANGED" == true ]; then
+            echo "changes_detected=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Push changes to Serverpod Docs
+        if: steps.check_changes.outputs.changes_detected == 'true'
+        working-directory: target
+        run: |
+          git config --global user.email "serverpod@serverpod.dev"
+          git config --global user.name "serverpod"
+          git checkout -B "$SYNC_BRANCH"
+          git commit -m "docs: Update framework CLI command reference (serverpod@${GITHUB_SHA::7})"
+          git push --force origin "$SYNC_BRANCH"
+
+      - name: Create PR in Serverpod Docs
+        if: steps.check_changes.outputs.changes_detected == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          EXISTING_PR=$(gh pr list --repo "$DOCS_REPOSITORY" --head "$SYNC_BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already open; branch \"$SYNC_BRANCH\" was force-updated."
+          else
+            gh pr create \
+              --repo "$DOCS_REPOSITORY" \
+              --base main \
+              --head "$SYNC_BRANCH" \
+              --title "docs: Update framework CLI command reference" \
+              --body "$(cat << EOF
+          Auto-generated update of the framework CLI command reference docs from the
+          command definitions in \`serverpod\`.
+
+          Triggered by: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+
+          > This branch (\`$SYNC_BRANCH\`) is force-updated on every relevant push to
+          > \`main\`, so always review the latest diff. Do not push manual commits to it —
+          > they will be overwritten. Curated command intros (\`_<command>.md\`) are
+          > maintained directly on \`main\` and are preserved by the generator.
+          EOF
+          )"
+          fi
+          # Merge automatically once all required checks and reviews on the
+          # docs repo have passed. (A force-push disables a previously enabled
+          # auto-merge, so this is re-enabled on every sync.)
+          gh pr merge "$SYNC_BRANCH" \
+            --repo "$DOCS_REPOSITORY" \
+            --auto \
+            --squash

--- a/tools/serverpod_cli/scripts/generate_command_usages.dart
+++ b/tools/serverpod_cli/scripts/generate_command_usages.dart
@@ -229,17 +229,25 @@ class _CommandDocumentationGenerator {
 
   StringBuffer _generateCommandPage(final Command command) {
     final StringBuffer markdown = StringBuffer();
+
+    final hasOptions = command.argParser.options.isNotEmpty;
+    final subcommands = command.subcommands.entries
+        .where((final e) => !_excludeCommand(e.value))
+        .toList();
+
+    // Commands that forward raw arguments (e.g. `cloud`) expose no options or
+    // subcommands, so there is nothing to document beyond the maintained intro.
+    if (!hasOptions && subcommands.isEmpty) {
+      return markdown;
+    }
+
     markdown.writeln('## Usage\n');
 
-    if (command.argParser.options.isNotEmpty) {
+    if (hasOptions) {
       markdown.writeln('```console');
       markdown.writeln(_stripGlobalOptions(command.usage));
       markdown.writeln('```\n');
     }
-
-    final subcommands = command.subcommands.entries.where(
-      (final e) => !_excludeCommand(e.value),
-    );
 
     if (subcommands.isNotEmpty) {
       final numberOfSubcommands = subcommands.length;
@@ -267,6 +275,6 @@ class _CommandDocumentationGenerator {
   }
 
   bool _excludeCommand(final Command command) {
-    return command.hidden && command.name != 'help';
+    return command.hidden || command.name == 'help';
   }
 }

--- a/tools/serverpod_cli/scripts/generate_command_usages.dart
+++ b/tools/serverpod_cli/scripts/generate_command_usages.dart
@@ -1,0 +1,267 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart' show Command;
+import 'package:cli_tools/cli_tools.dart';
+import 'package:path/path.dart' as path;
+import 'package:pub_semver/pub_semver.dart';
+import 'package:serverpod_cli/src/commands/analyze_pubspecs.dart';
+import 'package:serverpod_cli/src/commands/cloud.dart';
+import 'package:serverpod_cli/src/commands/create.dart';
+import 'package:serverpod_cli/src/commands/create_migration.dart';
+import 'package:serverpod_cli/src/commands/create_repair_migration.dart';
+import 'package:serverpod_cli/src/commands/generate.dart';
+import 'package:serverpod_cli/src/commands/generate_pubspecs.dart';
+import 'package:serverpod_cli/src/commands/language_server.dart';
+import 'package:serverpod_cli/src/commands/mcp.dart';
+import 'package:serverpod_cli/src/commands/migrate.dart';
+import 'package:serverpod_cli/src/commands/quickstart.dart';
+import 'package:serverpod_cli/src/commands/run.dart';
+import 'package:serverpod_cli/src/commands/start.dart';
+import 'package:serverpod_cli/src/commands/upgrade.dart';
+import 'package:serverpod_cli/src/commands/version.dart';
+import 'package:serverpod_cli/src/generated/version.dart';
+import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
+
+/// Generates the framework CLI command reference for the docs site.
+///
+/// Pass the target docs directory (the `cli` reference folder in
+/// `serverpod_docs`) as the only argument. The script writes the auto-generated
+/// usage blocks to `_generated/` and the per-command pages to `commands/`,
+/// leaving the hand-maintained `_<command>.md` intros untouched.
+void main(final List<String> args) {
+  if (args.length != 1) {
+    throw StateError('Expected the path to the docs directory as the only '
+        'argument.');
+  }
+  final docsPath = args.first;
+
+  final generatedPath = path.join(docsPath, '_generated');
+  final commandsPath = path.join(docsPath, 'commands');
+
+  Directory(generatedPath).createSync(recursive: true);
+  Directory(commandsPath).createSync(recursive: true);
+
+  // Keep this command list in sync with `buildCommandRunner` in
+  // `bin/serverpod_cli.dart`. Hidden commands are filtered out below.
+  final version = Version.parse(templateVersion);
+  final cli = ServerpodCommandRunner.createCommandRunner(
+    CompoundAnalytics([]),
+    true,
+    version,
+    onBeforeRunCommand: (_) async {},
+  )..addCommands([
+      AnalyzePubspecsCommand(),
+      CloudCommand(),
+      CreateCommand(),
+      QuickstartCommand(),
+      GenerateCommand(),
+      GeneratePubspecsCommand(),
+      LanguageServerCommand(),
+      McpCommand(),
+      CreateMigrationCommand(),
+      CreateRepairMigrationCommand(),
+      MigrateCommand(),
+      RunCommand(),
+      StartCommand(),
+      UpgradeCommand(),
+      VersionCommand(version),
+    ]);
+
+  final generator = _CommandDocumentationGenerator(cli);
+
+  final globalOptionsDoc = generator.generateGlobalOptionsPage();
+  File(
+    path.join(generatedPath, 'global_options.md'),
+  ).writeAsStringSync(globalOptionsDoc.toString());
+
+  final commandsDocs = generator.generateMarkdown();
+
+  for (final MapEntry(key: fileName, value: content) in commandsDocs.entries) {
+    final commandName = fileName.split('.').first;
+    _generateDocPage(
+      generatedPath,
+      commandsPath,
+      commandName,
+      commandName,
+      fileName,
+      content,
+    );
+  }
+
+  final currentCommands = commandsDocs.keys
+      .map((final file) => file.split('.').first)
+      .toSet();
+  _deleteRemovedCommandsFolders(currentCommands, commandsPath);
+  _deleteRemovedCommandsFiles(currentCommands, generatedPath);
+}
+
+void _generateDocPage(
+  final String generatedPath,
+  final String docBasePath,
+  final String docDirName,
+  final String docLabel,
+  final String docFileName,
+  final String docContent,
+) {
+  File(path.join(generatedPath, docFileName)).writeAsStringSync(docContent);
+
+  final docPath = path.join(docBasePath, docDirName);
+  Directory(docPath).createSync(recursive: true);
+
+  final relativeGeneratedPath = path.relative(generatedPath, from: docPath);
+
+  File(path.join(docPath, '${docFileName}x')).writeAsStringSync(
+    buildCommandMdxFileContent(docFileName, relativeGeneratedPath),
+  );
+
+  // Create an empty bespoke intro file if it does not exist. These are filled
+  // in manually and preserved across regenerations.
+  final bespokeFile = File(path.join(docPath, '_$docFileName'));
+  if (!bespokeFile.existsSync()) {
+    bespokeFile.writeAsStringSync('');
+  }
+
+  File(
+    path.join(docPath, '_category_.json'),
+  ).writeAsStringSync('{"label": "$docLabel"}');
+}
+
+String buildCommandMdxFileContent(
+  final String fileName,
+  final String relativeGeneratedPath,
+) {
+  final commandName = fileName.split('.').first;
+  final importName = _toImportIdentifier(commandName);
+  final generatedImportPath = path.join(relativeGeneratedPath, fileName);
+
+  // The title is forced empty so the heading from the maintained intro is used.
+  return '''
+---
+title: ""
+---
+import MaintainedCommandIntro from './_$fileName';
+import $importName from '$generatedImportPath';
+
+<MaintainedCommandIntro/>
+
+<$importName/>
+''';
+}
+
+/// Turns a command name into a valid PascalCase JS import identifier, e.g.
+/// `create-migration` -> `CreateMigration`.
+String _toImportIdentifier(final String commandName) {
+  return commandName
+      .split('-')
+      .map((final part) =>
+          part.isEmpty ? part : part[0].toUpperCase() + part.substring(1))
+      .join();
+}
+
+void _deleteRemovedCommandsFiles(
+  final Set<String> currentCommands,
+  final String generatedCommandsPath,
+) {
+  for (final entity in Directory(generatedCommandsPath).listSync()) {
+    if (entity is File &&
+        entity.path.endsWith('.md') &&
+        !entity.path.endsWith('global_options.md')) {
+      final fileName = path.basename(entity.path);
+      if (!currentCommands.contains(fileName.split('.').first)) {
+        entity.deleteSync();
+      }
+    }
+  }
+}
+
+void _deleteRemovedCommandsFolders(
+  final Set<String> currentCommands,
+  final String commandsPath,
+) {
+  for (final entity in Directory(commandsPath).listSync()) {
+    if (entity is Directory) {
+      final folderName = path.basename(entity.path);
+      if (!currentCommands.contains(folderName)) {
+        entity.deleteSync(recursive: true);
+      }
+    }
+  }
+}
+
+class _CommandDocumentationGenerator {
+  final BetterCommandRunner commandRunner;
+
+  _CommandDocumentationGenerator(this.commandRunner);
+
+  Map<String, String> generateMarkdown() {
+    final commands = commandRunner.commands.values;
+
+    final files = <String, String>{};
+
+    for (final command in commands) {
+      if (_excludeCommand(command)) continue;
+
+      final markdown = _generateCommandPage(command);
+
+      files['${command.name}.md'] = markdown.toString();
+    }
+
+    return files;
+  }
+
+  StringBuffer generateGlobalOptionsPage() {
+    final StringBuffer markdown = StringBuffer();
+    markdown.writeln('## Usage\n');
+
+    if (commandRunner.argParser.options.isNotEmpty) {
+      markdown.writeln('```console');
+      markdown.writeln(commandRunner.usage);
+      markdown.writeln('```\n');
+    }
+
+    return markdown;
+  }
+
+  StringBuffer _generateCommandPage(final Command command) {
+    final StringBuffer markdown = StringBuffer();
+    markdown.writeln('## Usage\n');
+
+    if (command.argParser.options.isNotEmpty) {
+      markdown.writeln('```console');
+      markdown.writeln(_stripGlobalOptions(command.usage));
+      markdown.writeln('```\n');
+    }
+
+    final subcommands = command.subcommands.entries.where(
+      (final e) => !_excludeCommand(e.value),
+    );
+
+    if (subcommands.isNotEmpty) {
+      final numberOfSubcommands = subcommands.length;
+      markdown.writeln('### Sub commands\n');
+      for (final (i, subcommand) in subcommands.indexed) {
+        markdown.writeln('#### `${subcommand.key}`\n');
+        markdown.writeln('```console');
+        markdown.writeln(_stripGlobalOptions(subcommand.value.usage));
+        markdown.writeln('```');
+        if (i < numberOfSubcommands - 1) {
+          markdown.writeln();
+        }
+      }
+    }
+    return markdown;
+  }
+
+  /// Removes the shared "Global options:" block from a command's usage. Those
+  /// options are documented on the dedicated global options page, so command
+  /// pages keep only their own options plus the pointer line.
+  String _stripGlobalOptions(final String usage) {
+    final index = usage.indexOf('\nGlobal options:');
+    if (index == -1) return usage.trimRight();
+    return usage.substring(0, index).trimRight();
+  }
+
+  bool _excludeCommand(final Command command) {
+    return command.hidden && command.name != 'help';
+  }
+}

--- a/tools/serverpod_cli/scripts/generate_command_usages.dart
+++ b/tools/serverpod_cli/scripts/generate_command_usages.dart
@@ -30,8 +30,10 @@ import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
 /// leaving the hand-maintained `_<command>.md` intros untouched.
 void main(final List<String> args) {
   if (args.length != 1) {
-    throw StateError('Expected the path to the docs directory as the only '
-        'argument.');
+    throw StateError(
+      'Expected the path to the docs directory as the only '
+      'argument.',
+    );
   }
   final docsPath = args.first;
 
@@ -44,28 +46,29 @@ void main(final List<String> args) {
   // Keep this command list in sync with `buildCommandRunner` in
   // `bin/serverpod_cli.dart`. Hidden commands are filtered out below.
   final version = Version.parse(templateVersion);
-  final cli = ServerpodCommandRunner.createCommandRunner(
-    CompoundAnalytics([]),
-    true,
-    version,
-    onBeforeRunCommand: (_) async {},
-  )..addCommands([
-      AnalyzePubspecsCommand(),
-      CloudCommand(),
-      CreateCommand(),
-      QuickstartCommand(),
-      GenerateCommand(),
-      GeneratePubspecsCommand(),
-      LanguageServerCommand(),
-      McpCommand(),
-      CreateMigrationCommand(),
-      CreateRepairMigrationCommand(),
-      MigrateCommand(),
-      RunCommand(),
-      StartCommand(),
-      UpgradeCommand(),
-      VersionCommand(version),
-    ]);
+  final cli =
+      ServerpodCommandRunner.createCommandRunner(
+        CompoundAnalytics([]),
+        true,
+        version,
+        onBeforeRunCommand: (_) async {},
+      )..addCommands([
+        AnalyzePubspecsCommand(),
+        CloudCommand(),
+        CreateCommand(),
+        QuickstartCommand(),
+        GenerateCommand(),
+        GeneratePubspecsCommand(),
+        LanguageServerCommand(),
+        McpCommand(),
+        CreateMigrationCommand(),
+        CreateRepairMigrationCommand(),
+        MigrateCommand(),
+        RunCommand(),
+        StartCommand(),
+        UpgradeCommand(),
+        VersionCommand(version),
+      ]);
 
   final generator = _CommandDocumentationGenerator(cli);
 
@@ -153,8 +156,10 @@ import $importName from '$generatedImportPath';
 String _toImportIdentifier(final String commandName) {
   return commandName
       .split('-')
-      .map((final part) =>
-          part.isEmpty ? part : part[0].toUpperCase() + part.substring(1))
+      .map(
+        (final part) =>
+            part.isEmpty ? part : part[0].toUpperCase() + part.substring(1),
+      )
       .join();
 }
 


### PR DESCRIPTION
## What

Adds an auto-sync bot that regenerates the framework `serverpod` CLI command reference and opens a rolling PR in [serverpod_docs](https://github.com/serverpod/serverpod_docs). This is a clone of the existing Serverpod Cloud docs-sync bot, adapted for the framework CLI.

Two pieces:

- **`tools/serverpod_cli/scripts/generate_command_usages.dart`** — instantiates `ServerpodCommandRunner` (mirroring `buildCommandRunner`), and writes the `_generated/*.md` usage blocks plus the per-command `.mdx` pages. The hand-maintained `_<command>.md` intros are preserved across runs. Strips the shared global-options block from command pages (documented on its own page) and handles hyphenated command names.
- **`.github/workflows/sync-cli-docs.yml`** — on pushes to `main` that touch the CLI command runner/commands, regenerates the docs, force-pushes the rolling `auto/framework-cli-docs-sync` branch, and opens (or refreshes) a single PR on `serverpod_docs` with auto-merge.

## Prerequisites before this can run

The workflow authenticates to `serverpod_docs` through a GitHub App. An org admin needs to:

- Install a GitHub App (reuse `serverpod-cloud-docs-sync` or a sibling) on `serverpod_docs` with **Contents: write** and **Pull requests: write**.
- Add `DOCS_SYNC_APP_CLIENT_ID` and `DOCS_SYNC_APP_PRIVATE_KEY` as secrets on this repo.
- Enable auto-merge in `serverpod_docs` settings.

The branch name (`auto/framework-cli-docs-sync`) is intentionally distinct from the Cloud bot's `auto/cli-docs-sync` so the two bots don't collide on the same docs repo.

## Related

- Docs structure (the CLI reference pages this bot maintains): serverpod/serverpod_docs#649. That should merge first so the curated intros exist on `main`.