### PR TITLE
feat: Make the WidgetRoute's build method return a nullable WebWidget

### DIFF
--- a/packages/serverpod/lib/src/web_server/web_server.dart
+++ b/packages/serverpod/lib/src/web_server/web_server.dart
@@ -457,7 +457,7 @@ abstract class WidgetRoute extends Route {
 
   /// Override this method to build your web widget from the current [session]
   /// and [request].
-  Future<WebWidget> build(Session session, Request request);
+  Future<WebWidget?> build(Session session, Request request);
 
   @override
   FutureOr<Result> handleCall(
@@ -465,6 +465,10 @@ abstract class WidgetRoute extends Route {
     Request req,
   ) async {
     var widget = await build(session, req);
+
+    if (widget == null) {
+      return Response.notFound(body: Body.fromString('Not found'));
+    }
 
     if (widget is RedirectWidget) {
       var uri = Uri.parse(widget.url);

--- a/packages/serverpod/test/web_server/widget_route_methods_test.dart
+++ b/packages/serverpod/test/web_server/widget_route_methods_test.dart
@@ -22,6 +22,15 @@ class GetPostRoute extends WidgetRoute {
   }
 }
 
+class NotFoundRoute extends WidgetRoute {
+  NotFoundRoute() : super(methods: {Method.get, Method.post});
+
+  @override
+  Future<WebWidget?> build(Session session, Request request) async {
+    return null;
+  }
+}
+
 void main() {
   group('Given a widget route that accepts GET and POST methods', () {
     late Serverpod pod;
@@ -49,6 +58,7 @@ void main() {
       );
 
       pod.webServer.addRoute(GetPostRoute(), '/test-route');
+      pod.webServer.addRoute(NotFoundRoute(), '/not-found-route');
 
       await pod.start();
       port = pod.webServer.port!;
@@ -79,6 +89,32 @@ void main() {
 
         expect(response.statusCode, 200);
         expect(response.body, contains('Method: Method.post'));
+      },
+    );
+
+    test(
+      'when GET request is made for a route that returns a null web widget, '
+      'then a 404 response is returned.',
+      () async {
+        var response = await http.get(
+          Uri.parse('http://localhost:$port/not-found-route'),
+        );
+
+        expect(response.statusCode, 404);
+        expect(response.body, contains('Not found'));
+      },
+    );
+
+    test(
+      'when POST request is made for a route that returns a null web widget, '
+      'then a 404 response is returned.',
+      () async {
+        var response = await http.post(
+          Uri.parse('http://localhost:$port/not-found-route'),
+        );
+
+        expect(response.statusCode, 404);
+        expect(response.body, contains('Not found'));
       },
     );
   });


### PR DESCRIPTION
Closes #4855 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None