### PR TITLE
fix: Improve the "Flutter web app not built" page

### DIFF
--- a/templates/serverpod_templates/projectname_server_upgrade/{{#website}}web{{!website}}/pages/build_flutter_app.html
+++ b/templates/serverpod_templates/projectname_server_upgrade/{{#website}}web{{!website}}/pages/build_flutter_app.html
@@ -2,30 +2,26 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Flutter App Not Built</title>
+    <title>Flutter web app not built</title>
     <link rel="stylesheet" href="/css/style.css">
   </head>
   <body>
     <div class="content">
       <div class="logo-box">
         <img src="/images/serverpod-logo.svg" width="160" style="margin-top: 8px; margin-bottom: 12px;">
-        <p><a href="https://serverpod.dev/">The missing server for Flutter</a></p>
       </div>
       <hr>
       <div class="info-box">
-        <p style="margin-bottom: 12px; font-weight: 600; color: #333;">Flutter app not built</p>
+        <p style="margin-bottom: 12px; font-weight: 600; color: #333;">Flutter web app not built</p>
         <p>
-          The Flutter web app has not been built yet.
-        </p>
-        <p>
-          To build the app, run the following command in your Flutter project directory:
+          The production version of your Flutter web app has not yet been built. The app is automatically built before deploying to Serverpod Cloud. If you want to manually build it, run the following command:
         </p>
         <div style="background-color: #f5f5f5; padding: 12px; border-radius: 6px; margin-top: 12px; margin-bottom: 12px; font-family: 'Courier New', monospace; font-size: 13px; color: #333; overflow-x: auto;">
-          flutter build web --base-href /app/ -o ../projectname_server/web/app
+          serverpod run flutter_build
         </div>
 
         <p>
-          After building, restart the Serverpod server to serve the app.
+          After the app has been built, restart the server and revisit this page.
         </p>
       </div>
       <hr>

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -84,23 +84,29 @@ void main() {
       );
 
       test(
-        'then the build Flutter app page uses a non-WASM build by default',
+        'then the build Flutter app page instructs users to run serverpod run flutter_build',
         () async {
           final buildFlutterAppPage = File(
             p.join(project.serverDir, 'web', 'pages', 'build_flutter_app.html'),
           );
           final content = await buildFlutterAppPage.readAsString();
 
+          expect(content, contains('Flutter web app not built'));
           expect(
             content,
             contains(
-              'flutter build web --base-href /app/ '
-              '-o ../${project.name}_server/web/app',
+              'The production version of your Flutter web app has not yet been '
+              'built. The app is automatically built before deploying to '
+              'Serverpod Cloud. If you want to manually build it, run the '
+              'following command:',
             ),
           );
+          expect(content, contains('serverpod run flutter_build'));
           expect(
             content,
-            isNot(contains('flutter build web --base-href /app/ --wasm')),
+            contains(
+              'After the app has been built, restart the server and revisit this page.',
+            ),
           );
         },
       );


### PR DESCRIPTION
Closes: #5407

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.