### PR TITLE
fix: Prevents the creation of orphaned images on subsequent IDP logins

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/facebook/business/facebook_idp.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/facebook/business/facebook_idp.dart
@@ -100,7 +100,7 @@ class FacebookIdp {
               where: (final t) => t.authUserId.equals(account.authUserId),
               transaction: transaction,
             );
-            if (user != null && user.image == null) {
+            if (user != null && user.imageId == null) {
               await _userProfiles.setUserImageFromUrl(
                 session,
                 account.authUserId,

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/firebase/business/firebase_idp.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/firebase/business/firebase_idp.dart
@@ -101,7 +101,7 @@ class FirebaseIdp {
               where: (final t) => t.authUserId.equals(account.authUserId),
               transaction: transaction,
             );
-            if (user != null && user.image == null) {
+            if (user != null && user.imageId == null) {
               await _userProfiles.setUserImageFromUrl(
                 session,
                 account.authUserId,

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/business/github_idp.dart
@@ -109,7 +109,7 @@ class GitHubIdp {
               where: (final t) => t.authUserId.equals(account.authUserId),
               transaction: transaction,
             );
-            if (user != null && user.image == null) {
+            if (user != null && user.imageId == null) {
               await _userProfiles.setUserImageFromUrl(
                 session,
                 account.authUserId,

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/google/business/google_idp.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/google/business/google_idp.dart
@@ -102,7 +102,7 @@ class GoogleIdp {
               where: (final t) => t.authUserId.equals(account.authUserId),
               transaction: transaction,
             );
-            if (user != null && user.image == null) {
+            if (user != null && user.imageId == null) {
               await _userProfiles.setUserImageFromUrl(
                 session,
                 account.authUserId,

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/microsoft/business/microsoft_idp.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/microsoft/business/microsoft_idp.dart
@@ -113,7 +113,7 @@ class MicrosoftIdp {
               where: (final t) => t.authUserId.equals(account.authUserId),
               transaction: transaction,
             );
-            if (user != null && user.image == null) {
+            if (user != null && user.imageId == null) {
               await _userProfiles.setUserImageFromBytes(
                 session,
                 account.authUserId,

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/facebook/facebook_idp_profile_image_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/facebook/facebook_idp_profile_image_test.dart
@@ -1,0 +1,161 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:serverpod_auth_idp_server/providers/facebook.dart';
+import 'package:test/test.dart';
+
+import '../test_tags.dart';
+import '../test_tools/serverpod_test_tools.dart';
+import '../test_utils/profile_image_idp_test_utils.dart';
+
+void main() {
+  withServerpod(
+    'Given a Facebook-backed user profile with an image,',
+    testGroupTagsOverride: TestTags.concurrencyOneTestTags,
+    (final sessionBuilder, final endpoints) {
+      late Session session;
+      late UuidValue authUserId;
+      late UserProfile userProfile;
+      late FacebookIdp facebookIdp;
+
+      const facebookUserIdentifier = 'facebook-user-id';
+      const facebookProfileImageUrl =
+          'https://serverpod.dev/facebook-profile-image.png';
+
+      setUp(() async {
+        session = sessionBuilder.build();
+        final userProfiles = UserProfiles(
+          config: UserProfileConfig(
+            imageFetchFunc: (final _) => onePixelPng,
+          ),
+        );
+        facebookIdp = FacebookIdp(
+          const FacebookIdpConfig(
+            appId: _facebookAppId,
+            appSecret: _facebookAppSecret,
+          ),
+          tokenManager: const TestTokenManager(),
+          userProfiles: userProfiles,
+        );
+
+        final authUser = await const AuthUsers().create(session);
+        authUserId = authUser.id;
+
+        await FacebookAccount.db.insertRow(
+          session,
+          FacebookAccount(
+            userIdentifier: facebookUserIdentifier,
+            email: 'test-${const Uuid().v4()}@facebook.com',
+            authUserId: authUserId,
+          ),
+        );
+
+        await userProfiles.createUserProfile(
+          session,
+          authUserId,
+          UserProfileData(
+            fullName: 'Facebook User',
+            email: 'test@example.com',
+          ),
+          imageSource: UserImageFromUrl.parse(facebookProfileImageUrl),
+        );
+
+        userProfile = (await UserProfile.db.findFirstRow(
+          session,
+          where: (final t) => t.authUserId.equals(authUserId),
+        ))!;
+      });
+
+      test(
+        'when the user signs in with Facebook again, '
+        'then no additional profile image row is created.',
+        () async {
+          final imagesBeforeSignIn = await UserProfileImage.db.find(
+            session,
+            where: (final t) => t.userProfileId.equals(userProfile.id!),
+          );
+          expect(imagesBeforeSignIn, hasLength(1));
+
+          await http.runWithClient(
+            () => facebookIdp.login(
+              session,
+              accessToken: _facebookAccessToken,
+            ),
+            () => _facebookClient(
+              userIdentifier: facebookUserIdentifier,
+              profileImageUrl: facebookProfileImageUrl,
+            ),
+          );
+
+          final imagesAfterSignIn = await UserProfileImage.db.find(
+            session,
+            where: (final t) => t.userProfileId.equals(userProfile.id!),
+          );
+          expect(imagesAfterSignIn, hasLength(1));
+        },
+      );
+    },
+  );
+}
+
+http.Client _facebookClient({
+  required final String userIdentifier,
+  required final String profileImageUrl,
+}) {
+  return MockClient((final request) async {
+    final debugTokenUrl = Uri.https(
+      'graph.facebook.com',
+      '/debug_token',
+      {
+        'input_token': _facebookAccessToken,
+        'access_token': '$_facebookAppId|$_facebookAppSecret',
+      },
+    );
+    if (request.method == 'GET' && request.url == debugTokenUrl) {
+      return http.Response(
+        jsonEncode({
+          'data': {
+            'is_valid': true,
+            'app_id': _facebookAppId,
+          },
+        }),
+        200,
+      );
+    }
+
+    final accountDetailsUrl = Uri.https(
+      'graph.facebook.com',
+      '/me',
+      {
+        'fields': 'id,name,first_name,last_name,email,picture.type(large)',
+        'access_token': _facebookAccessToken,
+      },
+    );
+    if (request.method == 'GET' && request.url == accountDetailsUrl) {
+      return http.Response(
+        jsonEncode({
+          'id': userIdentifier,
+          'email': 'test@example.com',
+          'name': 'Facebook User',
+          'first_name': 'Facebook',
+          'last_name': 'User',
+          'picture': {
+            'data': {
+              'url': profileImageUrl,
+            },
+          },
+        }),
+        200,
+      );
+    }
+
+    fail('Unexpected Facebook request: ${request.method} ${request.url}');
+  });
+}
+
+const _facebookAccessToken = 'facebook-access-token';
+const _facebookAppId = 'facebook-app-id';
+const _facebookAppSecret = 'facebook-app-secret';

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/firebase/firebase_idp_profile_image_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/firebase/firebase_idp_profile_image_test.dart
@@ -1,0 +1,124 @@
+import 'package:http/http.dart' as http;
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:serverpod_auth_idp_server/providers/firebase.dart';
+import 'package:test/test.dart';
+
+import '../test_tags.dart';
+import '../test_tools/serverpod_test_tools.dart';
+import '../test_utils/profile_image_idp_test_utils.dart';
+
+void main() {
+  withServerpod(
+    'Given a Firebase-backed user profile with an image,',
+    testGroupTagsOverride: TestTags.concurrencyOneTestTags,
+    (final sessionBuilder, final endpoints) {
+      late Session session;
+      late UuidValue authUserId;
+      late UserProfile userProfile;
+      late FirebaseIdp firebaseIdp;
+
+      const firebaseUserIdentifier = 'firebase-user-id';
+      const firebaseProfileImageUrl =
+          'https://serverpod.dev/firebase-profile-image.png';
+
+      setUp(() async {
+        session = sessionBuilder.build();
+        final userProfiles = UserProfiles(
+          config: UserProfileConfig(
+            imageFetchFunc: (final _) => onePixelPng,
+          ),
+        );
+        firebaseIdp = FirebaseIdp(
+          const FirebaseIdpConfig(
+            credentials: FirebaseServiceAccountCredentials(
+              projectId: _firebaseProjectId,
+            ),
+          ),
+          tokenIssuer: const TestTokenIssuer(),
+          userProfiles: userProfiles,
+        );
+
+        final authUser = await const AuthUsers().create(session);
+        authUserId = authUser.id;
+
+        await FirebaseAccount.db.insertRow(
+          session,
+          FirebaseAccount(
+            userIdentifier: firebaseUserIdentifier,
+            email: 'test-${const Uuid().v4()}@firebase.com',
+            authUserId: authUserId,
+          ),
+        );
+
+        await userProfiles.createUserProfile(
+          session,
+          authUserId,
+          UserProfileData(
+            fullName: 'Firebase User',
+            email: 'test@example.com',
+          ),
+          imageSource: UserImageFromUrl.parse(firebaseProfileImageUrl),
+        );
+
+        userProfile = (await UserProfile.db.findFirstRow(
+          session,
+          where: (final t) => t.authUserId.equals(authUserId),
+        ))!;
+      });
+
+      test(
+        'when the user signs in with Firebase again, '
+        'then no additional profile image row is created.',
+        () async {
+          final imagesBeforeSignIn = await UserProfileImage.db.find(
+            session,
+            where: (final t) => t.userProfileId.equals(userProfile.id!),
+          );
+          expect(imagesBeforeSignIn, hasLength(1));
+
+          final idToken = _createFirebaseIdToken(
+            firebaseUserIdentifier: firebaseUserIdentifier,
+            profileImageUrl: firebaseProfileImageUrl,
+          );
+
+          await http.runWithClient(
+            () => firebaseIdp.login(
+              session,
+              idToken: idToken,
+            ),
+            firebaseCertificatesClient,
+          );
+
+          final imagesAfterSignIn = await UserProfileImage.db.find(
+            session,
+            where: (final t) => t.userProfileId.equals(userProfile.id!),
+          );
+          expect(imagesAfterSignIn, hasLength(1));
+        },
+      );
+    },
+  );
+}
+
+String _createFirebaseIdToken({
+  required final String firebaseUserIdentifier,
+  required final String profileImageUrl,
+}) {
+  final now = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
+
+  return createSignedIdToken(
+    subject: firebaseUserIdentifier,
+    issuer: 'https://securetoken.google.com/$_firebaseProjectId',
+    audience: _firebaseProjectId,
+    claims: {
+      'auth_time': now,
+      'email': 'test@example.com',
+      'email_verified': true,
+      'name': 'Firebase User',
+      'picture': profileImageUrl,
+    },
+  );
+}
+
+const _firebaseProjectId = 'test-project-id';

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/github/github_idp_profile_image_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/github/github_idp_profile_image_test.dart
@@ -1,0 +1,140 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:serverpod_auth_idp_server/providers/github.dart';
+import 'package:test/test.dart';
+
+import '../test_tags.dart';
+import '../test_tools/serverpod_test_tools.dart';
+import '../test_utils/profile_image_idp_test_utils.dart';
+
+void main() {
+  withServerpod(
+    'Given a GitHub-backed user profile with an image,',
+    testGroupTagsOverride: TestTags.concurrencyOneTestTags,
+    (final sessionBuilder, final endpoints) {
+      late Session session;
+      late UuidValue authUserId;
+      late UserProfile userProfile;
+      late GitHubIdp githubIdp;
+
+      const githubUserIdentifier = '123456';
+      const githubProfileImageUrl =
+          'https://serverpod.dev/github-profile-image.png';
+
+      setUp(() async {
+        session = sessionBuilder.build();
+        final userProfiles = UserProfiles(
+          config: UserProfileConfig(
+            imageFetchFunc: (final _) => onePixelPng,
+          ),
+        );
+        githubIdp = GitHubIdp(
+          GitHubIdpConfig(
+            clientId: _githubClientId,
+            clientSecret: _githubClientSecret,
+          ),
+          tokenIssuer: const TestTokenIssuer(),
+          userProfiles: userProfiles,
+        );
+
+        final authUser = await const AuthUsers().create(session);
+        authUserId = authUser.id;
+
+        await GitHubAccount.db.insertRow(
+          session,
+          GitHubAccount(
+            userIdentifier: githubUserIdentifier,
+            email: 'test-${const Uuid().v4()}@github.com',
+            authUserId: authUserId,
+          ),
+        );
+
+        await userProfiles.createUserProfile(
+          session,
+          authUserId,
+          UserProfileData(
+            fullName: 'GitHub User',
+            email: 'test@example.com',
+          ),
+          imageSource: UserImageFromUrl.parse(githubProfileImageUrl),
+        );
+
+        userProfile = (await UserProfile.db.findFirstRow(
+          session,
+          where: (final t) => t.authUserId.equals(authUserId),
+        ))!;
+      });
+
+      test(
+        'when the user signs in with GitHub again, '
+        'then no additional profile image row is created.',
+        () async {
+          final imagesBeforeSignIn = await UserProfileImage.db.find(
+            session,
+            where: (final t) => t.userProfileId.equals(userProfile.id!),
+          );
+          expect(imagesBeforeSignIn, hasLength(1));
+
+          await http.runWithClient(
+            () => githubIdp.login(
+              session,
+              code: 'authorization-code',
+              codeVerifier: 'code-verifier',
+              redirectUri: 'https://serverpod.dev/auth/github/callback',
+            ),
+            () => _githubClient(
+              userIdentifier: githubUserIdentifier,
+              profileImageUrl: githubProfileImageUrl,
+            ),
+          );
+
+          final imagesAfterSignIn = await UserProfileImage.db.find(
+            session,
+            where: (final t) => t.userProfileId.equals(userProfile.id!),
+          );
+          expect(imagesAfterSignIn, hasLength(1));
+        },
+      );
+    },
+  );
+}
+
+http.Client _githubClient({
+  required final String userIdentifier,
+  required final String profileImageUrl,
+}) {
+  return MockClient((final request) async {
+    if (request.method == 'POST' &&
+        request.url == Uri.https('github.com', '/login/oauth/access_token')) {
+      return http.Response(
+        jsonEncode({
+          'access_token': _githubAccessToken,
+        }),
+        200,
+      );
+    }
+
+    if (request.method == 'GET' &&
+        request.url == Uri.https('api.github.com', '/user')) {
+      return http.Response(
+        jsonEncode({
+          'id': int.parse(userIdentifier),
+          'email': 'test@example.com',
+          'name': 'GitHub User',
+          'avatar_url': profileImageUrl,
+        }),
+        200,
+      );
+    }
+
+    fail('Unexpected GitHub request: ${request.method} ${request.url}');
+  });
+}
+
+const _githubAccessToken = 'github-access-token';
+const _githubClientId = 'github-client-id';
+const _githubClientSecret = 'github-client-secret';

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/google/google_idp_profile_image_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/google/google_idp_profile_image_test.dart
@@ -1,0 +1,131 @@
+import 'package:http/http.dart' as http;
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:serverpod_auth_idp_server/providers/google.dart';
+import 'package:test/test.dart';
+
+import '../test_tags.dart';
+import '../test_tools/serverpod_test_tools.dart';
+import '../test_utils/profile_image_idp_test_utils.dart';
+
+void main() {
+  withServerpod(
+    'Given a Google-backed user profile with an image,',
+    testGroupTagsOverride: TestTags.concurrencyOneTestTags,
+    (final sessionBuilder, final endpoints) {
+      late Session session;
+      late UuidValue authUserId;
+      late UserProfile userProfile;
+      late GoogleIdp googleIdp;
+
+      const googleUserIdentifier = 'google-user-id';
+      const googleProfileImageUrl =
+          'https://serverpod.dev/google-profile-image.png';
+
+      setUp(() async {
+        session = sessionBuilder.build();
+        final userProfiles = UserProfiles(
+          config: UserProfileConfig(
+            imageFetchFunc: (final _) => onePixelPng,
+          ),
+        );
+        googleIdp = GoogleIdp(
+          _googleIdpConfig(),
+          tokenIssuer: const TestTokenIssuer(),
+          userProfiles: userProfiles,
+        );
+
+        final authUser = await const AuthUsers().create(session);
+        authUserId = authUser.id;
+
+        await GoogleAccount.db.insertRow(
+          session,
+          GoogleAccount(
+            userIdentifier: googleUserIdentifier,
+            email: 'test-${const Uuid().v4()}@gmail.com',
+            authUserId: authUserId,
+          ),
+        );
+
+        await userProfiles.createUserProfile(
+          session,
+          authUserId,
+          UserProfileData(
+            fullName: 'Google User',
+            email: 'test@example.com',
+          ),
+          imageSource: UserImageFromUrl.parse(googleProfileImageUrl),
+        );
+
+        userProfile = (await UserProfile.db.findFirstRow(
+          session,
+          where: (final t) => t.authUserId.equals(authUserId),
+        ))!;
+      });
+
+      test(
+        'when the user signs in with Google again, '
+        'then no additional profile image row is created.',
+        () async {
+          final imagesBeforeSignIn = await UserProfileImage.db.find(
+            session,
+            where: (final t) => t.userProfileId.equals(userProfile.id!),
+          );
+          expect(imagesBeforeSignIn, hasLength(1));
+
+          final idToken = _createGoogleIdToken(
+            googleUserIdentifier: googleUserIdentifier,
+            profileImageUrl: googleProfileImageUrl,
+          );
+
+          await http.runWithClient(
+            () => googleIdp.login(
+              session,
+              idToken: idToken,
+              accessToken: null,
+            ),
+            googleJwksClient,
+          );
+
+          final imagesAfterSignIn = await UserProfileImage.db.find(
+            session,
+            where: (final t) => t.userProfileId.equals(userProfile.id!),
+          );
+          expect(imagesAfterSignIn, hasLength(1));
+        },
+      );
+    },
+  );
+}
+
+GoogleIdpConfig _googleIdpConfig() {
+  return GoogleIdpConfig(
+    clientSecret: GoogleClientSecret.fromJson({
+      'web': {
+        'client_id': _googleClientId,
+        'client_secret': 'secret',
+        'redirect_uris': ['uri'],
+      },
+    }),
+  );
+}
+
+String _createGoogleIdToken({
+  required final String googleUserIdentifier,
+  required final String profileImageUrl,
+}) {
+  return createSignedIdToken(
+    subject: googleUserIdentifier,
+    issuer: 'https://accounts.google.com',
+    audience: _googleClientId,
+    claims: {
+      'email': 'test@example.com',
+      'given_name': 'Google',
+      'name': 'Google User',
+      'picture': profileImageUrl,
+      'email_verified': true,
+    },
+  );
+}
+
+const _googleClientId = 'test-client-id';

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/microsoft/microsoft_idp_profile_image_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/microsoft/microsoft_idp_profile_image_test.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:serverpod_auth_idp_server/providers/microsoft.dart';
+import 'package:test/test.dart';
+
+import '../test_tags.dart';
+import '../test_tools/serverpod_test_tools.dart';
+import '../test_utils/profile_image_idp_test_utils.dart';
+
+void main() {
+  withServerpod(
+    'Given a Microsoft-backed user profile with an image,',
+    testGroupTagsOverride: TestTags.concurrencyOneTestTags,
+    (final sessionBuilder, final endpoints) {
+      late Session session;
+      late UuidValue authUserId;
+      late UserProfile userProfile;
+      late MicrosoftIdp microsoftIdp;
+
+      const microsoftUserIdentifier = 'microsoft-user-id';
+
+      setUp(() async {
+        session = sessionBuilder.build();
+        final userProfiles = UserProfiles(
+          config: UserProfileConfig(
+            imageFetchFunc: (final _) => onePixelPng,
+          ),
+        );
+        microsoftIdp = MicrosoftIdp(
+          MicrosoftIdpConfig(
+            clientId: _microsoftClientId,
+            clientSecret: _microsoftClientSecret,
+          ),
+          tokenIssuer: const TestTokenIssuer(),
+          userProfiles: userProfiles,
+        );
+
+        final authUser = await const AuthUsers().create(session);
+        authUserId = authUser.id;
+
+        await MicrosoftAccount.db.insertRow(
+          session,
+          MicrosoftAccount(
+            userIdentifier: microsoftUserIdentifier,
+            email: 'test-${const Uuid().v4()}@microsoft.com',
+            authUserId: authUserId,
+          ),
+        );
+
+        await userProfiles.createUserProfile(
+          session,
+          authUserId,
+          UserProfileData(
+            fullName: 'Microsoft User',
+            email: 'test@example.com',
+          ),
+          imageSource: UserImageFromBytes(onePixelPng),
+        );
+
+        userProfile = (await UserProfile.db.findFirstRow(
+          session,
+          where: (final t) => t.authUserId.equals(authUserId),
+        ))!;
+      });
+
+      test(
+        'when the user signs in with Microsoft again, '
+        'then no additional profile image row is created.',
+        () async {
+          final imagesBeforeSignIn = await UserProfileImage.db.find(
+            session,
+            where: (final t) => t.userProfileId.equals(userProfile.id!),
+          );
+          expect(imagesBeforeSignIn, hasLength(1));
+
+          await http.runWithClient(
+            () => microsoftIdp.login(
+              session,
+              code: 'authorization-code',
+              codeVerifier: 'code-verifier',
+              redirectUri: 'https://serverpod.dev/auth/microsoft/callback',
+              isWebPlatform: false,
+            ),
+            () => _microsoftClient(userIdentifier: microsoftUserIdentifier),
+          );
+
+          final imagesAfterSignIn = await UserProfileImage.db.find(
+            session,
+            where: (final t) => t.userProfileId.equals(userProfile.id!),
+          );
+          expect(imagesAfterSignIn, hasLength(1));
+        },
+      );
+    },
+  );
+}
+
+http.Client _microsoftClient({
+  required final String userIdentifier,
+}) {
+  return MockClient((final request) async {
+    if (request.method == 'POST' &&
+        request.url ==
+            Uri.https(
+              'login.microsoftonline.com',
+              '/common/oauth2/v2.0/token',
+            )) {
+      return http.Response(
+        jsonEncode({
+          'access_token': _microsoftAccessToken,
+        }),
+        200,
+      );
+    }
+
+    if (request.method == 'GET' &&
+        request.url == Uri.https('graph.microsoft.com', '/v1.0/me')) {
+      return http.Response(
+        jsonEncode({
+          'id': userIdentifier,
+          'mail': 'test@example.com',
+          'displayName': 'Microsoft User',
+        }),
+        200,
+      );
+    }
+
+    if (request.method == 'GET' &&
+        request.url ==
+            Uri.https('graph.microsoft.com', '/v1.0/me/photo/\$value')) {
+      return http.Response.bytes(onePixelPng, 200);
+    }
+
+    fail('Unexpected Microsoft request: ${request.method} ${request.url}');
+  });
+}
+
+const _microsoftAccessToken = 'microsoft-access-token';
+const _microsoftClientId = 'microsoft-client-id';
+const _microsoftClientSecret = 'microsoft-client-secret';

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/test_utils/profile_image_idp_test_utils.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/test_utils/profile_image_idp_test_utils.dart
@@ -1,0 +1,192 @@
+import 'dart:convert';
+
+import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:test/test.dart';
+
+class TestTokenIssuer implements TokenIssuer {
+  const TestTokenIssuer();
+
+  @override
+  Future<AuthSuccess> issueToken(
+    final Session session, {
+    required final UuidValue authUserId,
+    required final String method,
+    final Set<Scope>? scopes,
+    final Transaction? transaction,
+  }) async {
+    return AuthSuccess(
+      authStrategy: method,
+      token: 'test-token',
+      authUserId: authUserId,
+      scopeNames: (scopes ?? {})
+          .map((final scope) => scope.name)
+          .nonNulls
+          .toSet(),
+    );
+  }
+}
+
+class TestTokenManager extends TestTokenIssuer implements TokenManager {
+  const TestTokenManager();
+
+  @override
+  Future<List<TokenInfo>> listTokens(
+    final Session session, {
+    required final UuidValue? authUserId,
+    final String? method,
+    final String? tokenIssuer,
+    final Transaction? transaction,
+  }) async {
+    return [];
+  }
+
+  @override
+  Future<void> revokeAllTokens(
+    final Session session, {
+    required final UuidValue? authUserId,
+    final Transaction? transaction,
+    final String? method,
+    final String? tokenIssuer,
+  }) async {}
+
+  @override
+  Future<void> revokeToken(
+    final Session session, {
+    required final String tokenId,
+    final Transaction? transaction,
+    final String? tokenIssuer,
+  }) async {}
+
+  @override
+  Future<AuthenticationInfo?> validateToken(
+    final Session session,
+    final String token,
+  ) async {
+    return null;
+  }
+}
+
+String createSignedIdToken({
+  required final String subject,
+  required final String issuer,
+  required final String audience,
+  required final Map<String, dynamic> claims,
+}) {
+  final jwt = JWT(
+    {
+      ...claims,
+      'aud': audience,
+    },
+    subject: subject,
+    issuer: issuer,
+  );
+
+  return jwt.sign(
+    testRsaPrivateKey,
+    algorithm: JWTAlgorithm.RS256,
+    expiresIn: const Duration(minutes: 10),
+  );
+}
+
+http.Client googleJwksClient() {
+  return MockClient((final request) async {
+    expect(request.method, 'GET');
+    expect(
+      request.url,
+      Uri.parse('https://www.googleapis.com/oauth2/v3/certs'),
+    );
+
+    return http.Response(
+      jsonEncode({
+        'keys': [testRsaPublicJwk],
+      }),
+      200,
+    );
+  });
+}
+
+http.Client firebaseCertificatesClient() {
+  return MockClient((final request) async {
+    expect(request.method, 'GET');
+    expect(
+      request.url,
+      Uri.parse(
+        'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com',
+      ),
+    );
+
+    return http.Response(
+      jsonEncode({
+        'test-key': testRsaCertificatePem,
+      }),
+      200,
+    );
+  });
+}
+
+final onePixelPng = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+);
+
+final testRsaPrivateKey = RSAPrivateKey('''-----BEGIN PRIVATE KEY-----
+MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQC7VJTUt9Us8cKj
+MzEfYyjiWA4R4/M2bS1GB4t7NXp98C3SC6dVMvDuictGeurT8jNbvJZHtCSuYEvu
+NMoSfm76oqFvAp8Gy0iz5sxjZmSnXyCdPEovGhLa0VzMaQ8s+CLOyS56YyCFGeJZ
+qgtzJ6GR3eqoYSW9b9UMvkBpZODSctWSNGj3P7jRFDO5VoTwCQAWbFnOjDfH5Ulg
+p2PKSQnSJP3AJLQNFNe7br1XbrhV//eO+t51mIpGSDCUv3E0DDFcWDTH9cXDTTlR
+ZVEiR2BwpZOOkE/Z0/BVnhZYL71oZV34bKfWjQIt6V/isSMahdsAASACp4ZTGtwi
+VuNd9tybAgMBAAECggEBAKTmjaS6tkK8BlPXClTQ2vpz/N6uxDeS35mXpqasqskV
+laAidgg/sWqpjXDbXr93otIMLlWsM+X0CqMDgSXKejLS2jx4GDjI1ZTXg++0AMJ8
+sJ74pWzVDOfmCEQ/7wXs3+cbnXhKriO8Z036q92Qc1+N87SI38nkGa0ABH9CN83H
+mQqt4fB7UdHzuIRe/me2PGhIq5ZBzj6h3BpoPGzEP+x3l9YmK8t/1cN0pqI+dQwY
+dgfGjackLu/2qH80MCF7IyQaseZUOJyKrCLtSD/Iixv/hzDEUPfOCjFDgTpzf3cw
+ta8+oE4wHCo1iI1/4TlPkwmXx4qSXtmw4aQPz7IDQvECgYEA8KNThCO2gsC2I9PQ
+DM/8Cw0O983WCDY+oi+7JPiNAJwv5DYBqEZB1QYdj06YD16XlC/HAZMsMku1na2T
+N0driwenQQWzoev3g2S7gRDoS/FCJSI3jJ+kjgtaA7Qmzlgk1TxODN+G1H91HW7t
+0l7VnL27IWyYo2qRRK3jzxqUiPUCgYEAx0oQs2reBQGMVZnApD1jeq7n4MvNLcPv
+t8b/eU9iUv6Y4Mj0Suo/AU8lYZXm8ubbqAlwz2VSVunD2tOplHyMUrtCtObAfVDU
+AhCndKaA9gApgfb3xw1IKbuQ1u4IF1FJl3VtumfQn//LiH1B3rXhcdyo3/vIttEk
+48RakUKClU8CgYEAzV7W3COOlDDcQd935DdtKBFRAPRPAlspQUnzMi5eSHMD/ISL
+DY5IiQHbIH83D4bvXq0X7qQoSBSNP7Dvv3HYuqMhf0DaegrlBuJllFVVq9qPVRnK
+xt1Il2HgxOBvbhOT+9in1BzA+YJ99UzC85O0Qz06A+CmtHEy4aZ2kj5hHjECgYEA
+mNS4+A8Fkss8Js1RieK2LniBxMgmYml3pfVLKGnzmng7H2+cwPLhPIzIuwytXywh
+2bzbsYEfYx3EoEVgMEpPhoarQnYPukrJO4gwE2o5Te6T5mJSZGlQJQj9q4ZB2Dfz
+et6INsK0oG8XVGXSpQvQh3RUYekCZQkBBFcpqWpbIEsCgYAnM3DQf3FJoSnXaMhr
+VBIovic5l0xFkEHskAjFTevO86Fsz1C2aSeRKSqGFoOQ0tmJzBEs1R6KqnHInicD
+TQrKhArgLXX4v3CddjfTRJkFWDbE/CkvKZNOrcf1nhaGCPspRJj2KUkj1Fhl9Cnc
+dn/RsYEONbwQSjIfMPkvxF+8HQ==
+-----END PRIVATE KEY-----''');
+
+final testRsaPublicJwk = RSAPublicKey('''-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo
+4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u
++qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyeh
+kd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ
+0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdg
+cKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbc
+mwIDAQAB
+-----END PUBLIC KEY-----''').toJWK(algorithm: JWTAlgorithm.RS256);
+
+const testRsaCertificatePem = '''-----BEGIN CERTIFICATE-----
+MIIDGzCCAgOgAwIBAgIUXeVDixEJWQqQF+UiurwzvdfPvSQwDQYJKoZIhvcNAQEL
+BQAwHTEbMBkGA1UEAwwSc2VydmVycG9kLWlkcC10ZXN0MB4XDTI2MDcwMTAxMzQ0
+NFoXDTM2MDYyODAxMzQ0NFowHTEbMBkGA1UEAwwSc2VydmVycG9kLWlkcC10ZXN0
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo
+4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u
++qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyeh
+kd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ
+0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdg
+cKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbc
+mwIDAQABo1MwUTAdBgNVHQ4EFgQUZcMlbRfmmNwvd/ura7q2rKau0tYwHwYDVR0j
+BBgwFoAUZcMlbRfmmNwvd/ura7q2rKau0tYwDwYDVR0TAQH/BAUwAwEB/zANBgkq
+hkiG9w0BAQsFAAOCAQEAuXvA87/9oryydK0HTWS85d1GH2hoNlLU4SW1NMTD7Oed
+qEdXfV+tps3eZPTFw7YhmNcGW36MUi8Bno3mXSuMwY7tFubjGflw2Y1PLUpNDEUR
+h76SJB95mFHjW2ZunJ7yUjHHc8BSS7jCU+vfxa7fht9E2xUUnYidaY8lFdZg6HNQ
+gC5aLDNbKmzaSlfQC07IeCLD/vjWc34cV2gRSAb/7EOK7m+iG99yhMQUTfhJsuzU
+64L7M7fCAgPAuwiGEdGM+PCs5BtINzdjUr1ydUhzO6JTKcHTRzLd4dpvA//CH6oy
+qvso+oo8QluPoe5lzDOlf3aPkbij4TQt6pKP07sgiQ==
+-----END CERTIFICATE-----''';


### PR DESCRIPTION
Fixes: #5410

This PR also introduces a minimal mocking for all IDPs that can later be used to create integration tests without dealing with the complexity of credentials and other provider-specific infrastructure.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.