### PR TITLE
ci: Exit CLI docs generator after writing files

### DIFF
--- a/tools/serverpod_cli/scripts/generate_command_usages.dart
+++ b/tools/serverpod_cli/scripts/generate_command_usages.dart
@@ -96,6 +96,12 @@ void main(final List<String> args) {
       .toSet();
   _deleteRemovedCommandsFolders(currentCommands, commandsPath);
   _deleteRemovedCommandsFiles(currentCommands, generatedPath);
+
+  // Building the framework command runner leaves a non-daemon entry on the
+  // event loop (unlike the Cloud CLI), so the VM never exits on its own once
+  // main returns. All docs are written synchronously above, so terminate
+  // explicitly instead of hanging until the CI step times out.
+  exit(0);
 }
 
 void _generateDocPage(


### PR DESCRIPTION
## Problem

The `Sync CLI Docs to Serverpod Docs` workflow's `Generate CLI docs` step runs for ~47 minutes before GitHub kills it, even though it produces the correct output. Locally, `dart run scripts/generate_command_usages.dart` writes every generated file within ~12 seconds and then hangs indefinitely.

The cause is not slow work. Building the framework `ServerpodCommandRunner` and its command set (which, unlike the Cloud CLI, pulls in `analyzer`) leaves a non-daemon entry on the Dart event loop. `main` is fully synchronous and returns immediately after writing the docs, but the VM never exits on its own because the loop never drains. On CI the step keeps "running" until it is force-killed, which reads as ~47 minutes. The Cloud docs generator does not hit this because its runner drains cleanly (~5 min run).

## Solution

Call `exit(0)` at the end of `main` once all docs are written. Every file is written with synchronous `writeAsStringSync`, so there is nothing left to flush and exiting immediately is safe. Verified locally: the process now exits on its own in a few seconds and still produces the full doc set.