### PR TITLE
feat: Add support for cache busting with dedicated syntax in templating system

### DIFF
--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/web/widgets/google_sign_in_redirect_page_widget.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/web/widgets/google_sign_in_redirect_page_widget.dart
@@ -3,7 +3,7 @@ import 'package:serverpod/serverpod.dart';
 ///
 class GoogleSignInRedirectPageWidget extends WebWidget {
   @override
-  String toString() {
+  String render({String? Function(String)? onMissingVariable}) {
     return '''<html>
 
 <head>

--- a/packages/serverpod/lib/src/web_server/routes/static_route.dart
+++ b/packages/serverpod/lib/src/web_server/routes/static_route.dart
@@ -61,10 +61,8 @@ class StaticRoute extends Route {
   }
 
   /// Use [StaticRoute.withCacheBusting] to serve everything below
-  /// a given [root] with cache-busting support.
-  ///
-  /// The [mountPrefix] parameter specifies the URL prefix under which
-  /// static assets are served.
+  /// a given root with cache-busting support. The root is configured by
+  /// [CacheBustingConfig.fileSystemRoot]
   ///
   /// Use [cacheControlFactory] to customize what [CacheControlHeader] to
   /// return for a given asset. Defaults to a factory that produces a
@@ -73,22 +71,14 @@ class StaticRoute extends Route {
   /// The [host] parameter restricts this route to a specific virtual host
   /// (defaults to `null`, matching any host).
   factory StaticRoute.withCacheBusting(
-    Directory root, {
-    required String mountPrefix,
-    String separator = '@',
+    CacheBustingConfig config, {
     CacheControlFactory? cacheControlFactory,
     String? host,
   }) {
-    final cacheBustingConfig = CacheBustingConfig(
-      mountPrefix: mountPrefix,
-      fileSystemRoot: root,
-      separator: separator,
-    );
-
     return StaticRoute._(
       StaticHandler.directory(
-        root,
-        cacheBustingConfig: cacheBustingConfig,
+        config.fileSystemRoot,
+        cacheBustingConfig: config,
         cacheControl:
             cacheControlFactory ??
             StaticRoute.publicImmutable(maxAge: const Duration(days: 365)),

--- a/packages/serverpod/lib/src/web_server/routes/static_route.dart
+++ b/packages/serverpod/lib/src/web_server/routes/static_route.dart
@@ -60,6 +60,44 @@ class StaticRoute extends Route {
     );
   }
 
+  /// Use [StaticRoute.withCacheBusting] to serve everything below
+  /// a given [root] with cache-busting support.
+  ///
+  /// The [mountPrefix] parameter specifies the URL prefix under which
+  /// static assets are served.
+  ///
+  /// Use [cacheControlFactory] to customize what [CacheControlHeader] to
+  /// return for a given asset. Defaults to a factory that produces a
+  /// [CacheControlHeader] with public cache enabled and 1 year max age.
+  ///
+  /// The [host] parameter restricts this route to a specific virtual host
+  /// (defaults to `null`, matching any host).
+  factory StaticRoute.withCacheBusting(
+    Directory root, {
+    required String mountPrefix,
+    String separator = '@',
+    CacheControlFactory? cacheControlFactory,
+    String? host,
+  }) {
+    final cacheBustingConfig = CacheBustingConfig(
+      mountPrefix: mountPrefix,
+      fileSystemRoot: root,
+      separator: separator,
+    );
+
+    return StaticRoute._(
+      StaticHandler.directory(
+        root,
+        cacheBustingConfig: cacheBustingConfig,
+        cacheControl:
+            cacheControlFactory ??
+            StaticRoute.publicImmutable(maxAge: const Duration(days: 365)),
+      ).asHandler,
+      tailMatch: true,
+      host: host,
+    );
+  }
+
   /// Use [StaticRoute.file] to serve a single [file].
   ///
   /// Use [cacheControlFactory] to customize what [CacheControlHeader] to

--- a/packages/serverpod/lib/src/web_server/templates.dart
+++ b/packages/serverpod/lib/src/web_server/templates.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
-import 'package:mustache_template/mustache.dart';
 import 'package:path/path.dart';
+import 'package:whiskers/whiskers.dart';
 
 /// Global access to all templates loaded when starting the webserver.
 final Templates templates = Templates();
@@ -37,6 +37,8 @@ class Templates {
         _templates[templateKey] = Template(
           data,
           name: templateKey,
+          lenient: true,
+          htmlEscapeValues: false,
         );
       } else if (entity is Directory) {
         var subDirName = basename(entity.path);

--- a/packages/serverpod/lib/src/web_server/templates.dart
+++ b/packages/serverpod/lib/src/web_server/templates.dart
@@ -38,7 +38,6 @@ class Templates {
           data,
           name: templateKey,
           lenient: true,
-          htmlEscapeValues: false,
         );
       } else if (entity is Directory) {
         var subDirName = basename(entity.path);

--- a/packages/serverpod/lib/src/web_server/web_server.dart
+++ b/packages/serverpod/lib/src/web_server/web_server.dart
@@ -455,8 +455,11 @@ abstract class WidgetRoute extends Route {
   /// to a specific virtual host (defaults to `null`, matching any host).
   WidgetRoute({super.methods, super.path, super.host, this.cacheBustingConfig});
 
-  /// Used to cache-bust paths for {{@/path/to/asset}} patterns in the template.
+  /// Used to cache-bust paths for `{{{@/path/to/asset}}}` patterns in the template.
   final CacheBustingConfig? cacheBustingConfig;
+
+  /// Matches `@/path/to/asset` patterns in the template.
+  final _cacheBustingPathRegExp = RegExp(r'@/[^}]+');
 
   /// Override this method to build your web widget from the current [session]
   /// and [request].
@@ -487,13 +490,22 @@ abstract class WidgetRoute extends Route {
       ),
     );
 
-    // Cache-bust paths for {{@/path/to/asset}} patterns in the template.
+    // Cache-bust paths for {{{@/path/to/asset}}} patterns in the template.
     // This warms up CacheBustingConfig's cache so that the
     // cache-busted paths are available synchronously when rendering.
     if (cacheBustingConfig case final buster?) {
-      final regex = RegExp(r'\{\{@(/[^}]+)\}\}');
+      final regex = RegExp(r'\{\{\{@(/[^}]+)\}\}\}');
       final matches = regex
-          .allMatches(widget.render(onMissingVariable: (name) => '{{$name}}'))
+          .allMatches(
+            widget.render(
+              onMissingVariable: (name) {
+                if (_cacheBustingPathRegExp.hasMatch(name)) {
+                  return '{{{$name}}}';
+                }
+                return '{{$name}}';
+              },
+            ),
+          )
           .toList();
       for (final match in matches) {
         await buster.tryAssetPath(match.group(1)!);
@@ -503,10 +515,11 @@ abstract class WidgetRoute extends Route {
     final renderedContent = widget.render(
       onMissingVariable: (name) {
         if (cacheBustingConfig case final buster?) {
-          // Strip leading '@' from the name
-          // which is used to indicate that the asset should be cache-busted.
-          if (name.startsWith('@')) name = name.substring(1);
-          return buster.tryAssetPathSync(name);
+          if (_cacheBustingPathRegExp.hasMatch(name)) {
+            // Strip leading '@' from the path
+            // which is used to indicate that the asset should be cache-busted.
+            return buster.tryAssetPathSync(name.substring(1));
+          }
         }
         return null;
       },

--- a/packages/serverpod/lib/src/web_server/web_server.dart
+++ b/packages/serverpod/lib/src/web_server/web_server.dart
@@ -453,7 +453,10 @@ abstract class WidgetRoute extends Route {
   /// respond to (defaults to GET only). The [path] parameter specifies the
   /// suffix path (defaults to '/'). The [host] parameter restricts this route
   /// to a specific virtual host (defaults to `null`, matching any host).
-  WidgetRoute({super.methods, super.path, super.host});
+  WidgetRoute({super.methods, super.path, super.host, this.cacheBustingConfig});
+
+  /// Used to cache-bust paths for {{@/path/to/asset}} patterns in the template.
+  final CacheBustingConfig? cacheBustingConfig;
 
   /// Override this method to build your web widget from the current [session]
   /// and [request].
@@ -484,8 +487,33 @@ abstract class WidgetRoute extends Route {
       ),
     );
 
+    // Cache-bust paths for {{@/path/to/asset}} patterns in the template.
+    // This warms up CacheBustingConfig's cache so that the
+    // cache-busted paths are available synchronously when rendering.
+    if (cacheBustingConfig case final buster?) {
+      final regex = RegExp(r'\{\{@(/[^}]+)\}\}');
+      final matches = regex
+          .allMatches(widget.render(onMissingVariable: (name) => '{{$name}}'))
+          .toList();
+      for (final match in matches) {
+        await buster.tryAssetPath(match.group(1)!);
+      }
+    }
+
+    final renderedContent = widget.render(
+      onMissingVariable: (name) {
+        if (cacheBustingConfig case final buster?) {
+          // Strip leading '@' from the name
+          // which is used to indicate that the asset should be cache-busted.
+          if (name.startsWith('@')) name = name.substring(1);
+          return buster.tryAssetPathSync(name);
+        }
+        return null;
+      },
+    );
+
     return Response.ok(
-      body: Body.fromString(widget.toString(), mimeType: mimeType),
+      body: Body.fromString(renderedContent, mimeType: mimeType),
       headers: headers,
     );
   }

--- a/packages/serverpod/lib/src/web_server/widgets/web_widget.dart
+++ b/packages/serverpod/lib/src/web_server/widgets/web_widget.dart
@@ -1,11 +1,15 @@
-import 'package:mustache_template/mustache.dart';
-import 'package:serverpod/serverpod.dart';
 import 'dart:convert';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:whiskers/whiskers.dart';
 
 /// The base class for all web widgets. Override this class to create a custom
 /// widget type, or use one of the default types which covers most common use
 /// cases.
-abstract class WebWidget {}
+abstract class WebWidget {
+  /// Renders the widget.
+  String render({String? Function(String)? onMissingVariable});
+}
 
 /// A [WebWidget] based on a HTML template. The [name] of the template should
 /// correspond to a template file in your server's web/templates directory.
@@ -39,8 +43,14 @@ class TemplateWidget extends WebWidget {
   }
 
   @override
-  String toString() {
-    return template.renderString(values);
+  String toString() => render();
+
+  @override
+  String render({String? Function(String)? onMissingVariable}) {
+    return template.renderString(
+      values,
+      onMissingVariable: (name, context) => onMissingVariable?.call(name),
+    );
   }
 }
 
@@ -53,10 +63,13 @@ class ListWidget extends WebWidget {
   ListWidget({required this.widgets});
 
   @override
-  String toString() {
+  String toString() => render();
+
+  @override
+  String render({String? Function(String)? onMissingVariable}) {
     var rendered = <String>[];
     for (var widget in widgets) {
-      rendered.add(widget.toString());
+      rendered.add(widget.render(onMissingVariable: onMissingVariable));
     }
     return rendered.join('\n');
   }
@@ -72,9 +85,12 @@ class JsonWidget extends WebWidget {
   JsonWidget({required this.object});
 
   @override
-  String toString() {
+  String render({String? Function(String)? onMissingVariable}) {
     return SerializationManager.encode(object);
   }
+
+  @override
+  String toString() => render();
 }
 
 /// A [WebWidget] that renders a HTTP redirect to the provided [url].
@@ -86,7 +102,10 @@ class RedirectWidget extends WebWidget {
   RedirectWidget({required this.url});
 
   @override
-  String toString() {
+  String render({String? Function(String)? onMissingVariable}) {
     return '';
   }
+
+  @override
+  String toString() => render();
 }

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -26,7 +26,6 @@ dependencies:
   crypto: ^3.0.2
   http: '>=1.1.0 <2.0.0'
   meta: ^1.15.0
-  mustache_template: ^2.0.0
   path: ^1.8.3
   postgres: ^3.4.0
   redis: ^4.0.0
@@ -40,6 +39,7 @@ dependencies:
   uuid: ^4.5.3
   vm_service: '>=13.0.0 <16.0.0'
   web_socket: ^1.0.1
+  whiskers: ^0.1.1
   yaml: ^3.1.2
 
 dev_dependencies:

--- a/packages/serverpod/test/web_server/static_route_with_cache_busting_test.dart
+++ b/packages/serverpod/test/web_server/static_route_with_cache_busting_test.dart
@@ -1,0 +1,156 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/generated/protocol.dart' as internal;
+import 'package:test/test.dart';
+import 'package:path/path.dart' as p;
+
+import '../server/test_helpers/empty_endpoints.dart';
+
+void main() {
+  final portZeroConfig = ServerConfig(
+    port: 0,
+    publicScheme: 'http',
+    publicHost: 'localhost',
+    publicPort: 0,
+  );
+
+  group('Given a web server', () {
+    late Directory tempDir;
+    late Serverpod pod;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('static_route_test_');
+      await File(
+        p.join(tempDir.path, 'test.txt'),
+      ).writeAsString('Hello, World!');
+
+      pod = Serverpod(
+        [],
+        internal.Protocol(),
+        EmptyEndpoints(),
+        config: ServerpodConfig(
+          apiServer: portZeroConfig,
+          webServer: portZeroConfig,
+        ),
+      );
+    });
+
+    tearDown(() async {
+      await pod.shutdown(exitProcess: false);
+      await tempDir.delete(recursive: true);
+    });
+
+    test(
+      'when StaticRoute.withCacheBusting is created with a mount prefix, '
+      'then it serves files correctly',
+      () async {
+        pod.webServer.addRoute(
+          StaticRoute.withCacheBusting(
+            tempDir,
+            mountPrefix: '/static',
+          ),
+          '/static',
+        );
+
+        await pod.start();
+        var port = pod.webServer.port!;
+
+        var response = await http.get(
+          Uri.parse('http://localhost:$port/static/test.txt'),
+        );
+
+        expect(response.statusCode, 200);
+        expect(response.body, 'Hello, World!');
+      },
+    );
+
+    test(
+      'when StaticRoute.withCacheBusting is created without a cache control factory, '
+      'then it defaults to public immutable with 1 year max age',
+      () async {
+        pod.webServer.addRoute(
+          StaticRoute.withCacheBusting(
+            tempDir,
+            mountPrefix: '/static',
+          ),
+          '/static',
+        );
+
+        await pod.start();
+        var port = pod.webServer.port!;
+
+        var response = await http.get(
+          Uri.parse('http://localhost:$port/static/test.txt'),
+        );
+
+        expect(response.statusCode, 200);
+        expect(response.headers['cache-control'], contains('public'));
+        expect(response.headers['cache-control'], contains('immutable'));
+        expect(response.headers['cache-control'], contains('max-age=31536000'));
+
+        await pod.shutdown(exitProcess: false);
+      },
+    );
+
+    test(
+      'when StaticRoute.withCacheBusting is created with a custom cache control, '
+      'then it uses the custom cache control',
+      () async {
+        pod.webServer.addRoute(
+          StaticRoute.withCacheBusting(
+            tempDir,
+            mountPrefix: '/static',
+            cacheControlFactory: StaticRoute.noStore(),
+          ),
+          '/static',
+        );
+
+        await pod.start();
+        var port = pod.webServer.port!;
+
+        var response = await http.get(
+          Uri.parse('http://localhost:$port/static/test.txt'),
+        );
+
+        expect(response.statusCode, 200);
+        expect(response.headers['cache-control'], 'no-store');
+
+        await pod.shutdown(exitProcess: false);
+      },
+    );
+
+    test(
+      'when StaticRoute.withCacheBusting is created with a host parameter, '
+      'then it only responds to that host',
+      () async {
+        pod.webServer.addRoute(
+          StaticRoute.withCacheBusting(
+            tempDir,
+            mountPrefix: '/static',
+            host: 'assets.example.com',
+          ),
+          '/static',
+        );
+
+        await pod.start();
+        var port = pod.webServer.port!;
+
+        var responseNoHost = await http.get(
+          Uri.parse('http://localhost:$port/static/test.txt'),
+        );
+        expect(responseNoHost.statusCode, 404);
+
+        var responseWithHost = await http.get(
+          Uri.parse('http://localhost:$port/static/test.txt'),
+          headers: {'Host': 'assets.example.com'},
+        );
+        expect(responseWithHost.statusCode, 200);
+        expect(responseWithHost.body, 'Hello, World!');
+
+        await pod.shutdown(exitProcess: false);
+      },
+    );
+  });
+}

--- a/packages/serverpod/test/web_server/static_route_with_cache_busting_test.dart
+++ b/packages/serverpod/test/web_server/static_route_with_cache_busting_test.dart
@@ -48,8 +48,7 @@ void main() {
       () async {
         pod.webServer.addRoute(
           StaticRoute.withCacheBusting(
-            tempDir,
-            mountPrefix: '/static',
+            CacheBustingConfig(mountPrefix: '/static', fileSystemRoot: tempDir),
           ),
           '/static',
         );
@@ -72,8 +71,7 @@ void main() {
       () async {
         pod.webServer.addRoute(
           StaticRoute.withCacheBusting(
-            tempDir,
-            mountPrefix: '/static',
+            CacheBustingConfig(mountPrefix: '/static', fileSystemRoot: tempDir),
           ),
           '/static',
         );
@@ -100,8 +98,7 @@ void main() {
       () async {
         pod.webServer.addRoute(
           StaticRoute.withCacheBusting(
-            tempDir,
-            mountPrefix: '/static',
+            CacheBustingConfig(mountPrefix: '/static', fileSystemRoot: tempDir),
             cacheControlFactory: StaticRoute.noStore(),
           ),
           '/static',
@@ -127,8 +124,7 @@ void main() {
       () async {
         pod.webServer.addRoute(
           StaticRoute.withCacheBusting(
-            tempDir,
-            mountPrefix: '/static',
+            CacheBustingConfig(mountPrefix: '/static', fileSystemRoot: tempDir),
             host: 'assets.example.com',
           ),
           '/static',

--- a/packages/serverpod/test/web_server/web_widget_render_test.dart
+++ b/packages/serverpod/test/web_server/web_widget_render_test.dart
@@ -1,0 +1,114 @@
+import 'dart:io';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+void main() {
+  group('WebWidget', () {
+    test(
+      'Given a template with variables, '
+      'when render is called with onMissingVariable callback, '
+      'then missing variables are delegated to the callback',
+      () async {
+        await d.file('template_missing_var.html', '''
+<h1>Hello {{name}}</h1><p>{{missing}}</p>''').create();
+
+        await templates.loadAll(Directory(d.sandbox));
+
+        final widget = TemplateWidget(
+          name: 'template_missing_var',
+          values: {'name': 'World'},
+        );
+
+        final missingVars = <String>[];
+        final output = widget.render(
+          onMissingVariable: (name) {
+            missingVars.add(name);
+            return 'fallback:$name';
+          },
+        );
+
+        expect(output, '<h1>Hello World</h1><p>fallback:missing</p>');
+        expect(missingVars, ['missing']);
+      },
+    );
+
+    test(
+      'Given a ListWidget with multiple templates, '
+      'when render is called with onMissingVariable, '
+      'then the callback is forwarded to individual templates',
+      () async {
+        await d.file('1.html', '<p>{{value}}</p>').create();
+        await d.file('2.html', '<span>{{value}}</span>').create();
+
+        await templates.loadAll(Directory(d.sandbox));
+
+        final missingVars = <String>[];
+        final child1 = TemplateWidget(name: '1', values: {'value': 'hello'});
+        final child2 = TemplateWidget(name: '2', values: {});
+        final listWidget = ListWidget(widgets: [child1, child2]);
+
+        final output = listWidget.render(
+          onMissingVariable: (name) {
+            missingVars.add(name);
+            return 'fallback';
+          },
+        );
+
+        expect(output, '<p>hello</p>\n<span>fallback</span>');
+        expect(missingVars, ['value']);
+      },
+    );
+
+    test(
+      'Given a JsonWidget, when render is called with onMissingVariable, '
+      'then the callback is not invoked',
+      () {
+        final widget = JsonWidget(object: {'key': '{{value}}'});
+
+        final output = widget.render(
+          onMissingVariable: (name) => 'SHOULD_NOT_APPEAR',
+        );
+
+        expect(output, contains('"key"'));
+        expect(output, contains('"{{value}}"'));
+      },
+    );
+
+    test(
+      'Given a RedirectWidget, when render is called with onMissingVariable, '
+      'then empty string is returned',
+      () {
+        final widget = RedirectWidget(url: '/redirected');
+
+        final output = widget.render(
+          onMissingVariable: (name) => 'SHOULD_NOT_APPEAR',
+        );
+
+        expect(output, '');
+      },
+    );
+
+    test(
+      'Given a template with a variable, '
+      'when render is called without onMissingVariable, '
+      'then missing variables are rendered as empty strings',
+      () async {
+        await d.file('template_no_callback.html', '''
+<h1>Hello {{name}}</h1><p>{{missing}}</p>''').create();
+
+        await templates.loadAll(Directory(d.sandbox));
+
+        final widget = TemplateWidget(
+          name: 'template_no_callback',
+          values: {'name': 'World'},
+        );
+
+        final output = widget.render();
+
+        expect(output, '<h1>Hello World</h1><p></p>');
+      },
+    );
+  });
+}

--- a/packages/serverpod/test/web_server/widget_route_cache_busting_test.dart
+++ b/packages/serverpod/test/web_server/widget_route_cache_busting_test.dart
@@ -1,0 +1,130 @@
+import 'dart:io';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/generated/endpoints.dart';
+import 'package:serverpod/src/generated/protocol.dart' as internal;
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+final portZeroConfig = ServerConfig(
+  port: 0,
+  publicScheme: 'http',
+  publicHost: 'localhost',
+  publicPort: 0,
+);
+
+class CacheBustWidgetRoute extends WidgetRoute {
+  CacheBustWidgetRoute({super.cacheBustingConfig});
+
+  @override
+  Future<WebWidget> build(Session session, Request request) async {
+    return TemplateWidget(name: 'cache_bust_page');
+  }
+}
+
+class NonBustWidgetRoute extends WidgetRoute {
+  NonBustWidgetRoute();
+
+  @override
+  Future<WebWidget> build(Session session, Request request) async {
+    return TemplateWidget(name: 'non_bust_page');
+  }
+}
+
+void main() {
+  group('Given a WidgetRoute with cacheBustingConfig', () {
+    late Serverpod pod;
+    late int port;
+    late Directory assetDir;
+
+    setUp(() async {
+      assetDir = await Directory.systemTemp.createTemp('cache_bust_assets_');
+      await File(p.join(assetDir.path, 'style.css')).writeAsString('body {}');
+      await File(
+        p.join(assetDir.path, 'app.js'),
+      ).writeAsString('console.log("app");');
+
+      await d.file('cache_bust_page.html', '''
+<html>
+  <script src="{{@/static/app.js}}"></script>
+  <link rel="stylesheet" href="{{@/static/style.css}}">
+</html>''').create();
+
+      await d.file('non_bust_page.html', '''
+<html>
+  <script src="/static/app.js"></script>
+</html>''').create();
+
+      await templates.loadAll(Directory(d.sandbox));
+
+      pod = Serverpod(
+        [],
+        internal.Protocol(),
+        Endpoints(),
+        config: ServerpodConfig(
+          apiServer: portZeroConfig,
+          webServer: portZeroConfig,
+        ),
+      );
+
+      pod.webServer.addRoute(
+        CacheBustWidgetRoute(
+          cacheBustingConfig: CacheBustingConfig(
+            mountPrefix: '/static',
+            fileSystemRoot: assetDir,
+          ),
+        ),
+        '/bust-page',
+      );
+
+      pod.webServer.addRoute(
+        NonBustWidgetRoute(),
+        '/non-bust-page',
+      );
+
+      await pod.start();
+      port = pod.webServer.port!;
+    });
+
+    tearDown(() async {
+      await pod.shutdown(exitProcess: false);
+      await assetDir.delete(recursive: true);
+      templates.clear();
+    });
+
+    test(
+      'when template uses cache-busting patterns, then response contains cache-busted paths',
+      () async {
+        var response = await http.get(
+          Uri.parse('http://localhost:$port/bust-page'),
+        );
+
+        expect(response.statusCode, 200);
+        expect(response.body, contains('src="/static/app@'));
+        expect(response.body, contains('href="/static/style@'));
+        expect(response.body, contains('.js">'));
+        expect(response.body, contains('.css">'));
+        expect(response.body, isNot(contains('{{')));
+      },
+    );
+
+    test(
+      'when template has no cache-busting pattern, then response is unchanged',
+      () async {
+        var response = await http.get(
+          Uri.parse('http://localhost:$port/non-bust-page'),
+        );
+
+        expect(response.statusCode, 200);
+        expect(
+          response.body,
+          '<html>\n'
+          '  <script src="/static/app.js"></script>\n'
+          '</html>',
+        );
+      },
+    );
+  });
+}

--- a/packages/serverpod/test/web_server/widget_route_cache_busting_test.dart
+++ b/packages/serverpod/test/web_server/widget_route_cache_busting_test.dart
@@ -48,8 +48,8 @@ void main() {
 
       await d.file('cache_bust_page.html', '''
 <html>
-  <script src="{{@/static/app.js}}"></script>
-  <link rel="stylesheet" href="{{@/static/style.css}}">
+  <script src="{{{@/static/app.js}}}"></script>
+  <link rel="stylesheet" href="{{{@/static/style.css}}}">
 </html>''').create();
 
       await d.file('non_bust_page.html', '''

--- a/packages/serverpod/test/web_server/widget_route_methods_test.dart
+++ b/packages/serverpod/test/web_server/widget_route_methods_test.dart
@@ -10,7 +10,9 @@ class TestWidget extends WebWidget {
   TestWidget(this.method);
 
   @override
-  String toString() => '<html><body>Method: $method</body></html>';
+  String render({String? Function(String)? onMissingVariable}) {
+    return '<html><body>Method: $method</body></html>';
+  }
 }
 
 class GetPostRoute extends WidgetRoute {

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   crypto: ^3.0.2
   http: '>=1.1.0 <2.0.0'
   meta: ^1.15.0
-  mustache_template: ^2.0.0
   path: ^1.8.3
   postgres: ^3.4.0
   redis: ^4.0.0
@@ -39,6 +38,7 @@ dependencies:
   uuid: ^4.5.3
   vm_service: '>=13.0.0 <16.0.0'
   web_socket: ^1.0.1
+  whiskers: ^0.1.1
   yaml: ^3.1.2
 
 dev_dependencies:

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
@@ -60,7 +60,7 @@ void run(List<String> args) async {
   // These are used by the default web page.
   pod.webServer.addRoute(
     StaticRoute.withCacheBusting(cacheBustingConfig),
-    '/web',
+    cacheBustingConfig.mountPrefix,
   );
   // {{/webserver}}
 

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
@@ -9,7 +9,7 @@ import 'package:serverpod_auth_idp_server/providers/email.dart';
 // {{/auth}}
 
 // {{#webserver}}
-import '/src/cache_busting.dart';
+import 'src/cache_busting.dart';
 // {{/webserver}}
 import 'src/generated/endpoints.dart';
 import 'src/generated/protocol.dart';

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
@@ -8,6 +8,9 @@ import 'package:serverpod_auth_idp_server/core.dart';
 import 'package:serverpod_auth_idp_server/providers/email.dart';
 // {{/auth}}
 
+// {{#webserver}}
+import '/src/cache_busting.dart';
+// {{/webserver}}
 import 'src/generated/endpoints.dart';
 import 'src/generated/protocol.dart';
 // {{#webapp}}
@@ -55,9 +58,8 @@ void run(List<String> args) async {
   // {{#webserver}}
   // Serve all files in the web/static relative directory under /web.
   // These are used by the default web page.
-  final root = Directory(Uri(path: 'web/static').toFilePath());
   pod.webServer.addRoute(
-    StaticRoute.withCacheBusting(root, mountPrefix: '/web'),
+    StaticRoute.withCacheBusting(cacheBustingConfig),
     '/web',
   );
   // {{/webserver}}

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
@@ -56,7 +56,10 @@ void run(List<String> args) async {
   // Serve all files in the web/static relative directory under /web.
   // These are used by the default web page.
   final root = Directory(Uri(path: 'web/static').toFilePath());
-  pod.webServer.addRoute(StaticRoute.directory(root), '/web');
+  pod.webServer.addRoute(
+    StaticRoute.withCacheBusting(root, mountPrefix: '/web'),
+    '/web',
+  );
   // {{/webserver}}
 
   // {{#webapp}}

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
@@ -1,6 +1,6 @@
-// {{#webserver}}
+// {{#webapp}}
 import 'dart:io';
-// {{/webserver}}
+// {{/webapp}}
 
 import 'package:serverpod/serverpod.dart';
 // {{#auth}}

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/src/{{#webserver}}cache_busting{{!webserver}}.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/src/{{#webserver}}cache_busting{{!webserver}}.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:serverpod/serverpod.dart';
 
+/// Cache busting configuration.
+/// Used in WidgetRoutes to cache-bust asset paths.
 final cacheBustingConfig = CacheBustingConfig(
   mountPrefix: '/web',
   fileSystemRoot: Directory(Uri(path: 'web/static').toFilePath()),

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/src/{{#webserver}}cache_busting{{!webserver}}.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/src/{{#webserver}}cache_busting{{!webserver}}.dart
@@ -1,0 +1,8 @@
+import 'dart:io';
+
+import 'package:serverpod/serverpod.dart';
+
+final cacheBustingConfig = CacheBustingConfig(
+  mountPrefix: '/web',
+  fileSystemRoot: Directory(Uri(path: 'web/static').toFilePath()),
+);

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/src/{{#webserver}}web{{!webserver}}/routes/root.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/src/{{#webserver}}web{{!webserver}}/routes/root.dart
@@ -1,7 +1,10 @@
+import 'package:projectname_server/src/cache_busting.dart';
 import 'package:projectname_server/src/web/widgets/built_with_serverpod_page.dart';
 import 'package:serverpod/serverpod.dart';
 
 class RootRoute extends WidgetRoute {
+  RootRoute() : super(cacheBustingConfig: cacheBustingConfig);
+
   @override
   Future<TemplateWidget> build(Session session, Request request) async {
     return BuiltWithServerpodPageWidget();

--- a/templates/serverpod_templates/projectname_server_upgrade/{{#webserver}}web{{!webserver}}/templates/built_with_serverpod.html
+++ b/templates/serverpod_templates/projectname_server_upgrade/{{#webserver}}web{{!webserver}}/templates/built_with_serverpod.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8">
     <title>Built with Serverpod</title>
-    <link rel="stylesheet" href="/web/css/style.css">
+    <link rel="stylesheet" href="{{@/web/css/style.css}}">
   </head>
   <body>
     <div class="content">
       <div class="logo-box">
-        <img src="/web/images/serverpod-logo.svg" width="160" style="margin-top: 8px; margin-bottom: 12px;">
+        <img src="{{@/web/images/serverpod-logo.svg}}" width="160" style="margin-top: 8px; margin-bottom: 12px;">
         <p><a href="https://serverpod.dev/">The missing server for Flutter</a></p>
       </div>
       <hr>

--- a/templates/serverpod_templates/projectname_server_upgrade/{{#webserver}}web{{!webserver}}/templates/built_with_serverpod.html
+++ b/templates/serverpod_templates/projectname_server_upgrade/{{#webserver}}web{{!webserver}}/templates/built_with_serverpod.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8">
     <title>Built with Serverpod</title>
-    <link rel="stylesheet" href="{{@/web/css/style.css}}">
+    <link rel="stylesheet" href="{{{@/web/css/style.css}}}">
   </head>
   <body>
     <div class="content">
       <div class="logo-box">
-        <img src="{{@/web/images/serverpod-logo.svg}}" width="160" style="margin-top: 8px; margin-bottom: 12px;">
+        <img src="{{{@/web/images/serverpod-logo.svg}}}" width="160" style="margin-top: 8px; margin-bottom: 12px;">
         <p><a href="https://serverpod.dev/">The missing server for Flutter</a></p>
       </div>
       <hr>

--- a/tests/bootstrap_project/test/project_quickstart_test.dart
+++ b/tests/bootstrap_project/test/project_quickstart_test.dart
@@ -97,6 +97,25 @@ void main() async {
                 );
               });
 
+              test(
+                'has a src/cache_busting.dart file',
+                () {
+                  expect(
+                    File(
+                      path.join(
+                        tempPath,
+                        serverDir,
+                        'lib',
+                        'src',
+                        'cache_busting.dart',
+                      ),
+                    ).existsSync(),
+                    isTrue,
+                    reason: 'Server cache_busting.dart file does not exist.',
+                  );
+                },
+              );
+
               test('has a server.dart file', () {
                 expect(
                   File(
@@ -105,6 +124,95 @@ void main() async {
                   isTrue,
                 );
               });
+
+              test(
+                'then the server.dart contains webapp configurations',
+                () {
+                  final file = File(
+                    path.join(tempPath, serverDir, 'lib', 'server.dart'),
+                  );
+
+                  final content = file.readAsStringSync();
+
+                  expect(
+                    content,
+                    contains("import 'src/web/routes/app_config_route.dart';"),
+                    reason:
+                        'server.dart does not contain webapp configurations.',
+                  );
+
+                  expect(
+                    content,
+                    contains(
+                      "final root = Directory(Uri(path: 'web/static').toFilePath())",
+                    ),
+                    reason:
+                        'server.dart does not contain webapp configurations.',
+                  );
+
+                  expect(
+                    content,
+                    contains(
+                      "StaticRoute.withCacheBusting(root, mountPrefix: '/web')",
+                    ),
+                    reason:
+                        'server.dart does not contain webapp configurations.',
+                  );
+
+                  expect(
+                    content,
+                    contains('AppConfigRoute(apiConfig: pod.config.apiServer)'),
+                    reason:
+                        'server.dart does not contain webapp configurations.',
+                  );
+
+                  expect(
+                    content,
+                    contains(
+                      "final appDir = Directory(Uri(path: 'web/app').toFilePath())",
+                    ),
+                    reason:
+                        'server.dart does not contain webapp configurations.',
+                  );
+
+                  expect(
+                    content,
+                    contains('if (appDir.existsSync()) {'),
+                    reason:
+                        'server.dart does not contain webapp configurations.',
+                  );
+
+                  expect(
+                    content,
+                    contains(
+                      "Uri(path: 'web/pages/build_flutter_app.html').toFilePath()",
+                    ),
+                    reason:
+                        'server.dart does not contain webapp configurations.',
+                  );
+
+                  expect(
+                    content,
+                    contains('pod.webServer.addMiddleware('),
+                    reason:
+                        'server.dart does not contain webapp configurations.',
+                  );
+
+                  expect(
+                    content,
+                    contains('FallbackMiddleware('),
+                    reason:
+                        'server.dart does not contain webapp configurations.',
+                  );
+
+                  expect(
+                    content,
+                    contains('on: (response) => response.statusCode == 404'),
+                    reason:
+                        'server.dart does not contain webapp configurations.',
+                  );
+                },
+              );
 
               test('has an example_endpoint file', () {
                 expect(

--- a/tests/bootstrap_project/test/project_quickstart_test.dart
+++ b/tests/bootstrap_project/test/project_quickstart_test.dart
@@ -136,6 +136,13 @@ void main() async {
 
                   expect(
                     content,
+                    contains("import 'src/cache_busting.dart';"),
+                    reason:
+                        'server.dart does not contain webapp configurations.',
+                  );
+
+                  expect(
+                    content,
                     contains("import 'src/web/routes/app_config_route.dart';"),
                     reason:
                         'server.dart does not contain webapp configurations.',
@@ -144,16 +151,7 @@ void main() async {
                   expect(
                     content,
                     contains(
-                      "final root = Directory(Uri(path: 'web/static').toFilePath())",
-                    ),
-                    reason:
-                        'server.dart does not contain webapp configurations.',
-                  );
-
-                  expect(
-                    content,
-                    contains(
-                      "StaticRoute.withCacheBusting(root, mountPrefix: '/web')",
+                      'StaticRoute.withCacheBusting(cacheBustingConfig)',
                     ),
                     reason:
                         'server.dart does not contain webapp configurations.',

--- a/tests/bootstrap_project/test/project_server_test.dart
+++ b/tests/bootstrap_project/test/project_server_test.dart
@@ -378,6 +378,12 @@ void main() async {
 
               expect(
                 content,
+                contains("import 'src/cache_busting.dart';"),
+                reason: 'server.dart does not contain website configurations.',
+              );
+
+              expect(
+                content,
                 contains("import 'src/web/routes/root.dart';"),
                 reason: 'server.dart does not contain website configurations.',
               );
@@ -396,17 +402,7 @@ void main() async {
 
               expect(
                 content,
-                contains(
-                  "final root = Directory(Uri(path: 'web/static').toFilePath())",
-                ),
-                reason: 'server.dart does not contain website configurations.',
-              );
-
-              expect(
-                content,
-                contains(
-                  "StaticRoute.withCacheBusting(root, mountPrefix: '/web')",
-                ),
+                contains('StaticRoute.withCacheBusting(cacheBustingConfig)'),
                 reason: 'server.dart does not contain website configurations.',
               );
             },

--- a/tests/bootstrap_project/test/project_server_test.dart
+++ b/tests/bootstrap_project/test/project_server_test.dart
@@ -341,6 +341,22 @@ void main() async {
             );
           });
 
+          test('then the server project has a src/cache_busting.dart file', () {
+            expect(
+              File(
+                path.join(
+                  tempPath,
+                  serverDir,
+                  'lib',
+                  'src',
+                  'cache_busting.dart',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason: 'Server cache_busting.dart file does not exist.',
+            );
+          });
+
           test('then the server project has a server.dart file', () {
             expect(
               File(
@@ -389,7 +405,7 @@ void main() async {
               expect(
                 content,
                 contains(
-                  "pod.webServer.addRoute(StaticRoute.directory(root), '/web')",
+                  "StaticRoute.withCacheBusting(root, mountPrefix: '/web')",
                 ),
                 reason: 'server.dart does not contain website configurations.',
               );

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -267,6 +267,25 @@ void main() async {
           );
         });
 
+        test(
+          'has a src/cache_busting.dart file',
+          () {
+            expect(
+              File(
+                path.join(
+                  tempPath,
+                  serverDir,
+                  'lib',
+                  'src',
+                  'cache_busting.dart',
+                ),
+              ).existsSync(),
+              isTrue,
+              reason: 'Server cache_busting.dart file does not exist.',
+            );
+          },
+        );
+
         test('has a server.dart file', () {
           expect(
             File(
@@ -276,6 +295,85 @@ void main() async {
             reason: 'Server server.dart file does not exist.',
           );
         });
+
+        test(
+          'then the server.dart contains webapp configurations',
+          () {
+            final file = File(
+              path.join(tempPath, serverDir, 'lib', 'server.dart'),
+            );
+
+            final content = file.readAsStringSync();
+
+            expect(
+              content,
+              contains("import 'src/web/routes/app_config_route.dart';"),
+              reason: 'server.dart does not contain webapp configurations.',
+            );
+
+            expect(
+              content,
+              contains(
+                "final root = Directory(Uri(path: 'web/static').toFilePath())",
+              ),
+              reason: 'server.dart does not contain webapp configurations.',
+            );
+
+            expect(
+              content,
+              contains(
+                "StaticRoute.withCacheBusting(root, mountPrefix: '/web')",
+              ),
+              reason: 'server.dart does not contain webapp configurations.',
+            );
+
+            expect(
+              content,
+              contains('AppConfigRoute(apiConfig: pod.config.apiServer)'),
+              reason: 'server.dart does not contain webapp configurations.',
+            );
+
+            expect(
+              content,
+              contains(
+                "final appDir = Directory(Uri(path: 'web/app').toFilePath())",
+              ),
+              reason: 'server.dart does not contain webapp configurations.',
+            );
+
+            expect(
+              content,
+              contains('if (appDir.existsSync()) {'),
+              reason: 'server.dart does not contain webapp configurations.',
+            );
+
+            expect(
+              content,
+              contains(
+                "Uri(path: 'web/pages/build_flutter_app.html').toFilePath()",
+              ),
+              reason: 'server.dart does not contain webapp configurations.',
+            );
+
+            expect(
+              content,
+              contains('pod.webServer.addMiddleware('),
+              reason: 'server.dart does not contain webapp configurations.',
+            );
+
+            expect(
+              content,
+              contains('FallbackMiddleware('),
+              reason: 'server.dart does not contain webapp configurations.',
+            );
+
+            expect(
+              content,
+              contains('on: (response) => response.statusCode == 404'),
+              reason: 'server.dart does not contain webapp configurations.',
+            );
+          },
+        );
 
         test('has a Dockerfile', () {
           expect(

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -313,17 +313,13 @@ void main() async {
 
             expect(
               content,
-              contains(
-                "final root = Directory(Uri(path: 'web/static').toFilePath())",
-              ),
+              contains("import 'src/cache_busting.dart';"),
               reason: 'server.dart does not contain webapp configurations.',
             );
 
             expect(
               content,
-              contains(
-                "StaticRoute.withCacheBusting(root, mountPrefix: '/web')",
-              ),
+              contains('StaticRoute.withCacheBusting(cacheBustingConfig)'),
               reason: 'server.dart does not contain webapp configurations.',
             );
 
@@ -1218,7 +1214,7 @@ void main() async {
         );
         // TODO: Remove once StaticRoute.withCacheBusting is published.
         const staticRouteCacheBusting =
-            "StaticRoute.withCacheBusting(root, mountPrefix: '/web')";
+            "StaticRoute.withCacheBusting(cacheBustingConfig)";
 
         serverFile.writeAsStringSync(
           serverSource
@@ -1227,7 +1223,7 @@ void main() async {
               .replaceAll(cloudEmailConfig, 'EmailIdpConfigFromPasswords()')
               .replaceAll(
                 staticRouteCacheBusting,
-                'StaticRoute.directory(root)',
+                "StaticRoute.directory(Directory(Uri(path: 'web/static').toFilePath()))",
               ),
         );
 

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -1216,11 +1216,19 @@ void main() async {
         final cloudEmailConfig = RegExp(
           r'ServerpodCloudEmailIdpConfig\([^)]*\)',
         );
+        // TODO: Remove once StaticRoute.withCacheBusting is published.
+        const staticRouteCacheBusting =
+            "StaticRoute.withCacheBusting(root, mountPrefix: '/web')";
+
         serverFile.writeAsStringSync(
           serverSource
               .replaceAll(wasmHeaders, '')
               .replaceAll(sessionAlert, 'session.log(')
-              .replaceAll(cloudEmailConfig, 'EmailIdpConfigFromPasswords()'),
+              .replaceAll(cloudEmailConfig, 'EmailIdpConfigFromPasswords()')
+              .replaceAll(
+                staticRouteCacheBusting,
+                'StaticRoute.directory(root)',
+              ),
         );
 
         final dockerBuildProcess = await startProcess(

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -67,6 +67,7 @@ void main() {
           final content = await serverFile.readAsString();
           expect(content, contains('dart:io'));
           expect(content, contains('src/web/routes/root.dart'));
+          expect(content, contains('src/cache_busting.dart'));
         },
       );
 
@@ -205,6 +206,7 @@ void main() {
           final content = await serverFile.readAsString();
           expect(content, contains('dart:io'));
           expect(content, contains('src/web/routes/app_config_route.dart'));
+          expect(content, contains('src/cache_busting.dart'));
         },
       );
 
@@ -217,15 +219,7 @@ void main() {
           final content = await serverFile.readAsString();
           expect(
             content,
-            contains(
-              "final root = Directory(Uri(path: 'web/static').toFilePath());",
-            ),
-          );
-          expect(
-            content,
-            contains(
-              "StaticRoute.withCacheBusting(root, mountPrefix: '/web')",
-            ),
+            contains('StaticRoute.withCacheBusting(cacheBustingConfig)'),
           );
           expect(
             content,
@@ -501,6 +495,7 @@ void main() {
             isNot(contains('src/web/routes/app_config_route.dart')),
           );
           expect(content, isNot(contains('src/web/routes/root.dart')));
+          expect(content, isNot(contains('src/cache_busting.dart')));
         },
       );
 

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -81,7 +81,7 @@ void main() {
           expect(
             content,
             contains(
-              "pod.webServer.addRoute(StaticRoute.directory(root), '/web')",
+              "StaticRoute.withCacheBusting(root, mountPrefix: '/web')",
             ),
           );
         },
@@ -224,7 +224,7 @@ void main() {
           expect(
             content,
             contains(
-              "pod.webServer.addRoute(StaticRoute.directory(root), '/web')",
+              "StaticRoute.withCacheBusting(root, mountPrefix: '/web')",
             ),
           );
           expect(
@@ -478,6 +478,16 @@ void main() {
           await expectLater(templatesDir.exists(), completion(false));
         },
       );
+
+      test('then the server does not have a src/cache_busting.dart file', () {
+        expect(
+          File(
+            p.join(project.serverDir, 'lib', 'src', 'cache_busting.dart'),
+          ).existsSync(),
+          isFalse,
+          reason: 'Server cache_busting.dart file exists but should not.',
+        );
+      });
 
       test(
         'then the server server.dart does not contain web imports',

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -80,9 +80,7 @@ void main() {
           expect(content, contains('pod.webServer.addRoute(RootRoute()'));
           expect(
             content,
-            contains(
-              "StaticRoute.withCacheBusting(root, mountPrefix: '/web')",
-            ),
+            contains('StaticRoute.withCacheBusting(cacheBustingConfig)'),
           );
         },
       );

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -65,7 +65,6 @@ void main() {
             p.join(project.serverDir, 'lib', 'server.dart'),
           );
           final content = await serverFile.readAsString();
-          expect(content, contains('dart:io'));
           expect(content, contains('src/web/routes/root.dart'));
           expect(content, contains('src/cache_busting.dart'));
         },

--- a/tests/serverpod_test_server/test_integration/web_server/widget_route_cache_control_test.dart
+++ b/tests/serverpod_test_server/test_integration/web_server/widget_route_cache_control_test.dart
@@ -6,7 +6,9 @@ import 'package:http/http.dart' as http;
 // Test widget classes
 class TestHtmlWidget extends WebWidget {
   @override
-  String toString() => '<html><body>Test HTML</body></html>';
+  String render({String? Function(String)? onMissingVariable}) {
+    return '<html><body>Test HTML</body></html>';
+  }
 }
 
 class TestJsonWidget extends JsonWidget {

--- a/tools/serverpod_cli/lib/src/create/template_renderer.dart
+++ b/tools/serverpod_cli/lib/src/create/template_renderer.dart
@@ -220,10 +220,15 @@ class TemplateRenderer {
 
   String _renderTemplate(String content, TemplateContext context) {
     try {
-      var template = Template(content, lenient: true, htmlEscapeValues: false);
+      var template = Template(content, lenient: true);
       return template.renderString(
         context.toMustacheMap(),
-        onMissingVariable: (name, context) => '{{$name}}',
+        onMissingVariable: (name, context) {
+          // Variables matching @/asset/path are used for cache busting.
+          // Triple curly braces are used to skip HTML escaping.
+          if (RegExp(r'@/[^}]+').hasMatch(name)) return '{{{$name}}}';
+          return '{{$name}}';
+        },
       );
     } catch (_) {
       return content;

--- a/tools/serverpod_cli/lib/src/create/template_renderer.dart
+++ b/tools/serverpod_cli/lib/src/create/template_renderer.dart
@@ -220,7 +220,7 @@ class TemplateRenderer {
 
   String _renderTemplate(String content, TemplateContext context) {
     try {
-      var template = Template(content, lenient: true);
+      var template = Template(content, lenient: true, htmlEscapeValues: false);
       return template.renderString(
         context.toMustacheMap(),
         onMissingVariable: (name, context) => '{{$name}}',


### PR DESCRIPTION
This PR adds a dedicated syntax for cache busting asset paths: `{{@/path/to/asset}}`. The proposed `{{!/path/to/asset}}` does not work because `!` is used to mark a comment in mustache templates which are rendered as empty strings. 

The serverpod package now depends on `whiskers` instead of `mustache_template` to use the `onMissingVariable` callback support when rendering.

`StaticRoute.withCacheBusting` factory constructor has been introduced to make it simpler to handle cache busting setup.
The template for new projects now comes with cache busting pre-configured.

Other changes: 

- Templates are created with `lenient` set to true to allow for rendering with missing variables.
- Templates are created with `htmlEscapeValues` set to to false to prevent escaping special characters such as `/` in file paths.

Closes #5378 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

- `WebWidget` gains a `render` method with `onMissingVariable` callback to support cache busting using introduced mustache syntax.
