### PR TITLE
feat: Make "X Stop App" / "X Close Tab" hints clickable in serverpod start

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -205,6 +205,44 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
     }
   }
 
+  /// Stops [tab]'s app while it is running or launching - the tab stays so its
+  /// marker flips to stopped and it can be relaunched - and once stopped closes
+  /// the tab, refocusing the last remaining app tab. Bound to the `X` key and
+  /// the clickable `X Stop App`/`X Close Tab` status-line hint. Returns whether
+  /// it acted, so the key handler can fall through when the tab is in neither
+  /// state.
+  bool _stopOrCloseAppTab(AppLogTab tab) {
+    final state = component.holder.state;
+    final appId = tab.appId;
+    final running = state.isAppRunning?.call(appId) ?? false;
+    final launching = state.isAppLaunching?.call(appId) ?? false;
+
+    if (running || launching) {
+      final index = state.launchableApps.indexWhere((a) => a.id == appId);
+      if (index < 0) return false;
+      onStopApp?.call(index);
+      _rebuild();
+      return true;
+    }
+
+    if (tab.stopped) {
+      state.removeAppLogTab(appId);
+      final lastTab = state.appsTabArea?.tabs.whereType<AppLogTab>().lastOrNull;
+      if (lastTab == null) {
+        state.launchPanelIndex = 0;
+      } else {
+        state.tabs.focusTab(lastTab);
+        state.launchPanelIndex = state.launchableApps.indexWhere(
+          (a) => a.id == lastTab.appId,
+        );
+      }
+      _rebuild();
+      return true;
+    }
+
+    return false;
+  }
+
   @override
   void onExit() {
     final quit = onQuit;
@@ -252,6 +290,7 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
           onQuit: onQuit,
           onCopyAlert: copyAlert,
           onDismissAlert: dismissAlert,
+          onStopOrCloseAppTab: _stopOrCloseAppTab,
         ),
       ),
     );
@@ -276,38 +315,11 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
       return true;
     }
 
-    // 'x' acts on the active Flutter app tab: while the app is running (or
-    // launching) it stops the app - the tab stays so its marker flips to
-    // stopped and it can be relaunched - and once stopped it closes the tab.
+    // 'x' acts on the active Flutter app tab.
     if (event.logicalKey == LogicalKey.keyX) {
-      final appsArea = state.appsTabArea;
-      final activeTab = appsArea?.selected;
-      if (activeTab is AppLogTab) {
-        final appId = activeTab.appId;
-        final running = state.isAppRunning?.call(appId) ?? false;
-        final launching = state.isAppLaunching?.call(appId) ?? false;
-
-        if (running || launching) {
-          final index = state.launchableApps.indexWhere((a) => a.id == appId);
-          if (index >= 0) {
-            onStopApp?.call(index);
-            _rebuild();
-            return true;
-          }
-        } else if (activeTab.stopped) {
-          state.removeAppLogTab(appId);
-          final lastTab = appsArea?.tabs.whereType<AppLogTab>().lastOrNull;
-          if (lastTab == null) {
-            state.launchPanelIndex = 0;
-          } else {
-            state.tabs.focusTab(lastTab);
-            state.launchPanelIndex = state.launchableApps.indexWhere(
-              (a) => a.id == lastTab.appId,
-            );
-          }
-          _rebuild();
-          return true;
-        }
+      final activeTab = state.appsTabArea?.selected;
+      if (activeTab is AppLogTab && _stopOrCloseAppTab(activeTab)) {
+        return true;
       }
     }
 

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -30,6 +30,7 @@ class MainScreen extends StatelessComponent {
     this.onQuit,
     required this.onCopyAlert,
     required this.onDismissAlert,
+    required this.onStopOrCloseAppTab,
   });
 
   final ServerWatchState state;
@@ -54,6 +55,9 @@ class MainScreen extends StatelessComponent {
 
   /// Dismisses the pinned alert (also bound to `Esc`).
   final VoidCallback onDismissAlert;
+
+  /// Stops the app or closes the tab for the given app tab (also bound to `X`).
+  final void Function(AppLogTab tab) onStopOrCloseAppTab;
 
   List<(String, List<(String, String)>)> get _helpBindings => [
     (
@@ -523,21 +527,24 @@ class MainScreen extends StatelessComponent {
                   Text(labelSep, style: separatorStyle),
                   status,
                   Expanded(child: const SizedBox.shrink()),
-                  RichText(
-                    text: TextSpan(
-                      children: [
-                        TextSpan(
-                          text: 'X',
-                          style: TextStyle(
-                            color: st.activationKey,
-                            fontWeight: FontWeight.bold,
+                  GestureDetector(
+                    onTap: () => onStopOrCloseAppTab(tab),
+                    child: RichText(
+                      text: TextSpan(
+                        children: [
+                          TextSpan(
+                            text: 'X',
+                            style: TextStyle(
+                              color: st.activationKey,
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
-                        ),
-                        TextSpan(
-                          text: ' $xLabel',
-                          style: TextStyle(color: st.brightText),
-                        ),
-                      ],
+                          TextSpan(
+                            text: ' $xLabel',
+                            style: TextStyle(color: st.brightText),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ],


### PR DESCRIPTION
The `X Stop App` / `X Close Tab` hint shown below a Flutter app tab in the `serverpod start` TUI was keyboard-only.

This makes it clickable, so a click performs the same action as pressing `X`: stop the app while it's running/launching, then close the tab once stopped.

The `X`-key logic is extracted into a shared `_stopOrCloseAppTab(tab)` method used by both the key handler and the new click callback, and the hint is wrapped in a `GestureDetector`.

Fixes #5429 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None