### PR TITLE
fix: Allow unverified emails in Firebase IDP default account validation

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/protocol.dart
@@ -29,25 +29,27 @@ import 'providers/email/models/exceptions/email_account_request_exception_reason
     as _i9;
 import 'providers/facebook/models/facebook_access_token_verification_exception.dart'
     as _i10;
-import 'providers/firebase/models/firebase_id_token_verification_exception.dart'
+import 'providers/firebase/models/firebase_email_not_verified_exception.dart'
     as _i11;
-import 'providers/github/models/github_access_token_verification_exception.dart'
+import 'providers/firebase/models/firebase_id_token_verification_exception.dart'
     as _i12;
-import 'providers/google/models/google_id_token_verification_exception.dart'
+import 'providers/github/models/github_access_token_verification_exception.dart'
     as _i13;
-import 'providers/microsoft/models/microsoft_access_token_verification_exception.dart'
+import 'providers/google/models/google_id_token_verification_exception.dart'
     as _i14;
-import 'providers/passkey/models/passkey_challenge_expired_exception.dart'
+import 'providers/microsoft/models/microsoft_access_token_verification_exception.dart'
     as _i15;
-import 'providers/passkey/models/passkey_challenge_not_found_exception.dart'
+import 'providers/passkey/models/passkey_challenge_expired_exception.dart'
     as _i16;
-import 'providers/passkey/models/passkey_login_request.dart' as _i17;
+import 'providers/passkey/models/passkey_challenge_not_found_exception.dart'
+    as _i17;
+import 'providers/passkey/models/passkey_login_request.dart' as _i18;
 import 'providers/passkey/models/passkey_public_key_not_found_exception.dart'
-    as _i18;
-import 'providers/passkey/models/passkey_registration_request.dart' as _i19;
-import 'dart:typed_data' as _i20;
+    as _i19;
+import 'providers/passkey/models/passkey_registration_request.dart' as _i20;
+import 'dart:typed_data' as _i21;
 import 'package:serverpod_auth_core_client/serverpod_auth_core_client.dart'
-    as _i21;
+    as _i22;
 export 'providers/anonymous/models/exceptions/anonymous_account_blocked_exception.dart';
 export 'providers/anonymous/models/exceptions/anonymous_account_blocked_exception_reason.dart';
 export 'providers/email/models/exceptions/email_account_login_exception.dart';
@@ -57,6 +59,7 @@ export 'providers/email/models/exceptions/email_account_password_reset_exception
 export 'providers/email/models/exceptions/email_account_request_exception.dart';
 export 'providers/email/models/exceptions/email_account_request_exception_reason.dart';
 export 'providers/facebook/models/facebook_access_token_verification_exception.dart';
+export 'providers/firebase/models/firebase_email_not_verified_exception.dart';
 export 'providers/firebase/models/firebase_id_token_verification_exception.dart';
 export 'providers/github/models/github_access_token_verification_exception.dart';
 export 'providers/google/models/google_id_token_verification_exception.dart';
@@ -140,32 +143,35 @@ class Protocol extends _i1.SerializationManager {
     if (t == _i10.FacebookAccessTokenVerificationException) {
       return _i10.FacebookAccessTokenVerificationException.fromJson(data) as T;
     }
-    if (t == _i11.FirebaseIdTokenVerificationException) {
-      return _i11.FirebaseIdTokenVerificationException.fromJson(data) as T;
+    if (t == _i11.FirebaseEmailNotVerifiedException) {
+      return _i11.FirebaseEmailNotVerifiedException.fromJson(data) as T;
     }
-    if (t == _i12.GitHubAccessTokenVerificationException) {
-      return _i12.GitHubAccessTokenVerificationException.fromJson(data) as T;
+    if (t == _i12.FirebaseIdTokenVerificationException) {
+      return _i12.FirebaseIdTokenVerificationException.fromJson(data) as T;
     }
-    if (t == _i13.GoogleIdTokenVerificationException) {
-      return _i13.GoogleIdTokenVerificationException.fromJson(data) as T;
+    if (t == _i13.GitHubAccessTokenVerificationException) {
+      return _i13.GitHubAccessTokenVerificationException.fromJson(data) as T;
     }
-    if (t == _i14.MicrosoftAccessTokenVerificationException) {
-      return _i14.MicrosoftAccessTokenVerificationException.fromJson(data) as T;
+    if (t == _i14.GoogleIdTokenVerificationException) {
+      return _i14.GoogleIdTokenVerificationException.fromJson(data) as T;
     }
-    if (t == _i15.PasskeyChallengeExpiredException) {
-      return _i15.PasskeyChallengeExpiredException.fromJson(data) as T;
+    if (t == _i15.MicrosoftAccessTokenVerificationException) {
+      return _i15.MicrosoftAccessTokenVerificationException.fromJson(data) as T;
     }
-    if (t == _i16.PasskeyChallengeNotFoundException) {
-      return _i16.PasskeyChallengeNotFoundException.fromJson(data) as T;
+    if (t == _i16.PasskeyChallengeExpiredException) {
+      return _i16.PasskeyChallengeExpiredException.fromJson(data) as T;
     }
-    if (t == _i17.PasskeyLoginRequest) {
-      return _i17.PasskeyLoginRequest.fromJson(data) as T;
+    if (t == _i17.PasskeyChallengeNotFoundException) {
+      return _i17.PasskeyChallengeNotFoundException.fromJson(data) as T;
     }
-    if (t == _i18.PasskeyPublicKeyNotFoundException) {
-      return _i18.PasskeyPublicKeyNotFoundException.fromJson(data) as T;
+    if (t == _i18.PasskeyLoginRequest) {
+      return _i18.PasskeyLoginRequest.fromJson(data) as T;
     }
-    if (t == _i19.PasskeyRegistrationRequest) {
-      return _i19.PasskeyRegistrationRequest.fromJson(data) as T;
+    if (t == _i19.PasskeyPublicKeyNotFoundException) {
+      return _i19.PasskeyPublicKeyNotFoundException.fromJson(data) as T;
+    }
+    if (t == _i20.PasskeyRegistrationRequest) {
+      return _i20.PasskeyRegistrationRequest.fromJson(data) as T;
     }
     if (t == _i1.getType<_i2.AnonymousAccountBlockedException?>()) {
       return (data != null
@@ -221,61 +227,67 @@ class Protocol extends _i1.SerializationManager {
               : null)
           as T;
     }
-    if (t == _i1.getType<_i11.FirebaseIdTokenVerificationException?>()) {
+    if (t == _i1.getType<_i11.FirebaseEmailNotVerifiedException?>()) {
       return (data != null
-              ? _i11.FirebaseIdTokenVerificationException.fromJson(data)
+              ? _i11.FirebaseEmailNotVerifiedException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i12.GitHubAccessTokenVerificationException?>()) {
+    if (t == _i1.getType<_i12.FirebaseIdTokenVerificationException?>()) {
       return (data != null
-              ? _i12.GitHubAccessTokenVerificationException.fromJson(data)
+              ? _i12.FirebaseIdTokenVerificationException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i13.GoogleIdTokenVerificationException?>()) {
+    if (t == _i1.getType<_i13.GitHubAccessTokenVerificationException?>()) {
       return (data != null
-              ? _i13.GoogleIdTokenVerificationException.fromJson(data)
+              ? _i13.GitHubAccessTokenVerificationException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i14.MicrosoftAccessTokenVerificationException?>()) {
+    if (t == _i1.getType<_i14.GoogleIdTokenVerificationException?>()) {
       return (data != null
-              ? _i14.MicrosoftAccessTokenVerificationException.fromJson(data)
+              ? _i14.GoogleIdTokenVerificationException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i15.PasskeyChallengeExpiredException?>()) {
+    if (t == _i1.getType<_i15.MicrosoftAccessTokenVerificationException?>()) {
       return (data != null
-              ? _i15.PasskeyChallengeExpiredException.fromJson(data)
+              ? _i15.MicrosoftAccessTokenVerificationException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i16.PasskeyChallengeNotFoundException?>()) {
+    if (t == _i1.getType<_i16.PasskeyChallengeExpiredException?>()) {
       return (data != null
-              ? _i16.PasskeyChallengeNotFoundException.fromJson(data)
+              ? _i16.PasskeyChallengeExpiredException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i17.PasskeyLoginRequest?>()) {
-      return (data != null ? _i17.PasskeyLoginRequest.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i18.PasskeyPublicKeyNotFoundException?>()) {
+    if (t == _i1.getType<_i17.PasskeyChallengeNotFoundException?>()) {
       return (data != null
-              ? _i18.PasskeyPublicKeyNotFoundException.fromJson(data)
+              ? _i17.PasskeyChallengeNotFoundException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i19.PasskeyRegistrationRequest?>()) {
+    if (t == _i1.getType<_i18.PasskeyLoginRequest?>()) {
+      return (data != null ? _i18.PasskeyLoginRequest.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i19.PasskeyPublicKeyNotFoundException?>()) {
       return (data != null
-              ? _i19.PasskeyRegistrationRequest.fromJson(data)
+              ? _i19.PasskeyPublicKeyNotFoundException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<({_i20.ByteData challenge, _i1.UuidValue id})>()) {
+    if (t == _i1.getType<_i20.PasskeyRegistrationRequest?>()) {
+      return (data != null
+              ? _i20.PasskeyRegistrationRequest.fromJson(data)
+              : null)
+          as T;
+    }
+    if (t == _i1.getType<({_i21.ByteData challenge, _i1.UuidValue id})>()) {
       return (
-            challenge: deserialize<_i20.ByteData>(
+            challenge: deserialize<_i21.ByteData>(
               ((data as Map)['n'] as Map)['challenge'],
             ),
             id: deserialize<_i1.UuidValue>(data['n']['id']),
@@ -283,7 +295,7 @@ class Protocol extends _i1.SerializationManager {
           as T;
     }
     try {
-      return _i21.Protocol().deserialize<T>(data, t);
+      return _i22.Protocol().deserialize<T>(data, t);
     } on _i1.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
@@ -306,22 +318,24 @@ class Protocol extends _i1.SerializationManager {
         'EmailAccountRequestExceptionReason',
       _i10.FacebookAccessTokenVerificationException =>
         'FacebookAccessTokenVerificationException',
-      _i11.FirebaseIdTokenVerificationException =>
+      _i11.FirebaseEmailNotVerifiedException =>
+        'FirebaseEmailNotVerifiedException',
+      _i12.FirebaseIdTokenVerificationException =>
         'FirebaseIdTokenVerificationException',
-      _i12.GitHubAccessTokenVerificationException =>
+      _i13.GitHubAccessTokenVerificationException =>
         'GitHubAccessTokenVerificationException',
-      _i13.GoogleIdTokenVerificationException =>
+      _i14.GoogleIdTokenVerificationException =>
         'GoogleIdTokenVerificationException',
-      _i14.MicrosoftAccessTokenVerificationException =>
+      _i15.MicrosoftAccessTokenVerificationException =>
         'MicrosoftAccessTokenVerificationException',
-      _i15.PasskeyChallengeExpiredException =>
+      _i16.PasskeyChallengeExpiredException =>
         'PasskeyChallengeExpiredException',
-      _i16.PasskeyChallengeNotFoundException =>
+      _i17.PasskeyChallengeNotFoundException =>
         'PasskeyChallengeNotFoundException',
-      _i17.PasskeyLoginRequest => 'PasskeyLoginRequest',
-      _i18.PasskeyPublicKeyNotFoundException =>
+      _i18.PasskeyLoginRequest => 'PasskeyLoginRequest',
+      _i19.PasskeyPublicKeyNotFoundException =>
         'PasskeyPublicKeyNotFoundException',
-      _i19.PasskeyRegistrationRequest => 'PasskeyRegistrationRequest',
+      _i20.PasskeyRegistrationRequest => 'PasskeyRegistrationRequest',
       _ => null,
     };
   }
@@ -357,23 +371,25 @@ class Protocol extends _i1.SerializationManager {
         return 'EmailAccountRequestExceptionReason';
       case _i10.FacebookAccessTokenVerificationException():
         return 'FacebookAccessTokenVerificationException';
-      case _i11.FirebaseIdTokenVerificationException():
+      case _i11.FirebaseEmailNotVerifiedException():
+        return 'FirebaseEmailNotVerifiedException';
+      case _i12.FirebaseIdTokenVerificationException():
         return 'FirebaseIdTokenVerificationException';
-      case _i12.GitHubAccessTokenVerificationException():
+      case _i13.GitHubAccessTokenVerificationException():
         return 'GitHubAccessTokenVerificationException';
-      case _i13.GoogleIdTokenVerificationException():
+      case _i14.GoogleIdTokenVerificationException():
         return 'GoogleIdTokenVerificationException';
-      case _i14.MicrosoftAccessTokenVerificationException():
+      case _i15.MicrosoftAccessTokenVerificationException():
         return 'MicrosoftAccessTokenVerificationException';
-      case _i15.PasskeyChallengeExpiredException():
+      case _i16.PasskeyChallengeExpiredException():
         return 'PasskeyChallengeExpiredException';
-      case _i16.PasskeyChallengeNotFoundException():
+      case _i17.PasskeyChallengeNotFoundException():
         return 'PasskeyChallengeNotFoundException';
-      case _i17.PasskeyLoginRequest():
+      case _i18.PasskeyLoginRequest():
         return 'PasskeyLoginRequest';
-      case _i18.PasskeyPublicKeyNotFoundException():
+      case _i19.PasskeyPublicKeyNotFoundException():
         return 'PasskeyPublicKeyNotFoundException';
-      case _i19.PasskeyRegistrationRequest():
+      case _i20.PasskeyRegistrationRequest():
         return 'PasskeyRegistrationRequest';
     }
     return null;
@@ -418,38 +434,41 @@ class Protocol extends _i1.SerializationManager {
         data['data'],
       );
     }
+    if (dataClassName == 'FirebaseEmailNotVerifiedException') {
+      return deserialize<_i11.FirebaseEmailNotVerifiedException>(data['data']);
+    }
     if (dataClassName == 'FirebaseIdTokenVerificationException') {
-      return deserialize<_i11.FirebaseIdTokenVerificationException>(
+      return deserialize<_i12.FirebaseIdTokenVerificationException>(
         data['data'],
       );
     }
     if (dataClassName == 'GitHubAccessTokenVerificationException') {
-      return deserialize<_i12.GitHubAccessTokenVerificationException>(
+      return deserialize<_i13.GitHubAccessTokenVerificationException>(
         data['data'],
       );
     }
     if (dataClassName == 'GoogleIdTokenVerificationException') {
-      return deserialize<_i13.GoogleIdTokenVerificationException>(data['data']);
+      return deserialize<_i14.GoogleIdTokenVerificationException>(data['data']);
     }
     if (dataClassName == 'MicrosoftAccessTokenVerificationException') {
-      return deserialize<_i14.MicrosoftAccessTokenVerificationException>(
+      return deserialize<_i15.MicrosoftAccessTokenVerificationException>(
         data['data'],
       );
     }
     if (dataClassName == 'PasskeyChallengeExpiredException') {
-      return deserialize<_i15.PasskeyChallengeExpiredException>(data['data']);
+      return deserialize<_i16.PasskeyChallengeExpiredException>(data['data']);
     }
     if (dataClassName == 'PasskeyChallengeNotFoundException') {
-      return deserialize<_i16.PasskeyChallengeNotFoundException>(data['data']);
+      return deserialize<_i17.PasskeyChallengeNotFoundException>(data['data']);
     }
     if (dataClassName == 'PasskeyLoginRequest') {
-      return deserialize<_i17.PasskeyLoginRequest>(data['data']);
+      return deserialize<_i18.PasskeyLoginRequest>(data['data']);
     }
     if (dataClassName == 'PasskeyPublicKeyNotFoundException') {
-      return deserialize<_i18.PasskeyPublicKeyNotFoundException>(data['data']);
+      return deserialize<_i19.PasskeyPublicKeyNotFoundException>(data['data']);
     }
     if (dataClassName == 'PasskeyRegistrationRequest') {
-      return deserialize<_i19.PasskeyRegistrationRequest>(data['data']);
+      return deserialize<_i20.PasskeyRegistrationRequest>(data['data']);
     }
     return super.deserializeByClassName(data);
   }
@@ -525,7 +544,7 @@ class Protocol extends _i1.SerializationManager {
     if (record == null) {
       return null;
     }
-    if (record is ({_i20.ByteData challenge, _i1.UuidValue id})) {
+    if (record is ({_i21.ByteData challenge, _i1.UuidValue id})) {
       return {
         "n": {
           "challenge": record.challenge.toJson(),
@@ -534,7 +553,7 @@ class Protocol extends _i1.SerializationManager {
       };
     }
     try {
-      return _i21.Protocol().mapRecordToJson(record);
+      return _i22.Protocol().mapRecordToJson(record);
     } catch (_) {}
     throw Exception('Unsupported record type ${record.runtimeType}');
   }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/providers/firebase/models/firebase_email_not_verified_exception.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/providers/firebase/models/firebase_email_not_verified_exception.dart
@@ -1,0 +1,63 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod_client/serverpod_client.dart' as _i1;
+
+/// Exception to be thrown when a Firebase account's email has not been
+/// verified, but the configured validation requires it.
+///
+/// This is only thrown when the Firebase identity provider is configured with
+/// `FirebaseIdpConfig.requireVerifiedEmail` (or a custom validation that
+/// throws it). Clients can catch this to prompt the user to verify their
+/// email address.
+abstract class FirebaseEmailNotVerifiedException
+    implements _i1.SerializableException, _i1.SerializableModel {
+  FirebaseEmailNotVerifiedException._();
+
+  factory FirebaseEmailNotVerifiedException() =
+      _FirebaseEmailNotVerifiedExceptionImpl;
+
+  factory FirebaseEmailNotVerifiedException.fromJson(
+    Map<String, dynamic> jsonSerialization,
+  ) {
+    return FirebaseEmailNotVerifiedException();
+  }
+
+  /// Returns a shallow copy of this [FirebaseEmailNotVerifiedException]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  FirebaseEmailNotVerifiedException copyWith();
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'serverpod_auth_idp.FirebaseEmailNotVerifiedException',
+    };
+  }
+
+  @override
+  String toString() {
+    return 'FirebaseEmailNotVerifiedException';
+  }
+}
+
+class _FirebaseEmailNotVerifiedExceptionImpl
+    extends FirebaseEmailNotVerifiedException {
+  _FirebaseEmailNotVerifiedExceptionImpl() : super._();
+
+  /// Returns a shallow copy of this [FirebaseEmailNotVerifiedException]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  FirebaseEmailNotVerifiedException copyWith() {
+    return FirebaseEmailNotVerifiedException();
+  }
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/providers/firebase.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/providers/firebase.dart
@@ -6,7 +6,10 @@ export 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart'
     show AuthSuccess;
 
 export '../src/generated/protocol.dart'
-    show FirebaseAccount, FirebaseIdTokenVerificationException;
+    show
+        FirebaseAccount,
+        FirebaseEmailNotVerifiedException,
+        FirebaseIdTokenVerificationException;
 export '../src/providers/firebase/business/firebase_id_token_config.dart'
     show FirebaseIdTokenValidationServerException;
 export '../src/providers/firebase/business/firebase_idp.dart';

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/protocol.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/protocol.dart
@@ -43,28 +43,30 @@ import 'providers/facebook/models/facebook_access_token_verification_exception.d
     as _i19;
 import 'providers/facebook/models/facebook_account.dart' as _i20;
 import 'providers/firebase/models/firebase_account.dart' as _i21;
-import 'providers/firebase/models/firebase_id_token_verification_exception.dart'
+import 'providers/firebase/models/firebase_email_not_verified_exception.dart'
     as _i22;
-import 'providers/github/models/github_access_token_verification_exception.dart'
+import 'providers/firebase/models/firebase_id_token_verification_exception.dart'
     as _i23;
-import 'providers/github/models/github_account.dart' as _i24;
-import 'providers/google/models/google_account.dart' as _i25;
+import 'providers/github/models/github_access_token_verification_exception.dart'
+    as _i24;
+import 'providers/github/models/github_account.dart' as _i25;
+import 'providers/google/models/google_account.dart' as _i26;
 import 'providers/google/models/google_id_token_verification_exception.dart'
-    as _i26;
-import 'providers/microsoft/models/microsoft_access_token_verification_exception.dart'
     as _i27;
-import 'providers/microsoft/models/microsoft_account.dart' as _i28;
-import 'providers/passkey/models/passkey_account.dart' as _i29;
-import 'providers/passkey/models/passkey_challenge.dart' as _i30;
+import 'providers/microsoft/models/microsoft_access_token_verification_exception.dart'
+    as _i28;
+import 'providers/microsoft/models/microsoft_account.dart' as _i29;
+import 'providers/passkey/models/passkey_account.dart' as _i30;
+import 'providers/passkey/models/passkey_challenge.dart' as _i31;
 import 'providers/passkey/models/passkey_challenge_expired_exception.dart'
-    as _i31;
-import 'providers/passkey/models/passkey_challenge_not_found_exception.dart'
     as _i32;
-import 'providers/passkey/models/passkey_login_request.dart' as _i33;
+import 'providers/passkey/models/passkey_challenge_not_found_exception.dart'
+    as _i33;
+import 'providers/passkey/models/passkey_login_request.dart' as _i34;
 import 'providers/passkey/models/passkey_public_key_not_found_exception.dart'
-    as _i34;
-import 'providers/passkey/models/passkey_registration_request.dart' as _i35;
-import 'dart:typed_data' as _i36;
+    as _i35;
+import 'providers/passkey/models/passkey_registration_request.dart' as _i36;
+import 'dart:typed_data' as _i37;
 export 'common/rate_limited_request_attempt/models/rate_limited_request_attempt.dart';
 export 'common/secret_challenge/models/secret_challenge.dart';
 export 'providers/anonymous/models/anonymous_account.dart';
@@ -83,6 +85,7 @@ export 'providers/email/models/exceptions/email_account_request_exception_reason
 export 'providers/facebook/models/facebook_access_token_verification_exception.dart';
 export 'providers/facebook/models/facebook_account.dart';
 export 'providers/firebase/models/firebase_account.dart';
+export 'providers/firebase/models/firebase_email_not_verified_exception.dart';
 export 'providers/firebase/models/firebase_id_token_verification_exception.dart';
 export 'providers/github/models/github_access_token_verification_exception.dart';
 export 'providers/github/models/github_account.dart';
@@ -1153,47 +1156,50 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (t == _i21.FirebaseAccount) {
       return _i21.FirebaseAccount.fromJson(data) as T;
     }
-    if (t == _i22.FirebaseIdTokenVerificationException) {
-      return _i22.FirebaseIdTokenVerificationException.fromJson(data) as T;
+    if (t == _i22.FirebaseEmailNotVerifiedException) {
+      return _i22.FirebaseEmailNotVerifiedException.fromJson(data) as T;
     }
-    if (t == _i23.GitHubAccessTokenVerificationException) {
-      return _i23.GitHubAccessTokenVerificationException.fromJson(data) as T;
+    if (t == _i23.FirebaseIdTokenVerificationException) {
+      return _i23.FirebaseIdTokenVerificationException.fromJson(data) as T;
     }
-    if (t == _i24.GitHubAccount) {
-      return _i24.GitHubAccount.fromJson(data) as T;
+    if (t == _i24.GitHubAccessTokenVerificationException) {
+      return _i24.GitHubAccessTokenVerificationException.fromJson(data) as T;
     }
-    if (t == _i25.GoogleAccount) {
-      return _i25.GoogleAccount.fromJson(data) as T;
+    if (t == _i25.GitHubAccount) {
+      return _i25.GitHubAccount.fromJson(data) as T;
     }
-    if (t == _i26.GoogleIdTokenVerificationException) {
-      return _i26.GoogleIdTokenVerificationException.fromJson(data) as T;
+    if (t == _i26.GoogleAccount) {
+      return _i26.GoogleAccount.fromJson(data) as T;
     }
-    if (t == _i27.MicrosoftAccessTokenVerificationException) {
-      return _i27.MicrosoftAccessTokenVerificationException.fromJson(data) as T;
+    if (t == _i27.GoogleIdTokenVerificationException) {
+      return _i27.GoogleIdTokenVerificationException.fromJson(data) as T;
     }
-    if (t == _i28.MicrosoftAccount) {
-      return _i28.MicrosoftAccount.fromJson(data) as T;
+    if (t == _i28.MicrosoftAccessTokenVerificationException) {
+      return _i28.MicrosoftAccessTokenVerificationException.fromJson(data) as T;
     }
-    if (t == _i29.PasskeyAccount) {
-      return _i29.PasskeyAccount.fromJson(data) as T;
+    if (t == _i29.MicrosoftAccount) {
+      return _i29.MicrosoftAccount.fromJson(data) as T;
     }
-    if (t == _i30.PasskeyChallenge) {
-      return _i30.PasskeyChallenge.fromJson(data) as T;
+    if (t == _i30.PasskeyAccount) {
+      return _i30.PasskeyAccount.fromJson(data) as T;
     }
-    if (t == _i31.PasskeyChallengeExpiredException) {
-      return _i31.PasskeyChallengeExpiredException.fromJson(data) as T;
+    if (t == _i31.PasskeyChallenge) {
+      return _i31.PasskeyChallenge.fromJson(data) as T;
     }
-    if (t == _i32.PasskeyChallengeNotFoundException) {
-      return _i32.PasskeyChallengeNotFoundException.fromJson(data) as T;
+    if (t == _i32.PasskeyChallengeExpiredException) {
+      return _i32.PasskeyChallengeExpiredException.fromJson(data) as T;
     }
-    if (t == _i33.PasskeyLoginRequest) {
-      return _i33.PasskeyLoginRequest.fromJson(data) as T;
+    if (t == _i33.PasskeyChallengeNotFoundException) {
+      return _i33.PasskeyChallengeNotFoundException.fromJson(data) as T;
     }
-    if (t == _i34.PasskeyPublicKeyNotFoundException) {
-      return _i34.PasskeyPublicKeyNotFoundException.fromJson(data) as T;
+    if (t == _i34.PasskeyLoginRequest) {
+      return _i34.PasskeyLoginRequest.fromJson(data) as T;
     }
-    if (t == _i35.PasskeyRegistrationRequest) {
-      return _i35.PasskeyRegistrationRequest.fromJson(data) as T;
+    if (t == _i35.PasskeyPublicKeyNotFoundException) {
+      return _i35.PasskeyPublicKeyNotFoundException.fromJson(data) as T;
+    }
+    if (t == _i36.PasskeyRegistrationRequest) {
+      return _i36.PasskeyRegistrationRequest.fromJson(data) as T;
     }
     if (t == _i1.getType<_i4.RateLimitedRequestAttempt?>()) {
       return (data != null
@@ -1283,70 +1289,76 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (t == _i1.getType<_i21.FirebaseAccount?>()) {
       return (data != null ? _i21.FirebaseAccount.fromJson(data) : null) as T;
     }
-    if (t == _i1.getType<_i22.FirebaseIdTokenVerificationException?>()) {
+    if (t == _i1.getType<_i22.FirebaseEmailNotVerifiedException?>()) {
       return (data != null
-              ? _i22.FirebaseIdTokenVerificationException.fromJson(data)
+              ? _i22.FirebaseEmailNotVerifiedException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i23.GitHubAccessTokenVerificationException?>()) {
+    if (t == _i1.getType<_i23.FirebaseIdTokenVerificationException?>()) {
       return (data != null
-              ? _i23.GitHubAccessTokenVerificationException.fromJson(data)
+              ? _i23.FirebaseIdTokenVerificationException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i24.GitHubAccount?>()) {
-      return (data != null ? _i24.GitHubAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i25.GoogleAccount?>()) {
-      return (data != null ? _i25.GoogleAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i26.GoogleIdTokenVerificationException?>()) {
+    if (t == _i1.getType<_i24.GitHubAccessTokenVerificationException?>()) {
       return (data != null
-              ? _i26.GoogleIdTokenVerificationException.fromJson(data)
+              ? _i24.GitHubAccessTokenVerificationException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i27.MicrosoftAccessTokenVerificationException?>()) {
+    if (t == _i1.getType<_i25.GitHubAccount?>()) {
+      return (data != null ? _i25.GitHubAccount.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i26.GoogleAccount?>()) {
+      return (data != null ? _i26.GoogleAccount.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i27.GoogleIdTokenVerificationException?>()) {
       return (data != null
-              ? _i27.MicrosoftAccessTokenVerificationException.fromJson(data)
+              ? _i27.GoogleIdTokenVerificationException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i28.MicrosoftAccount?>()) {
-      return (data != null ? _i28.MicrosoftAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i29.PasskeyAccount?>()) {
-      return (data != null ? _i29.PasskeyAccount.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i30.PasskeyChallenge?>()) {
-      return (data != null ? _i30.PasskeyChallenge.fromJson(data) : null) as T;
-    }
-    if (t == _i1.getType<_i31.PasskeyChallengeExpiredException?>()) {
+    if (t == _i1.getType<_i28.MicrosoftAccessTokenVerificationException?>()) {
       return (data != null
-              ? _i31.PasskeyChallengeExpiredException.fromJson(data)
+              ? _i28.MicrosoftAccessTokenVerificationException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i32.PasskeyChallengeNotFoundException?>()) {
+    if (t == _i1.getType<_i29.MicrosoftAccount?>()) {
+      return (data != null ? _i29.MicrosoftAccount.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i30.PasskeyAccount?>()) {
+      return (data != null ? _i30.PasskeyAccount.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i31.PasskeyChallenge?>()) {
+      return (data != null ? _i31.PasskeyChallenge.fromJson(data) : null) as T;
+    }
+    if (t == _i1.getType<_i32.PasskeyChallengeExpiredException?>()) {
       return (data != null
-              ? _i32.PasskeyChallengeNotFoundException.fromJson(data)
+              ? _i32.PasskeyChallengeExpiredException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i33.PasskeyLoginRequest?>()) {
-      return (data != null ? _i33.PasskeyLoginRequest.fromJson(data) : null)
-          as T;
-    }
-    if (t == _i1.getType<_i34.PasskeyPublicKeyNotFoundException?>()) {
+    if (t == _i1.getType<_i33.PasskeyChallengeNotFoundException?>()) {
       return (data != null
-              ? _i34.PasskeyPublicKeyNotFoundException.fromJson(data)
+              ? _i33.PasskeyChallengeNotFoundException.fromJson(data)
               : null)
           as T;
     }
-    if (t == _i1.getType<_i35.PasskeyRegistrationRequest?>()) {
+    if (t == _i1.getType<_i34.PasskeyLoginRequest?>()) {
+      return (data != null ? _i34.PasskeyLoginRequest.fromJson(data) : null)
+          as T;
+    }
+    if (t == _i1.getType<_i35.PasskeyPublicKeyNotFoundException?>()) {
       return (data != null
-              ? _i35.PasskeyRegistrationRequest.fromJson(data)
+              ? _i35.PasskeyPublicKeyNotFoundException.fromJson(data)
+              : null)
+          as T;
+    }
+    if (t == _i1.getType<_i36.PasskeyRegistrationRequest?>()) {
+      return (data != null
+              ? _i36.PasskeyRegistrationRequest.fromJson(data)
               : null)
           as T;
     }
@@ -1365,9 +1377,9 @@ class Protocol extends _i1.DatabaseSerializationManager {
               : null)
           as T;
     }
-    if (t == _i1.getType<({_i36.ByteData challenge, _i1.UuidValue id})>()) {
+    if (t == _i1.getType<({_i37.ByteData challenge, _i1.UuidValue id})>()) {
       return (
-            challenge: deserialize<_i36.ByteData>(
+            challenge: deserialize<_i37.ByteData>(
               ((data as Map)['n'] as Map)['challenge'],
             ),
             id: deserialize<_i1.UuidValue>(data['n']['id']),
@@ -1411,27 +1423,29 @@ class Protocol extends _i1.DatabaseSerializationManager {
         'FacebookAccessTokenVerificationException',
       _i20.FacebookAccount => 'FacebookAccount',
       _i21.FirebaseAccount => 'FirebaseAccount',
-      _i22.FirebaseIdTokenVerificationException =>
+      _i22.FirebaseEmailNotVerifiedException =>
+        'FirebaseEmailNotVerifiedException',
+      _i23.FirebaseIdTokenVerificationException =>
         'FirebaseIdTokenVerificationException',
-      _i23.GitHubAccessTokenVerificationException =>
+      _i24.GitHubAccessTokenVerificationException =>
         'GitHubAccessTokenVerificationException',
-      _i24.GitHubAccount => 'GitHubAccount',
-      _i25.GoogleAccount => 'GoogleAccount',
-      _i26.GoogleIdTokenVerificationException =>
+      _i25.GitHubAccount => 'GitHubAccount',
+      _i26.GoogleAccount => 'GoogleAccount',
+      _i27.GoogleIdTokenVerificationException =>
         'GoogleIdTokenVerificationException',
-      _i27.MicrosoftAccessTokenVerificationException =>
+      _i28.MicrosoftAccessTokenVerificationException =>
         'MicrosoftAccessTokenVerificationException',
-      _i28.MicrosoftAccount => 'MicrosoftAccount',
-      _i29.PasskeyAccount => 'PasskeyAccount',
-      _i30.PasskeyChallenge => 'PasskeyChallenge',
-      _i31.PasskeyChallengeExpiredException =>
+      _i29.MicrosoftAccount => 'MicrosoftAccount',
+      _i30.PasskeyAccount => 'PasskeyAccount',
+      _i31.PasskeyChallenge => 'PasskeyChallenge',
+      _i32.PasskeyChallengeExpiredException =>
         'PasskeyChallengeExpiredException',
-      _i32.PasskeyChallengeNotFoundException =>
+      _i33.PasskeyChallengeNotFoundException =>
         'PasskeyChallengeNotFoundException',
-      _i33.PasskeyLoginRequest => 'PasskeyLoginRequest',
-      _i34.PasskeyPublicKeyNotFoundException =>
+      _i34.PasskeyLoginRequest => 'PasskeyLoginRequest',
+      _i35.PasskeyPublicKeyNotFoundException =>
         'PasskeyPublicKeyNotFoundException',
-      _i35.PasskeyRegistrationRequest => 'PasskeyRegistrationRequest',
+      _i36.PasskeyRegistrationRequest => 'PasskeyRegistrationRequest',
       _ => null,
     };
   }
@@ -1485,33 +1499,35 @@ class Protocol extends _i1.DatabaseSerializationManager {
         return 'FacebookAccount';
       case _i21.FirebaseAccount():
         return 'FirebaseAccount';
-      case _i22.FirebaseIdTokenVerificationException():
+      case _i22.FirebaseEmailNotVerifiedException():
+        return 'FirebaseEmailNotVerifiedException';
+      case _i23.FirebaseIdTokenVerificationException():
         return 'FirebaseIdTokenVerificationException';
-      case _i23.GitHubAccessTokenVerificationException():
+      case _i24.GitHubAccessTokenVerificationException():
         return 'GitHubAccessTokenVerificationException';
-      case _i24.GitHubAccount():
+      case _i25.GitHubAccount():
         return 'GitHubAccount';
-      case _i25.GoogleAccount():
+      case _i26.GoogleAccount():
         return 'GoogleAccount';
-      case _i26.GoogleIdTokenVerificationException():
+      case _i27.GoogleIdTokenVerificationException():
         return 'GoogleIdTokenVerificationException';
-      case _i27.MicrosoftAccessTokenVerificationException():
+      case _i28.MicrosoftAccessTokenVerificationException():
         return 'MicrosoftAccessTokenVerificationException';
-      case _i28.MicrosoftAccount():
+      case _i29.MicrosoftAccount():
         return 'MicrosoftAccount';
-      case _i29.PasskeyAccount():
+      case _i30.PasskeyAccount():
         return 'PasskeyAccount';
-      case _i30.PasskeyChallenge():
+      case _i31.PasskeyChallenge():
         return 'PasskeyChallenge';
-      case _i31.PasskeyChallengeExpiredException():
+      case _i32.PasskeyChallengeExpiredException():
         return 'PasskeyChallengeExpiredException';
-      case _i32.PasskeyChallengeNotFoundException():
+      case _i33.PasskeyChallengeNotFoundException():
         return 'PasskeyChallengeNotFoundException';
-      case _i33.PasskeyLoginRequest():
+      case _i34.PasskeyLoginRequest():
         return 'PasskeyLoginRequest';
-      case _i34.PasskeyPublicKeyNotFoundException():
+      case _i35.PasskeyPublicKeyNotFoundException():
         return 'PasskeyPublicKeyNotFoundException';
-      case _i35.PasskeyRegistrationRequest():
+      case _i36.PasskeyRegistrationRequest():
         return 'PasskeyRegistrationRequest';
     }
     className = _i2.Protocol().getClassNameForObject(data);
@@ -1587,53 +1603,56 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (dataClassName == 'FirebaseAccount') {
       return deserialize<_i21.FirebaseAccount>(data['data']);
     }
+    if (dataClassName == 'FirebaseEmailNotVerifiedException') {
+      return deserialize<_i22.FirebaseEmailNotVerifiedException>(data['data']);
+    }
     if (dataClassName == 'FirebaseIdTokenVerificationException') {
-      return deserialize<_i22.FirebaseIdTokenVerificationException>(
+      return deserialize<_i23.FirebaseIdTokenVerificationException>(
         data['data'],
       );
     }
     if (dataClassName == 'GitHubAccessTokenVerificationException') {
-      return deserialize<_i23.GitHubAccessTokenVerificationException>(
+      return deserialize<_i24.GitHubAccessTokenVerificationException>(
         data['data'],
       );
     }
     if (dataClassName == 'GitHubAccount') {
-      return deserialize<_i24.GitHubAccount>(data['data']);
+      return deserialize<_i25.GitHubAccount>(data['data']);
     }
     if (dataClassName == 'GoogleAccount') {
-      return deserialize<_i25.GoogleAccount>(data['data']);
+      return deserialize<_i26.GoogleAccount>(data['data']);
     }
     if (dataClassName == 'GoogleIdTokenVerificationException') {
-      return deserialize<_i26.GoogleIdTokenVerificationException>(data['data']);
+      return deserialize<_i27.GoogleIdTokenVerificationException>(data['data']);
     }
     if (dataClassName == 'MicrosoftAccessTokenVerificationException') {
-      return deserialize<_i27.MicrosoftAccessTokenVerificationException>(
+      return deserialize<_i28.MicrosoftAccessTokenVerificationException>(
         data['data'],
       );
     }
     if (dataClassName == 'MicrosoftAccount') {
-      return deserialize<_i28.MicrosoftAccount>(data['data']);
+      return deserialize<_i29.MicrosoftAccount>(data['data']);
     }
     if (dataClassName == 'PasskeyAccount') {
-      return deserialize<_i29.PasskeyAccount>(data['data']);
+      return deserialize<_i30.PasskeyAccount>(data['data']);
     }
     if (dataClassName == 'PasskeyChallenge') {
-      return deserialize<_i30.PasskeyChallenge>(data['data']);
+      return deserialize<_i31.PasskeyChallenge>(data['data']);
     }
     if (dataClassName == 'PasskeyChallengeExpiredException') {
-      return deserialize<_i31.PasskeyChallengeExpiredException>(data['data']);
+      return deserialize<_i32.PasskeyChallengeExpiredException>(data['data']);
     }
     if (dataClassName == 'PasskeyChallengeNotFoundException') {
-      return deserialize<_i32.PasskeyChallengeNotFoundException>(data['data']);
+      return deserialize<_i33.PasskeyChallengeNotFoundException>(data['data']);
     }
     if (dataClassName == 'PasskeyLoginRequest') {
-      return deserialize<_i33.PasskeyLoginRequest>(data['data']);
+      return deserialize<_i34.PasskeyLoginRequest>(data['data']);
     }
     if (dataClassName == 'PasskeyPublicKeyNotFoundException') {
-      return deserialize<_i34.PasskeyPublicKeyNotFoundException>(data['data']);
+      return deserialize<_i35.PasskeyPublicKeyNotFoundException>(data['data']);
     }
     if (dataClassName == 'PasskeyRegistrationRequest') {
-      return deserialize<_i35.PasskeyRegistrationRequest>(data['data']);
+      return deserialize<_i36.PasskeyRegistrationRequest>(data['data']);
     }
     if (dataClassName.startsWith('serverpod.')) {
       data['className'] = dataClassName.substring(10);
@@ -1734,16 +1753,16 @@ class Protocol extends _i1.DatabaseSerializationManager {
         return _i20.FacebookAccount.t;
       case _i21.FirebaseAccount:
         return _i21.FirebaseAccount.t;
-      case _i24.GitHubAccount:
-        return _i24.GitHubAccount.t;
-      case _i25.GoogleAccount:
-        return _i25.GoogleAccount.t;
-      case _i28.MicrosoftAccount:
-        return _i28.MicrosoftAccount.t;
-      case _i29.PasskeyAccount:
-        return _i29.PasskeyAccount.t;
-      case _i30.PasskeyChallenge:
-        return _i30.PasskeyChallenge.t;
+      case _i25.GitHubAccount:
+        return _i25.GitHubAccount.t;
+      case _i26.GoogleAccount:
+        return _i26.GoogleAccount.t;
+      case _i29.MicrosoftAccount:
+        return _i29.MicrosoftAccount.t;
+      case _i30.PasskeyAccount:
+        return _i30.PasskeyAccount.t;
+      case _i31.PasskeyChallenge:
+        return _i31.PasskeyChallenge.t;
     }
     return null;
   }
@@ -1764,7 +1783,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
     if (record == null) {
       return null;
     }
-    if (record is ({_i36.ByteData challenge, _i1.UuidValue id})) {
+    if (record is ({_i37.ByteData challenge, _i1.UuidValue id})) {
       return {
         "n": {
           "challenge": record.challenge.toJson(),

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/firebase/models/firebase_email_not_verified_exception.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/firebase/models/firebase_email_not_verified_exception.dart
@@ -1,0 +1,73 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+
+/// Exception to be thrown when a Firebase account's email has not been
+/// verified, but the configured validation requires it.
+///
+/// This is only thrown when the Firebase identity provider is configured with
+/// `FirebaseIdpConfig.requireVerifiedEmail` (or a custom validation that
+/// throws it). Clients can catch this to prompt the user to verify their
+/// email address.
+abstract class FirebaseEmailNotVerifiedException
+    implements
+        _i1.SerializableException,
+        _i1.SerializableModel,
+        _i1.ProtocolSerialization {
+  FirebaseEmailNotVerifiedException._();
+
+  factory FirebaseEmailNotVerifiedException() =
+      _FirebaseEmailNotVerifiedExceptionImpl;
+
+  factory FirebaseEmailNotVerifiedException.fromJson(
+    Map<String, dynamic> jsonSerialization,
+  ) {
+    return FirebaseEmailNotVerifiedException();
+  }
+
+  /// Returns a shallow copy of this [FirebaseEmailNotVerifiedException]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  FirebaseEmailNotVerifiedException copyWith();
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'serverpod_auth_idp.FirebaseEmailNotVerifiedException',
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
+    return {
+      '__className__': 'serverpod_auth_idp.FirebaseEmailNotVerifiedException',
+    };
+  }
+
+  @override
+  String toString() {
+    return 'FirebaseEmailNotVerifiedException';
+  }
+}
+
+class _FirebaseEmailNotVerifiedExceptionImpl
+    extends FirebaseEmailNotVerifiedException {
+  _FirebaseEmailNotVerifiedExceptionImpl() : super._();
+
+  /// Returns a shallow copy of this [FirebaseEmailNotVerifiedException]
+  /// with some or all fields replaced by the given arguments.
+  @_i1.useResult
+  @override
+  FirebaseEmailNotVerifiedException copyWith() {
+    return FirebaseEmailNotVerifiedException();
+  }
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/firebase/business/firebase_idp_config.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/firebase/business/firebase_idp_config.dart
@@ -39,11 +39,18 @@ class FirebaseIdpConfig extends IdentityProviderBuilder<FirebaseIdp> {
   ///
   /// This function should throw an exception if the account details do not
   /// match the requirements. If the function returns normally, the account
-  /// is considered valid.
+  /// is considered valid. Thrown exceptions that implement
+  /// [SerializableException] are passed through to the client, while any
+  /// other exception surfaces as a generic
+  /// [FirebaseIdTokenVerificationException].
   ///
   /// It can be used to enforce additional requirements on the Firebase account
   /// details before allowing the user to sign in, such as requiring a verified
   /// email or specific email domains.
+  ///
+  /// By default all account details are accepted, including unverified
+  /// emails — see [validateFirebaseAccountDetails]. To reject accounts whose
+  /// email has not been verified, pass [requireVerifiedEmail].
   final FirebaseAccountDetailsValidation firebaseAccountDetailsValidation;
 
   /// Callback to be invoked after a new Firebase account has been created
@@ -66,15 +73,30 @@ class FirebaseIdpConfig extends IdentityProviderBuilder<FirebaseIdp> {
 
   /// Default validation function for extracted Firebase account details.
   ///
-  /// By default, this validates that the email is verified. Override this
-  /// to implement custom validation logic.
+  /// Accepts all account details, including unverified emails. Firebase
+  /// Email/Password accounts start out with an unverified email and users are
+  /// typically signed in right after signup, before they have clicked the
+  /// verification link — rejecting unverified emails would block that flow.
+  ///
+  /// To require a verified email, use [requireVerifiedEmail] instead.
   static void validateFirebaseAccountDetails(
     final FirebaseAccountDetails accountDetails,
+  ) {}
+
+  /// Validation function that requires the email to be verified when present.
+  ///
+  /// Throws a [FirebaseEmailNotVerifiedException] if an email is present but
+  /// has not been verified. Accounts without an email (e.g. phone
+  /// authentication) are accepted.
+  ///
+  /// Note that with Firebase Email/Password sign-in this blocks users from
+  /// signing in between signup and clicking the verification link Firebase
+  /// emails them.
+  static void requireVerifiedEmail(
+    final FirebaseAccountDetails accountDetails,
   ) {
-    // Firebase accounts may not have email if using phone auth
-    // Only validate verifiedEmail if email is present
     if (accountDetails.email != null && accountDetails.verifiedEmail != true) {
-      throw FirebaseUserInfoMissingDataException();
+      throw FirebaseEmailNotVerifiedException();
     }
   }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/firebase/business/firebase_idp_utils.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/firebase/business/firebase_idp_utils.dart
@@ -158,6 +158,8 @@ class FirebaseIdpUtils {
     FirebaseAccountDetails details;
     try {
       details = _parseAccountDetails(data);
+    } on SerializableException {
+      rethrow;
     } catch (e) {
       session.logAndThrow('Invalid user info from Firebase: $e');
     }
@@ -188,6 +190,8 @@ class FirebaseIdpUtils {
 
     try {
       config.firebaseAccountDetailsValidation(details);
+    } on SerializableException {
+      rethrow;
     } catch (e) {
       throw FirebaseUserInfoMissingDataException();
     }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/firebase/models/firebase_email_not_verified_exception.spy.yaml
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/firebase/models/firebase_email_not_verified_exception.spy.yaml
@@ -1,0 +1,8 @@
+### Exception to be thrown when a Firebase account's email has not been
+### verified, but the configured validation requires it.
+###
+### This is only thrown when the Firebase identity provider is configured with
+### `FirebaseIdpConfig.requireVerifiedEmail` (or a custom validation that
+### throws it). Clients can catch this to prompt the user to verify their
+### email address.
+exception: FirebaseEmailNotVerifiedException

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/firebase/firebase_idp_config_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/firebase/firebase_idp_config_test.dart
@@ -6,9 +6,13 @@ void main() {
     late FirebaseAccountDetails accountDetails;
 
     setUp(() {
-      accountDetails = _createAccountDetails(
+      accountDetails = (
+        userIdentifier: 'firebase-uid',
         email: 'test@example.com',
+        fullName: null,
+        image: null,
         verifiedEmail: false,
+        phone: null,
       );
     });
 
@@ -25,8 +29,8 @@ void main() {
     );
 
     test(
-      'when applying the requireVerifiedEmail validation then it throws a '
-      'FirebaseEmailNotVerifiedException',
+      'when applying the requireVerifiedEmail validation '
+      'then it throws a FirebaseEmailNotVerifiedException',
       () {
         expect(
           () => FirebaseIdpConfig.requireVerifiedEmail(accountDetails),
@@ -36,48 +40,58 @@ void main() {
     );
   });
 
-  group('Given account details with an email whose verification status is '
-      'unknown', () {
-    late FirebaseAccountDetails accountDetails;
+  group(
+    'Given account details with an email whose verification status is unknown',
+    () {
+      late FirebaseAccountDetails accountDetails;
 
-    setUp(() {
-      accountDetails = _createAccountDetails(
-        email: 'test@example.com',
-        verifiedEmail: null,
+      setUp(() {
+        accountDetails = (
+          userIdentifier: 'firebase-uid',
+          email: 'test@example.com',
+          fullName: null,
+          image: null,
+          verifiedEmail: null,
+          phone: null,
+        );
+      });
+
+      test(
+        'when applying the default validation then the details are accepted',
+        () {
+          expect(
+            () => FirebaseIdpConfig.validateFirebaseAccountDetails(
+              accountDetails,
+            ),
+            returnsNormally,
+          );
+        },
       );
-    });
 
-    test(
-      'when applying the default validation then the details are accepted',
-      () {
-        expect(
-          () => FirebaseIdpConfig.validateFirebaseAccountDetails(
-            accountDetails,
-          ),
-          returnsNormally,
-        );
-      },
-    );
-
-    test(
-      'when applying the requireVerifiedEmail validation then it throws a '
-      'FirebaseEmailNotVerifiedException',
-      () {
-        expect(
-          () => FirebaseIdpConfig.requireVerifiedEmail(accountDetails),
-          throwsA(isA<FirebaseEmailNotVerifiedException>()),
-        );
-      },
-    );
-  });
+      test(
+        'when applying the requireVerifiedEmail validation '
+        'then it throws a FirebaseEmailNotVerifiedException',
+        () {
+          expect(
+            () => FirebaseIdpConfig.requireVerifiedEmail(accountDetails),
+            throwsA(isA<FirebaseEmailNotVerifiedException>()),
+          );
+        },
+      );
+    },
+  );
 
   group('Given account details with a verified email', () {
     late FirebaseAccountDetails accountDetails;
 
     setUp(() {
-      accountDetails = _createAccountDetails(
+      accountDetails = (
+        userIdentifier: 'firebase-uid',
         email: 'test@example.com',
+        fullName: null,
+        image: null,
         verifiedEmail: true,
+        phone: null,
       );
     });
 
@@ -94,8 +108,8 @@ void main() {
     );
 
     test(
-      'when applying the requireVerifiedEmail validation then the details '
-      'are accepted',
+      'when applying the requireVerifiedEmail validation '
+      'then the details are accepted',
       () {
         expect(
           () => FirebaseIdpConfig.requireVerifiedEmail(accountDetails),
@@ -109,7 +123,14 @@ void main() {
     late FirebaseAccountDetails accountDetails;
 
     setUp(() {
-      accountDetails = _createAccountDetails(phone: '+1234567890');
+      accountDetails = (
+        userIdentifier: 'firebase-uid',
+        email: null,
+        fullName: null,
+        image: null,
+        verifiedEmail: null,
+        phone: '+1234567890',
+      );
     });
 
     test(
@@ -125,8 +146,8 @@ void main() {
     );
 
     test(
-      'when applying the requireVerifiedEmail validation then the details '
-      'are accepted',
+      'when applying the requireVerifiedEmail validation '
+      'then the details are accepted',
       () {
         expect(
           () => FirebaseIdpConfig.requireVerifiedEmail(accountDetails),
@@ -135,19 +156,4 @@ void main() {
       },
     );
   });
-}
-
-FirebaseAccountDetails _createAccountDetails({
-  final String? email,
-  final bool? verifiedEmail,
-  final String? phone,
-}) {
-  return (
-    userIdentifier: 'firebase-uid',
-    email: email,
-    fullName: null,
-    image: null,
-    verifiedEmail: verifiedEmail,
-    phone: phone,
-  );
 }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/firebase/firebase_idp_config_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/firebase/firebase_idp_config_test.dart
@@ -1,0 +1,153 @@
+import 'package:serverpod_auth_idp_server/providers/firebase.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given account details with an unverified email', () {
+    late FirebaseAccountDetails accountDetails;
+
+    setUp(() {
+      accountDetails = _createAccountDetails(
+        email: 'test@example.com',
+        verifiedEmail: false,
+      );
+    });
+
+    test(
+      'when applying the default validation then the details are accepted',
+      () {
+        expect(
+          () => FirebaseIdpConfig.validateFirebaseAccountDetails(
+            accountDetails,
+          ),
+          returnsNormally,
+        );
+      },
+    );
+
+    test(
+      'when applying the requireVerifiedEmail validation then it throws a '
+      'FirebaseEmailNotVerifiedException',
+      () {
+        expect(
+          () => FirebaseIdpConfig.requireVerifiedEmail(accountDetails),
+          throwsA(isA<FirebaseEmailNotVerifiedException>()),
+        );
+      },
+    );
+  });
+
+  group('Given account details with an email whose verification status is '
+      'unknown', () {
+    late FirebaseAccountDetails accountDetails;
+
+    setUp(() {
+      accountDetails = _createAccountDetails(
+        email: 'test@example.com',
+        verifiedEmail: null,
+      );
+    });
+
+    test(
+      'when applying the default validation then the details are accepted',
+      () {
+        expect(
+          () => FirebaseIdpConfig.validateFirebaseAccountDetails(
+            accountDetails,
+          ),
+          returnsNormally,
+        );
+      },
+    );
+
+    test(
+      'when applying the requireVerifiedEmail validation then it throws a '
+      'FirebaseEmailNotVerifiedException',
+      () {
+        expect(
+          () => FirebaseIdpConfig.requireVerifiedEmail(accountDetails),
+          throwsA(isA<FirebaseEmailNotVerifiedException>()),
+        );
+      },
+    );
+  });
+
+  group('Given account details with a verified email', () {
+    late FirebaseAccountDetails accountDetails;
+
+    setUp(() {
+      accountDetails = _createAccountDetails(
+        email: 'test@example.com',
+        verifiedEmail: true,
+      );
+    });
+
+    test(
+      'when applying the default validation then the details are accepted',
+      () {
+        expect(
+          () => FirebaseIdpConfig.validateFirebaseAccountDetails(
+            accountDetails,
+          ),
+          returnsNormally,
+        );
+      },
+    );
+
+    test(
+      'when applying the requireVerifiedEmail validation then the details '
+      'are accepted',
+      () {
+        expect(
+          () => FirebaseIdpConfig.requireVerifiedEmail(accountDetails),
+          returnsNormally,
+        );
+      },
+    );
+  });
+
+  group('Given account details without an email', () {
+    late FirebaseAccountDetails accountDetails;
+
+    setUp(() {
+      accountDetails = _createAccountDetails(phone: '+1234567890');
+    });
+
+    test(
+      'when applying the default validation then the details are accepted',
+      () {
+        expect(
+          () => FirebaseIdpConfig.validateFirebaseAccountDetails(
+            accountDetails,
+          ),
+          returnsNormally,
+        );
+      },
+    );
+
+    test(
+      'when applying the requireVerifiedEmail validation then the details '
+      'are accepted',
+      () {
+        expect(
+          () => FirebaseIdpConfig.requireVerifiedEmail(accountDetails),
+          returnsNormally,
+        );
+      },
+    );
+  });
+}
+
+FirebaseAccountDetails _createAccountDetails({
+  final String? email,
+  final bool? verifiedEmail,
+  final String? phone,
+}) {
+  return (
+    userIdentifier: 'firebase-uid',
+    email: email,
+    fullName: null,
+    image: null,
+    verifiedEmail: verifiedEmail,
+    phone: phone,
+  );
+}


### PR DESCRIPTION
The Firebase identity provider's default `firebaseAccountDetailsValidation` rejected any sign-in where an email was present but not verified. Firebase Email/Password accounts start out with `email_verified: false` and users are typically signed in immediately after signup, before they have clicked the verification link, so the default configuration blocked the very first `login()` call of every new user. 

Additionally, the rejection surfaced as a generic `FirebaseIdTokenVerificationException`, giving no hint that email verification was the cause.

- **The default validation now accepts all account details**, including unverified emails. Account linking is keyed on the Firebase UID, so accepting unverified emails does not allow linking into existing accounts.
- **Strict validation is now opt-in** via the new static `FirebaseIdpConfig.requireVerifiedEmail`, which can be passed as `firebaseAccountDetailsValidation`.
- **A new serializable `FirebaseEmailNotVerifiedException`** is thrown by the strict validation.
- **Validation exceptions implementing `SerializableException` are no longer swallowed.** Previously any exception from the validation callback was rewrapped twice, ending up as a generic `FirebaseIdTokenVerificationException`.

Fixes #5154 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
- The default `firebaseAccountDetailsValidation` on `FirebaseIdpConfig` no longer rejects unverified emails. Projects relying on the previous strict behavior must opt back in with `firebaseAccountDetailsValidation: FirebaseIdpConfig.requireVerifiedEmail`, which now throws the new `FirebaseEmailNotVerifiedException` (passed through to the client) instead of an exception rewrapped into `FirebaseIdTokenVerificationException`.