### PR TITLE
feat: Show inline "Copied" confirmation and make alert copy/dismiss clickable in serverpod start

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_service_client: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
-  serverpod_tui: ^0.7.0
+  serverpod_tui: ^0.8.0
   skills: ^0.3.1
   source_span: ^1.10.0
   stream_channel: ^2.1.1

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -250,6 +250,8 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
           },
           onLaunchApp: _launchApp,
           onQuit: onQuit,
+          onCopyAlert: copyAlert,
+          onDismissAlert: dismissAlert,
         ),
       ),
     );

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -28,6 +28,8 @@ class MainScreen extends StatelessComponent {
     this.onLaunchApp,
     this.onTabSelected,
     this.onQuit,
+    required this.onCopyAlert,
+    required this.onDismissAlert,
   });
 
   final ServerWatchState state;
@@ -46,6 +48,12 @@ class MainScreen extends StatelessComponent {
   /// Invoked after a tab is selected via mouse click so the screen redraws.
   final VoidCallback? onTabSelected;
   final VoidCallback? onQuit;
+
+  /// Copies the pinned alert's segment (also bound to the `C` key).
+  final VoidCallback onCopyAlert;
+
+  /// Dismisses the pinned alert (also bound to `Esc`).
+  final VoidCallback onDismissAlert;
 
   List<(String, List<(String, String)>)> get _helpBindings => [
     (
@@ -122,6 +130,9 @@ class MainScreen extends StatelessComponent {
                                       child: AlertLine(
                                         alert: alert,
                                         time: state.alertTime,
+                                        copied: state.alertCopied,
+                                        onCopy: onCopyAlert,
+                                        onDismiss: onDismissAlert,
                                       ),
                                     ),
                                   ],

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
   serverpod_serialization: 3.5.0-beta.12
   serverpod_service_client: 3.5.0-beta.12
   serverpod_shared: 3.5.0-beta.12
-  serverpod_tui: ^0.7.0
+  serverpod_tui: ^0.8.0
   skills: ^0.3.1
   source_span: ^1.10.0
   stream_channel: ^2.1.1


### PR DESCRIPTION
When copying a value from a pinned alert in the `serverpod start` TUI, the CLI appended a "Copied to clipboard" line at the bottom of the interface. This replaces that with an  inline confirmation: pressing `C` or clicking it swaps `C Copy` for a green `✓ Copied`.

https://github.com/user-attachments/assets/28cf21a3-3e81-494c-8321-fc3620b71a3d


Fixes #5425 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None