### PR TITLE
feat: Serve flutter web app under root if website is not enabled

### DIFF
--- a/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -26,12 +26,22 @@ serverpod:
       windows: >-
         (if exist web\app rmdir /S /Q web\app)
         & cd /D ..\projectname_flutter
+        # {{#website}}
         && flutter build web --base-href /app/
+        # {{/website}}
+        # {{^website}}
+        && flutter build web --base-href /
+        # {{/website}}
         && xcopy /E /I /Y build\web ..\projectname_server\web\app
       posix: |
         cd ../projectname_flutter
+        # {{#website}}
         flutter build web --base-href /app/ --output ../projectname_server/web/app
-
+        # {{/website}}
+        # {{^website}}
+        flutter build web --base-href / --output ../projectname_server/web/app
+        # {{/website}}
+  
   # Companion Flutter apps that `serverpod start` can launch (Ctrl+R), keyed
   # by a display alias. The default device is the web server, opening the
   # machine's default browser when ready. All non-reserved properties are

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -26,12 +26,22 @@ serverpod:
       windows: >-
         (if exist web\app rmdir /S /Q web\app)
         & cd /D ..\projectname_flutter
+        # {{#website}}
         && flutter build web --base-href /app/
+        # {{/website}}
+        # {{^website}}
+        && flutter build web --base-href /
+        # {{/website}}
         && xcopy /E /I /Y build\web ..\projectname_server\web\app
       posix: |
         cd ../projectname_flutter
+        # {{#website}}
         flutter build web --base-href /app/ --output ../projectname_server/web/app
-
+        # {{/website}}
+        # {{^website}}
+        flutter build web --base-href / --output ../projectname_server/web/app
+        # {{/website}}
+  
   # Companion Flutter apps that `serverpod start` can launch (Ctrl+R), keyed
   # by a display alias. The default device is the web server, opening the
   # machine's default browser when ready. All non-reserved properties are

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
@@ -71,7 +71,12 @@ void run(List<String> args) async {
   // Checks if the flutter web app has been built and serves it if it has.
   final appDir = Directory(Uri(path: 'web/app').toFilePath());
   if (appDir.existsSync()) {
+    // {{#website}}
     // Serve the flutter web app under the /app path.
+    // {{/website}}
+    // {{^website}}
+    // Serve the flutter web app under /.
+    // {{/website}}
     pod.webServer.addRoute(
       FlutterRoute(
         appDir,
@@ -79,7 +84,12 @@ void run(List<String> args) async {
         // true and add the --wasm flag to the flutter build command.
         enableWasmHeaders: false,
       ),
+      // {{#website}}
       '/app',
+      // {{/website}}
+      // {{^website}}
+      '/',
+      // {{/website}}
     );
   } else {
     // If the flutter web app has not been built, serve the build app page.
@@ -89,7 +99,12 @@ void run(List<String> args) async {
           Uri(path: 'web/pages/build_flutter_app.html').toFilePath(),
         ),
       ),
+      // {{#website}}
       '/app/**',
+      // {{/website}}
+      // {{^website}}
+      '/**',
+      // {{/website}}
     );
   }
   // {{/webapp}}

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
@@ -53,10 +53,10 @@ void run(List<String> args) async {
   // {{/website}}
 
   // {{#webserver}}
-  // Serve all files in the web/static relative directory under /.
+  // Serve all files in the web/static relative directory under /web.
   // These are used by the default web page.
   final root = Directory(Uri(path: 'web/static').toFilePath());
-  pod.webServer.addRoute(StaticRoute.directory(root));
+  pod.webServer.addRoute(StaticRoute.directory(root), '/web');
   // {{/webserver}}
 
   // {{#webapp}}
@@ -93,12 +93,24 @@ void run(List<String> args) async {
     );
   } else {
     // If the flutter web app has not been built, serve the build app page.
-    pod.webServer.addRoute(
-      StaticRoute.file(
-        File(
-          Uri(path: 'web/pages/build_flutter_app.html').toFilePath(),
-        ),
+    final defaultRoute = StaticRoute.file(
+      File(
+        Uri(path: 'web/pages/build_flutter_app.html').toFilePath(),
       ),
+    );
+
+    // {{^website}}
+    pod.webServer.addMiddleware(
+      FallbackMiddleware(
+        fallback: defaultRoute,
+        on: (response) => response.statusCode == 404,
+      ).call,
+      '/',
+    );
+    // {{/website}}
+
+    pod.webServer.addRoute(
+      defaultRoute,
       // {{#website}}
       '/app/**',
       // {{/website}}

--- a/templates/serverpod_templates/projectname_server_upgrade/{{#webserver}}web{{!webserver}}/pages/build_flutter_app.html
+++ b/templates/serverpod_templates/projectname_server_upgrade/{{#webserver}}web{{!webserver}}/pages/build_flutter_app.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8">
     <title>Flutter web app not built</title>
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/web/css/style.css">
   </head>
   <body>
     <div class="content">
       <div class="logo-box">
-        <img src="/images/serverpod-logo.svg" width="160" style="margin-top: 8px; margin-bottom: 12px;">
+        <img src="/web/images/serverpod-logo.svg" width="160" style="margin-top: 8px; margin-bottom: 12px;">
       </div>
       <hr>
       <div class="info-box">

--- a/templates/serverpod_templates/projectname_server_upgrade/{{#webserver}}web{{!webserver}}/static/css/style.css
+++ b/templates/serverpod_templates/projectname_server_upgrade/{{#webserver}}web{{!webserver}}/static/css/style.css
@@ -2,7 +2,7 @@ html {
     box-sizing: border-box;
     font-size: 14px;
     font-family: Arial, Helvetica, sans-serif;
-    background: url('/images/background.svg') no-repeat center center fixed; 
+    background: url('/web/images/background.svg') no-repeat center center fixed;
     -webkit-background-size: cover;
     -moz-background-size: cover;
     -o-background-size: cover;

--- a/templates/serverpod_templates/projectname_server_upgrade/{{#webserver}}web{{!webserver}}/templates/built_with_serverpod.html
+++ b/templates/serverpod_templates/projectname_server_upgrade/{{#webserver}}web{{!webserver}}/templates/built_with_serverpod.html
@@ -16,11 +16,13 @@
         <p>Served at: {{served}}</p>
         <p>Run mode: {{runmode}}</p>
       </div>
+      <!-- {{#webapp}} -->
       <div style="text-align: center; margin: 20px 0;">
         <a class="cta" href="/app">
             Open Flutter app 
           </a>
       </div>
+      <!-- {{/webapp}} -->
       <hr>
       <div class="link-box">
         <a href="https://serverpod.dev">Serverpod</a>

--- a/templates/serverpod_templates/projectname_server_upgrade/{{#webserver}}web{{!webserver}}/templates/built_with_serverpod.html
+++ b/templates/serverpod_templates/projectname_server_upgrade/{{#webserver}}web{{!webserver}}/templates/built_with_serverpod.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8">
     <title>Built with Serverpod</title>
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/web/css/style.css">
   </head>
   <body>
     <div class="content">
       <div class="logo-box">
-        <img src="/images/serverpod-logo.svg" width="160" style="margin-top: 8px; margin-bottom: 12px;">
+        <img src="/web/images/serverpod-logo.svg" width="160" style="margin-top: 8px; margin-bottom: 12px;">
         <p><a href="https://serverpod.dev/">The missing server for Flutter</a></p>
       </div>
       <hr>

--- a/tests/bootstrap_project/lib/src/util.dart
+++ b/tests/bootstrap_project/lib/src/util.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -86,6 +87,50 @@ Future<Process> startProcess(
       .listen((e) => print('COMMAND "$command" stdout: $e'));
 
   return process;
+}
+
+Future<Process> startProcessAndWaitForKeywords(
+  String command,
+  List<String> arguments, {
+  String? workingDirectory,
+  Map<String, String>? environment,
+  bool ignorePlatform = false,
+  required List<String> keywords,
+}) async {
+  final completer = Completer<Process>();
+
+  var process = await Process.start(
+    _getCommandToRun(command, ignorePlatform),
+    arguments,
+    workingDirectory: workingDirectory,
+    environment: environment,
+  );
+
+  void checkForKeywords(String data) {
+    if (keywords.isEmpty) return;
+    for (var keyword in keywords) {
+      if (data.contains(keyword)) {
+        if (!completer.isCompleted) {
+          completer.complete(process);
+        }
+      }
+    }
+  }
+
+  process.stderr.transform(utf8.decoder).listen((e) {
+    print('COMMAND "$command" stderr: $e');
+    checkForKeywords(e);
+  });
+  process.stdout.transform(utf8.decoder).listen((e) {
+    print('COMMAND "$command" stdout: $e');
+    checkForKeywords(e);
+  });
+
+  if (keywords.isEmpty && !completer.isCompleted) {
+    completer.complete(process);
+  }
+
+  return completer.future;
 }
 
 Future<Process> startServerpodCli(

--- a/tests/bootstrap_project/test/project_server_test.dart
+++ b/tests/bootstrap_project/test/project_server_test.dart
@@ -791,14 +791,12 @@ void main() async {
         );
         assert((await createProcess.exitCode) == 0);
 
-        startProjectProcess = await startProcess(
+        startProjectProcess = await startProcessAndWaitForKeywords(
           'dart',
           ['bin/main.dart', '--apply-migrations'],
           workingDirectory: commandRoot,
+          keywords: ['Webserver listening on'],
         );
-
-        // Wait for web server to be up
-        await Future.delayed(const Duration(seconds: 10));
       });
 
       tearDownAll(() async {

--- a/tests/bootstrap_project/test/project_server_test.dart
+++ b/tests/bootstrap_project/test/project_server_test.dart
@@ -1,6 +1,7 @@
 @Timeout(Duration(minutes: 15))
 import 'dart:io';
 
+import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
@@ -758,6 +759,63 @@ void main() async {
               );
             },
           );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a created project with the server template and a running pod',
+    () {
+      final (:projectName, :commandRoot) = createRandomProjectName(tempPath);
+
+      late Process createProcess;
+      late Process startProjectProcess;
+
+      setUpAll(() async {
+        createProcess = await startServerpodCli(
+          [
+            'create',
+            projectName,
+            '--template',
+            'server',
+            '-v',
+            '--no-analytics',
+            '--no-interactive',
+          ],
+          rootPath: rootPath,
+          workingDirectory: tempPath,
+          environment: {
+            'SERVERPOD_HOME': rootPath,
+          },
+        );
+        assert((await createProcess.exitCode) == 0);
+
+        startProjectProcess = await startProcess(
+          'dart',
+          ['bin/main.dart', '--apply-migrations'],
+          workingDirectory: commandRoot,
+        );
+
+        // Wait for web server to be up
+        await Future.delayed(const Duration(seconds: 10));
+      });
+
+      tearDownAll(() async {
+        createProcess.kill();
+        startProjectProcess.kill();
+      });
+
+      test(
+        'when requesting the static website under / then it is is served',
+        () async {
+          final response = await http.get(Uri.parse('http://localhost:8082'));
+          expect(response.statusCode, equals(200));
+          expect(
+            response.body,
+            contains('<title>Built with Serverpod</title>'),
+          );
+          expect(response.body, isNot(contains('Open Flutter app')));
         },
       );
     },

--- a/tests/bootstrap_project/test/project_server_test.dart
+++ b/tests/bootstrap_project/test/project_server_test.dart
@@ -817,5 +817,8 @@ void main() async {
         },
       );
     },
+    skip: Platform.isWindows
+        ? 'Windows does not support postgres in github actions'
+        : null,
   );
 }

--- a/tests/bootstrap_project/test/project_server_test.dart
+++ b/tests/bootstrap_project/test/project_server_test.dart
@@ -350,6 +350,98 @@ void main() async {
             );
           });
 
+          test(
+            'then the server.dart contains website configurations',
+            () {
+              final file = File(
+                path.join(tempPath, serverDir, 'lib', 'server.dart'),
+              );
+
+              final content = file.readAsStringSync();
+
+              expect(
+                content,
+                contains("import 'src/web/routes/root.dart';"),
+                reason: 'server.dart does not contain website configurations.',
+              );
+
+              expect(
+                content,
+                contains("pod.webServer.addRoute(RootRoute(), '/')"),
+                reason: 'server.dart does not contain website configurations.',
+              );
+
+              expect(
+                content,
+                contains("pod.webServer.addRoute(RootRoute(), '/index.html')"),
+                reason: 'server.dart does not contain website configurations.',
+              );
+
+              expect(
+                content,
+                contains(
+                  "final root = Directory(Uri(path: 'web/static').toFilePath())",
+                ),
+                reason: 'server.dart does not contain website configurations.',
+              );
+
+              expect(
+                content,
+                contains(
+                  "pod.webServer.addRoute(StaticRoute.directory(root), '/web')",
+                ),
+                reason: 'server.dart does not contain website configurations.',
+              );
+            },
+          );
+
+          test(
+            'then the server.dart does not contain Flutter web app configurations',
+            () {
+              final file = File(
+                path.join(tempPath, serverDir, 'lib', 'server.dart'),
+              );
+
+              final content = file.readAsStringSync();
+
+              expect(
+                content,
+                isNot(
+                  contains("import 'src/web/routes/app_config_route.dart';"),
+                ),
+                reason: 'server.dart contains Flutter web app configurations.',
+              );
+
+              expect(
+                content,
+                isNot(
+                  contains('AppConfigRoute(apiConfig: pod.config.apiServer)'),
+                ),
+                reason: 'server.dart contains Flutter web app configurations.',
+              );
+
+              expect(
+                content,
+                isNot(
+                  contains(
+                    "final appDir = Directory(Uri(path: 'web/app').toFilePath())",
+                  ),
+                ),
+                reason: 'server.dart contains Flutter web app configurations.',
+              );
+
+              expect(
+                content,
+                isNot(
+                  contains(
+                    "Uri(path: 'web/pages/build_flutter_app.html').toFilePath()",
+                  ),
+                ),
+                reason: 'server.dart contains Flutter web app configurations.',
+              );
+            },
+          );
+
           test('then the server project has a Dockerfile', () {
             expect(
               File(path.join(tempPath, serverDir, 'Dockerfile')).existsSync(),

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -1241,14 +1241,15 @@ void main() async {
       );
       assert((await createProcess.exitCode) == 0);
 
-      startProjectProcess = await startProcess(
+      startProjectProcess = await startProcessAndWaitForKeywords(
         'dart',
         ['bin/main.dart', '--apply-migrations'],
         workingDirectory: commandRoot,
+        keywords: ['Webserver listening on'],
       );
 
       // Wait for web server to be up
-      await Future.delayed(const Duration(seconds: 10));
+      await Future.delayed(const Duration(seconds: 30));
     });
 
     tearDownAll(() async {
@@ -1287,14 +1288,15 @@ void main() async {
         expect(await flutterBuildProcess.exitCode, 0);
 
         startProjectProcess.kill();
-        startProjectProcess = await startProcess(
+        startProjectProcess = await startProcessAndWaitForKeywords(
           'dart',
           ['bin/main.dart', '--apply-migrations'],
           workingDirectory: commandRoot,
+          keywords: ['Webserver listening on'],
         );
 
         // Wait for web server to be up
-        await Future.delayed(const Duration(seconds: 10));
+        await Future.delayed(const Duration(seconds: 30));
       });
 
       test(

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -1217,4 +1217,104 @@ void main() async {
           : null,
     );
   });
+
+  group('Given a created project and a running pod', () {
+    final (:projectName, :commandRoot) = createRandomProjectName(tempPath);
+
+    late Process createProcess;
+    late Process startProjectProcess;
+
+    setUpAll(() async {
+      createProcess = await startServerpodCli(
+        [
+          'create',
+          projectName,
+          '-v',
+          '--no-analytics',
+          '--no-interactive',
+        ],
+        rootPath: rootPath,
+        workingDirectory: tempPath,
+        environment: {
+          'SERVERPOD_HOME': rootPath,
+        },
+      );
+      assert((await createProcess.exitCode) == 0);
+
+      startProjectProcess = await startProcess(
+        'dart',
+        ['bin/main.dart', '--apply-migrations'],
+        workingDirectory: commandRoot,
+      );
+
+      // Wait for web server to be up
+      await Future.delayed(const Duration(seconds: 10));
+    });
+
+    tearDownAll(() async {
+      createProcess.kill();
+      startProjectProcess.kill();
+    });
+
+    test(
+      'when requesting the Flutter web app under / before it is built, '
+      'then the "Flutter web app not built" page is served',
+      () async {
+        final response = await http.get(Uri.parse('http://localhost:8082'));
+        expect(response.statusCode, equals(200));
+        expect(
+          response.body,
+          contains('<title>Flutter web app not built</title>'),
+        );
+        expect(
+          response.body,
+          isNot(
+            contains(
+              '<meta name="description" content="A new Flutter project.">',
+            ),
+          ),
+        );
+      },
+    );
+
+    group('Given the Flutter web app is built and the pod is restarted', () {
+      setUp(() async {
+        final flutterBuildProcess = await startProcess(
+          'serverpod',
+          ['run', 'flutter_build'],
+          workingDirectory: commandRoot,
+        );
+        expect(await flutterBuildProcess.exitCode, 0);
+
+        startProjectProcess.kill();
+        startProjectProcess = await startProcess(
+          'dart',
+          ['bin/main.dart', '--apply-migrations'],
+          workingDirectory: commandRoot,
+        );
+
+        // Wait for web server to be up
+        await Future.delayed(const Duration(seconds: 10));
+      });
+
+      test(
+        'when requesting the Flutter web app under /, '
+        'then the web app is served successfully',
+        () async {
+          final response = await http.get(Uri.parse('http://localhost:8082'));
+          expect(response.statusCode, equals(200));
+          expect(
+            response.body,
+            isNot(contains('<title>Flutter web app not built</title>')),
+          );
+          expect(
+            response.body,
+            contains(
+              '<meta name="description" content="A new Flutter project.">',
+            ),
+          );
+        },
+      );
+    });
+  });
 }

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -1279,10 +1279,13 @@ void main() async {
 
       group('Given the Flutter web app is built and the pod is restarted', () {
         setUp(() async {
-          final flutterBuildProcess = await startProcess(
-            'serverpod',
+          final flutterBuildProcess = await startServerpodCli(
             ['run', 'flutter_build'],
+            rootPath: rootPath,
             workingDirectory: commandRoot,
+            environment: {
+              'SERVERPOD_HOME': rootPath,
+            },
           );
           expect(await flutterBuildProcess.exitCode, 0);
 

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -1218,105 +1218,105 @@ void main() async {
     );
   });
 
-  group('Given a created project and a running pod', () {
-    final (:projectName, :commandRoot) = createRandomProjectName(tempPath);
+  group(
+    'Given a created project and a running pod',
+    () {
+      final (:projectName, :commandRoot) = createRandomProjectName(tempPath);
 
-    late Process createProcess;
-    late Process startProjectProcess;
+      late Process createProcess;
+      late Process startProjectProcess;
 
-    setUpAll(() async {
-      createProcess = await startServerpodCli(
-        [
-          'create',
-          projectName,
-          '-v',
-          '--no-analytics',
-          '--no-interactive',
-        ],
-        rootPath: rootPath,
-        workingDirectory: tempPath,
-        environment: {
-          'SERVERPOD_HOME': rootPath,
-        },
-      );
-      assert((await createProcess.exitCode) == 0);
-
-      startProjectProcess = await startProcessAndWaitForKeywords(
-        'dart',
-        ['bin/main.dart', '--apply-migrations'],
-        workingDirectory: commandRoot,
-        keywords: ['Webserver listening on'],
-      );
-
-      // Wait for web server to be up
-      await Future.delayed(const Duration(seconds: 30));
-    });
-
-    tearDownAll(() async {
-      createProcess.kill();
-      startProjectProcess.kill();
-    });
-
-    test(
-      'when requesting the Flutter web app under / before it is built, '
-      'then the "Flutter web app not built" page is served',
-      () async {
-        final response = await http.get(Uri.parse('http://localhost:8082'));
-        expect(response.statusCode, equals(200));
-        expect(
-          response.body,
-          contains('<title>Flutter web app not built</title>'),
+      setUpAll(() async {
+        createProcess = await startServerpodCli(
+          [
+            'create',
+            projectName,
+            '-v',
+            '--no-analytics',
+            '--no-interactive',
+          ],
+          rootPath: rootPath,
+          workingDirectory: tempPath,
+          environment: {
+            'SERVERPOD_HOME': rootPath,
+          },
         );
-        expect(
-          response.body,
-          isNot(
-            contains(
-              '<meta name="description" content="A new Flutter project.">',
-            ),
-          ),
-        );
-      },
-    );
+        assert((await createProcess.exitCode) == 0);
 
-    group('Given the Flutter web app is built and the pod is restarted', () {
-      setUp(() async {
-        final flutterBuildProcess = await startProcess(
-          'serverpod',
-          ['run', 'flutter_build'],
-          workingDirectory: commandRoot,
-        );
-        expect(await flutterBuildProcess.exitCode, 0);
-
-        startProjectProcess.kill();
         startProjectProcess = await startProcessAndWaitForKeywords(
           'dart',
           ['bin/main.dart', '--apply-migrations'],
           workingDirectory: commandRoot,
           keywords: ['Webserver listening on'],
         );
+      });
 
-        // Wait for web server to be up
-        await Future.delayed(const Duration(seconds: 30));
+      tearDownAll(() async {
+        createProcess.kill();
+        startProjectProcess.kill();
       });
 
       test(
-        'when requesting the Flutter web app under /, '
-        'then the web app is served successfully',
+        'when requesting the Flutter web app under / before it is built, '
+        'then the "Flutter web app not built" page is served',
         () async {
           final response = await http.get(Uri.parse('http://localhost:8082'));
           expect(response.statusCode, equals(200));
           expect(
             response.body,
-            isNot(contains('<title>Flutter web app not built</title>')),
+            contains('<title>Flutter web app not built</title>'),
           );
           expect(
             response.body,
-            contains(
-              '<meta name="description" content="A new Flutter project.">',
+            isNot(
+              contains(
+                '<meta name="description" content="A new Flutter project.">',
+              ),
             ),
           );
         },
       );
-    });
-  });
+
+      group('Given the Flutter web app is built and the pod is restarted', () {
+        setUp(() async {
+          final flutterBuildProcess = await startProcess(
+            'serverpod',
+            ['run', 'flutter_build'],
+            workingDirectory: commandRoot,
+          );
+          expect(await flutterBuildProcess.exitCode, 0);
+
+          startProjectProcess.kill();
+          startProjectProcess = await startProcessAndWaitForKeywords(
+            'dart',
+            ['bin/main.dart', '--apply-migrations'],
+            workingDirectory: commandRoot,
+            keywords: ['Webserver listening on'],
+          );
+        });
+
+        test(
+          'when requesting the Flutter web app under /, '
+          'then the web app is served successfully',
+          () async {
+            final response = await http.get(Uri.parse('http://localhost:8082'));
+            expect(response.statusCode, equals(200));
+            expect(
+              response.body,
+              isNot(contains('<title>Flutter web app not built</title>')),
+            );
+            expect(
+              response.body,
+              contains(
+                '<meta name="description" content="A new Flutter project.">',
+              ),
+            );
+          },
+        );
+      });
+    },
+    skip: Platform.isWindows
+        ? 'Windows does not support postgres in github actions'
+        : null,
+  );
 }

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -639,10 +639,13 @@ void main() {
 
       group('Given the Flutter web app is built and the pod is restarted', () {
         setUp(() async {
-          final flutterBuildProcess = await startProcess(
-            'serverpod',
+          final flutterBuildProcess = await startServerpodCli(
             ['run', 'flutter_build'],
+            rootPath: rootPath,
             workingDirectory: project.serverDir,
+            environment: {
+              'SERVERPOD_HOME': rootPath,
+            },
           );
           expect(await flutterBuildProcess.exitCode, 0);
 

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -357,7 +357,7 @@ void main() {
       );
 
       test(
-        'then theserver.dart has a fallback middleware for the default route',
+        'then the server.dart has a fallback middleware for the default route',
         () async {
           final serverFile = File(
             p.join(project.serverDir, 'lib', 'server.dart'),

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -677,5 +677,8 @@ void main() {
         );
       });
     },
+    skip: Platform.isWindows
+        ? 'Windows does not support postgres in github actions'
+        : null,
   );
 }

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -78,7 +78,9 @@ void main() {
           expect(content, contains('pod.webServer.addRoute(RootRoute()'));
           expect(
             content,
-            contains('pod.webServer.addRoute(StaticRoute.directory(root))'),
+            contains(
+              "pod.webServer.addRoute(StaticRoute.directory(root), '/web')",
+            ),
           );
         },
       );
@@ -219,7 +221,9 @@ void main() {
           );
           expect(
             content,
-            contains('pod.webServer.addRoute(StaticRoute.directory(root));'),
+            contains(
+              "pod.webServer.addRoute(StaticRoute.directory(root), '/web')",
+            ),
           );
           expect(
             content,
@@ -276,7 +280,7 @@ void main() {
           final pubspec = File(p.join(project.serverDir, 'pubspec.yaml'));
           final content = await pubspec.readAsString();
 
-          expect(content, contains('flutter build web --base-href /app/'));
+          expect(content, contains('flutter build web'));
           expect(content, isNot(contains('--wasm')));
         },
       );
@@ -329,11 +333,11 @@ void main() {
 
   group(
     'Given a TemplateContext with webapp enabled and website disabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           webapp: true,
           website: false,
         ),
@@ -351,16 +355,48 @@ void main() {
           expect(content, contains("'/**'"));
         },
       );
+
+      test(
+        'then theserver.dart has a fallback middleware for the default route',
+        () async {
+          final serverFile = File(
+            p.join(project.serverDir, 'lib', 'server.dart'),
+          );
+          final content = await serverFile.readAsString();
+          expect(content, contains('pod.webServer.addMiddleware('));
+          expect(content, contains('FallbackMiddleware('));
+          expect(
+            content,
+            contains('on: (response) => response.statusCode == 404'),
+          );
+        },
+      );
+
+      test(
+        'then the server pubspec contains Flutter build script with base-href /',
+        () async {
+          final pubspec = File(p.join(project.serverDir, 'pubspec.yaml'));
+          final content = await pubspec.readAsString();
+
+          expect(content, contains('flutter build web --base-href /'));
+          expect(
+            content,
+            contains(
+              'flutter build web --base-href / --output ../${project.name}_server/web/app',
+            ),
+          );
+        },
+      );
     },
   );
 
   group(
     'Given a TemplateContext with webapp and website enabled, '
-    'when performCreate is called with the context and a server template type',
+    'when performCreate is called with the context and a fullstack template type',
     () {
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
-          template: ServerpodTemplateType.server,
+          template: ServerpodTemplateType.fullstack,
           webapp: true,
           website: true,
         ),
@@ -379,6 +415,38 @@ void main() {
           );
           expect(content, contains("'/app'"));
           expect(content, contains("'/app/**'"));
+        },
+      );
+
+      test(
+        'then the server.dart does not have a fallback middleware for the default route',
+        () async {
+          final serverFile = File(
+            p.join(project.serverDir, 'lib', 'server.dart'),
+          );
+          final content = await serverFile.readAsString();
+          expect(content, isNot(contains('pod.webServer.addMiddleware(')));
+          expect(content, isNot(contains('FallbackMiddleware(')));
+          expect(
+            content,
+            isNot(contains('on: (response) => response.statusCode == 404')),
+          );
+        },
+      );
+
+      test(
+        'then the server pubspec contains Flutter build script with base-href /app',
+        () async {
+          final pubspec = File(p.join(project.serverDir, 'pubspec.yaml'));
+          final content = await pubspec.readAsString();
+
+          expect(content, contains('flutter build web --base-href /app'));
+          expect(
+            content,
+            contains(
+              'flutter build web --base-href /app/ --output ../${project.name}_server/web/app',
+            ),
+          );
         },
       );
     },

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -1,6 +1,8 @@
+@Timeout(Duration(minutes: 5))
 import 'dart:io';
 
 import 'package:bootstrap_project/src/util.dart';
+import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/create/create.dart';
 import 'package:serverpod_cli/src/create/template_context.dart';
@@ -569,6 +571,115 @@ void main() {
           expect(content, contains('webServer:'));
         },
       );
+    },
+  );
+
+  group(
+    'Given a project is created with fullstack template and webapp and website enabled, '
+    'and the pod is running',
+    () {
+      late Process startProjectProcess;
+
+      final project = setUpPerformCreateInTempDir(
+        context: TemplateContext(
+          template: ServerpodTemplateType.fullstack,
+          webapp: true,
+          website: true,
+        ),
+      );
+
+      setUpAll(() async {
+        startProjectProcess = await startProcess(
+          'dart',
+          ['bin/main.dart', '--apply-migrations'],
+          workingDirectory: project.serverDir,
+        );
+
+        // Wait for web server to be up
+        await Future.delayed(const Duration(seconds: 10));
+      });
+
+      tearDownAll(() {
+        startProjectProcess.kill();
+      });
+
+      test(
+        'when requesting the static website under / then it is is served',
+        () async {
+          final response = await http.get(Uri.parse('http://localhost:8082'));
+          expect(response.statusCode, equals(200));
+          expect(
+            response.body,
+            contains('<title>Built with Serverpod</title>'),
+          );
+          expect(response.body, contains('Open Flutter app'));
+        },
+      );
+
+      test(
+        'when requesting the Flutter web app under /app before it is built, '
+        'then the "Flutter web app not built" page is served',
+        () async {
+          final response = await http.get(
+            Uri.parse('http://localhost:8082/app'),
+          );
+          expect(response.statusCode, equals(200));
+          expect(
+            response.body,
+            contains('<title>Flutter web app not built</title>'),
+          );
+          expect(
+            response.body,
+            isNot(
+              contains(
+                '<meta name="description" content="A new Flutter project.">',
+              ),
+            ),
+          );
+        },
+      );
+
+      group('Given the Flutter web app is built and the pod is restarted', () {
+        setUp(() async {
+          final flutterBuildProcess = await startProcess(
+            'serverpod',
+            ['run', 'flutter_build'],
+            workingDirectory: project.serverDir,
+          );
+          expect(await flutterBuildProcess.exitCode, 0);
+
+          startProjectProcess.kill();
+          startProjectProcess = await startProcess(
+            'dart',
+            ['bin/main.dart', '--apply-migrations'],
+            workingDirectory: project.serverDir,
+          );
+
+          // Wait for web server to be up
+          await Future.delayed(const Duration(seconds: 10));
+        });
+
+        test(
+          'when requesting the Flutter web app under /app, '
+          'then the web app is served successfully',
+          () async {
+            final response = await http.get(
+              Uri.parse('http://localhost:8082/app'),
+            );
+            expect(response.statusCode, equals(200));
+            expect(
+              response.body,
+              isNot(contains('<title>Flutter web app not built</title>')),
+            );
+            expect(
+              response.body,
+              contains(
+                '<meta name="description" content="A new Flutter project.">',
+              ),
+            );
+          },
+        );
+      });
     },
   );
 }

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -589,14 +589,12 @@ void main() {
       );
 
       setUpAll(() async {
-        startProjectProcess = await startProcess(
+        startProjectProcess = await startProcessAndWaitForKeywords(
           'dart',
           ['bin/main.dart', '--apply-migrations'],
           workingDirectory: project.serverDir,
+          keywords: ['Webserver listening on'],
         );
-
-        // Wait for web server to be up
-        await Future.delayed(const Duration(seconds: 10));
       });
 
       tearDownAll(() {
@@ -649,14 +647,12 @@ void main() {
           expect(await flutterBuildProcess.exitCode, 0);
 
           startProjectProcess.kill();
-          startProjectProcess = await startProcess(
+          startProjectProcess = await startProcessAndWaitForKeywords(
             'dart',
             ['bin/main.dart', '--apply-migrations'],
             workingDirectory: project.serverDir,
+            keywords: ['Webserver listening on'],
           );
-
-          // Wait for web server to be up
-          await Future.delayed(const Duration(seconds: 10));
         });
 
         test(

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -328,6 +328,63 @@ void main() {
   );
 
   group(
+    'Given a TemplateContext with webapp enabled and website disabled, '
+    'when performCreate is called with the context and a server template type',
+    () {
+      final project = setUpPerformCreateInTempDir(
+        context: TemplateContext(
+          template: ServerpodTemplateType.server,
+          webapp: true,
+          website: false,
+        ),
+      );
+
+      test(
+        'then the server server.dart serves the Flutter web app under /',
+        () async {
+          final serverFile = File(
+            p.join(project.serverDir, 'lib', 'server.dart'),
+          );
+          final content = await serverFile.readAsString();
+          expect(content, contains('// Serve the flutter web app under /.'));
+          expect(content, contains("'/'"));
+          expect(content, contains("'/**'"));
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a TemplateContext with webapp and website enabled, '
+    'when performCreate is called with the context and a server template type',
+    () {
+      final project = setUpPerformCreateInTempDir(
+        context: TemplateContext(
+          template: ServerpodTemplateType.server,
+          webapp: true,
+          website: true,
+        ),
+      );
+
+      test(
+        'then the server server.dart serves the Flutter web app under the /app path',
+        () async {
+          final serverFile = File(
+            p.join(project.serverDir, 'lib', 'server.dart'),
+          );
+          final content = await serverFile.readAsString();
+          expect(
+            content,
+            contains('// Serve the flutter web app under the /app path.'),
+          );
+          expect(content, contains("'/app'"));
+          expect(content, contains("'/app/**'"));
+        },
+      );
+    },
+  );
+
+  group(
     'Given a TemplateContext with webapp and website disabled, '
     'when performCreate is called with the context and a fullstack template type',
     () {

--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -137,7 +137,8 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
       auth: true,
       redis: true,
       postgres: true,
-      webapp: true,
+      website: template == ServerpodTemplateType.server,
+      webapp: template != ServerpodTemplateType.server,
       ides: [TemplateIde.claude, TemplateIde.cursor, TemplateIde.vscode],
     );
 

--- a/tools/serverpod_cli/lib/src/create/template_renderer.dart
+++ b/tools/serverpod_cli/lib/src/create/template_renderer.dart
@@ -230,9 +230,9 @@ class TemplateRenderer {
     }
   }
 
-  /// Preprocesses [content] by stripping `// ` / `# ` comment prefixes
-  /// from Mustache directives, so that templates can embed directives
-  /// inside otherwise-valid source files.
+  /// Preprocesses [content] by stripping `// ` / `# ` / `<!-- `
+  /// comment prefixes from Mustache directives, so that templates
+  /// can embed directives inside otherwise-valid source files.
   String _preprocessContent(String content) {
     var result = content;
     result = result.replaceAllMapped(
@@ -241,6 +241,10 @@ class TemplateRenderer {
     );
     result = result.replaceAllMapped(
       RegExp(r'#\s*(\{\{[^}]+\}\})'),
+      (match) => match.group(1)!,
+    );
+    result = result.replaceAllMapped(
+      RegExp(r'<!--\s*(\{\{[^}]+\}\})\s*-->'),
       (match) => match.group(1)!,
     );
     return result;

--- a/tools/serverpod_cli/test/commands/create/template_renderer/file_test.dart
+++ b/tools/serverpod_cli/test/commands/create/template_renderer/file_test.dart
@@ -338,4 +338,128 @@ import 'auth.web';
       await expectLater(file.exists(), completion(false));
     },
   );
+
+  group(
+    'Given a HTML file with template directives in its content',
+    () {
+      late File file;
+
+      setUp(() async {
+        file = File(p.join(testDir.path, 'test.html'));
+        await file.writeAsString('''
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Built with Serverpod</title>
+    <link rel="stylesheet" href="/web/css/style.css">
+  </head>
+  <body>
+    <!-- {{#webapp}} -->
+      <div>
+        <a class="cta" href="/app">
+            Open Flutter app 
+          </a>
+      </div>
+    <!-- {{/webapp}} -->
+    <!-- {{#website}} -->
+      <div>
+        <a class="cta" href="/">
+            Open Website 
+          </a>
+      </div>
+    <!-- {{/website}} -->
+  </body>
+</html>
+''');
+      });
+
+      test(
+        'when rendering the template with true context values, '
+        'then all the sections with conditional directives are retained in the file',
+        () async {
+          await renderTestDir(TemplateContext(website: true, webapp: true));
+          final content = await file.readAsString();
+          expect(
+            content,
+            matches(
+              r'<!DOCTYPE html>\n'
+              r'<html lang="en">\n'
+              r'  <head>\n'
+              r'    <meta charset="utf-8">\n'
+              r'    <title>Built with Serverpod</title>\n'
+              r'    <link rel="stylesheet" href="/web/css/style.css">\n'
+              r'  </head>\n'
+              r'  <body>\n'
+              r'      <div>\n'
+              r'        <a class="cta" href="/app">\n'
+              r'            Open Flutter app \n'
+              r'          </a>\n'
+              r'      </div>\n'
+              r'      <div>\n'
+              r'        <a class="cta" href="/">\n'
+              r'            Open Website \n'
+              r'          </a>\n'
+              r'      </div>\n'
+              r'  </body>\n'
+              r'</html>\n',
+            ),
+          );
+        },
+      );
+
+      test(
+        'when rendering the template with a mix of true and false context values, '
+        'then only the sections with true conditional directives are retained in the file',
+        () async {
+          await renderTestDir(TemplateContext(website: true, webapp: false));
+          final content = await file.readAsString();
+          expect(
+            content,
+            matches(
+              r'<!DOCTYPE html>\n'
+              r'<html lang="en">\n'
+              r'  <head>\n'
+              r'    <meta charset="utf-8">\n'
+              r'    <title>Built with Serverpod</title>\n'
+              r'    <link rel="stylesheet" href="/web/css/style.css">\n'
+              r'  </head>\n'
+              r'  <body>\n'
+              r'      <div>\n'
+              r'        <a class="cta" href="/">\n'
+              r'            Open Website \n'
+              r'          </a>\n'
+              r'      </div>\n'
+              r'  </body>\n'
+              r'</html>\n',
+            ),
+          );
+        },
+      );
+
+      test(
+        'when rendering the template with empty context, '
+        'then all conditional sections are removed from the file',
+        () async {
+          await renderTestDir(TemplateContext());
+          final content = await file.readAsString();
+          expect(
+            content,
+            matches(
+              r'<!DOCTYPE html>\n'
+              r'<html lang="en">\n'
+              r'  <head>\n'
+              r'    <meta charset="utf-8">\n'
+              r'    <title>Built with Serverpod</title>\n'
+              r'    <link rel="stylesheet" href="/web/css/style.css">\n'
+              r'  </head>\n'
+              r'  <body>\n'
+              r'  </body>\n'
+              r'</html>\n',
+            ),
+          );
+        },
+      );
+    },
+  );
 }


### PR DESCRIPTION
The Flutter web app will now be served under `/` if Flutter app only option is enabled for the web server.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None