### PR TITLE
fix: Adds missing export of `DeepCollectionEquality` for shared models

### DIFF
--- a/packages/serverpod/lib/serverpod.dart
+++ b/packages/serverpod/lib/serverpod.dart
@@ -36,6 +36,3 @@ export 'package:serverpod/src/cache/cache_miss_handler.dart';
 // Experimental features
 export 'src/server/experimental_features.dart';
 export 'diagnostic_events.dart';
-
-export 'package:meta/meta.dart' show useResult, immutable;
-export 'package:collection/collection.dart' show DeepCollectionEquality;

--- a/packages/serverpod_client/lib/serverpod_client.dart
+++ b/packages/serverpod_client/lib/serverpod_client.dart
@@ -7,4 +7,3 @@ export 'src/serverpod_client_shared.dart';
 export 'src/method_stream/method_stream_manager_exceptions.dart';
 export 'src/streaming_connection_handler.dart';
 export 'src/file_uploader.dart';
-export 'package:collection/collection.dart' show DeepCollectionEquality;

--- a/packages/serverpod_serialization/lib/serverpod_serialization.dart
+++ b/packages/serverpod_serialization/lib/serverpod_serialization.dart
@@ -1,3 +1,4 @@
+export 'package:collection/collection.dart' show DeepCollectionEquality;
 export 'package:meta/meta.dart' show useResult, immutable;
 export 'package:uuid/uuid.dart';
 

--- a/packages/serverpod_serialization/pubspec.yaml
+++ b/packages/serverpod_serialization/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
   sdk: '^3.10.3'
 
 dependencies:
+  collection: ^1.18.0
   meta: ^1.15.0
   uuid: ^4.5.3
   yaml: ^3.1.2

--- a/templates/pubspecs/packages/serverpod_serialization/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_serialization/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
   sdk: DART_VERSION
 
 dependencies:
+  collection: ^1.18.0
   meta: ^1.15.0
   uuid: ^4.5.3
   yaml: ^3.1.2

--- a/tests/serverpod_test_client/lib/src/protocol/immutable/immutable_object_with_list.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/immutable/immutable_object_with_list.dart
@@ -12,6 +12,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:serverpod_test_client/src/protocol/protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart' as _i3;
 
 @_i1.immutable
 abstract class ImmutableObjectWithList implements _i1.SerializableModel {
@@ -44,7 +45,7 @@ abstract class ImmutableObjectWithList implements _i1.SerializableModel {
         ) ||
         other.runtimeType == runtimeType &&
             other is ImmutableObjectWithList &&
-            const _i1.DeepCollectionEquality().equals(
+            const _i3.DeepCollectionEquality().equals(
               other.listVariable,
               listVariable,
             );
@@ -54,7 +55,7 @@ abstract class ImmutableObjectWithList implements _i1.SerializableModel {
   int get hashCode {
     return Object.hash(
       runtimeType,
-      const _i1.DeepCollectionEquality().hash(listVariable),
+      const _i3.DeepCollectionEquality().hash(listVariable),
     );
   }
 

--- a/tests/serverpod_test_client/lib/src/protocol/immutable/immutable_object_with_map.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/immutable/immutable_object_with_map.dart
@@ -12,6 +12,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_client/serverpod_client.dart' as _i1;
 import 'package:serverpod_test_client/src/protocol/protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart' as _i3;
 
 @_i1.immutable
 abstract class ImmutableObjectWithMap implements _i1.SerializableModel {
@@ -45,7 +46,7 @@ abstract class ImmutableObjectWithMap implements _i1.SerializableModel {
         ) ||
         other.runtimeType == runtimeType &&
             other is ImmutableObjectWithMap &&
-            const _i1.DeepCollectionEquality().equals(
+            const _i3.DeepCollectionEquality().equals(
               other.mapVariable,
               mapVariable,
             );
@@ -55,7 +56,7 @@ abstract class ImmutableObjectWithMap implements _i1.SerializableModel {
   int get hashCode {
     return Object.hash(
       runtimeType,
-      const _i1.DeepCollectionEquality().hash(mapVariable),
+      const _i3.DeepCollectionEquality().hash(mapVariable),
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/immutable/immutable_object_with_list.dart
+++ b/tests/serverpod_test_server/lib/src/generated/immutable/immutable_object_with_list.dart
@@ -12,6 +12,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_test_server/src/generated/protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart' as _i3;
 
 @_i1.immutable
 abstract class ImmutableObjectWithList
@@ -45,7 +46,7 @@ abstract class ImmutableObjectWithList
         ) ||
         other.runtimeType == runtimeType &&
             other is ImmutableObjectWithList &&
-            const _i1.DeepCollectionEquality().equals(
+            const _i3.DeepCollectionEquality().equals(
               other.listVariable,
               listVariable,
             );
@@ -55,7 +56,7 @@ abstract class ImmutableObjectWithList
   int get hashCode {
     return Object.hash(
       runtimeType,
-      const _i1.DeepCollectionEquality().hash(listVariable),
+      const _i3.DeepCollectionEquality().hash(listVariable),
     );
   }
 

--- a/tests/serverpod_test_server/lib/src/generated/immutable/immutable_object_with_map.dart
+++ b/tests/serverpod_test_server/lib/src/generated/immutable/immutable_object_with_map.dart
@@ -12,6 +12,7 @@
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod/serverpod.dart' as _i1;
 import 'package:serverpod_test_server/src/generated/protocol.dart' as _i2;
+import 'package:serverpod_serialization/serverpod_serialization.dart' as _i3;
 
 @_i1.immutable
 abstract class ImmutableObjectWithMap
@@ -46,7 +47,7 @@ abstract class ImmutableObjectWithMap
         ) ||
         other.runtimeType == runtimeType &&
             other is ImmutableObjectWithMap &&
-            const _i1.DeepCollectionEquality().equals(
+            const _i3.DeepCollectionEquality().equals(
               other.mapVariable,
               mapVariable,
             );
@@ -56,7 +57,7 @@ abstract class ImmutableObjectWithMap
   int get hashCode {
     return Object.hash(
       runtimeType,
-      const _i1.DeepCollectionEquality().hash(mapVariable),
+      const _i3.DeepCollectionEquality().hash(mapVariable),
     );
   }
 

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -1088,7 +1088,7 @@ class SerializableModelLibraryGenerator {
             var otherProperty = refer('other').property(name);
 
             if (field.type.isCollectionType) {
-              return refer('DeepCollectionEquality', serverpodUrl(serverCode))
+              return refer('DeepCollectionEquality', serverpodSerializationUrl)
                   .constInstance([])
                   .property('equals')
                   .call([otherProperty, thisProperty]);
@@ -1140,7 +1140,7 @@ class SerializableModelLibraryGenerator {
             if (field.type.isCollectionType) {
               return refer(
                 'DeepCollectionEquality',
-                serverpodUrl(serverCode),
+                serverpodSerializationUrl,
               ).constInstance([]).property('hash').call([refer(field.name)]);
             }
 

--- a/tools/serverpod_cli/test/generator/dart/shared_code_generator/immutable_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/shared_code_generator/immutable_test.dart
@@ -2,6 +2,7 @@ import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:path/path.dart' as path;
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/generator/dart/shared_code_generator.dart';
+import 'package:serverpod_cli/src/generator/shared.dart';
 import 'package:test/test.dart';
 
 import '../../../test_util/builders/generator_config_builder.dart';
@@ -294,6 +295,77 @@ void main() {
               reason: 'No @immutable annotation found on $testClassName',
             );
           });
+        });
+      });
+    },
+  );
+
+  group(
+    'Given an immutable shared class with a list field when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withClassName(testClassName)
+            .withFileName(testClassFileName)
+            .withIsImmutable(true)
+            .withListField('events', 'String')
+            .withSharedPackageName(sharedPackageName)
+            .build(),
+      ];
+
+      late var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      late var generatedCode = codeMap[expectedFilePath]!;
+
+      late var compilationUnit = parseString(
+        content: generatedCode,
+      ).unit;
+
+      test(
+        'then DeepCollectionEquality is imported from serverpod_serialization.',
+        () {
+          expect(generatedCode, contains(serverpodSerializationUrl));
+          expect(
+            generatedCode,
+            isNot(contains('package:collection/collection.dart')),
+          );
+          expect(generatedCode, contains('DeepCollectionEquality'));
+        },
+      );
+
+      group('then the $testClassName', () {
+        late var baseClass = CompilationUnitHelpers.tryFindClassDeclaration(
+          compilationUnit,
+          name: testClassName,
+        );
+
+        test('has a hashCode method using DeepCollectionEquality.', () {
+          var hashCodeGetter = CompilationUnitHelpers.tryFindMethodDeclaration(
+            baseClass!,
+            name: 'hashCode',
+          );
+
+          expect(hashCodeGetter, isNotNull);
+          expect(
+            hashCodeGetter!.body.toSource().contains('DeepCollectionEquality'),
+            isTrue,
+          );
+        });
+
+        test('has a == operator using DeepCollectionEquality.', () {
+          var equalsOperator = CompilationUnitHelpers.tryFindMethodDeclaration(
+            baseClass!,
+            name: '==',
+          );
+
+          expect(equalsOperator, isNotNull);
+          expect(
+            equalsOperator!.body.toSource().contains('DeepCollectionEquality'),
+            isTrue,
+          );
         });
       });
     },


### PR DESCRIPTION
Fixes: #5418

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.