### PR TITLE
fix: Fix `upsert` with `updateWhere` that matches rows on SQLite

### DIFF
--- a/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
@@ -337,10 +337,12 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
             ),
         ];
 
-        // NOTE: Since we transform batch inserts into multiple single-row
-        // inserts, to achieve the same effect as a batch upsert, we need to
-        // throw if the input had duplicate rows - as happen with Postgres.
-        if (results.map((r) => r.id).toSet().length != rows.length) {
+        // NOTE: Since we transform batch upserts into multiple single-row
+        // upserts, to achieve the same effect as a batch upsert, we need to
+        // throw if the same row was affected twice - as happens with Postgres.
+        // Rows filtered out by [updateWhere] return nothing and must not be
+        // counted, so duplicates are detected among the returned ids only.
+        if (results.map((r) => r.id).toSet().length != results.length) {
           throw _SqliteDatabaseQueryException(
             'ON CONFLICT DO UPDATE command cannot affect row a second time',
             code: SqliteErrorCode.integrityConstraintViolation,

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/upsert_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/upsert_test.dart
@@ -250,6 +250,35 @@ void main() async {
     );
 
     test(
+      'when batch upserting with an updateWhere clause that filters out a conflicting row '
+      'then only the remaining rows are returned.',
+      () async {
+        var data = <UniqueData>[
+          UniqueData(number: 17, email: 'existing@serverpod.dev'),
+          UniqueData(number: 3, email: 'new@serverpod.dev'),
+        ];
+
+        var result = await UniqueData.db.upsert(
+          session,
+          data,
+          conflictColumns: (t) => [t.email],
+          updateWhere: (t) => t.number.equals(99),
+        );
+
+        expect(result, hasLength(1));
+        expect(result.first.email, 'new@serverpod.dev');
+        expect(result.first.number, 3);
+
+        var stored = await UniqueData.db.findFirstRow(
+          session,
+          where: (t) => t.email.equals('existing@serverpod.dev'),
+        );
+        expect(stored, isNotNull);
+        expect(stored!.number, 1);
+      },
+    );
+
+    test(
       'when batch upserting a mix of new and conflicting rows then both inserts and updates happen.',
       () async {
         var data = <UniqueData>[

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/upsert_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/upsert_test.dart
@@ -261,6 +261,35 @@ void main() async {
     );
 
     test(
+      'when batch upserting with an updateWhere clause that filters out a conflicting row '
+      'then only the remaining rows are returned.',
+      () async {
+        var data = <UniqueData>[
+          UniqueData(number: 17, email: 'existing@serverpod.dev'),
+          UniqueData(number: 3, email: 'new@serverpod.dev'),
+        ];
+
+        var result = await UniqueData.db.upsert(
+          session,
+          data,
+          conflictColumns: (t) => [t.email],
+          updateWhere: (t) => t.number.equals(99),
+        );
+
+        expect(result, hasLength(1));
+        expect(result.first.email, 'new@serverpod.dev');
+        expect(result.first.number, 3);
+
+        var stored = await UniqueData.db.findFirstRow(
+          session,
+          where: (t) => t.email.equals('existing@serverpod.dev'),
+        );
+        expect(stored, isNotNull);
+        expect(stored!.number, 1);
+      },
+    );
+
+    test(
       'when batch upserting a mix of new and conflicting rows then both inserts and updates happen.',
       () async {
         var data = <UniqueData>[


### PR DESCRIPTION
The SQLite adapter implements batch `upsert` by decomposing it into single-row upserts and then applying a duplicate-conflict heuristic that compares the number of distinct returned ids against the number of *input* rows. This conflates two situations:

- A genuine duplicate when two input rows resolve to the same conflict target. In such cases, Postgres raises "ON CONFLICT DO UPDATE command cannot affect row a second time".
- A row whose `DO UPDATE` is legitimately skipped by `updateWhere`, which returns no row and, therefore, makes the counts differ.

There was a bug in the implementation that would falsely throw an integrity-constraint-violation error in the latter case and roll back the transaction.

The fix is to detect duplicates among the *returned* ids, which still catches the true "same row affected twice" case while no longer counting rows skipped by `updateWhere`.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.