### PR TITLE
feat: Add the `displayName` for Flutter app configs for a pretty tab title

### DIFF
--- a/packages/serverpod/skills/serverpod-configuration/SKILL.md
+++ b/packages/serverpod/skills/serverpod-configuration/SKILL.md
@@ -118,8 +118,8 @@ in the server `pubspec.yaml` under `serverpod: flutter_apps:`, a map of display
 alias to properties (alongside `serverpod: scripts:`):
 
 - `path`: path to the Flutter package, relative to the server package.
-- `displayName`: optional human-readable label for TUI tab names and
-  breadcrumbs. When omitted, the app id is used.
+- `displayName`: optional human-readable label for TUI tab names. When omitted,
+  the app id is used.
 - `auto_launch`: launch this app automatically on `serverpod start`. Apps
   without it are launched on demand with `Ctrl+R`.
 - `device`: the `flutter run -d` target. Defaults to the web server (opening a

--- a/packages/serverpod/skills/serverpod-configuration/SKILL.md
+++ b/packages/serverpod/skills/serverpod-configuration/SKILL.md
@@ -118,6 +118,8 @@ in the server `pubspec.yaml` under `serverpod: flutter_apps:`, a map of display
 alias to properties (alongside `serverpod: scripts:`):
 
 - `path`: path to the Flutter package, relative to the server package.
+- `displayName`: optional human-readable label for TUI tab names and
+  breadcrumbs. When omitted, the app id is used.
 - `auto_launch`: launch this app automatically on `serverpod start`. Apps
   without it are launched on demand with `Ctrl+R`.
 - `device`: the `flutter run -d` target. Defaults to the web server (opening a
@@ -136,6 +138,7 @@ serverpod:
   flutter_apps:
     Admin:
       path: ../apps/admin
+      displayName: "Admin app"
       auto_launch: true
       device: chrome
       target: lib/main.dart

--- a/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/pubspecs/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -31,7 +31,7 @@ serverpod:
       posix: |
         cd ../projectname_flutter
         flutter build web --base-href /app/ --output ../projectname_server/web/app
-  
+
   # Companion Flutter apps that `serverpod start` can launch (Ctrl+R), keyed
   # by a display alias. The default device is the web server, opening the
   # machine's default browser when ready. All non-reserved properties are
@@ -39,6 +39,7 @@ serverpod:
   #
   # Admin:
   #   path: ../apps/admin_flutter
+  #   displayName: "Admin app"
   #   auto_launch: true
   #   device: chrome
   #   target: lib/main.dart
@@ -52,6 +53,7 @@ serverpod:
   flutter_apps:
     projectname:
       path: ../projectname_flutter
+      displayName: "flutter_app_display_name"
       auto_launch: true
       target: lib/driver.dart
 # {{/flutterApp}}

--- a/templates/serverpod_templates/projectname_server/pubspec.yaml
+++ b/templates/serverpod_templates/projectname_server/pubspec.yaml
@@ -31,7 +31,7 @@ serverpod:
       posix: |
         cd ../projectname_flutter
         flutter build web --base-href /app/ --output ../projectname_server/web/app
-  
+
   # Companion Flutter apps that `serverpod start` can launch (Ctrl+R), keyed
   # by a display alias. The default device is the web server, opening the
   # machine's default browser when ready. All non-reserved properties are
@@ -39,6 +39,7 @@ serverpod:
   #
   # Admin:
   #   path: ../apps/admin_flutter
+  #   displayName: "Admin app"
   #   auto_launch: true
   #   device: chrome
   #   target: lib/main.dart
@@ -52,6 +53,7 @@ serverpod:
   flutter_apps:
     projectname:
       path: ../projectname_flutter
+      displayName: "flutter_app_display_name"
       auto_launch: true
       target: lib/driver.dart
 # {{/flutterApp}}

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -437,7 +437,7 @@ class MainScreen extends StatelessComponent {
     };
   }
 
-  /// Breadcrumb for a Flutter app tab: horizontal rules, muted label, and URL
+  /// Breadcrumb for a Flutter app tab: horizontal rules, muted app id, and URL
   /// or startup stage.
   Component? _buildFlutterStatusLine(ServerpodThemeData st, AppLogTab tab) {
     final mutedText = TextStyle(
@@ -482,7 +482,7 @@ class MainScreen extends StatelessComponent {
 
     Component child = Row(
       children: [
-        Text(' ${tab.label}', style: mutedText),
+        Text(' ${tab.appId}', style: mutedText),
         Text(' │ ', style: separatorStyle),
         indicator,
       ],

--- a/tools/serverpod_cli/lib/src/config/flutter_app_config.dart
+++ b/tools/serverpod_cli/lib/src/config/flutter_app_config.dart
@@ -9,9 +9,9 @@ import '../util/yaml_util.dart';
 /// One configured companion Flutter app.
 ///
 /// Configured under the `serverpod: flutter_apps:` map in the server's
-/// `pubspec.yaml`, keyed by app id. Reserved properties (`path`, `auto_launch`,
-/// `device`) are interpreted directly; any other property is forwarded to
-/// `flutter run` via [extraRunArgs].
+/// `pubspec.yaml`, keyed by app id. Reserved properties (`path`, `displayName`,
+/// `auto_launch`, `device`) are interpreted directly; any other property is
+/// forwarded to `flutter run` via [extraRunArgs].
 class FlutterAppConfig {
   /// Creates a [FlutterAppConfig].
   const FlutterAppConfig({
@@ -43,7 +43,7 @@ class FlutterAppConfig {
 
   /// Extra arguments forwarded verbatim to `flutter run`, derived from any
   /// non-reserved properties on the app's entry — e.g. `target: lib/main.dart`
-  /// becomes `--target=lib/main.dart`. The reserved keys (`path`,
+  /// becomes `--target=lib/main.dart`. The reserved keys (`path`, `displayName`,
   /// `auto_launch`, `device`) are excluded.
   final List<String> extraRunArgs;
 
@@ -89,8 +89,9 @@ String? computeFlutterAppsFingerprint(File serverPubspecFile) {
 ///
 /// Apps are configured under `serverpod: flutter_apps:` (a sibling of
 /// `serverpod: scripts:`), a map keyed by app id whose entries are maps of
-/// properties. The reserved properties (`path`, `auto_launch`, `device`) are
-/// interpreted directly; every other property is forwarded to `flutter run`
+/// properties. The reserved properties (`path`, `displayName`, `auto_launch`,
+/// `device`) are interpreted directly; every other property is forwarded to
+/// `flutter run`
 /// (see [_flutterRunArgsFromProps]). When the section is absent the default
 /// sibling `../<projectName>_flutter` app is synthesized (only if it exists).
 List<FlutterAppConfig> loadFlutterApps({
@@ -162,12 +163,23 @@ List<FlutterAppConfig> loadFlutterApps({
       );
     }
 
+    final displayNameNode = propsNode.nodes['displayName'];
+    final displayNameValue = displayNameNode?.value;
+    if (displayNameValue != null &&
+        (displayNameValue is! String || displayNameValue.isEmpty)) {
+      throw SourceSpanFormatException(
+        'The "$id" flutter app "displayName" property must be a non-empty '
+        'string. Or remove the property to use the app id as the display name.',
+        displayNameNode!.span,
+      );
+    }
+
     final relativePathParts = p.split(pathValue);
 
     apps.add(
       FlutterAppConfig(
         id: id,
-        name: id,
+        name: displayNameValue as String? ?? id,
         relativePathParts: relativePathParts,
         serverPackageDirectoryPathParts: serverPackageDirectoryPathParts,
         autoLaunch: autoLaunchValue ?? false,
@@ -214,7 +226,25 @@ List<FlutterAppConfig> _synthesizeDefaultFlutterApps({
 
 /// Properties the parser interprets itself; every other key under an app's
 /// entry is forwarded to `flutter run`.
-const _reservedFlutterAppKeys = {'path', 'auto_launch', 'device'};
+const _reservedFlutterAppKeys = {
+  'path',
+  'displayName',
+  'auto_launch',
+  'device',
+};
+
+/// Formats an app id into a human-readable display name for new projects.
+///
+/// Capitalizes the first letter, replaces underscores with spaces, and appends
+/// ` app` — e.g. `todo` → `Todo app`, `my_project` → `My project app`.
+String formatFlutterAppDisplayName(String appId) {
+  if (appId.isEmpty) return ' app';
+
+  final withSpaces = appId.replaceAll('_', ' ');
+  final capitalized =
+      '${withSpaces[0].toUpperCase()}${withSpaces.substring(1)}';
+  return '$capitalized app';
+}
 
 /// Builds `flutter run` arguments from the non-reserved properties of
 /// [propsNode], preserving the order they appear in the pubspec.

--- a/tools/serverpod_cli/lib/src/config/flutter_app_config.dart
+++ b/tools/serverpod_cli/lib/src/config/flutter_app_config.dart
@@ -236,13 +236,20 @@ const _reservedFlutterAppKeys = {
 /// Formats an app id into a human-readable display name for new projects.
 ///
 /// Capitalizes the first letter, replaces underscores with spaces, and appends
-/// ` app` — e.g. `todo` → `Todo app`, `my_project` → `My project app`.
+/// ` app` when the id does not already end with `app` — e.g. `todo` → `Todo app`,
+/// `my_project` → `My project app`, `todo_app` → `Todo app`.
 String formatFlutterAppDisplayName(String appId) {
   if (appId.isEmpty) return ' app';
 
   final withSpaces = appId.replaceAll('_', ' ');
   final capitalized =
       '${withSpaces[0].toUpperCase()}${withSpaces.substring(1)}';
+
+  final lower = capitalized.toLowerCase();
+  if (lower.endsWith(' app') || lower.endsWith('app')) {
+    return capitalized;
+  }
+
   return '$capitalized app';
 }
 

--- a/tools/serverpod_cli/lib/src/config/flutter_app_config.dart
+++ b/tools/serverpod_cli/lib/src/config/flutter_app_config.dart
@@ -29,7 +29,7 @@ class FlutterAppConfig {
   /// This is the key under `serverpod: flutter_apps:` in the server pubspec.
   final String id;
 
-  /// Display name used for tab labels and breadcrumbs.
+  /// Display name used for tab labels in the start TUI.
   final String name;
 
   /// Whether `serverpod start` launches this app automatically on startup

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -9,6 +9,7 @@ import 'package:cli_tools/cli_tools.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/src/config/experimental_feature.dart';
+import 'package:serverpod_cli/src/config/flutter_app_config.dart';
 import 'package:serverpod_cli/src/create/database_setup.dart';
 import 'package:serverpod_cli/src/create/generate_files.dart';
 import 'package:serverpod_cli/src/create/ide.dart';
@@ -1174,6 +1175,10 @@ List<String> _copyServerTemplates(
       Replacement(
         slotName: 'projectname',
         replacement: name,
+      ),
+      Replacement(
+        slotName: 'flutter_app_display_name',
+        replacement: formatFlutterAppDisplayName(name),
       ),
       if (customServerpodPath != null)
         Replacement(

--- a/tools/serverpod_cli/test/integration/generator_config/flutter_apps_config_test.dart
+++ b/tools/serverpod_cli/test/integration/generator_config/flutter_apps_config_test.dart
@@ -507,6 +507,24 @@ serverpod:
       expect(formatFlutterAppDisplayName('adminPortal'), 'AdminPortal app');
     },
   );
+
+  test(
+    'Given a flutter app id that already ends with "_app", '
+    'when formatFlutterAppDisplayName is called '
+    'then " app" is not appended again',
+    () {
+      expect(formatFlutterAppDisplayName('todo_app'), 'Todo app');
+    },
+  );
+
+  test(
+    'Given a flutter app id that already ends with "app", '
+    'when formatFlutterAppDisplayName is called '
+    'then " app" is not appended again',
+    () {
+      expect(formatFlutterAppDisplayName('todoapp'), 'Todoapp');
+    },
+  );
 }
 
 d.DirectoryDescriptor _createProject({

--- a/tools/serverpod_cli/test/integration/generator_config/flutter_apps_config_test.dart
+++ b/tools/serverpod_cli/test/integration/generator_config/flutter_apps_config_test.dart
@@ -91,6 +91,128 @@ serverpod:
     );
   });
 
+  group('Given a server pubspec with flutter_apps displayName', () {
+    setUpAll(() async {
+      var projectDir = _createProject(
+        pubspecServerpodSection: '''
+serverpod:
+  flutter_apps:
+    todo:
+      path: ../my_project_flutter
+      displayName: "Todo app"
+''',
+        includeFlutterApps: true,
+      );
+      await projectDir.create();
+    });
+
+    test(
+      'when loading flutter apps '
+      'then displayName is used as the app name',
+      () {
+        final apps = _loadApps();
+
+        expect(apps[0].id, 'todo');
+        expect(apps[0].name, 'Todo app');
+        expect(apps[0].extraRunArgs, isEmpty);
+      },
+    );
+  });
+
+  group('Given a server pubspec without flutter_apps displayName', () {
+    setUpAll(() async {
+      var projectDir = _createProject(
+        pubspecServerpodSection: '''
+serverpod:
+  flutter_apps:
+    todo:
+      path: ../my_project_flutter
+''',
+        includeFlutterApps: true,
+      );
+      await projectDir.create();
+    });
+
+    test(
+      'when loading flutter apps '
+      'then the app id is used as the app name',
+      () {
+        final apps = _loadApps();
+
+        expect(apps[0].id, 'todo');
+        expect(apps[0].name, 'todo');
+      },
+    );
+  });
+
+  group('Given a server pubspec with an empty displayName', () {
+    setUpAll(() async {
+      var projectDir = _createProject(
+        pubspecServerpodSection: '''
+serverpod:
+  flutter_apps:
+    Admin:
+      path: ../my_project_flutter
+      displayName: ""
+''',
+      );
+      await projectDir.create();
+    });
+
+    test(
+      'when loading flutter apps '
+      'then SourceSpanFormatException is thrown',
+      () {
+        expect(
+          _loadApps,
+          throwsA(
+            isA<SourceSpanFormatException>().having(
+              (e) => e.message,
+              'message',
+              'The "Admin" flutter app "displayName" property must be a '
+                  'non-empty string. Or remove the property to use the app id '
+                  'as the display name.',
+            ),
+          ),
+        );
+      },
+    );
+  });
+
+  group('Given a server pubspec with a non-string displayName', () {
+    setUpAll(() async {
+      var projectDir = _createProject(
+        pubspecServerpodSection: '''
+serverpod:
+  flutter_apps:
+    Admin:
+      path: ../my_project_flutter
+      displayName: true
+''',
+      );
+      await projectDir.create();
+    });
+
+    test(
+      'when loading flutter apps '
+      'then SourceSpanFormatException is thrown',
+      () {
+        expect(
+          _loadApps,
+          throwsA(
+            isA<SourceSpanFormatException>().having(
+              (e) => e.message,
+              'message',
+              'The "Admin" flutter app "displayName" property must be a '
+                  'non-empty string. Or remove the property to use the app id '
+                  'as the display name.',
+            ),
+          ),
+        );
+      },
+    );
+  });
+
   group(
     'Given a server pubspec with flutter_apps device and forwarded options',
     () {
@@ -358,6 +480,33 @@ serverpod:
       },
     );
   });
+
+  test(
+    'Given a simple flutter app id, '
+    'when formatFlutterAppDisplayName is called '
+    'then the name is capitalized with " app" appended',
+    () {
+      expect(formatFlutterAppDisplayName('todo'), 'Todo app');
+    },
+  );
+
+  test(
+    'Given a flutter app id with underscores, '
+    'when formatFlutterAppDisplayName is called '
+    'then underscores are replaced with spaces',
+    () {
+      expect(formatFlutterAppDisplayName('my_project'), 'My project app');
+    },
+  );
+
+  test(
+    'Given a flutter app id with mixed casing, '
+    'when formatFlutterAppDisplayName is called '
+    'then only the first letter is capitalized',
+    () {
+      expect(formatFlutterAppDisplayName('adminPortal'), 'AdminPortal app');
+    },
+  );
 }
 
 d.DirectoryDescriptor _createProject({


### PR DESCRIPTION
Closes: #5413

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.