### PR TITLE
fix: Fix the background of the `SignInWidget` and `EmailSignInWidget` not being transparent

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/email/email_sign_in_widget.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/email/email_sign_in_widget.dart
@@ -172,6 +172,7 @@ class _EmailSignInWidgetState extends State<EmailSignInWidget> {
           animation: primaryAnimation,
           secondaryAnimation: secondaryAnimation,
           transitionType: SharedAxisTransitionType.horizontal,
+          fillColor: Colors.transparent,
           child: child,
         );
       },

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/sign_in_widget.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/sign_in_widget.dart
@@ -153,6 +153,7 @@ class _SignInWidgetState extends State<SignInWidget> {
     if (!auth.idp.hasAny) {
       return Material(
         type: MaterialType.transparency,
+        color: Colors.transparent,
         child: Center(
           child: Text(
             texts.noAuthenticationProvidersConfigured,
@@ -232,6 +233,7 @@ class _SignInWidgetState extends State<SignInWidget> {
     return SignInFlowCoordinatorWidget(
       child: Material(
         type: MaterialType.transparency,
+        color: Colors.transparent,
         child: SignInWidgetsColumn(
           spacing: 12,
           children: [

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/storybook/lib/stories/email.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/storybook/lib/stories/email.dart
@@ -96,20 +96,17 @@ Widget _buildEmailStory(BuildContext context, EmailFlowScreen screen) {
   );
 
   return wrapWidgetInDefaultColumn([
-    Theme(
-      data: ThemeData(canvasColor: Colors.white),
-      child: EmailSignInWidget(
-        client: context.read<Client>(),
-        startScreen: screen,
-        onError: (error) {
-          context.showErrorSnackBar(error.toString());
-        },
-        onAuthenticated: () {
-          context.showSuccessSnackBar('Authenticated with email!');
-        },
-        onTermsAndConditionsPressed: showTermsAndConditions ? () {} : null,
-        onPrivacyPolicyPressed: showPrivacyPolicy ? () {} : null,
-      ),
+    EmailSignInWidget(
+      client: context.read<Client>(),
+      startScreen: screen,
+      onError: (error) {
+        context.showErrorSnackBar(error.toString());
+      },
+      onAuthenticated: () {
+        context.showSuccessSnackBar('Authenticated with email!');
+      },
+      onTermsAndConditionsPressed: showTermsAndConditions ? () {} : null,
+      onPrivacyPolicyPressed: showPrivacyPolicy ? () {} : null,
     ),
   ], width: width.toDouble());
 }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/test/email_sign_in_widget_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/test/email_sign_in_widget_test.dart
@@ -1,0 +1,73 @@
+import 'package:animations/animations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:serverpod_auth_idp_flutter/serverpod_auth_idp_flutter.dart';
+
+void main() {
+  testWidgets(
+    'Given an EmailSignInWidget with a custom theme canvas color, '
+    'when the registration screen is shown, '
+    'then the shared axis transition uses a transparent fill color.',
+    (tester) async {
+      final controller = EmailAuthController(client: _TestClient());
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(canvasColor: Colors.red),
+          home: Scaffold(
+            body: SignInLocalizationProvider(
+              child: EmailSignInWidget(
+                controller: controller,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final transition = tester.widget<SharedAxisTransition>(
+        find.byType(SharedAxisTransition),
+      );
+
+      expect(transition.fillColor, Colors.transparent);
+    },
+  );
+}
+
+class _TestClient extends ServerpodClientShared {
+  _TestClient()
+    : super(
+        'http://localhost:8080/',
+        _TestSerializationManager(),
+        streamingConnectionTimeout: null,
+        connectionTimeout: null,
+      );
+
+  @override
+  Map<String, EndpointRef> get endpointRefLookup => {};
+
+  @override
+  Map<String, ModuleEndpointCaller> get moduleLookup => {};
+
+  @override
+  Future<T> callServerEndpoint<T>(
+    String endpoint,
+    String method,
+    Map<String, dynamic> args, {
+    bool authenticated = true,
+  }) async {
+    throw UnimplementedError('Not used by this test.');
+  }
+
+  @override
+  dynamic callStreamingServerEndpoint<T, G>(
+    String endpoint,
+    String method,
+    Map<String, dynamic> args,
+    Map<String, Stream> streams, {
+    bool authenticated = true,
+  }) {
+    throw UnimplementedError('Not used by this test.');
+  }
+}
+
+class _TestSerializationManager extends SerializationManager {}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/test/sign_in_widget_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/test/sign_in_widget_test.dart
@@ -30,6 +30,7 @@ void main() {
       final surface = tester.widget<Material>(surfaceFinder.first);
 
       expect(surface.type, MaterialType.transparency);
+      expect(surface.color, Colors.transparent);
       expect(surface.borderRadius, isNull);
       expect(surface.shape, isNull);
       expect(surface.clipBehavior, Clip.none);


### PR DESCRIPTION
Fixes an issue in which the background of both `SignInWidget` and `EmailSignInWidget` would retain a slighly different color when changing the theme.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.