### PR TITLE
feat: Remove experimental flag from `serverpod start` command

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -112,8 +112,9 @@ class StartCommand extends ServerpodCommand<StartOption> {
 
   @override
   final description =
-      'Generate code and start the server. '
-      'Use --watch to watch for changes and hot reload.';
+      'Start the full development stack with hot reload: generates code, '
+      'runs the server, and launches the companion Flutter apps in an '
+      'interactive terminal UI.';
 
   @override
   String get invocation => 'serverpod start [-- <server-args>]';

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -111,11 +111,8 @@ class StartCommand extends ServerpodCommand<StartOption> {
   final name = 'start';
 
   @override
-  bool get hidden => true;
-
-  @override
   final description =
-      'EXPERIMENTAL! Generate code and start the server. '
+      'Generate code and start the server. '
       'Use --watch to watch for changes and hot reload.';
 
   @override

--- a/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
+++ b/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
@@ -105,6 +105,23 @@ commands:
     exclusiveFlags:
       - [list, no-list]
 
+  - name: start
+    flags:
+      -w, --watch: "Watch files and use the Frontend Server for fast incremental compilation. With --no-watch, the server is started via `dart run`."
+      --no-watch: "Watch files and use the Frontend Server for fast incremental compilation. With --no-watch, the server is started via `dart run`."
+      -d, --directory=: "The server directory (defaults to auto-detect from current directory)."
+      --docker: "Start Docker Compose services if a docker-compose.yaml exists. Default off; pass --docker to opt in to compose-managed services (typically Redis when running PostgreSQL separately)."
+      --no-docker: "Start Docker Compose services if a docker-compose.yaml exists. Default off; pass --docker to opt in to compose-managed services (typically Redis when running PostgreSQL separately)."
+      --tui: "Show interactive terminal UI."
+      --no-tui: "Show interactive terminal UI."
+      --flutter: "Auto-launch the companion Flutter apps as configured on the server pubspec.yaml with `auto_launch: true`. Use --no-flutter to disable auto-launch. Apps can still be started on demand from the TUI."
+      --no-flutter: "Auto-launch the companion Flutter apps as configured on the server pubspec.yaml with `auto_launch: true`. Use --no-flutter to disable auto-launch. Apps can still be started on demand from the TUI."
+    exclusiveFlags:
+      - [watch, no-watch]
+      - [docker, no-docker]
+      - [tui, no-tui]
+      - [flutter, no-flutter]
+
   - name: upgrade
 
   - name: version


### PR DESCRIPTION
The `serverpod start` command was marked as experimental for the 3.5.0-beta release, but the flag was not removed for 4.0.0 as intended. This PR removes the `EXPERIMENTAL!` description prefix and unhides the command, so it appears in `serverpod --help` and in the generated CLI reference docs.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making. (No behavior to test — existing tests pass.)
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None.