### PR TITLE
feat: Add support for creating server only projects

### DIFF
--- a/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -15,8 +15,8 @@ dev_dependencies:
   lints: '>=3.0.0 <7.0.0'
   serverpod_test: SERVERPOD_VERSION
   test: ^1.25.5
-# {{#flutterApp}}
 
+# {{#flutterApp}}
 serverpod:
   scripts:
     # Build the Flutter web app and copy it to the server's web directory.

--- a/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -20,7 +20,8 @@ serverpod:
   scripts:
     # Starts the server and applies migrations
     start: dart bin/main.dart --apply-migrations
-
+    # {{#flutterApp}}
+    
     # Build the Flutter web app and copy it to the server's web directory.
     # Windows uses xcopy since flutter's --output flag doesn't work there.
     # See: https://github.com/flutter/flutter/issues/157886
@@ -33,7 +34,9 @@ serverpod:
       posix: |
         cd ../projectname_flutter
         flutter build web --base-href /app/ --output ../projectname_server/web/app
-
+    # {{/flutterApp}}
+  # {{#flutterApp}}
+  
   # Companion Flutter apps that `serverpod start` can launch (Ctrl+R), keyed
   # by a display alias. The default device is the web server, opening the
   # machine's default browser when ready. All non-reserved properties are
@@ -56,3 +59,4 @@ serverpod:
       path: ../projectname_flutter
       auto_launch: true
       target: lib/driver.dart
+  # {{/flutterApp}}

--- a/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -15,13 +15,10 @@ dev_dependencies:
   lints: '>=3.0.0 <7.0.0'
   serverpod_test: SERVERPOD_VERSION
   test: ^1.25.5
+# {{#flutterApp}}
 
 serverpod:
   scripts:
-    # Starts the server and applies migrations
-    start: dart bin/main.dart --apply-migrations
-    # {{#flutterApp}}
-    
     # Build the Flutter web app and copy it to the server's web directory.
     # Windows uses xcopy since flutter's --output flag doesn't work there.
     # See: https://github.com/flutter/flutter/issues/157886
@@ -34,8 +31,6 @@ serverpod:
       posix: |
         cd ../projectname_flutter
         flutter build web --base-href /app/ --output ../projectname_server/web/app
-    # {{/flutterApp}}
-  # {{#flutterApp}}
   
   # Companion Flutter apps that `serverpod start` can launch (Ctrl+R), keyed
   # by a display alias. The default device is the web server, opening the
@@ -59,4 +54,4 @@ serverpod:
       path: ../projectname_flutter
       auto_launch: true
       target: lib/driver.dart
-  # {{/flutterApp}}
+# {{/flutterApp}}

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_service_client: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
-  serverpod_tui: ^0.5.0
+  serverpod_tui: ^0.6.0
   skills: ^0.3.1
   source_span: ^1.10.0
   stream_channel: ^2.1.1

--- a/templates/serverpod_templates/projectname_server/README.md
+++ b/templates/serverpod_templates/projectname_server/README.md
@@ -2,14 +2,9 @@
 
 This is the starting point for your Serverpod server.
 
-To run your server, you first need to start Postgres and Redis. It's easiest to do with Docker.
+Start your server by running:
 
-    docker compose up --build --detach
+    cd projectname
+    serverpod start
 
-Then you can start the Serverpod server.
-
-    dart bin/main.dart
-
-When you are finished, you can shut down Serverpod with `Ctrl-C`, then stop Postgres and Redis.
-
-    docker compose stop
+When you are finished, you can shut down Serverpod with `Q`.

--- a/templates/serverpod_templates/projectname_server/README.md
+++ b/templates/serverpod_templates/projectname_server/README.md
@@ -7,4 +7,4 @@ Start your server by running:
     cd projectname
     serverpod start
 
-When you are finished, you can shut down Serverpod with `Q`.
+When you are finished, you can shut down the running server with `Q`.

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -20,6 +20,7 @@ serverpod:
   scripts:
     # Starts the server and applies migrations
     start: dart bin/main.dart --apply-migrations
+    # {{#flutterApp}}
 
     # Build the Flutter web app and copy it to the server's web directory.
     # Windows uses xcopy since flutter's --output flag doesn't work there.
@@ -33,7 +34,9 @@ serverpod:
       posix: |
         cd ../projectname_flutter
         flutter build web --base-href /app/ --output ../projectname_server/web/app
-
+    # {{/flutterApp}}
+  # {{#flutterApp}}
+  
   # Companion Flutter apps that `serverpod start` can launch (Ctrl+R), keyed
   # by a display alias. The default device is the web server, opening the
   # machine's default browser when ready. All non-reserved properties are
@@ -56,3 +59,4 @@ serverpod:
       path: ../projectname_flutter
       auto_launch: true
       target: lib/driver.dart
+  # {{/flutterApp}}

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -15,8 +15,8 @@ dev_dependencies:
   lints: '>=3.0.0 <7.0.0'
   serverpod_test: 3.5.0-beta.12
   test: ^1.25.5
-# {{#flutterApp}}
 
+# {{#flutterApp}}
 serverpod:
   scripts:
     # Build the Flutter web app and copy it to the server's web directory.

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -15,10 +15,10 @@ dev_dependencies:
   lints: '>=3.0.0 <7.0.0'
   serverpod_test: 3.5.0-beta.12
   test: ^1.25.5
+# {{#flutterApp}}
 
 serverpod:
   scripts:
-    # {{#flutterApp}}
     # Build the Flutter web app and copy it to the server's web directory.
     # Windows uses xcopy since flutter's --output flag doesn't work there.
     # See: https://github.com/flutter/flutter/issues/157886

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -54,4 +54,4 @@ serverpod:
       path: ../projectname_flutter
       auto_launch: true
       target: lib/driver.dart
-  # {{/flutterApp}}
+# {{/flutterApp}}

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -19,7 +19,6 @@ dev_dependencies:
 serverpod:
   scripts:
     # {{#flutterApp}}
-    
     # Build the Flutter web app and copy it to the server's web directory.
     # Windows uses xcopy since flutter's --output flag doesn't work there.
     # See: https://github.com/flutter/flutter/issues/157886

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -34,8 +34,6 @@ serverpod:
       posix: |
         cd ../projectname_flutter
         flutter build web --base-href /app/ --output ../projectname_server/web/app
-    # {{/flutterApp}}
-  # {{#flutterApp}}
   
   # Companion Flutter apps that `serverpod start` can launch (Ctrl+R), keyed
   # by a display alias. The default device is the web server, opening the

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -18,8 +18,6 @@ dev_dependencies:
 
 serverpod:
   scripts:
-    # Starts the server and applies migrations
-    start: dart bin/main.dart --apply-migrations
     # {{#flutterApp}}
     
     # Build the Flutter web app and copy it to the server's web directory.

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -21,7 +21,7 @@ serverpod:
     # Starts the server and applies migrations
     start: dart bin/main.dart --apply-migrations
     # {{#flutterApp}}
-
+    
     # Build the Flutter web app and copy it to the server's web directory.
     # Windows uses xcopy since flutter's --output flag doesn't work there.
     # See: https://github.com/flutter/flutter/issues/157886

--- a/templates/serverpod_templates/vscode/launch.json
+++ b/templates/serverpod_templates/vscode/launch.json
@@ -1,6 +1,7 @@
 {
   "version": "0.2.0",
   "configurations": [
+    // {{#flutterApp}}
     {
       // Attaches to the Flutter app `serverpod start` spawns. Don't
       // launch a second instance here - it would race for the port.
@@ -11,6 +12,7 @@
       "preLaunchTask": "serverpod_start",
       "internalConsoleOptions": "neverOpen"
     },
+    // {{/flutterApp}}
     {
       "name": "projectname_server",
       "type": "dart",
@@ -23,7 +25,12 @@
   "compounds": [
     {
       "name": "projectname (full stack)",
-      "configurations": ["projectname_server", "projectname_flutter"],
+      "configurations": [
+        "projectname_server",
+        // {{#flutterApp}}
+        "projectname_flutter"
+        // {{/flutterApp}}
+      ],
       // Stopping one session stops both; the orphan blocks re-attach.
       "stopAll": true,
       "presentation": {

--- a/templates/serverpod_templates/vscode/launch.json
+++ b/templates/serverpod_templates/vscode/launch.json
@@ -21,15 +21,15 @@
       "preLaunchTask": "serverpod_start",
       "internalConsoleOptions": "neverOpen"
     }
-  ],
+  ]
+  // {{#flutterApp}}
+  ,
   "compounds": [
     {
       "name": "projectname (full stack)",
       "configurations": [
         "projectname_server",
-        // {{#flutterApp}}
         "projectname_flutter"
-        // {{/flutterApp}}
       ],
       // Stopping one session stops both; the orphan blocks re-attach.
       "stopAll": true,
@@ -38,4 +38,5 @@
       }
     }
   ]
+  // {{/flutterApp}}
 }

--- a/templates/serverpod_templates/vscode/launch.json
+++ b/templates/serverpod_templates/vscode/launch.json
@@ -21,9 +21,8 @@
       "preLaunchTask": "serverpod_start",
       "internalConsoleOptions": "neverOpen"
     }
-  ]
   // {{#flutterApp}}
-  ,
+  ],
   "compounds": [
     {
       "name": "projectname (full stack)",
@@ -37,6 +36,6 @@
         "order": 1
       }
     }
-  ]
   // {{/flutterApp}}
+  ]
 }

--- a/tests/bootstrap_project/test/project_server_test.dart
+++ b/tests/bootstrap_project/test/project_server_test.dart
@@ -73,7 +73,10 @@ void main() async {
           });
 
           test('then a flutter project folder is not created', () {
-            expect(Directory(flutterDir).existsSync(), isFalse);
+            expect(
+              Directory(path.join(tempPath, flutterDir)).existsSync(),
+              isFalse,
+            );
           });
 
           test('then the workspace has a root pubspec.yaml file', () {
@@ -312,7 +315,7 @@ void main() async {
             'then the server pubspec does not contain the flutter_build script',
             () {
               final content = File(
-                path.join(serverDir, 'pubspec.yaml'),
+                path.join(tempPath, serverDir, 'pubspec.yaml'),
               ).readAsStringSync();
               expect(content, contains('scripts:'));
               expect(content, isNot(contains('flutter_build:')));
@@ -323,7 +326,7 @@ void main() async {
             'then the server pubspec does not contain the flutter_apps section',
             () {
               final content = File(
-                path.join(serverDir, 'pubspec.yaml'),
+                path.join(tempPath, serverDir, 'pubspec.yaml'),
               ).readAsStringSync();
               expect(content, isNot(contains('flutter_apps:')));
             },

--- a/tests/bootstrap_project/test/project_server_test.dart
+++ b/tests/bootstrap_project/test/project_server_test.dart
@@ -1,0 +1,670 @@
+@Timeout(Duration(minutes: 15))
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+import '../lib/src/util.dart';
+
+const tempDirName = 'temp_project_server';
+
+void main() async {
+  final rootPath = path.join(Directory.current.path, '..', '..');
+  final cliProjectPath = getServerpodCliProjectPath(rootPath: rootPath);
+  final tempPath = path.join(rootPath, tempDirName);
+
+  setUpAll(() async {
+    await Directory(tempPath).create();
+    final pubGetProcess = await startProcess('dart', [
+      'pub',
+      'get',
+    ], workingDirectory: cliProjectPath);
+    assert(await pubGetProcess.exitCode == 0);
+  });
+
+  tearDownAll(() async {
+    try {
+      await Directory(tempPath).delete(recursive: true);
+    } catch (e) {}
+  });
+
+  group(
+    'Given a clean state',
+    () {
+      final (:projectName, commandRoot: _) = createRandomProjectName(tempPath);
+      final (:serverDir, :flutterDir, :clientDir) = createProjectFolderPaths(
+        projectName,
+      );
+
+      group(
+        'when creating a new project with the server template',
+        () {
+          setUpAll(() async {
+            var createProcess = await startServerpodCli(
+              [
+                'create',
+                '--template',
+                'server',
+                projectName,
+                '-v',
+                '--no-analytics',
+                '--no-interactive',
+              ],
+              rootPath: rootPath,
+              workingDirectory: tempPath,
+              environment: {
+                'SERVERPOD_HOME': rootPath,
+              },
+            );
+
+            var exitCode = await createProcess.exitCode;
+            assert(exitCode == 0);
+          });
+
+          test('then there are no linting errors in the new project', () async {
+            final process = await startProcess(
+              'dart',
+              ['analyze', '--fatal-infos', '--fatal-warnings', projectName],
+              workingDirectory: tempPath,
+            );
+
+            var exitCode = await process.exitCode;
+            expect(exitCode, 0, reason: 'Linting errors in new project.');
+          });
+
+          test('then a flutter project folder is not created', () {
+            expect(Directory(flutterDir).existsSync(), isFalse);
+          });
+
+          test('then the workspace has a root pubspec.yaml file', () {
+            expect(
+              File(
+                path.join(tempPath, projectName, 'pubspec.yaml'),
+              ).existsSync(),
+              isTrue,
+              reason: 'Root workspace pubspec file does not exist.',
+            );
+          });
+
+          test('then the workspace root pubspec.yaml has name: _', () {
+            final content = File(
+              path.join(tempPath, projectName, 'pubspec.yaml'),
+            ).readAsStringSync();
+            expect(content, contains('name: _'));
+          });
+
+          test(
+            'then the workspace root pubspec.yaml has workspace section',
+            () {
+              final content = File(
+                path.join(tempPath, projectName, 'pubspec.yaml'),
+              ).readAsStringSync();
+              expect(content, contains('workspace:'));
+              expect(content, contains('${projectName}_client'));
+              expect(content, contains('${projectName}_server'));
+            },
+          );
+
+          test(
+            'then the workspace has a root .gitignore that ignores workspace .dart_tool and .scloud',
+            () {
+              final rootGitignore = File(
+                path.join(tempPath, projectName, '.gitignore'),
+              );
+              expect(rootGitignore.existsSync(), isTrue);
+
+              final content = rootGitignore.readAsStringSync();
+              expect(content, contains('.dart_tool/'));
+              expect(content, contains('.scloud/'));
+            },
+          );
+
+          test('then the server pubspec.yaml has resolution: workspace', () {
+            final content = File(
+              path.join(tempPath, serverDir, 'pubspec.yaml'),
+            ).readAsStringSync();
+            expect(content, contains('resolution: workspace'));
+          });
+
+          test('then the client pubspec.yaml has resolution: workspace', () {
+            final content = File(
+              path.join(tempPath, clientDir, 'pubspec.yaml'),
+            ).readAsStringSync();
+            expect(content, contains('resolution: workspace'));
+          });
+
+          test('then the workspace root has pubspec.lock file', () {
+            expect(
+              File(
+                path.join(tempPath, projectName, 'pubspec.lock'),
+              ).existsSync(),
+              isTrue,
+              reason: 'Root pubspec.lock file does not exist.',
+            );
+          });
+
+          test(
+            'then the workspace does not copy template pubspec lock files into packages',
+            () {
+              final packageDirs = [serverDir, clientDir];
+
+              for (final packageDir in packageDirs) {
+                expect(
+                  File(
+                    path.join(tempPath, packageDir, 'pubspec.lock'),
+                  ).existsSync(),
+                  isFalse,
+                  reason: 'Template pubspec.lock was copied into $packageDir.',
+                );
+              }
+            },
+          );
+
+          test(
+            'then the workspace does not copy template pubspec override files',
+            () {
+              final packageDirs = [projectName, serverDir, clientDir];
+
+              for (final packageDir in packageDirs) {
+                expect(
+                  File(
+                    path.join(tempPath, packageDir, 'pubspec_overrides.yaml'),
+                  ).existsSync(),
+                  isFalse,
+                  reason:
+                      'Template pubspec_overrides.yaml was copied into $packageDir.',
+                );
+              }
+            },
+          );
+
+          test(
+            'then the workspace does not copy template melos project files',
+            () {
+              final packageDirs = [projectName, serverDir, clientDir];
+
+              for (final packageDir in packageDirs) {
+                final directory = Directory(path.join(tempPath, packageDir));
+                final melosProjectFiles = directory
+                    .listSync()
+                    .whereType<File>()
+                    .where((file) {
+                      final fileName = path.basename(file.path);
+                      return fileName.startsWith('melos_') &&
+                          fileName.endsWith('.iml');
+                    });
+
+                expect(
+                  melosProjectFiles,
+                  isEmpty,
+                  reason:
+                      'Template melos project file was copied into $packageDir.',
+                );
+              }
+            },
+          );
+
+          test('then the workspace has AGENTS.md file', () {
+            final agentsMd = File(
+              path.join(tempPath, projectName, 'AGENTS.md'),
+            );
+            expect(agentsMd.existsSync(), isTrue);
+            expect(agentsMd.readAsStringSync(), isNotEmpty);
+          });
+
+          test('then the workspace has CLAUDE.md file', () {
+            final claudeMd = File(
+              path.join(tempPath, projectName, 'CLAUDE.md'),
+            );
+            expect(claudeMd.existsSync(), isTrue);
+            expect(claudeMd.readAsStringSync(), '@AGENTS.md\n');
+          });
+
+          test('then the workspace has agent skills installed', () {
+            expect(
+              Directory(
+                path.join(tempPath, projectName, '.agents', 'skills'),
+              ).existsSync(),
+              isTrue,
+            );
+            expect(
+              Directory(
+                path.join(tempPath, projectName, '.claude', 'skills'),
+              ).existsSync(),
+              isTrue,
+            );
+            expect(
+              Directory(
+                path.join(tempPath, projectName, '.cursor', 'skills'),
+              ).existsSync(),
+              isTrue,
+            );
+          });
+
+          group(
+            'then the workspace has Serverpod and Dart MCP servers configured',
+            () {
+              final serverDirRelative = '${projectName}_server';
+              final genericConfig =
+                  '''
+{
+  "mcpServers": {
+    "serverpod": {
+      "command": "serverpod",
+      "args": ["mcp-server", "--server-dir", "$serverDirRelative"]
+    },
+    "dart": {
+      "command": "dart",
+      "args": ["mcp-server"]
+    }
+  }
+}
+''';
+
+              test('for Claude', () {
+                final claude = File(
+                  path.join(tempPath, projectName, '.mcp.json'),
+                );
+                expect(claude.existsSync(), isTrue);
+                expect(claude.readAsStringSync(), genericConfig);
+              });
+
+              test('for Cursor', () {
+                final cursor = File(
+                  path.join(tempPath, projectName, '.cursor/mcp.json'),
+                );
+                expect(cursor.existsSync(), isTrue);
+                expect(cursor.readAsStringSync(), genericConfig);
+              });
+
+              test('for VS Code', () {
+                final vscode = File(
+                  path.join(tempPath, projectName, '.vscode/mcp.json'),
+                );
+                expect(vscode.existsSync(), isTrue);
+                expect(
+                  vscode.readAsStringSync(),
+                  genericConfig.replaceAll('mcpServers', 'servers'),
+                );
+              });
+            },
+          );
+
+          test('then the server project folder is created', () {
+            expect(
+              Directory(path.join(tempPath, serverDir)).existsSync(),
+              isTrue,
+              reason: 'Server folder does not exist.',
+            );
+          });
+
+          test('then the server project has a pubspec file', () {
+            expect(
+              File(
+                path.join(tempPath, serverDir, 'pubspec.yaml'),
+              ).existsSync(),
+              isTrue,
+              reason: 'Server pubspec file does not exist.',
+            );
+          });
+
+          test(
+            'then the server pubspec does not contain the flutter_build script',
+            () {
+              final content = File(
+                path.join(serverDir, 'pubspec.yaml'),
+              ).readAsStringSync();
+              expect(content, contains('scripts:'));
+              expect(content, isNot(contains('flutter_build:')));
+            },
+          );
+
+          test(
+            'then the server pubspec does not contain the flutter_apps section',
+            () {
+              final content = File(
+                path.join(serverDir, 'pubspec.yaml'),
+              ).readAsStringSync();
+              expect(content, isNot(contains('flutter_apps:')));
+            },
+          );
+
+          test('then the server project has a .gitignore file', () {
+            expect(
+              File(path.join(tempPath, serverDir, '.gitignore')).existsSync(),
+              isTrue,
+              reason: 'Server .gitignore file does not exist.',
+            );
+          });
+
+          test('then the server project has a server.dart file', () {
+            expect(
+              File(
+                path.join(tempPath, serverDir, 'lib', 'server.dart'),
+              ).existsSync(),
+              isTrue,
+              reason: 'Server server.dart file does not exist.',
+            );
+          });
+
+          test('then the server project has a Dockerfile', () {
+            expect(
+              File(path.join(tempPath, serverDir, 'Dockerfile')).existsSync(),
+              isTrue,
+              reason: 'Server Dockerfile does not exist.',
+            );
+          });
+
+          test('then the server project has an example_endpoint file', () {
+            expect(
+              File(
+                path.join(
+                  tempPath,
+                  serverDir,
+                  'lib',
+                  'src',
+                  'greetings',
+                  'greeting_endpoint.dart',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason: 'Server greeting_endpoint file does not exist.',
+            );
+          });
+
+          test('then the server project has a generated endpoints file', () {
+            expect(
+              File(
+                path.join(
+                  tempPath,
+                  serverDir,
+                  'lib',
+                  'src',
+                  'generated',
+                  'endpoints.dart',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason: 'Server generated endpoints file does not exist.',
+            );
+          });
+
+          test('then the server project has a generated test tools file', () {
+            expect(
+              File(
+                path.join(
+                  tempPath,
+                  serverDir,
+                  'test',
+                  'integration',
+                  'test_tools',
+                  'serverpod_test_tools.dart',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason:
+                  'Server generated integration test tools file does not exist.',
+            );
+          });
+
+          test('then the server project has a generated example file', () {
+            expect(
+              File(
+                path.join(
+                  tempPath,
+                  serverDir,
+                  'lib',
+                  'src',
+                  'generated',
+                  'greetings',
+                  'greeting.dart',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason: 'Server generated greeting endpoint file does not exist.',
+            );
+          });
+
+          test('then the server project has the project migrations folder', () {
+            expect(
+              Directory(
+                path.join(
+                  tempPath,
+                  serverDir,
+                  'migrations',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason: 'Server migrations folder does not exist.',
+            );
+          });
+
+          test('then the server project has project migration registry', () {
+            expect(
+              File(
+                path.join(
+                  tempPath,
+                  serverDir,
+                  'migrations',
+                  'migration_registry.txt',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason: 'Server migration registry does not exist.',
+            );
+          });
+
+          test(
+            'then the server project has a generated protocol.yaml file',
+            () {
+              expect(
+                File(
+                  path.join(
+                    tempPath,
+                    serverDir,
+                    'lib',
+                    'src',
+                    'generated',
+                    'protocol.yaml',
+                  ),
+                ).existsSync(),
+                isTrue,
+                reason: 'Server generated protocol.yaml file does not exist.',
+              );
+            },
+          );
+
+          test('then the client project folder is created', () {
+            expect(
+              Directory(path.join(tempPath, clientDir)).existsSync(),
+              isTrue,
+              reason: 'Client folder does not exist.',
+            );
+          });
+
+          test(
+            'then the client project has a pubspec file with serverpod_auth_idp_client dependency',
+            () {
+              final pubspec = File(
+                path.join(tempPath, clientDir, 'pubspec.yaml'),
+              );
+              expect(
+                pubspec.existsSync(),
+                isTrue,
+                reason: 'Client pubspec file does not exist.',
+              );
+              expect(
+                pubspec.readAsStringSync(),
+                contains('serverpod_auth_idp_client:'),
+                reason:
+                    'Client pubspec file does not have serverpod_auth_idp_client dependency.',
+              );
+            },
+          );
+
+          test('then the client project has a project_client file', () {
+            expect(
+              File(
+                path.join(
+                  tempPath,
+                  clientDir,
+                  'lib',
+                  '${projectName}_client.dart',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason: 'Client project_client file does not exist.',
+            );
+          });
+
+          test('then the client project has a protocol client file', () {
+            expect(
+              File(
+                path.join(
+                  tempPath,
+                  clientDir,
+                  'lib',
+                  'src',
+                  'protocol',
+                  'client.dart',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason: 'Client protocol client file does not exist.',
+            );
+          });
+
+          test('then the .github directory has tests workflow', () {
+            expect(
+              File(
+                path.join(
+                  tempPath,
+                  projectName,
+                  '.github',
+                  'workflows',
+                  'tests.yml',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason: 'tests.yml workflow does not exist.',
+            );
+          });
+
+          test('then the .github directory has format workflow', () {
+            expect(
+              File(
+                path.join(
+                  tempPath,
+                  projectName,
+                  '.github',
+                  'workflows',
+                  'format.yml',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason: 'format.yml workflow does not exist.',
+            );
+          });
+
+          test('then the .github directory has analyze workflow', () {
+            expect(
+              File(
+                path.join(
+                  tempPath,
+                  projectName,
+                  '.github',
+                  'workflows',
+                  'analyze.yml',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason: 'analyze.yml workflow does not exist.',
+            );
+          });
+
+          test('then the .vscode directory has launch.json', () {
+            expect(
+              File(
+                path.join(
+                  tempPath,
+                  projectName,
+                  '.vscode',
+                  'launch.json',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason: 'launch.json does not exist.',
+            );
+          });
+
+          test(
+            'then the .vscode launch.json does not have flutter configuration',
+            () {
+              final launchJson = File(
+                path.join(
+                  tempPath,
+                  projectName,
+                  '.vscode',
+                  'launch.json',
+                ),
+              ).readAsStringSync();
+
+              expect(
+                launchJson.contains('"${projectName}_flutter"'),
+                isFalse,
+                reason: 'launch.json contains flutter configuration.',
+              );
+            },
+          );
+
+          test(
+            'then the .vscode launch.json has server configuration',
+            () {
+              final launchJson = File(
+                path.join(
+                  tempPath,
+                  projectName,
+                  '.vscode',
+                  'launch.json',
+                ),
+              ).readAsStringSync();
+
+              expect(
+                launchJson.contains('"${projectName}_server"'),
+                isTrue,
+                reason: 'launch.json does not contain server configuration.',
+              );
+            },
+          );
+
+          test(
+            'then the .vscode launch.json has compound configuration for full stack',
+            () {
+              final launchJson = File(
+                path.join(
+                  tempPath,
+                  projectName,
+                  '.vscode',
+                  'launch.json',
+                ),
+              ).readAsStringSync();
+
+              expect(
+                launchJson.contains('"compounds"'),
+                isTrue,
+                reason: 'launch.json does not contain compounds section.',
+              );
+
+              expect(
+                launchJson.contains('"${projectName} (full stack)"'),
+                isTrue,
+                reason:
+                    'launch.json does not contain full stack compound configuration.',
+              );
+            },
+          );
+        },
+      );
+    },
+  );
+}

--- a/tests/bootstrap_project/test/project_server_test.dart
+++ b/tests/bootstrap_project/test/project_server_test.dart
@@ -312,12 +312,12 @@ void main() async {
           });
 
           test(
-            'then the server pubspec does not contain the flutter_build script',
+            'then the server pubspec does not contain the serverpod scripts section',
             () {
               final content = File(
                 path.join(tempPath, serverDir, 'pubspec.yaml'),
               ).readAsStringSync();
-              expect(content, contains('scripts:'));
+              expect(content, isNot(contains('scripts:')));
               expect(content, isNot(contains('flutter_build:')));
             },
           );
@@ -641,7 +641,7 @@ void main() async {
           );
 
           test(
-            'then the .vscode launch.json has compound configuration for full stack',
+            'then the .vscode launch.json does not have compound configuration for full stack',
             () {
               final launchJson = File(
                 path.join(
@@ -654,15 +654,15 @@ void main() async {
 
               expect(
                 launchJson.contains('"compounds"'),
-                isTrue,
-                reason: 'launch.json does not contain compounds section.',
+                isFalse,
+                reason: 'launch.json contains compounds section.',
               );
 
               expect(
                 launchJson.contains('"${projectName} (full stack)"'),
-                isTrue,
+                isFalse,
                 reason:
-                    'launch.json does not contain full stack compound configuration.',
+                    'launch.json contains full stack compound configuration.',
               );
             },
           );

--- a/tests/bootstrap_project/test_perform_create/auth_test.dart
+++ b/tests/bootstrap_project/test_perform_create/auth_test.dart
@@ -22,11 +22,11 @@ void main() {
 
   group(
     'Given a TemplateContext with auth and a database option enabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           auth: true,
           postgres: true,
         ),
@@ -195,11 +195,11 @@ void main() {
 
   group(
     'Given a TemplateContext with auth disabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           auth: false,
         ),
       );
@@ -364,11 +364,11 @@ void main() {
 
   group(
     'Given a TemplateContext with auth disabled and a database option enabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           auth: false,
           postgres: true,
         ),

--- a/tests/bootstrap_project/test_perform_create/database_test.dart
+++ b/tests/bootstrap_project/test_perform_create/database_test.dart
@@ -22,11 +22,11 @@ void main() {
 
   group(
     'Given a TemplateContext with redis disabled and no database option enabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           postgres: false,
           redis: false,
           sqlite: false,

--- a/tests/bootstrap_project/test_perform_create/docker_test.dart
+++ b/tests/bootstrap_project/test_perform_create/docker_test.dart
@@ -22,11 +22,11 @@ void main() {
 
   group(
     'Given a TemplateContext with postgres and redis disabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           redis: false,
           postgres: false,
         ),

--- a/tests/bootstrap_project/test_perform_create/postgres_test.dart
+++ b/tests/bootstrap_project/test_perform_create/postgres_test.dart
@@ -22,11 +22,11 @@ void main() {
 
   group(
     'Given a TemplateContext with postgres enabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           postgres: true,
         ),
       );
@@ -129,11 +129,11 @@ void main() {
 
   group(
     'Given a TemplateContext with postgres disabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           postgres: false,
         ),
       );

--- a/tests/bootstrap_project/test_perform_create/redis_test.dart
+++ b/tests/bootstrap_project/test_perform_create/redis_test.dart
@@ -22,11 +22,11 @@ void main() {
 
   group(
     'Given a TemplateContext with redis enabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           redis: true,
         ),
       );
@@ -86,11 +86,11 @@ void main() {
 
   group(
     'Given a TemplateContext with redis disabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           redis: false,
         ),
       );

--- a/tests/bootstrap_project/test_perform_create/sqlite_test.dart
+++ b/tests/bootstrap_project/test_perform_create/sqlite_test.dart
@@ -22,11 +22,11 @@ void main() {
 
   group(
     'Given a TemplateContext with sqlite enabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           sqlite: true,
         ),
       );
@@ -77,11 +77,11 @@ void main() {
 
   group(
     'Given a TemplateContext with sqlite disabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           sqlite: false,
         ),
       );

--- a/tests/bootstrap_project/test_perform_create/upgrade_test.dart
+++ b/tests/bootstrap_project/test_perform_create/upgrade_test.dart
@@ -44,7 +44,7 @@ void main() {
         result = await getCreateConfigState(
           name: '.',
           force: false,
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           interactive: false,
           configs: ServerpodCreateConfig.values,
           workingDirectory: Directory(project.projectRoot),
@@ -86,7 +86,7 @@ void main() {
 
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           auth: true,
           redis: true,
           postgres: true,
@@ -99,7 +99,7 @@ void main() {
         result = await getCreateConfigState(
           name: '.',
           force: false,
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           interactive: false,
           configs: ServerpodCreateConfig.values,
           workingDirectory: Directory(project.projectRoot),

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -22,11 +22,11 @@ void main() {
 
   group(
     'Given a TemplateContext with website enabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           website: true,
         ),
       );
@@ -159,11 +159,11 @@ void main() {
 
   group(
     'Given a TemplateContext with webapp enabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           webapp: true,
         ),
       );
@@ -329,11 +329,11 @@ void main() {
 
   group(
     'Given a TemplateContext with webapp and website disabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           webapp: false,
           website: false,
         ),

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -36,11 +36,13 @@ enum CreateOption<V> implements OptionDefinition<V> {
       enumParser: EnumParser(ServerpodTemplateType.values),
       argName: 'template',
       argAbbrev: 't',
-      defaultsTo: ServerpodTemplateType.server,
+      defaultsTo: ServerpodTemplateType.fullstack,
       helpText: 'Template to use when creating a new project',
       allowedValues: ServerpodTemplateType.values,
       allowedHelp: {
         'mini': 'Mini project with minimal features and no database',
+        'fullstack':
+            'Fullstack project including a server and a companion Flutter app',
         'server': 'Server project with standard features including database',
         'module': 'Serverpod Module project',
       },
@@ -136,6 +138,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
       redis: true,
       postgres: true,
       webapp: true,
+      flutterApp: true,
       ides: [TemplateIde.claude, TemplateIde.cursor, TemplateIde.vscode],
     );
 

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -138,7 +138,6 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
       redis: true,
       postgres: true,
       webapp: true,
-      flutterApp: template != ServerpodTemplateType.server,
       ides: [TemplateIde.claude, TemplateIde.cursor, TemplateIde.vscode],
     );
 

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -138,7 +138,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
       redis: true,
       postgres: true,
       webapp: true,
-      flutterApp: true,
+      flutterApp: template != ServerpodTemplateType.server,
       ides: [TemplateIde.claude, TemplateIde.cursor, TemplateIde.vscode],
     );
 

--- a/tools/serverpod_cli/lib/src/commands/create/tui/config.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/config.dart
@@ -33,7 +33,11 @@ enum ServerpodCreateConfig<T extends FormConfigOption>
   ),
   webserver<WebServerConfigOption>(
     label: 'Web server',
-    options: WebServerConfigOption.values,
+    options: [
+      WebServerConfigOption.appOnly,
+      WebServerConfigOption.appAndWebsite,
+      WebServerConfigOption.none,
+    ],
     defaultOptions: {WebServerConfigOption.appOnly},
     description: FormDescription(
       label:
@@ -44,7 +48,24 @@ enum ServerpodCreateConfig<T extends FormConfigOption>
     requirements: [
       FormRequirement<TemplateTypeOption>(
         config: ServerpodCreateConfig.template,
-        configOption: TemplateTypeOption.server,
+        configOptions: {TemplateTypeOption.serverAndApp},
+      ),
+    ],
+  ),
+  serverOnlyWebserver<WebServerConfigOption>(
+    label: 'Web server',
+    options: [WebServerConfigOption.website, WebServerConfigOption.none],
+    defaultOptions: {WebServerConfigOption.website},
+    description: FormDescription(
+      label:
+          'Serverpod can serve web pages (e.g., a landing page or a companion '
+          'HTML site) in addition to your app\'s API.',
+      spacing: 2,
+    ),
+    requirements: [
+      FormRequirement<TemplateTypeOption>(
+        config: ServerpodCreateConfig.template,
+        configOptions: {TemplateTypeOption.server},
       ),
     ],
   ),
@@ -61,11 +82,14 @@ enum ServerpodCreateConfig<T extends FormConfigOption>
     requirements: [
       FormRequirement<TemplateTypeOption>(
         config: ServerpodCreateConfig.template,
-        configOption: TemplateTypeOption.server,
+        configOptions: {
+          TemplateTypeOption.server,
+          TemplateTypeOption.serverAndApp,
+        },
       ),
       FormRequirement<DatabaseConfigOption>(
         config: ServerpodCreateConfig.database,
-        configOption: DatabaseConfigOption.database,
+        configOptions: {DatabaseConfigOption.database},
       ),
     ],
   ),
@@ -125,7 +149,8 @@ enum DatabaseConfigOption implements FormConfigOption {
 
 /// [FormConfigOption] for supported template types.
 enum TemplateTypeOption implements FormConfigOption {
-  server('Server & Flutter app'),
+  serverAndApp('Server & Flutter app'),
+  server('Server only'),
   module('Module')
   ;
 
@@ -139,6 +164,7 @@ enum TemplateTypeOption implements FormConfigOption {
 enum WebServerConfigOption implements FormConfigOption {
   appOnly('Flutter app only (recommended)'),
   appAndWebsite('App and website'),
+  website('Website'),
   none('None')
   ;
 
@@ -167,6 +193,7 @@ enum IdeOption implements FormConfigOption {
 extension TemplateTypeOptionExtension on TemplateTypeOption {
   ServerpodTemplateType get toTemplate => switch (this) {
     TemplateTypeOption.server => ServerpodTemplateType.server,
+    TemplateTypeOption.serverAndApp => ServerpodTemplateType.fullstack,
     TemplateTypeOption.module => ServerpodTemplateType.module,
   };
 }
@@ -174,6 +201,7 @@ extension TemplateTypeOptionExtension on TemplateTypeOption {
 extension ServerpodTemplateTypeExtension on ServerpodTemplateType {
   TemplateTypeOption get toConfigOption => switch (this) {
     ServerpodTemplateType.server => TemplateTypeOption.server,
+    ServerpodTemplateType.fullstack => TemplateTypeOption.serverAndApp,
     ServerpodTemplateType.module => TemplateTypeOption.module,
     ServerpodTemplateType.mini => throw UnsupportedError(
       'Mini template is not supported in the config.',

--- a/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
@@ -147,11 +147,13 @@ class MainScreen extends StatelessComponent {
         Button(
           name: 'Navigate',
           activationChar: hasSingleScreen ? '←→' : '←↑↓→',
-          activationKeys: const [
+          activationKeys: [
             LogicalKey.arrowLeft,
             LogicalKey.arrowRight,
-            LogicalKey.arrowUp,
-            LogicalKey.arrowDown,
+            if (!hasSingleScreen) ...{
+              LogicalKey.arrowUp,
+              LogicalKey.arrowDown,
+            },
           ],
           onActivate: (key) {
             switch (key) {
@@ -162,15 +164,23 @@ class MainScreen extends StatelessComponent {
                 state.form.focusRight();
                 break;
               case LogicalKey.arrowUp:
-                state.form.focusUp();
+                if (isSummary) {
+                  scrollController.scrollUp(3);
+                } else {
+                  state.form.focusUp();
+                }
                 break;
               case LogicalKey.arrowDown:
-                state.form.focusDown();
+                if (isSummary) {
+                  scrollController.scrollDown(3);
+                } else {
+                  state.form.focusDown();
+                }
                 break;
             }
             holder.markDirty();
           },
-          enabled: !isSummary && !creatingProject,
+          enabled: !creatingProject,
         ),
         Button(
           name: 'Select',

--- a/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
@@ -208,7 +208,7 @@ Future<void> _preExit({
       type: TextLogType.success,
     );
 
-    if (template.isServer) logStartInstructions(projectPath);
+    if (template.hasServer) logStartInstructions(projectPath);
     if (template.isMini) logMiniStartInstructions(projectPath);
   }
 

--- a/tools/serverpod_cli/lib/src/commands/create/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/state.dart
@@ -84,6 +84,18 @@ class CreateConfigState extends TuiState {
       fallback: defaults.website,
     );
 
+    final website = _isOptionSelected(
+      ServerpodCreateConfig.serverOnlyWebserver,
+      WebServerConfigOption.website,
+      fallback: defaults.website,
+    );
+
+    final serverAndApp = _isOptionSelected(
+      ServerpodCreateConfig.template,
+      TemplateTypeOption.serverAndApp,
+      fallback: defaults.flutterApp,
+    );
+
     return TemplateContext(
       template: template,
       auth: _isOptionSelected(
@@ -101,8 +113,9 @@ class CreateConfigState extends TuiState {
         DatabaseConfigOption.database,
         fallback: defaults.postgres,
       ),
+      flutterApp: serverAndApp,
       webapp: webapp || appAndWebsite,
-      website: appAndWebsite,
+      website: website || appAndWebsite,
       ides: selectedIdes.toTemplateIdes,
     );
   }

--- a/tools/serverpod_cli/lib/src/commands/create/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/state.dart
@@ -90,12 +90,6 @@ class CreateConfigState extends TuiState {
       fallback: defaults.website,
     );
 
-    final serverAndApp = _isOptionSelected(
-      ServerpodCreateConfig.template,
-      TemplateTypeOption.serverAndApp,
-      fallback: defaults.flutterApp,
-    );
-
     return TemplateContext(
       template: template,
       auth: _isOptionSelected(
@@ -113,7 +107,6 @@ class CreateConfigState extends TuiState {
         DatabaseConfigOption.database,
         fallback: defaults.postgres,
       ),
-      flutterApp: serverAndApp,
       webapp: webapp || appAndWebsite,
       website: website || appAndWebsite,
       ides: selectedIdes.toTemplateIdes,

--- a/tools/serverpod_cli/lib/src/commands/quickstart.dart
+++ b/tools/serverpod_cli/lib/src/commands/quickstart.dart
@@ -130,7 +130,6 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
       redis: true,
       postgres: true,
       webapp: true,
-      flutterApp: true,
       ides: [TemplateIde.claude, TemplateIde.cursor, TemplateIde.vscode],
     );
 
@@ -149,7 +148,6 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
           redis: true,
           postgres: true,
           webapp: true,
-          flutterApp: true,
         ),
       );
       return;

--- a/tools/serverpod_cli/lib/src/commands/quickstart.dart
+++ b/tools/serverpod_cli/lib/src/commands/quickstart.dart
@@ -26,18 +26,22 @@ enum QuickstartOption<V> implements OptionDefinition<V> {
   template(
     EnumOption(
       enumParser: EnumParser([
+        ServerpodTemplateType.fullstack,
         ServerpodTemplateType.server,
         ServerpodTemplateType.module,
       ]),
       argName: 'template',
       argAbbrev: 't',
-      defaultsTo: ServerpodTemplateType.server,
+      defaultsTo: ServerpodTemplateType.fullstack,
       helpText: 'Template to use when creating a new project',
       allowedValues: [
+        ServerpodTemplateType.fullstack,
         ServerpodTemplateType.server,
         ServerpodTemplateType.module,
       ],
       allowedHelp: {
+        'fullstack':
+            'Fullstack project including a server and a companion Flutter app',
         'server': 'Server project with standard features including database',
         'module': 'Serverpod Module project',
       },
@@ -126,6 +130,7 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
       redis: true,
       postgres: true,
       webapp: true,
+      flutterApp: true,
       ides: [TemplateIde.claude, TemplateIde.cursor, TemplateIde.vscode],
     );
 
@@ -144,6 +149,7 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
           redis: true,
           postgres: true,
           webapp: true,
+          flutterApp: true,
         ),
       );
       return;

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -34,7 +34,14 @@ import 'template_renderer.dart';
 
 enum ServerpodTemplateType {
   mini('mini'),
+
+  /// Project with a server and a Flutter app.
+  fullstack('fullstack'),
+
+  /// Server only project.
   server('server'),
+
+  /// Module project.
   module('module'),
   ;
 
@@ -52,7 +59,10 @@ enum ServerpodTemplateType {
 }
 
 extension ServerpodTemplateTypeExtension on ServerpodTemplateType {
-  bool get isServer => this == ServerpodTemplateType.server;
+  /// Whether the template is for a server or fullstack project
+  bool get hasServer =>
+      this == ServerpodTemplateType.server ||
+      this == ServerpodTemplateType.fullstack;
   bool get isModule => this == ServerpodTemplateType.module;
   bool get isMini => this == ServerpodTemplateType.mini;
 }
@@ -191,7 +201,7 @@ Future<CreateResult> performCreate(
   bool success = await log.progress(
     'Creating project directories.',
     () async {
-      _createProjectDirectories(template, serverpodDirs);
+      _createProjectDirectories(template, serverpodDirs, context);
       return true;
     },
     newParagraph: true,
@@ -199,8 +209,7 @@ Future<CreateResult> performCreate(
 
   final writtenPaths = <String>{};
 
-  if (template == ServerpodTemplateType.server ||
-      template == ServerpodTemplateType.mini) {
+  if (template.hasServer || template.isMini) {
     success &= await log.progress(
       'Writing project files.',
       () async {
@@ -208,13 +217,14 @@ Future<CreateResult> performCreate(
           _copyServerTemplates(
             serverpodDirs,
             name: name,
+            context: context,
             customServerpodPath: productionMode ? null : serverpodHome,
           ),
         );
         return true;
       },
     );
-  } else if (template == ServerpodTemplateType.module) {
+  } else if (template.isModule) {
     success &= await log.progress('Writing project files.', () async {
       writtenPaths.addAll(
         _copyModuleTemplates(
@@ -227,7 +237,7 @@ Future<CreateResult> performCreate(
     });
   }
 
-  if (template == ServerpodTemplateType.server) {
+  if (template.hasServer) {
     success &= await log.progress(
       'Writing additional project files.',
       () async {
@@ -239,12 +249,13 @@ Future<CreateResult> performCreate(
             context: context,
             customServerpodPath: productionMode ? null : serverpodHome,
           ),
-          ...await _copyFlutterUpgrade(
-            serverpodDirs,
-            name: name,
-            context: context,
-            customServerpodPath: productionMode ? null : serverpodHome,
-          ),
+          if (context.flutterApp)
+            ...await _copyFlutterUpgrade(
+              serverpodDirs,
+              name: name,
+              context: context,
+              customServerpodPath: productionMode ? null : serverpodHome,
+            ),
         ]);
         return true;
       },
@@ -257,8 +268,7 @@ Future<CreateResult> performCreate(
     return CommandLineTools.dartPubGet(serverpodDirs.projectDir);
   });
 
-  if (template == ServerpodTemplateType.server ||
-      template == ServerpodTemplateType.mini) {
+  if (context.flutterApp && (template.hasServer || template.isMini)) {
     success &= await log.progress(
       'Creating Flutter app platform files.',
       () {
@@ -278,8 +288,7 @@ Future<CreateResult> performCreate(
     interactive: interactive,
   );
 
-  if (template == ServerpodTemplateType.server ||
-      template == ServerpodTemplateType.module) {
+  if (template.hasServer || template.isModule) {
     success &= await log.progress('Creating default database migration.', () {
       return DatabaseSetup.createDefaultMigration(
         serverpodDirs.serverDir,
@@ -303,7 +312,7 @@ Future<CreateResult> performCreate(
 
     var projectDirPath = p.basename(serverpodDirs.projectDir.path);
 
-    if (template == ServerpodTemplateType.server) {
+    if (template.hasServer) {
       logStartInstructions(projectDirPath);
     } else if (template == ServerpodTemplateType.mini) {
       logMiniStartInstructions(projectDirPath);
@@ -482,7 +491,7 @@ Future<CreateResult> _performUpgrade({
   required bool createDefaultMigration,
   Directory? workingDirectory,
 }) async {
-  if (context.template != ServerpodTemplateType.server) {
+  if (!context.template.hasServer) {
     _logError('The upgrade command can only be used with server templates.');
     return CreateFailure();
   }
@@ -511,8 +520,11 @@ Future<CreateResult> _performUpgrade({
     );
   }
 
+  final hasFlutterProject = await serverpodDir.flutterDir.exists();
+
   final writtenPaths = <String>{};
   var success = true;
+
   success &= await log.progress(
     'Upgrading project.',
     () async {
@@ -524,12 +536,13 @@ Future<CreateResult> _performUpgrade({
           context: context,
           customServerpodPath: productionMode ? null : serverpodHome,
         ),
-        ...await _copyFlutterUpgrade(
-          serverpodDir,
-          name: name,
-          context: context,
-          customServerpodPath: productionMode ? null : serverpodHome,
-        ),
+        if (hasFlutterProject)
+          ...await _copyFlutterUpgrade(
+            serverpodDir,
+            name: name,
+            context: context,
+            customServerpodPath: productionMode ? null : serverpodHome,
+          ),
       ]);
       return true;
     },
@@ -685,13 +698,14 @@ class ServerpodDirectories {
 void _createProjectDirectories(
   ServerpodTemplateType template,
   ServerpodDirectories serverpodDirs,
+  TemplateContext context,
 ) {
   _createDirectory(serverpodDirs.projectDir);
   _createDirectory(serverpodDirs.serverDir);
   _createDirectory(serverpodDirs.clientDir);
 
-  if (template == ServerpodTemplateType.server) {
-    _createDirectory(serverpodDirs.flutterDir);
+  if (template.hasServer) {
+    if (context.flutterApp) _createDirectory(serverpodDirs.flutterDir);
     _createDirectory(serverpodDirs.githubDir);
     _createDirectory(serverpodDirs.vscodeDir);
   }
@@ -1087,6 +1101,7 @@ void _addDependenciesToPubspec({
 List<String> _copyServerTemplates(
   ServerpodDirectories serverpodDirs, {
   required String name,
+  required TemplateContext context,
   String? customServerpodPath,
 }) {
   final writtenPaths = <String>[];
@@ -1182,42 +1197,44 @@ List<String> _copyServerTemplates(
   );
   writtenPaths.addAll(copier.copyFiles());
 
-  log.debug('Copying Flutter files', newParagraph: true);
-  copier = Copier(
-    srcDir: Directory(
-      p.join(resourceManager.templateDirectory.path, 'projectname_flutter'),
-    ),
-    dstDir: serverpodDirs.flutterDir,
-    replacements: [
-      Replacement(
-        slotName: 'projectname',
-        replacement: name,
+  if (context.flutterApp) {
+    log.debug('Copying Flutter files', newParagraph: true);
+    copier = Copier(
+      srcDir: Directory(
+        p.join(resourceManager.templateDirectory.path, 'projectname_flutter'),
       ),
-      if (customServerpodPath != null)
+      dstDir: serverpodDirs.flutterDir,
+      replacements: [
         Replacement(
-          slotName: 'path: ../../../packages/',
-          replacement: 'path: $customServerpodPath/packages/',
+          slotName: 'projectname',
+          replacement: name,
         ),
-    ],
-    fileNameReplacements: [
-      Replacement(
-        slotName: 'projectname',
-        replacement: name,
-      ),
-      const Replacement(
-        slotName: 'gitignore',
-        replacement: '.gitignore',
-      ),
-    ],
-    ignoreFileNames: [
-      'ios',
-      'android',
-      'web',
-      'macos',
-      'build',
-    ],
-  );
-  writtenPaths.addAll(copier.copyFiles());
+        if (customServerpodPath != null)
+          Replacement(
+            slotName: 'path: ../../../packages/',
+            replacement: 'path: $customServerpodPath/packages/',
+          ),
+      ],
+      fileNameReplacements: [
+        Replacement(
+          slotName: 'projectname',
+          replacement: name,
+        ),
+        const Replacement(
+          slotName: 'gitignore',
+          replacement: '.gitignore',
+        ),
+      ],
+      ignoreFileNames: [
+        'ios',
+        'android',
+        'web',
+        'macos',
+        'build',
+      ],
+    );
+    writtenPaths.addAll(copier.copyFiles());
+  }
 
   log.debug('Enabling workspace configuration', newParagraph: true);
   _enableWorkspaceInRootPubspec(
@@ -1227,7 +1244,7 @@ List<String> _copyServerTemplates(
     workspaceMembers: [
       '${name}_client',
       '${name}_server',
-      '${name}_flutter',
+      if (context.flutterApp) '${name}_flutter',
     ],
   );
   return writtenPaths;

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -257,6 +257,11 @@ Future<CreateResult> performCreate(
               customServerpodPath: productionMode ? null : serverpodHome,
             ),
         ]);
+        await _copyClientUpgrade(
+          serverpodDirs,
+          context: context,
+          customServerpodPath: productionMode ? null : serverpodHome,
+        );
         return true;
       },
     );
@@ -544,6 +549,11 @@ Future<CreateResult> _performUpgrade({
             customServerpodPath: productionMode ? null : serverpodHome,
           ),
       ]);
+      await _copyClientUpgrade(
+        serverpodDir,
+        context: context,
+        customServerpodPath: productionMode ? null : serverpodHome,
+      );
       return true;
     },
   );
@@ -719,6 +729,49 @@ void _createDirectory(Directory dir) {
   dir.createSync();
 }
 
+Future<void> _copyClientUpgrade(
+  ServerpodDirectories serverpodDirs, {
+  required TemplateContext context,
+  String? customServerpodPath,
+}) async {
+  log.debug('Adding auth dependencies to client pubspec', newParagraph: true);
+  _addDependenciesToPubspec(
+    pubspecFile: File(p.join(serverpodDirs.clientDir.path, 'pubspec.yaml')),
+    additions: [
+      (
+        name: 'serverpod_auth_idp_client',
+        source: DependencySource.version(
+          VersionConstraint.parse(templateVersion),
+        ),
+        type: DependencyType.normal,
+      ),
+    ],
+  );
+
+  if (customServerpodPath != null && context.auth) {
+    log.debug('Adding auth path overrides to root pubspec', newParagraph: true);
+    _addDependenciesToPubspec(
+      pubspecFile: File(p.join(serverpodDirs.projectDir.path, 'pubspec.yaml')),
+      additions: [
+        (
+          name: 'serverpod_auth_core_client',
+          source: DependencySourcePath(
+            '$customServerpodPath/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client',
+          ),
+          type: DependencyType.override,
+        ),
+        (
+          name: 'serverpod_auth_idp_client',
+          source: DependencySourcePath(
+            '$customServerpodPath/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client',
+          ),
+          type: DependencyType.override,
+        ),
+      ],
+    );
+  }
+}
+
 Future<List<String>> _copyFlutterUpgrade(
   ServerpodDirectories serverpodDirs, {
   required String name,
@@ -769,20 +822,6 @@ Future<List<String>> _copyFlutterUpgrade(
         ),
       ],
     );
-
-    log.debug('Adding auth dependencies to client pubspec', newParagraph: true);
-    _addDependenciesToPubspec(
-      pubspecFile: File(p.join(serverpodDirs.clientDir.path, 'pubspec.yaml')),
-      additions: [
-        (
-          name: 'serverpod_auth_idp_client',
-          source: DependencySource.version(
-            VersionConstraint.parse(templateVersion),
-          ),
-          type: DependencyType.normal,
-        ),
-      ],
-    );
   }
 
   if (customServerpodPath != null && context.auth) {
@@ -798,23 +837,9 @@ Future<List<String>> _copyFlutterUpgrade(
           type: DependencyType.override,
         ),
         (
-          name: 'serverpod_auth_core_client',
-          source: DependencySourcePath(
-            '$customServerpodPath/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client',
-          ),
-          type: DependencyType.override,
-        ),
-        (
           name: 'serverpod_auth_core_flutter',
           source: DependencySourcePath(
             '$customServerpodPath/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter',
-          ),
-          type: DependencyType.override,
-        ),
-        (
-          name: 'serverpod_auth_idp_client',
-          source: DependencySourcePath(
-            '$customServerpodPath/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client',
           ),
           type: DependencyType.override,
         ),

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -734,19 +734,21 @@ Future<void> _copyClientUpgrade(
   required TemplateContext context,
   String? customServerpodPath,
 }) async {
-  log.debug('Adding auth dependencies to client pubspec', newParagraph: true);
-  _addDependenciesToPubspec(
-    pubspecFile: File(p.join(serverpodDirs.clientDir.path, 'pubspec.yaml')),
-    additions: [
-      (
-        name: 'serverpod_auth_idp_client',
-        source: DependencySource.version(
-          VersionConstraint.parse(templateVersion),
+  if (context.auth) {
+    log.debug('Adding auth dependencies to client pubspec', newParagraph: true);
+    _addDependenciesToPubspec(
+      pubspecFile: File(p.join(serverpodDirs.clientDir.path, 'pubspec.yaml')),
+      additions: [
+        (
+          name: 'serverpod_auth_idp_client',
+          source: DependencySource.version(
+            VersionConstraint.parse(templateVersion),
+          ),
+          type: DependencyType.normal,
         ),
-        type: DependencyType.normal,
-      ),
-    ],
-  );
+      ],
+    );
+  }
 
   if (customServerpodPath != null && context.auth) {
     log.debug('Adding auth path overrides to root pubspec', newParagraph: true);

--- a/tools/serverpod_cli/lib/src/create/template_context.dart
+++ b/tools/serverpod_cli/lib/src/create/template_context.dart
@@ -62,7 +62,10 @@ class TemplateContext {
       'webapp': webapp,
       'webserver': webserver,
       'website': website,
-      'flutterApp': flutterApp || template == ServerpodTemplateType.fullstack,
+      'flutterApp':
+          flutterApp ||
+          template == ServerpodTemplateType.fullstack ||
+          template == ServerpodTemplateType.mini,
     };
   }
 }

--- a/tools/serverpod_cli/lib/src/create/template_context.dart
+++ b/tools/serverpod_cli/lib/src/create/template_context.dart
@@ -11,6 +11,7 @@ class TemplateContext {
     this.sqlite = false,
     this.website = false,
     this.webapp = false,
+    this.flutterApp = false,
     this.ides = const [],
   });
 
@@ -35,6 +36,9 @@ class TemplateContext {
   /// True if web app is enabled.
   final bool webapp;
 
+  /// True if companion Flutter app is enabled.
+  final bool flutterApp;
+
   /// The configured IDEs.
   final List<TemplateIde> ides;
 
@@ -58,6 +62,7 @@ class TemplateContext {
       'webapp': webapp,
       'webserver': webserver,
       'website': website,
+      'flutterApp': flutterApp,
     };
   }
 }

--- a/tools/serverpod_cli/lib/src/create/template_context.dart
+++ b/tools/serverpod_cli/lib/src/create/template_context.dart
@@ -11,7 +11,6 @@ class TemplateContext {
     this.sqlite = false,
     this.website = false,
     this.webapp = false,
-    this.flutterApp = false,
     this.ides = const [],
   });
 
@@ -37,7 +36,9 @@ class TemplateContext {
   final bool webapp;
 
   /// True if companion Flutter app is enabled.
-  final bool flutterApp;
+  bool get flutterApp =>
+      template == ServerpodTemplateType.fullstack ||
+      template == ServerpodTemplateType.mini;
 
   /// The configured IDEs.
   final List<TemplateIde> ides;
@@ -62,10 +63,7 @@ class TemplateContext {
       'webapp': webapp,
       'webserver': webserver,
       'website': website,
-      'flutterApp':
-          flutterApp ||
-          template == ServerpodTemplateType.fullstack ||
-          template == ServerpodTemplateType.mini,
+      'flutterApp': flutterApp,
     };
   }
 }

--- a/tools/serverpod_cli/lib/src/create/template_context.dart
+++ b/tools/serverpod_cli/lib/src/create/template_context.dart
@@ -4,7 +4,7 @@ import 'package:serverpod_cli/src/create/ide.dart';
 /// Context containing values for rendering templates.
 class TemplateContext {
   TemplateContext({
-    this.template = ServerpodTemplateType.server,
+    this.template = ServerpodTemplateType.fullstack,
     this.auth = false,
     this.redis = false,
     this.postgres = false,
@@ -62,7 +62,7 @@ class TemplateContext {
       'webapp': webapp,
       'webserver': webserver,
       'website': website,
-      'flutterApp': flutterApp,
+      'flutterApp': flutterApp || template == ServerpodTemplateType.fullstack,
     };
   }
 }

--- a/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
+++ b/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
@@ -53,7 +53,7 @@ commands:
       -n, --name=!: "The name of the project to create.\nCan also be specified as the first argument."
     completion:
       flag:
-        template: ["mini", "server", "module"]
+        template: ["mini", "fullstack", "server", "module"]
 
   - name: quickstart
     flags:
@@ -62,7 +62,7 @@ commands:
       -n, --name=!: "The name of the project to create.\nCan also be specified as the first argument."
     completion:
       flag:
-        template: ["server", "module"]
+        template: ["fullstack", "server", "module"]
 
   - name: generate
     flags:

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
   serverpod_serialization: 3.5.0-beta.12
   serverpod_service_client: 3.5.0-beta.12
   serverpod_shared: 3.5.0-beta.12
-  serverpod_tui: ^0.5.0
+  serverpod_tui: ^0.6.0
   skills: ^0.3.1
   source_span: ^1.10.0
   stream_channel: ^2.1.1

--- a/tools/serverpod_cli/test/commands/create/template_renderer/template_context_test.dart
+++ b/tools/serverpod_cli/test/commands/create/template_renderer/template_context_test.dart
@@ -102,6 +102,7 @@ void main() {
         webapp: true,
         website: true,
         sqlite: true,
+        flutterApp: true,
       );
       expect(
         context.toMustacheMap(),
@@ -115,6 +116,7 @@ void main() {
           'webserver': true,
           'docker': true,
           'database': true,
+          'flutterApp': true,
         },
       );
     },

--- a/tools/serverpod_cli/test/commands/create/template_renderer/template_context_test.dart
+++ b/tools/serverpod_cli/test/commands/create/template_renderer/template_context_test.dart
@@ -102,7 +102,6 @@ void main() {
         webapp: true,
         website: true,
         sqlite: true,
-        flutterApp: true,
       );
       expect(
         context.toMustacheMap(),

--- a/tools/serverpod_cli/test/commands/create/tui/state_test.dart
+++ b/tools/serverpod_cli/test/commands/create/tui/state_test.dart
@@ -8,20 +8,20 @@ import 'package:test/test.dart';
 
 void main() {
   group(
-    'Given a CreateConfigState, '
+    'Given a CreateConfigState with server and app template type, '
     'when converting to template context',
     () {
       late CreateConfigState state;
 
       setUp(() {
-        state = CreateConfigState(ServerpodTemplateType.server);
+        state = CreateConfigState(ServerpodTemplateType.fullstack);
       });
 
       test(
         'then TemplateContext has correct value for template',
         () {
           var context = state.toTemplateContext();
-          expect(context.template, ServerpodTemplateType.server);
+          expect(context.template, ServerpodTemplateType.fullstack);
 
           state.form.updateSelectedOption(
             ServerpodCreateConfig.template,
@@ -30,6 +30,14 @@ void main() {
 
           context = state.toTemplateContext();
           expect(context.template, ServerpodTemplateType.module);
+
+          state.form.updateSelectedOption(
+            ServerpodCreateConfig.template,
+            TemplateTypeOption.server,
+          );
+
+          context = state.toTemplateContext();
+          expect(context.template, ServerpodTemplateType.server);
         },
       );
 
@@ -38,6 +46,42 @@ void main() {
         () {
           final context = state.toTemplateContext();
           expect(context.auth, isTrue);
+        },
+      );
+
+      test(
+        'then TemplateContext has the correct default value for flutterApp',
+        () {
+          final context = state.toTemplateContext();
+          expect(context.flutterApp, isTrue);
+        },
+      );
+
+      test(
+        'when the server template option is selected, '
+        'then flutterApp is disabled in TemplateContext',
+        () {
+          state.form.updateSelectedOption(
+            ServerpodCreateConfig.template,
+            TemplateTypeOption.server,
+          );
+
+          final context = state.toTemplateContext();
+          expect(context.flutterApp, isFalse);
+        },
+      );
+
+      test(
+        'when the server template option is selected, '
+        'then website is enabled in TemplateContext',
+        () {
+          state.form.updateSelectedOption(
+            ServerpodCreateConfig.template,
+            TemplateTypeOption.server,
+          );
+
+          final context = state.toTemplateContext();
+          expect(context.website, isTrue);
         },
       );
 

--- a/tools/serverpod_cli/test/commands/quickstart_command_test.dart
+++ b/tools/serverpod_cli/test/commands/quickstart_command_test.dart
@@ -23,11 +23,11 @@ void main() {
       },
     );
 
-    test('when parsing configuration then default template is server', () {
+    test('when parsing configuration then default template is fullstack', () {
       final argResults = command.argParser.parse(['myproject']);
       final config = command.resolveConfiguration(argResults);
 
-      expect(config.value(QuickstartOption.template).name, equals('server'));
+      expect(config.value(QuickstartOption.template).name, equals('fullstack'));
     });
 
     test('when parsing configuration then default force is false', () {


### PR DESCRIPTION
This PR adds support for creating server only projects. A new `ServerpodTemplateType.fullstack` value has been introduced to be the default (server and Flutter app) while `ServerpodTemplateType.server` indicates server only project.

Server only projects only allow for a webserver with website configurations to be chosen from the TUI.
The create TUI also gains a scroll improvement on the summary screen.

Closes #5367 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None