### PR TITLE
fix: Add the missing `databaseInterceptor` parameter to `withServerpod`

### DIFF
--- a/examples/middleware/middleware_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/examples/middleware/middleware_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -85,6 +85,9 @@ export 'package:serverpod_test/serverpod_test_public_exports.dart';
 /// and before it is used to start the server. Use this to override particular
 /// settings in the server configuration.
 ///
+/// [databaseInterceptor] Optional interceptor that replaces the default database for each session.
+/// See [Serverpod.databaseInterceptor] for more information.
+///
 /// [testGroupTagsOverride] By default Serverpod test tools tags the `withServerpod` test group with `"integration"`.
 /// This is to provide a simple way to only run unit or integration tests.
 /// This property allows this tag to be overridden to something else. Defaults to `['integration']`.
@@ -103,6 +106,7 @@ void withServerpod(
   _i1.TestClosure<TestEndpoints> testClosure, {
   bool? applyMigrations,
   _i2.ServerpodConfig Function(_i2.ServerpodConfig)? configOverride,
+  _i2.DatabaseInterceptor? databaseInterceptor,
   bool? enableSessionLogging,
   _i2.ExperimentalFeatures? experimentalFeatures,
   _i1.RollbackDatabase? rollbackDatabase,
@@ -129,6 +133,7 @@ void withServerpod(
       experimentalFeatures: experimentalFeatures,
       configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
+      databaseInterceptor: databaseInterceptor,
     ),
     maybeRollbackDatabase: rollbackDatabase,
     maybeEnableSessionLogging: enableSessionLogging,

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -92,6 +92,9 @@ export 'package:serverpod_test/serverpod_test_public_exports.dart';
 /// and before it is used to start the server. Use this to override particular
 /// settings in the server configuration.
 ///
+/// [databaseInterceptor] Optional interceptor that replaces the default database for each session.
+/// See [Serverpod.databaseInterceptor] for more information.
+///
 /// [testGroupTagsOverride] By default Serverpod test tools tags the `withServerpod` test group with `"integration"`.
 /// This is to provide a simple way to only run unit or integration tests.
 /// This property allows this tag to be overridden to something else. Defaults to `['integration']`.
@@ -110,6 +113,7 @@ void withServerpod(
   _i1.TestClosure<TestEndpoints> testClosure, {
   bool? applyMigrations,
   _i2.ServerpodConfig Function(_i2.ServerpodConfig)? configOverride,
+  _i2.DatabaseInterceptor? databaseInterceptor,
   bool? enableSessionLogging,
   _i2.ExperimentalFeatures? experimentalFeatures,
   _i1.RollbackDatabase? rollbackDatabase,
@@ -136,6 +140,7 @@ void withServerpod(
       experimentalFeatures: experimentalFeatures,
       configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
+      databaseInterceptor: databaseInterceptor,
     ),
     maybeRollbackDatabase: rollbackDatabase,
     maybeEnableSessionLogging: enableSessionLogging,

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -93,6 +93,9 @@ export 'package:serverpod_test/serverpod_test_public_exports.dart';
 /// and before it is used to start the server. Use this to override particular
 /// settings in the server configuration.
 ///
+/// [databaseInterceptor] Optional interceptor that replaces the default database for each session.
+/// See [Serverpod.databaseInterceptor] for more information.
+///
 /// [testGroupTagsOverride] By default Serverpod test tools tags the `withServerpod` test group with `"integration"`.
 /// This is to provide a simple way to only run unit or integration tests.
 /// This property allows this tag to be overridden to something else. Defaults to `['integration']`.
@@ -111,6 +114,7 @@ void withServerpod(
   _i1.TestClosure<TestEndpoints> testClosure, {
   bool? applyMigrations,
   _i2.ServerpodConfig Function(_i2.ServerpodConfig)? configOverride,
+  _i2.DatabaseInterceptor? databaseInterceptor,
   bool? enableSessionLogging,
   _i2.ExperimentalFeatures? experimentalFeatures,
   _i1.RollbackDatabase? rollbackDatabase,
@@ -137,6 +141,7 @@ void withServerpod(
       experimentalFeatures: experimentalFeatures,
       configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
+      databaseInterceptor: databaseInterceptor,
     ),
     maybeRollbackDatabase: rollbackDatabase,
     maybeEnableSessionLogging: enableSessionLogging,

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/serverpod_test_tools.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/serverpod_test_tools.dart
@@ -86,6 +86,9 @@ export 'package:serverpod_test/serverpod_test_public_exports.dart';
 /// and before it is used to start the server. Use this to override particular
 /// settings in the server configuration.
 ///
+/// [databaseInterceptor] Optional interceptor that replaces the default database for each session.
+/// See [Serverpod.databaseInterceptor] for more information.
+///
 /// [testGroupTagsOverride] By default Serverpod test tools tags the `withServerpod` test group with `"integration"`.
 /// This is to provide a simple way to only run unit or integration tests.
 /// This property allows this tag to be overridden to something else. Defaults to `['integration']`.
@@ -104,6 +107,7 @@ void withServerpod(
   _i1.TestClosure<TestEndpoints> testClosure, {
   bool? applyMigrations,
   _i2.ServerpodConfig Function(_i2.ServerpodConfig)? configOverride,
+  _i2.DatabaseInterceptor? databaseInterceptor,
   bool? enableSessionLogging,
   _i2.ExperimentalFeatures? experimentalFeatures,
   _i1.RollbackDatabase? rollbackDatabase,
@@ -130,6 +134,7 @@ void withServerpod(
       experimentalFeatures: experimentalFeatures,
       configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
+      databaseInterceptor: databaseInterceptor,
     ),
     maybeRollbackDatabase: rollbackDatabase,
     maybeEnableSessionLogging: enableSessionLogging,

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/test_tools/serverpod_test_tools.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/test_tools/serverpod_test_tools.dart
@@ -83,6 +83,9 @@ export 'package:serverpod_test/serverpod_test_public_exports.dart';
 /// and before it is used to start the server. Use this to override particular
 /// settings in the server configuration.
 ///
+/// [databaseInterceptor] Optional interceptor that replaces the default database for each session.
+/// See [Serverpod.databaseInterceptor] for more information.
+///
 /// [testGroupTagsOverride] By default Serverpod test tools tags the `withServerpod` test group with `"integration"`.
 /// This is to provide a simple way to only run unit or integration tests.
 /// This property allows this tag to be overridden to something else. Defaults to `['integration']`.
@@ -101,6 +104,7 @@ void withServerpod(
   _i1.TestClosure<TestEndpoints> testClosure, {
   bool? applyMigrations,
   _i2.ServerpodConfig Function(_i2.ServerpodConfig)? configOverride,
+  _i2.DatabaseInterceptor? databaseInterceptor,
   bool? enableSessionLogging,
   _i2.ExperimentalFeatures? experimentalFeatures,
   _i1.RollbackDatabase? rollbackDatabase,
@@ -127,6 +131,7 @@ void withServerpod(
       experimentalFeatures: experimentalFeatures,
       configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
+      databaseInterceptor: databaseInterceptor,
     ),
     maybeRollbackDatabase: rollbackDatabase,
     maybeEnableSessionLogging: enableSessionLogging,

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -83,6 +83,9 @@ export 'package:serverpod_test/serverpod_test_public_exports.dart';
 /// and before it is used to start the server. Use this to override particular
 /// settings in the server configuration.
 ///
+/// [databaseInterceptor] Optional interceptor that replaces the default database for each session.
+/// See [Serverpod.databaseInterceptor] for more information.
+///
 /// [testGroupTagsOverride] By default Serverpod test tools tags the `withServerpod` test group with `"integration"`.
 /// This is to provide a simple way to only run unit or integration tests.
 /// This property allows this tag to be overridden to something else. Defaults to `['integration']`.
@@ -101,6 +104,7 @@ void withServerpod(
   _i1.TestClosure<TestEndpoints> testClosure, {
   bool? applyMigrations,
   _i2.ServerpodConfig Function(_i2.ServerpodConfig)? configOverride,
+  _i2.DatabaseInterceptor? databaseInterceptor,
   bool? enableSessionLogging,
   _i2.ExperimentalFeatures? experimentalFeatures,
   _i1.RollbackDatabase? rollbackDatabase,
@@ -127,6 +131,7 @@ void withServerpod(
       experimentalFeatures: experimentalFeatures,
       configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
+      databaseInterceptor: databaseInterceptor,
     ),
     maybeRollbackDatabase: rollbackDatabase,
     maybeEnableSessionLogging: enableSessionLogging,

--- a/packages/serverpod_test/lib/src/test_serverpod.dart
+++ b/packages/serverpod_test/lib/src/test_serverpod.dart
@@ -123,6 +123,7 @@ class TestServerpod<T extends InternalTestEndpoints> {
     Directory? serverDirectory,
     ExperimentalFeatures? experimentalFeatures,
     RuntimeParametersListBuilder? runtimeParametersBuilder,
+    DatabaseInterceptor? databaseInterceptor,
     ServerpodConfig Function(ServerpodConfig)? configOverride,
   }) : testServerOutputMode =
            testServerOutputMode ?? TestServerOutputMode.normal {
@@ -143,6 +144,7 @@ class TestServerpod<T extends InternalTestEndpoints> {
           configOverride: configOverride,
           experimentalFeatures: experimentalFeatures,
           runtimeParametersBuilder: runtimeParametersBuilder,
+          databaseInterceptor: databaseInterceptor,
         );
         endpoints.initializeEndpoints(serverpod.server);
         return serverpod;

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -91,6 +91,9 @@ export 'package:serverpod_test/serverpod_test_public_exports.dart';
 /// and before it is used to start the server. Use this to override particular
 /// settings in the server configuration.
 ///
+/// [databaseInterceptor] Optional interceptor that replaces the default database for each session.
+/// See [Serverpod.databaseInterceptor] for more information.
+///
 /// [testGroupTagsOverride] By default Serverpod test tools tags the `withServerpod` test group with `"integration"`.
 /// This is to provide a simple way to only run unit or integration tests.
 /// This property allows this tag to be overridden to something else. Defaults to `['integration']`.
@@ -109,6 +112,7 @@ void withServerpod(
   _i1.TestClosure<TestEndpoints> testClosure, {
   bool? applyMigrations,
   _i2.ServerpodConfig Function(_i2.ServerpodConfig)? configOverride,
+  _i2.DatabaseInterceptor? databaseInterceptor,
   bool? enableSessionLogging,
   _i2.ExperimentalFeatures? experimentalFeatures,
   _i1.RollbackDatabase? rollbackDatabase,
@@ -135,6 +139,7 @@ void withServerpod(
       experimentalFeatures: experimentalFeatures,
       configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
+      databaseInterceptor: databaseInterceptor,
     ),
     maybeRollbackDatabase: rollbackDatabase,
     maybeEnableSessionLogging: enableSessionLogging,

--- a/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -90,6 +90,9 @@ export 'package:serverpod_test/serverpod_test_public_exports.dart';
 /// and before it is used to start the server. Use this to override particular
 /// settings in the server configuration.
 ///
+/// [databaseInterceptor] Optional interceptor that replaces the default database for each session.
+/// See [Serverpod.databaseInterceptor] for more information.
+///
 /// [testGroupTagsOverride] By default Serverpod test tools tags the `withServerpod` test group with `"integration"`.
 /// This is to provide a simple way to only run unit or integration tests.
 /// This property allows this tag to be overridden to something else. Defaults to `['integration']`.
@@ -108,6 +111,7 @@ void withServerpod(
   _i1.TestClosure<TestEndpoints> testClosure, {
   bool? applyMigrations,
   _i2.ServerpodConfig Function(_i2.ServerpodConfig)? configOverride,
+  _i2.DatabaseInterceptor? databaseInterceptor,
   bool? enableSessionLogging,
   _i2.ExperimentalFeatures? experimentalFeatures,
   _i1.RollbackDatabase? rollbackDatabase,
@@ -134,6 +138,7 @@ void withServerpod(
       experimentalFeatures: experimentalFeatures,
       configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
+      databaseInterceptor: databaseInterceptor,
     ),
     maybeRollbackDatabase: rollbackDatabase,
     maybeEnableSessionLogging: enableSessionLogging,

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/test/integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/test/integration/test_tools/serverpod_test_tools.dart
@@ -86,6 +86,9 @@ export 'package:serverpod_test/serverpod_test_public_exports.dart';
 /// and before it is used to start the server. Use this to override particular
 /// settings in the server configuration.
 ///
+/// [databaseInterceptor] Optional interceptor that replaces the default database for each session.
+/// See [Serverpod.databaseInterceptor] for more information.
+///
 /// [testGroupTagsOverride] By default Serverpod test tools tags the `withServerpod` test group with `"integration"`.
 /// This is to provide a simple way to only run unit or integration tests.
 /// This property allows this tag to be overridden to something else. Defaults to `['integration']`.
@@ -104,6 +107,7 @@ void withServerpod(
   _i1.TestClosure<TestEndpoints> testClosure, {
   bool? applyMigrations,
   _i2.ServerpodConfig Function(_i2.ServerpodConfig)? configOverride,
+  _i2.DatabaseInterceptor? databaseInterceptor,
   bool? enableSessionLogging,
   _i2.ExperimentalFeatures? experimentalFeatures,
   _i1.RollbackDatabase? rollbackDatabase,
@@ -130,6 +134,7 @@ void withServerpod(
       experimentalFeatures: experimentalFeatures,
       configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
+      databaseInterceptor: databaseInterceptor,
     ),
     maybeRollbackDatabase: rollbackDatabase,
     maybeEnableSessionLogging: enableSessionLogging,

--- a/tests/serverpod_test_server/test_integration/test_tools/database_interceptor_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/database_interceptor_test.dart
@@ -1,0 +1,35 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+import 'serverpod_test_tools.dart';
+
+void main() {
+  var interceptorCallCount = 0;
+
+  final DatabaseInterceptor databaseInterceptor = (_, inner) {
+    interceptorCallCount++;
+    return inner;
+  };
+
+  withServerpod(
+    'Given withServerpod with a database interceptor,',
+    databaseInterceptor: databaseInterceptor,
+    testServerOutputMode: TestServerOutputMode.silent,
+    (sessionBuilder, _) {
+      test(
+        'when building a test session, '
+        'then the database interceptor is called for that session.',
+        () {
+          var interceptorCallCountBeforeBuild = interceptorCallCount;
+
+          sessionBuilder.build();
+
+          expect(
+            interceptorCallCount,
+            interceptorCallCountBeforeBuild + 1,
+          );
+        },
+      );
+    },
+  );
+}

--- a/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -137,6 +137,9 @@ export 'package:serverpod_test/serverpod_test_public_exports.dart';
 /// and before it is used to start the server. Use this to override particular
 /// settings in the server configuration.
 ///
+/// [databaseInterceptor] Optional interceptor that replaces the default database for each session.
+/// See [Serverpod.databaseInterceptor] for more information.
+///
 /// [testGroupTagsOverride] By default Serverpod test tools tags the `withServerpod` test group with `"integration"`.
 /// This is to provide a simple way to only run unit or integration tests.
 /// This property allows this tag to be overridden to something else. Defaults to `['integration']`.
@@ -155,6 +158,7 @@ void withServerpod(
   _i1.TestClosure<TestEndpoints> testClosure, {
   bool? applyMigrations,
   _i2.ServerpodConfig Function(_i2.ServerpodConfig)? configOverride,
+  _i2.DatabaseInterceptor? databaseInterceptor,
   bool? enableSessionLogging,
   _i2.ExperimentalFeatures? experimentalFeatures,
   _i1.RollbackDatabase? rollbackDatabase,
@@ -181,6 +185,7 @@ void withServerpod(
       experimentalFeatures: experimentalFeatures,
       configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
+      databaseInterceptor: databaseInterceptor,
     ),
     maybeRollbackDatabase: rollbackDatabase,
     maybeEnableSessionLogging: enableSessionLogging,

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/serverpod_test_tools.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/test_tools/serverpod_test_tools.dart
@@ -88,6 +88,9 @@ export 'package:serverpod_test/serverpod_test_public_exports.dart';
 /// and before it is used to start the server. Use this to override particular
 /// settings in the server configuration.
 ///
+/// [databaseInterceptor] Optional interceptor that replaces the default database for each session.
+/// See [Serverpod.databaseInterceptor] for more information.
+///
 /// [testGroupTagsOverride] By default Serverpod test tools tags the `withServerpod` test group with `"integration"`.
 /// This is to provide a simple way to only run unit or integration tests.
 /// This property allows this tag to be overridden to something else. Defaults to `['integration']`.
@@ -106,6 +109,7 @@ void withServerpod(
   _i1.TestClosure<TestEndpoints> testClosure, {
   bool? applyMigrations,
   _i2.ServerpodConfig Function(_i2.ServerpodConfig)? configOverride,
+  _i2.DatabaseInterceptor? databaseInterceptor,
   bool? enableSessionLogging,
   _i2.ExperimentalFeatures? experimentalFeatures,
   _i1.RollbackDatabase? rollbackDatabase,
@@ -132,6 +136,7 @@ void withServerpod(
       experimentalFeatures: experimentalFeatures,
       configOverride: configOverride,
       runtimeParametersBuilder: runtimeParametersBuilder,
+      databaseInterceptor: databaseInterceptor,
     ),
     maybeRollbackDatabase: rollbackDatabase,
     maybeEnableSessionLogging: enableSessionLogging,

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/doc_comments/with_serverpod_doc_comment.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/doc_comments/with_serverpod_doc_comment.dart
@@ -51,6 +51,9 @@ A function to override the server configuration. This function is called with
 the default server configuration after it is loaded from the config/ directory
 and before it is used to start the server. Use this to override particular
 settings in the server configuration.''',
+  'databaseInterceptor': '''
+Optional interceptor that replaces the default database for each session.
+See [Serverpod.databaseInterceptor] for more information.''',
   'testGroupTagsOverride': '''
 By default Serverpod test tools tags the `withServerpod` test group with `"integration"`.
 This is to provide a simple way to only run unit or integration tests.

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/server_test_tools_generator.dart
@@ -764,6 +764,12 @@ class ServerTestToolsGenerator {
         ),
         Parameter(
           (p) => p
+            ..name = 'databaseInterceptor'
+            ..named = true
+            ..type = refer('DatabaseInterceptor?', serverpodUrl(true)),
+        ),
+        Parameter(
+          (p) => p
             ..name = 'runtimeParametersBuilder'
             ..named = true
             ..type = refer('RuntimeParametersListBuilder?', serverpodUrl(true)),
@@ -829,6 +835,8 @@ class ServerTestToolsGenerator {
                           'runtimeParametersBuilder': refer(
                             'runtimeParametersBuilder',
                           ),
+                        if (config.isFeatureEnabled(ServerpodFeature.database))
+                          'databaseInterceptor': refer('databaseInterceptor'),
                       },
                     ),
                   ],

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/test_tools_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/test_tools_test.dart
@@ -74,6 +74,7 @@ void main() {
               r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
               r'  bool\? applyMigrations,\n'
               r'  _i\d\.ServerpodConfig Function\(_i\d\.ServerpodConfig\)\? configOverride,\n'
+              r'  _i\d\.DatabaseInterceptor\? databaseInterceptor,\n'
               r'  bool\? enableSessionLogging,\n'
               r'  _i\d\.ExperimentalFeatures\? experimentalFeatures,\n'
               r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
@@ -118,6 +119,10 @@ void main() {
           expect(
             testToolsFile,
             contains('\n///\n/// [enableSessionLogging] '),
+          );
+          expect(
+            testToolsFile,
+            contains('\n///\n/// [databaseInterceptor] '),
           );
           expect(
             testToolsFile,
@@ -241,7 +246,7 @@ void main() {
       late var testToolsFile = codeMap[expectedFileName];
 
       test(
-        'then test tools file has `withServerpod` function without `rollbackDatabase` and `applyMigrations` parameters',
+        'then test tools file has `withServerpod` function without database configuration parameters',
         () {
           expect(
             testToolsFile,
@@ -322,11 +327,15 @@ void main() {
       );
 
       test(
-        'then doc comments for `applyMigrations` and `rollbackDatabase` are not present',
+        'then doc comments for database configuration parameters are not present',
         () async {
           expect(
             testToolsFile,
             isNot(contains('/// [applyMigrations]')),
+          );
+          expect(
+            testToolsFile,
+            isNot(contains('/// [databaseInterceptor]')),
           );
           expect(
             testToolsFile,
@@ -375,6 +384,7 @@ void main() {
               r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
               r'  bool\? applyMigrations,\n'
               r'  _i\d\.ServerpodConfig Function\(_i\d\.ServerpodConfig\)\? configOverride,\n'
+              r'  _i\d\.DatabaseInterceptor\? databaseInterceptor,\n'
               r'  bool\? enableSessionLogging,\n'
               r'  _i\d\.ExperimentalFeatures\? experimentalFeatures,\n'
               r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
@@ -419,6 +429,10 @@ void main() {
           expect(
             testToolsFile,
             contains('\n///\n/// [enableSessionLogging] '),
+          );
+          expect(
+            testToolsFile,
+            contains('\n///\n/// [databaseInterceptor] '),
           );
           expect(
             testToolsFile,
@@ -523,6 +537,7 @@ void main() {
               r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
               r'  bool\? applyMigrations,\n'
               r'  _i\d\.ServerpodConfig Function\(_i\d\.ServerpodConfig\)\? configOverride,\n'
+              r'  _i\d\.DatabaseInterceptor\? databaseInterceptor,\n'
               r'  bool\? enableSessionLogging,\n'
               r'  _i\d\.ExperimentalFeatures\? experimentalFeatures,\n'
               r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
@@ -567,6 +582,10 @@ void main() {
           expect(
             testToolsFile,
             contains('\n///\n/// [enableSessionLogging] '),
+          );
+          expect(
+            testToolsFile,
+            contains('\n///\n/// [databaseInterceptor] '),
           );
           expect(
             testToolsFile,
@@ -1890,6 +1909,7 @@ void main() {
               r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
               r'  bool\? applyMigrations,\n'
               r'  _i\d\.ServerpodConfig Function\(_i\d\.ServerpodConfig\)\? configOverride,\n'
+              r'  _i\d\.DatabaseInterceptor\? databaseInterceptor,\n'
               r'  bool\? enableSessionLogging,\n'
               r'  _i\d\.ExperimentalFeatures\? experimentalFeatures,\n'
               r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'
@@ -1973,6 +1993,7 @@ void main() {
               r'  _i\d\.TestClosure<TestEndpoints> testClosure, \{\n'
               r'  bool\? applyMigrations,\n'
               r'  _i\d\.ServerpodConfig Function\(_i\d\.ServerpodConfig\)\? configOverride,\n'
+              r'  _i\d\.DatabaseInterceptor\? databaseInterceptor,\n'
               r'  bool\? enableSessionLogging,\n'
               r'  _i\d\.ExperimentalFeatures\? experimentalFeatures,\n'
               r'  _i\d\.RollbackDatabase\? rollbackDatabase,\n'


### PR DESCRIPTION
This PR fixes a missing parameter on the `withServerpod` after the introduction of the `databaseInterceptor` feature.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.