### PR TITLE
feat: Improve create TUI

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_service_client: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
-  serverpod_tui: ^0.8.0
+  serverpod_tui: ^0.9.0
   skills: ^0.3.1
   source_span: ^1.10.0
   stream_channel: ^2.1.1

--- a/tools/serverpod_cli/lib/src/commands/create/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/app.dart
@@ -1,4 +1,6 @@
-import 'package:nocterm/nocterm.dart';
+import 'dart:math' as math;
+
+import 'package:nocterm/nocterm.dart' hide LogEntry;
 import 'package:serverpod_cli/src/commands/create/tui/main_screen.dart';
 import 'package:serverpod_cli/src/commands/create/tui/state_holder.dart';
 import 'package:serverpod_tui/serverpod_tui.dart';
@@ -37,8 +39,7 @@ class ServerpodCreateAppState extends TuiAppState<ServerpodCreateApp> {
   @override
   void onExit() => component.onQuit();
 
-  @override
-  Component buildApp(BuildContext context) {
+  Component _buildMainScreen() {
     return Focusable(
       focused: true,
       // Pass all keys through to the form fields below.
@@ -51,6 +52,30 @@ class ServerpodCreateAppState extends TuiAppState<ServerpodCreateApp> {
         onQuit: component.onQuit,
         isUpgrade: component.isUpgrade,
       ),
+    );
+  }
+
+  @override
+  Component buildApp(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth > 80 || constraints.maxHeight > 24) {
+          return Container(
+            color: Color.defaultColor,
+            alignment: Alignment.center,
+            child: ConstrainedBox(
+              constraints: BoxConstraints.tight(
+                Size(
+                  math.min(constraints.maxWidth, 80),
+                  math.min(constraints.maxHeight, 24),
+                ),
+              ),
+              child: _buildMainScreen(),
+            ),
+          );
+        }
+        return _buildMainScreen();
+      },
     );
   }
 }

--- a/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
@@ -26,13 +26,29 @@ class MainScreen extends StatelessComponent {
     final theme = ServerpodTheme.of(context);
     final state = holder.state;
     final creatingProject = state.creatingProject;
-    final summaryMessageAction = isUpgrade ? 'upgrade' : 'create';
+    final summaryAction = isUpgrade ? 'Upgrade' : 'Create';
+
+    void onSubmit() {
+      final canCreate =
+          (state.form.hasSingleScreen || state.form.isSummary) &&
+          state.canCreate;
+
+      if (canCreate) {
+        state.markCreatingProject();
+        holder.markDirty();
+        onCreate();
+      } else {
+        state.form.nextScreen();
+        holder.markDirty();
+      }
+    }
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Expanded(
           child: BorderedBox(
+            backgroundColor: Color.defaultColor,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -50,7 +66,9 @@ class MainScreen extends StatelessComponent {
                           scrollController: scrollController,
                           rebuild: holder.markDirty,
                           summaryDescription:
-                              'Press Enter to $summaryMessageAction the project.',
+                              'Press Enter to ${summaryAction.toLowerCase()} the project.',
+                          onSubmit: onSubmit,
+                          submitButtonLabel: summaryAction,
                         ),
                 ),
               ],
@@ -146,14 +164,12 @@ class MainScreen extends StatelessComponent {
           ),
         Button(
           name: 'Navigate',
-          activationChar: hasSingleScreen ? '←→' : '←↑↓→',
-          activationKeys: [
+          activationChar: '←↑↓→',
+          activationKeys: const [
             LogicalKey.arrowLeft,
             LogicalKey.arrowRight,
-            if (!hasSingleScreen) ...{
-              LogicalKey.arrowUp,
-              LogicalKey.arrowDown,
-            },
+            LogicalKey.arrowUp,
+            LogicalKey.arrowDown,
           ],
           onActivate: (key) {
             switch (key) {
@@ -190,7 +206,7 @@ class MainScreen extends StatelessComponent {
             state.form.onSelect();
             holder.markDirty();
           },
-          enabled: !isSummary && !creatingProject,
+          enabled: !creatingProject,
         ),
         Button(
           name: 'Quit',

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -56,7 +56,7 @@ dependencies:
   serverpod_serialization: 4.0.0-beta.0
   serverpod_service_client: 4.0.0-beta.0
   serverpod_shared: 4.0.0-beta.0
-  serverpod_tui: ^0.8.0
+  serverpod_tui: ^0.9.0
   skills: ^0.3.1
   source_span: ^1.10.0
   stream_channel: ^2.1.1


### PR DESCRIPTION
The create tui gains a `Create` button on the terminal screen (summary or first screen for quickstart). The UI is now constrained in a 80x24 centered container at its largest size.

Closes #5408 

https://github.com/user-attachments/assets/bcb2a3a2-5adf-404b-833a-6b91e7a8d2e2

https://github.com/user-attachments/assets/7b1a3c91-d93d-470d-8320-c8f9198057ff

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None