### PR TITLE
fix: Mark Flutter app tabs ready on non-web devices

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -376,7 +376,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   IOSink Function(FlutterAppConfig app)? flutterStderrSinkFor,
   void Function(FlutterAppConfig app)? onEnsureFlutterAppTab,
   void Function(FlutterAppConfig app, String stage)? onFlutterProgress,
-  void Function(FlutterAppConfig app, String url)? onFlutterReady,
+  void Function(FlutterAppConfig app, String? url)? onFlutterReady,
   void Function(FlutterAppConfig app)? onFlutterLaunchFailed,
   void Function(FlutterAppConfig app)? onFlutterStop,
   Future<void> Function(ServerProcess server)? onServerStart,
@@ -1142,7 +1142,9 @@ Future<void> _runTuiBackend({
       onFlutterReady: (app, url) {
         final tab = holder.state.appLogTabFor(app.id);
         if (tab != null) {
-          tab.url = url;
+          // Non-web devices publish no URL; the status line then falls back
+          // to its generic running label.
+          tab.url = url ?? tab.url;
           tab.ready = true;
           tab.stopped = false;
           holder.markDirty();

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -1142,9 +1142,9 @@ Future<void> _runTuiBackend({
       onFlutterReady: (app, url) {
         final tab = holder.state.appLogTabFor(app.id);
         if (tab != null) {
-          // Non-web devices publish no URL; the status line then falls back
-          // to its generic running label.
-          tab.url = url ?? tab.url;
+          // Null on non-web devices, which publish no URL; the status line
+          // then falls back to its generic running label.
+          tab.url = url;
           tab.ready = true;
           tab.stopped = false;
           holder.markDirty();

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -248,9 +248,13 @@ class FlutterAppManager {
         onProgress(runtime.app, stage);
         log.info('  ${runtime.app.name}: $stage');
       },
-      // Non-web devices never publish an `app.webLaunchUrl`, so `app.started`
-      // is their only launch-complete signal.
-      onStarted: () => _signalReady(runtime, process.flutterAppUrl),
+      // Only non-web devices ready on `app.started`; web-server devices ready
+      // on URL publication, which `app.started` must never preempt.
+      onStarted:
+          device == flutterDeviceWebServer ||
+              device == flutterDeviceWebServerWithBrowser
+          ? null
+          : () => _signalReady(runtime, process.flutterAppUrl),
     );
 
     try {
@@ -427,12 +431,16 @@ class FlutterAppManager {
   }
 
   /// Invokes [onReady] at most once per launch. Ready has two sources - the
-  /// published web URL (web devices, fires first when present) and the
-  /// daemon's `app.started` event (all devices) - so the second one is
-  /// swallowed here.
+  /// published web URL (web devices) and the daemon's `app.started` event
+  /// (non-web devices) - so a second signal is swallowed here.
   void _signalReady(_AppRuntime runtime, String? url) {
     if (runtime.readySignaled) return;
     runtime.readySignaled = true;
+    log.info(
+      url == null
+          ? '${runtime.app.name} is running.'
+          : '${runtime.app.name} running at $url',
+    );
     onReady(runtime.app, url);
   }
 
@@ -467,7 +475,6 @@ class FlutterAppManager {
 
     final url = process.flutterAppUrl;
     if (url != null) {
-      log.info('${runtime.app.name} running at $url');
       _signalReady(runtime, url);
     }
 

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -83,7 +83,11 @@ class FlutterAppManager {
   final String serverpodToolDir;
   final String runMode;
   final void Function(FlutterAppConfig app, String stage) onProgress;
-  final void Function(FlutterAppConfig app, String url) onReady;
+
+  /// Fires once per launch when the app is up: on the published web URL
+  /// for web devices, or on the daemon's `app.started` event otherwise
+  /// ([url] is null when the device publishes no URL).
+  final void Function(FlutterAppConfig app, String? url) onReady;
   final Future<void> Function(FlutterAppConfig app, FlutterProcess process)
   onStart;
   final void Function(FlutterAppConfig app) onStop;
@@ -131,14 +135,14 @@ class FlutterAppManager {
   /// Whether [appId] has a running Flutter process.
   bool isRunning(String appId) => processFor(appId)?.isRunning ?? false;
 
-  /// Whether [appId] is starting up (spawn through URL publication).
+  /// Whether [appId] is starting up (spawn through the ready signal).
   bool isLaunching(String appId) {
     final runtime = _runtimeFor(appId);
     if (runtime == null) return false;
     if (runtime.spawnInFlight) return true;
     final process = runtime.process;
     if (process == null || !process.isRunning) return false;
-    return process.flutterAppUrl == null;
+    return !runtime.readySignaled;
   }
 
   /// Injects [process] for [appId] in tests.
@@ -222,6 +226,7 @@ class FlutterAppManager {
     if (runtime.spawnInFlight) return;
 
     runtime.spawnInFlight = true;
+    runtime.readySignaled = false;
     final isRelaunch = runtime.relaunchInProgress;
     runtime.relaunchInProgress = false;
 
@@ -229,7 +234,8 @@ class FlutterAppManager {
 
     final device = runtime.app.device ?? flutterDeviceWebServerWithBrowser;
 
-    final process = FlutterProcess(
+    late final FlutterProcess process;
+    process = FlutterProcess(
       flutterPackageDir: p.joinAll(runtime.app.pathParts),
       device: device,
       extraArgs: runtime.app.extraRunArgs,
@@ -242,6 +248,9 @@ class FlutterAppManager {
         onProgress(runtime.app, stage);
         log.info('  ${runtime.app.name}: $stage');
       },
+      // Non-web devices never publish an `app.webLaunchUrl`, so `app.started`
+      // is their only launch-complete signal.
+      onStarted: () => _signalReady(runtime, process.flutterAppUrl),
     );
 
     try {
@@ -417,6 +426,16 @@ class FlutterAppManager {
     );
   }
 
+  /// Invokes [onReady] at most once per launch. Ready has two sources - the
+  /// published web URL (web devices, fires first when present) and the
+  /// daemon's `app.started` event (all devices) - so the second one is
+  /// swallowed here.
+  void _signalReady(_AppRuntime runtime, String? url) {
+    if (runtime.readySignaled) return;
+    runtime.readySignaled = true;
+    onReady(runtime.app, url);
+  }
+
   Future<void> _connectAfterLaunch(
     _AppRuntime runtime,
     FlutterProcess process, {
@@ -449,7 +468,7 @@ class FlutterAppManager {
     final url = process.flutterAppUrl;
     if (url != null) {
       log.info('${runtime.app.name} running at $url');
-      onReady(runtime.app, url);
+      _signalReady(runtime, url);
     }
 
     await log.progress(
@@ -483,4 +502,5 @@ class _AppRuntime {
   FlutterDependencyTracker? dependencyTracker;
   bool spawnInFlight = false;
   bool relaunchInProgress = false;
+  bool readySignaled = false;
 }

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -248,13 +248,10 @@ class FlutterAppManager {
         onProgress(runtime.app, stage);
         log.info('  ${runtime.app.name}: $stage');
       },
-      // Only non-web devices ready on `app.started`; web-server devices ready
-      // on URL publication, which `app.started` must never preempt.
-      onStarted:
-          device == flutterDeviceWebServer ||
-              device == flutterDeviceWebServerWithBrowser
-          ? null
-          : () => _signalReady(runtime, process.flutterAppUrl),
+      // The ready signal for non-web devices, which never publish a URL. Web
+      // devices publish their URL before `app.started`, so it is carried
+      // along here when the URL path has not signaled first.
+      onStarted: () => _signalReady(runtime, process.flutterAppUrl),
     );
 
     try {

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -57,6 +57,11 @@ class FlutterProcess {
   /// messages in between.
   final void Function(String stage)? _onProgress;
 
+  /// Fires on the daemon's `app.started` event, i.e. the app is fully up
+  /// on its device. This is the only launch-complete signal on non-web
+  /// devices, which never publish an `app.webLaunchUrl`.
+  final void Function()? _onStarted;
+
   /// When true, open [flutterAppUrl] in the default browser once it is
   /// published by the daemon (`app.webLaunchUrl`).
   final bool _launchBrowser;
@@ -103,6 +108,7 @@ class FlutterProcess {
     List<String> extraArgs = const [],
     VmServiceProxy? flutterProxy,
     void Function(String stage)? onProgress,
+    void Function()? onStarted,
     IOSink? stdoutSink,
     IOSink? stderrSink,
     List<String>? machineArgsOverride,
@@ -114,6 +120,7 @@ class FlutterProcess {
        _extraArgs = extraArgs,
        _flutterProxy = flutterProxy,
        _onProgress = onProgress,
+       _onStarted = onStarted,
        _stdout = stdoutSink ?? stdout,
        _stderr = stderrSink ?? stderr,
        _launchBrowser = device == flutterDeviceWebServerWithBrowser,
@@ -550,6 +557,7 @@ class FlutterProcess {
           }
         case 'app.started':
           _onProgress?.call('ready');
+          _onStarted?.call();
         case 'app.stop':
           log.debug('Flutter daemon emitted app.stop; tearing down.');
           unawaited(_onAppStop());

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -53,8 +53,7 @@ class FlutterProcess {
   final VmServiceProxy? _flutterProxy;
 
   /// Fires `'launching'` on spawn, `'connecting'` before VM-service
-  /// connect, `'ready'` on `app.started`, plus verbatim `app.progress`
-  /// messages in between.
+  /// connect, plus verbatim `app.progress` messages in between.
   final void Function(String stage)? _onProgress;
 
   /// Fires on the daemon's `app.started` event, i.e. the app is fully up
@@ -556,7 +555,6 @@ class FlutterProcess {
             _onProgress?.call(message);
           }
         case 'app.started':
-          _onProgress?.call('ready');
           _onStarted?.call();
         case 'app.stop':
           log.debug('Flutter daemon emitted app.stop; tearing down.');

--- a/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
@@ -43,113 +43,191 @@ Future<({HttpServer server, String wsUri})> _startFakeVmService() async {
   );
 }
 
-FlutterAppConfig _testApp({
-  required Directory serverDir,
-  required Directory flutterDir,
-  required String id,
-  required String name,
-}) {
-  return FlutterAppConfig(
-    id: id,
-    name: name,
-    relativePathParts: p.split(
-      p.relative(flutterDir.path, from: serverDir.path),
-    ),
-    serverPackageDirectoryPathParts: p.split(serverDir.path),
-    // `web-server` (no browser) so launches never spawn a real browser and the
-    // VM-service connect waits without a timeout, as the manager tests expect.
-    device: 'web-server',
-  );
+/// One fabricated Flutter app in a [_ManagerFixture].
+class _AppSpec {
+  const _AppSpec(
+    this.id, {
+    // `web-server` (no browser) so launches never spawn a real browser and
+    // the VM-service connect waits without a timeout, as most manager tests
+    // expect. Pass a desktop device (e.g. `linux`) for non-web scenarios.
+    this.device = 'web-server',
+  });
+
+  final String id;
+  final String device;
+
+  /// Directory (and package) name of the fabricated Flutter app.
+  String get dirName => '${id.replaceAll('-', '_')}_flutter';
 }
 
-void main() {
-  group('Given a FlutterAppManager with two configured apps', () {
-    late Directory tempDir;
-    late Directory serverDir;
-    late Directory flutterDirA;
-    late Directory flutterDirB;
-    late FlutterAppManager manager;
-    late FlutterAppConfig appA;
-    late FlutterAppConfig appB;
-    late String launchedAppId;
+/// Shared scaffolding for [FlutterAppManager] tests.
+///
+/// Builds a temp tree with a server package and one fabricated Flutter
+/// package per [_AppSpec] - a directory whose pubspec.yaml carries the
+/// `flutter: sdk: flutter` marker is all the manager needs; no real Flutter
+/// project is involved. The server pubspec.yaml wires the apps up under
+/// `serverpod: flutter_apps:`, and when a [shim] is given the manager's
+/// `flutter` executable is replaced by that Dart script from
+/// `flutter_shims/`, so launches speak the `--machine` protocol without
+/// Flutter tooling. Callbacks default to no-ops; pass overrides to capture
+/// events. Call [dispose] from tearDown.
+class _ManagerFixture {
+  _ManagerFixture._({
+    required this.tempDir,
+    required this.serverDir,
+    required this.serverPubspecFile,
+    required this.manager,
+    required Map<String, Directory> flutterDirs,
+    required HttpServer? fakeVmServer,
+  }) : _flutterDirs = flutterDirs,
+       _fakeVmServer = fakeVmServer;
 
-    setUp(() async {
-      tempDir = await Directory.systemTemp.createTemp('flutter_mgr_test_');
-      serverDir = Directory(p.join(tempDir.path, 'project_server'))
-        ..createSync(recursive: true);
-      flutterDirA = Directory(p.join(tempDir.path, 'app_a_flutter'))
-        ..createSync(recursive: true);
-      flutterDirB = Directory(p.join(tempDir.path, 'app_b_flutter'))
-        ..createSync(recursive: true);
+  final Directory tempDir;
+  final Directory serverDir;
+  final File serverPubspecFile;
+  final FlutterAppManager manager;
+  final Map<String, Directory> _flutterDirs;
+  final HttpServer? _fakeVmServer;
 
-      for (final dir in [flutterDirA, flutterDirB]) {
-        File(p.join(dir.path, 'pubspec.yaml')).writeAsStringSync('''
-name: ${p.basename(dir.path)}
+  static Future<_ManagerFixture> create({
+    List<_AppSpec> apps = const [_AppSpec('project')],
+    String? shim,
+    List<String> shimArgs = const [],
+    bool fakeVmService = false,
+    bool initialize = true,
+    void Function(FlutterAppConfig app, String stage)? onProgress,
+    void Function(FlutterAppConfig app, String? url)? onReady,
+    void Function(FlutterAppConfig app)? onStop,
+    void Function(FlutterAppConfig app)? onLaunchFailed,
+    void Function(FlutterAppConfig app)? onEnsureAppTab,
+    IOSink Function(FlutterAppConfig app)? stdoutSinkFor,
+    IOSink Function(FlutterAppConfig app)? stderrSinkFor,
+  }) async {
+    final tempDir = await Directory.systemTemp.createTemp('flutter_mgr_test_');
+    final serverDir = Directory(p.join(tempDir.path, 'project_server'))
+      ..createSync(recursive: true);
+
+    final flutterDirs = <String, Directory>{
+      for (final spec in apps)
+        spec.id: _createFlutterPackage(tempDir, spec.dirName),
+    };
+
+    final appEntries = StringBuffer();
+    for (final spec in apps) {
+      appEntries.writeln('    ${spec.id}:');
+      appEntries.writeln('      path: ../${spec.dirName}');
+      appEntries.writeln('      device: ${spec.device}');
+    }
+    final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
+    serverPubspecFile.writeAsStringSync('''
+name: project_server
+serverpod:
+  flutter_apps:
+$appEntries''');
+
+    HttpServer? fakeVmServer;
+    final resolvedShimArgs = <String>[...shimArgs];
+    if (fakeVmService) {
+      final fake = await _startFakeVmService();
+      fakeVmServer = fake.server;
+      resolvedShimArgs.add('--ws=${fake.wsUri}');
+    }
+
+    final manager = FlutterAppManager(
+      projectName: 'project',
+      launchFlutterApp: false,
+      serverPubspecFile: serverPubspecFile,
+      serverPackageDirectoryPathParts: p.split(serverDir.path),
+      serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
+      runMode: 'development',
+      onProgress: onProgress ?? (_, _) {},
+      onReady: onReady ?? (_, _) {},
+      onStart: (_, _) async {},
+      onStop: onStop ?? (_) {},
+      onLaunchFailed: onLaunchFailed ?? (_) {},
+      onEnsureAppTab: onEnsureAppTab ?? (_) {},
+      stdoutSinkFor: stdoutSinkFor ?? (_) => stdout,
+      stderrSinkFor: stderrSinkFor ?? (_) => stderr,
+      flutterExecutableForTesting: shim == null ? null : _dartExecutable(),
+      argsOverrideForTesting: shim == null
+          ? null
+          : (_) => [_shimPath(shim), ...resolvedShimArgs],
+    );
+
+    if (initialize) await manager.initialize();
+
+    return _ManagerFixture._(
+      tempDir: tempDir,
+      serverDir: serverDir,
+      serverPubspecFile: serverPubspecFile,
+      manager: manager,
+      flutterDirs: flutterDirs,
+      fakeVmServer: fakeVmServer,
+    );
+  }
+
+  /// The fabricated Flutter package directory for [id].
+  Directory flutterDir(String id) => _flutterDirs[id]!;
+
+  /// A standalone config for [id], for calling manager members that take a
+  /// [FlutterAppConfig] directly (only the id is significant).
+  FlutterAppConfig appConfig(String id) => FlutterAppConfig(
+    id: id,
+    name: id,
+    relativePathParts: ['..', '${id.replaceAll('-', '_')}_flutter'],
+    serverPackageDirectoryPathParts: p.split(serverDir.path),
+  );
+
+  /// Fabricates an additional Flutter package (e.g. before rewriting the
+  /// server pubspec to grow the `flutter_apps` config).
+  Directory addFlutterPackage(String dirName) =>
+      _createFlutterPackage(tempDir, dirName);
+
+  static Directory _createFlutterPackage(Directory tempDir, String dirName) {
+    final dir = Directory(p.join(tempDir.path, dirName))
+      ..createSync(recursive: true);
+    File(p.join(dir.path, 'pubspec.yaml')).writeAsStringSync('''
+name: $dirName
 dependencies:
   flutter:
     sdk: flutter
 ''');
-      }
+    return dir;
+  }
 
-      appA = _testApp(
-        serverDir: serverDir,
-        flutterDir: flutterDirA,
-        id: 'app-a',
-        name: 'App A',
-      );
-      appB = _testApp(
-        serverDir: serverDir,
-        flutterDir: flutterDirB,
-        id: 'app-b',
-        name: 'App B',
-      );
+  Future<void> dispose() async {
+    await manager.dispose();
+    await _fakeVmServer?.close(force: true);
+    await tempDir.delete(recursive: true);
+  }
+}
 
-      final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
-      serverPubspecFile.writeAsStringSync('''
-name: server
-serverpod:
-  flutter_apps:
-    app-a:
-      path: ../app_a_flutter
-    app-b:
-      path: ../app_b_flutter
-''');
+void main() {
+  group('Given a FlutterAppManager with two configured apps', () {
+    late _ManagerFixture f;
+    late String launchedAppId;
 
+    setUp(() async {
       launchedAppId = '';
-      manager = FlutterAppManager(
-        projectName: 'project',
-        launchFlutterApp: false,
-        serverPubspecFile: serverPubspecFile,
-        serverPackageDirectoryPathParts: p.split(serverDir.path),
-        serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
-        runMode: 'development',
-        onProgress: (_, _) {},
-        onReady: (_, _) {},
-        onStart: (_, _) async {},
-        onStop: (_) {},
-        onLaunchFailed: (_) {},
+      f = await _ManagerFixture.create(
+        apps: const [_AppSpec('app-a'), _AppSpec('app-b')],
+        shim: 'never_publishes_uri.dart',
+        initialize: false,
         onEnsureAppTab: (app) => launchedAppId = app.id,
-        stdoutSinkFor: (_) => stdout,
-        stderrSinkFor: (_) => stderr,
-        flutterExecutableForTesting: _dartExecutable(),
-        argsOverrideForTesting: (_) => [_shimPath('never_publishes_uri.dart')],
       );
     });
 
-    tearDown(() async {
-      await manager.dispose();
-      await tempDir.delete(recursive: true);
-    });
+    tearDown(() => f.dispose());
 
     test(
       'when initialize is called then each app gets its own info file',
       () async {
-        await manager.initialize();
+        await f.manager.initialize();
 
         expect(
           File(
             p.join(
-              serverDir.path,
+              f.serverDir.path,
               '.dart_tool',
               'serverpod',
               'flutter-vm-service-info-app-a.json',
@@ -160,7 +238,7 @@ serverpod:
         expect(
           File(
             p.join(
-              serverDir.path,
+              f.serverDir.path,
               '.dart_tool',
               'serverpod',
               'flutter-vm-service-info-app-b.json',
@@ -173,27 +251,27 @@ serverpod:
 
     group('that is initialized', () {
       setUp(() async {
-        await manager.initialize();
+        await f.manager.initialize();
       });
 
       test(
         'when two apps are launched then both run concurrently',
         () async {
-          await manager.launch(appA.id);
-          await manager.launch(appB.id);
+          await f.manager.launch('app-a');
+          await f.manager.launch('app-b');
 
-          expect(manager.isRunning(appA.id), isTrue);
-          expect(manager.isRunning(appB.id), isTrue);
-          expect(manager.runningAppIds, containsAll([appA.id, appB.id]));
+          expect(f.manager.isRunning('app-a'), isTrue);
+          expect(f.manager.isRunning('app-b'), isTrue);
+          expect(f.manager.runningAppIds, containsAll(['app-a', 'app-b']));
         },
       );
 
       test(
         'when launch is called then onEnsureAppTab is invoked',
         () async {
-          await manager.launch(appA.id);
+          await f.manager.launch('app-a');
 
-          expect(launchedAppId, appA.id);
+          expect(launchedAppId, 'app-a');
         },
       );
 
@@ -204,28 +282,28 @@ serverpod:
           // first await, so the app reads as launching the instant the call is
           // kicked off — no fixed wait needed. The shim never publishes a URL,
           // so it stays launching until torn down in tearDown.
-          unawaited(manager.launch(appA.id));
+          unawaited(f.manager.launch('app-a'));
 
-          expect(manager.isLaunching(appA.id), isTrue);
-          expect(manager.isLaunching(appB.id), isFalse);
+          expect(f.manager.isLaunching('app-a'), isTrue);
+          expect(f.manager.isLaunching('app-b'), isFalse);
         },
       );
 
       test(
         'when stopAll is called then running apps stop and info files are removed',
         () async {
-          await manager.launch(appA.id);
+          await f.manager.launch('app-a');
           final infoFile = p.join(
-            serverDir.path,
+            f.serverDir.path,
             '.dart_tool',
             'serverpod',
             'flutter-vm-service-info-app-a.json',
           );
           expect(File(infoFile).existsSync(), isTrue);
 
-          await manager.stopAll();
+          await f.manager.stopAll();
 
-          expect(manager.isRunning(appA.id), isFalse);
+          expect(f.manager.isRunning('app-a'), isFalse);
           expect(File(infoFile).existsSync(), isFalse);
         },
       );
@@ -233,19 +311,19 @@ serverpod:
       test(
         'when stop is called then only that app stops and its info file remains',
         () async {
-          await manager.launch(appA.id);
-          await manager.launch(appB.id);
+          await f.manager.launch('app-a');
+          await f.manager.launch('app-b');
           final infoFile = p.join(
-            serverDir.path,
+            f.serverDir.path,
             '.dart_tool',
             'serverpod',
             'flutter-vm-service-info-app-a.json',
           );
 
-          await manager.stop(appA.id);
+          await f.manager.stop('app-a');
 
-          expect(manager.isRunning(appA.id), isFalse);
-          expect(manager.isRunning(appB.id), isTrue);
+          expect(f.manager.isRunning('app-a'), isFalse);
+          expect(f.manager.isRunning('app-b'), isTrue);
           // Unlike stopAll, a single stop keeps the info file for relaunch.
           expect(File(infoFile).existsSync(), isTrue);
         },
@@ -254,10 +332,10 @@ serverpod:
       test(
         'when stop is called for an unknown or stopped app then it is a no-op',
         () async {
-          await manager.stop('does-not-exist');
-          await manager.stop(appA.id);
+          await f.manager.stop('does-not-exist');
+          await f.manager.stop('app-a');
 
-          expect(manager.isRunning(appA.id), isFalse);
+          expect(f.manager.isRunning('app-a'), isFalse);
         },
       );
 
@@ -265,33 +343,37 @@ serverpod:
         'when an app is stopped then its entry is dropped from dtdUris while '
         'others remain',
         () async {
-          await manager.launch(appA.id);
-          await manager.launch(appB.id);
+          await f.manager.launch('app-a');
+          await f.manager.launch('app-b');
 
           // The never_publishes_uri shim starts the process but never emits
           // app.dtd, so each running app maps to a null DTD URI. dtdUris backs
           // the get_flutter_app_dtd MCP tool.
-          expect(manager.dtdUris, {appA.id: null, appB.id: null});
+          expect(f.manager.dtdUris, {'app-a': null, 'app-b': null});
 
-          await manager.stop(appA.id);
+          await f.manager.stop('app-a');
 
           // The stopped app is gone entirely, not merely mapped to null; the
           // still-running app is untouched.
-          expect(manager.dtdUris, {appB.id: null});
-          expect(manager.dtdUris.containsKey(appA.id), isFalse);
+          expect(f.manager.dtdUris, {'app-b': null});
+          expect(f.manager.dtdUris.containsKey('app-a'), isFalse);
         },
       );
 
       test(
         'when changed paths are under one app lib then only that app id matches',
         () async {
-          await manager.launch(appA.id);
-          await manager.launch(appB.id);
+          await f.manager.launch('app-a');
+          await f.manager.launch('app-b');
 
-          final adminPath = p.join(flutterDirA.path, 'lib', 'main.dart');
+          final adminPath = p.join(
+            f.flutterDir('app-a').path,
+            'lib',
+            'main.dart',
+          );
           expect(
-            manager.appIdsForChangedPaths([adminPath]),
-            {appA.id},
+            f.manager.appIdsForChangedPaths([adminPath]),
+            {'app-a'},
           );
         },
       );
@@ -299,29 +381,11 @@ serverpod:
   });
 
   group('Given a FlutterAppManager wired with per-app log sinks', () {
-    late Directory tempDir;
-    late FlutterAppConfig appA;
-    late FlutterAppConfig appB;
+    late _ManagerFixture f;
     late Map<String, List<String>> sinkLines;
-    late FlutterAppManager manager;
 
     setUp(() async {
-      tempDir = await Directory.systemTemp.createTemp('flutter_mgr_test_');
-      final serverDir = Directory(p.join(tempDir.path, 'project_server'))
-        ..createSync(recursive: true);
-      appA = const FlutterAppConfig(
-        id: 'app-a',
-        name: 'App A',
-        relativePathParts: ['..', 'app_a_flutter'],
-        serverPackageDirectoryPathParts: [],
-      );
-      appB = const FlutterAppConfig(
-        id: 'app-b',
-        name: 'App B',
-        relativePathParts: ['..', 'app_b_flutter'],
-        serverPackageDirectoryPathParts: [],
-      );
-      sinkLines = {appA.id: [], appB.id: []};
+      sinkLines = {'app-a': [], 'app-b': []};
 
       IOSink sinkFor(List<String> lines) {
         final controller = StreamController<List<int>>();
@@ -329,143 +393,67 @@ serverpod:
         return IOSink(controller.sink);
       }
 
-      final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
-      serverPubspecFile.writeAsStringSync('''
-name: server
-serverpod:
-  flutter_apps:
-    app-a:
-      path: ../app_a_flutter
-    app-b:
-      path: ../app_b_flutter
-''');
-
-      manager = FlutterAppManager(
-        projectName: 'project',
-        launchFlutterApp: false,
-        serverpodToolDir: 'unused',
-        serverPubspecFile: serverPubspecFile,
-        serverPackageDirectoryPathParts: p.split(serverDir.path),
-        runMode: 'development',
-        onProgress: (_, _) {},
-        onReady: (_, _) {},
-        onStart: (_, _) async {},
-        onStop: (_) {},
-        onLaunchFailed: (_) {},
-        onEnsureAppTab: (_) {},
+      f = await _ManagerFixture.create(
+        apps: const [_AppSpec('app-a'), _AppSpec('app-b')],
+        initialize: false,
         stdoutSinkFor: (app) => sinkFor(sinkLines[app.id]!),
         stderrSinkFor: (app) => sinkFor(sinkLines[app.id]!),
       );
     });
 
-    tearDown(() async {
-      await manager.dispose();
-      await tempDir.delete(recursive: true);
-    });
+    tearDown(() => f.dispose());
 
     test(
       'when stdoutSinkFor is called then each app gets its own sink target',
       () async {
-        manager.stdoutSinkFor(appA).write('line-a\n');
-        manager.stdoutSinkFor(appB).write('line-b\n');
+        f.manager.stdoutSinkFor(f.appConfig('app-a')).write('line-a\n');
+        f.manager.stdoutSinkFor(f.appConfig('app-b')).write('line-b\n');
         await Future<void>.delayed(Duration.zero);
 
-        expect(sinkLines[appA.id], ['line-a\n']);
-        expect(sinkLines[appB.id], ['line-b\n']);
+        expect(sinkLines['app-a'], ['line-a\n']);
+        expect(sinkLines['app-b'], ['line-b\n']);
       },
     );
   });
 
   group(
-    'Given an initialized FlutterAppManager running the emits_machine_events shim',
+    'Given an initialized FlutterAppManager running an app on a web device',
     () {
-      late Directory tempDir;
-      late Directory serverDir;
-      late Directory flutterDir;
-      late FlutterAppConfig app;
-      late FlutterAppManager manager;
+      late _ManagerFixture f;
       // Completed by onReady once the shim publishes its web URL, so the test
       // waits for exactly that event rather than a fixed duration.
-      late Completer<String> ready;
+      late Completer<String?> ready;
       // Completed by onStop.
       late Completer<void> stop;
 
       setUp(() async {
-        tempDir = await Directory.systemTemp.createTemp('flutter_mgr_shim_');
-        serverDir = Directory(p.join(tempDir.path, 'project_server'))
-          ..createSync(recursive: true);
-        flutterDir = Directory(p.join(tempDir.path, 'project_flutter'))
-          ..createSync(recursive: true);
-        File(p.join(flutterDir.path, 'pubspec.yaml')).writeAsStringSync('''
-name: project_flutter
-dependencies:
-  flutter:
-    sdk: flutter
-''');
-
-        app = _testApp(
-          serverDir: serverDir,
-          flutterDir: flutterDir,
-          id: 'project',
-          name: 'Project',
-        );
-
-        final fake = await _startFakeVmService();
-        addTearDown(() => fake.server.close(force: true));
-        final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
-        serverPubspecFile.writeAsStringSync('''
-name: project_server
-serverpod:
-  flutter_apps:
-    project:
-      path: ../project_flutter
-''');
-
-        ready = Completer<String>();
+        ready = Completer<String?>();
         stop = Completer<void>();
-        ready = Completer<String>();
-        manager = FlutterAppManager(
-          projectName: 'project',
-          launchFlutterApp: false,
-          serverPubspecFile: serverPubspecFile,
-          serverPackageDirectoryPathParts: p.split(serverDir.path),
-          serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
-          runMode: 'development',
-          onProgress: (_, _) {},
+        // The emits_machine_events shim plays the web-device daemon: it
+        // publishes app.webLaunchUrl before app.debugPort and app.started.
+        f = await _ManagerFixture.create(
+          shim: 'emits_machine_events.dart',
+          shimArgs: const ['--web-url=http://localhost:9999'],
+          fakeVmService: true,
           onReady: (_, url) => ready.complete(url),
-          onStart: (_, _) async {},
           onStop: (_) => stop.complete(),
-          onLaunchFailed: (_) {},
-          onEnsureAppTab: (_) {},
-          stdoutSinkFor: (_) => stdout,
-          stderrSinkFor: (_) => stderr,
-          flutterExecutableForTesting: _dartExecutable(),
-          argsOverrideForTesting: (_) => [
-            _shimPath('emits_machine_events.dart'),
-            '--ws=${fake.wsUri}',
-            '--web-url=http://localhost:9999',
-          ],
         );
-        await manager.initialize();
       });
 
-      tearDown(() async {
-        await manager.dispose();
-        await tempDir.delete(recursive: true);
-      });
+      tearDown(() => f.dispose());
 
       test(
         'when launch completes then onReady receives the app URL',
         () async {
-          await manager.launch(app.id);
+          await f.manager.launch('project');
 
           final readyUrl = await ready.future.timeout(
             const Duration(seconds: 30),
           );
 
           expect(readyUrl, 'http://localhost:9999');
-          expect(manager.isRunning(app.id), isTrue);
-          expect(manager.isLaunching(app.id), isFalse);
+          expect(f.manager.isRunning('project'), isTrue);
+          expect(f.manager.isLaunching('project'), isFalse);
         },
       );
 
@@ -473,16 +461,16 @@ serverpod:
         'when the app is stopped',
         () {
           setUp(() async {
-            await manager.launch(app.id);
+            await f.manager.launch('project');
             await ready.future.timeout(const Duration(seconds: 30));
             // onReady fires on the web URL, which the shim emits before app.dtd,
             // so wait until the DTD URI has been parsed too.
-            await _eventually(() => manager.dtdUris['project'] != null);
+            await _eventually(() => f.manager.dtdUris['project'] != null);
 
             // The shim emits app.dtd, so the running app reports its DTD URI.
-            expect(manager.dtdUris, {'project': 'ws://127.0.0.1:9100/ws'});
+            expect(f.manager.dtdUris, {'project': 'ws://127.0.0.1:9100/ws'});
 
-            await manager.stop(app.id);
+            await f.manager.stop('project');
           });
 
           test(
@@ -490,7 +478,7 @@ serverpod:
             () {
               // Stopping the app drops it from the map that backs the
               // get_flutter_app_dtd MCP tool, so its DTD URI is no longer returned.
-              expect(manager.dtdUris, isEmpty);
+              expect(f.manager.dtdUris, isEmpty);
             },
           );
 
@@ -503,77 +491,75 @@ serverpod:
   );
 
   group(
-    'Given an initialized FlutterAppManager whose app exits during the build',
+    'Given an initialized FlutterAppManager running an app on a desktop device',
     () {
-      late Directory tempDir;
-      late Directory serverDir;
-      late Directory flutterDir;
-      late FlutterAppConfig app;
-      late FlutterAppManager manager;
-      late Completer<FlutterAppConfig> launchFailed;
-      var readyCalls = 0;
+      late _ManagerFixture f;
+      // Completed by onReady; desktop devices never publish a web URL, so
+      // the shim's app.started event is what must complete this.
+      late Completer<String?> ready;
+      late int readyCalls;
 
       setUp(() async {
-        tempDir = await Directory.systemTemp.createTemp('flutter_mgr_fail_');
-        serverDir = Directory(p.join(tempDir.path, 'project_server'))
-          ..createSync(recursive: true);
-        flutterDir = Directory(p.join(tempDir.path, 'project_flutter'))
-          ..createSync(recursive: true);
-        File(p.join(flutterDir.path, 'pubspec.yaml')).writeAsStringSync('''
-name: project_flutter
-dependencies:
-  flutter:
-    sdk: flutter
-''');
-
-        app = _testApp(
-          serverDir: serverDir,
-          flutterDir: flutterDir,
-          id: 'project',
-          name: 'Project',
+        ready = Completer<String?>();
+        readyCalls = 0;
+        // The emits_desktop_machine_events shim plays the desktop-device
+        // daemon: it publishes app.debugPort and app.started, but no
+        // app.webLaunchUrl (that event is web-only).
+        f = await _ManagerFixture.create(
+          apps: const [_AppSpec('project', device: 'linux')],
+          shim: 'emits_desktop_machine_events.dart',
+          fakeVmService: true,
+          onReady: (_, url) {
+            readyCalls++;
+            ready.complete(url);
+          },
         );
+      });
 
-        final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
-        serverPubspecFile.writeAsStringSync('''
-name: project_server
-serverpod:
-  flutter_apps:
-    project:
-      path: ../project_flutter
-''');
+      tearDown(() => f.dispose());
 
+      test(
+        'when the app finishes launching then onReady fires once without a '
+        'URL and the app is running, not launching',
+        () async {
+          await f.manager.launch('project');
+
+          final readyUrl = await ready.future.timeout(
+            const Duration(seconds: 30),
+          );
+
+          expect(readyUrl, isNull);
+          expect(readyCalls, 1);
+          expect(f.manager.isRunning('project'), isTrue);
+          expect(f.manager.isLaunching('project'), isFalse);
+        },
+      );
+    },
+  );
+
+  group(
+    'Given an initialized FlutterAppManager whose app exits during the build',
+    () {
+      late _ManagerFixture f;
+      late Completer<FlutterAppConfig> launchFailed;
+      late int readyCalls;
+
+      setUp(() async {
         readyCalls = 0;
         launchFailed = Completer<FlutterAppConfig>();
-        manager = FlutterAppManager(
-          projectName: 'project',
-          launchFlutterApp: false,
-          serverPubspecFile: serverPubspecFile,
-          serverPackageDirectoryPathParts: p.split(serverDir.path),
-          serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
-          runMode: 'development',
-          onProgress: (_, _) {},
+        f = await _ManagerFixture.create(
+          shim: 'exits_during_build.dart',
           onReady: (_, _) => readyCalls++,
-          onStart: (_, _) async {},
-          onStop: (_) {},
           onLaunchFailed: (app) => launchFailed.complete(app),
-          onEnsureAppTab: (_) {},
-          stdoutSinkFor: (_) => stdout,
-          stderrSinkFor: (_) => stderr,
-          flutterExecutableForTesting: _dartExecutable(),
-          argsOverrideForTesting: (_) => [_shimPath('exits_during_build.dart')],
         );
-        await manager.initialize();
       });
 
-      tearDown(() async {
-        await manager.dispose();
-        await tempDir.delete(recursive: true);
-      });
+      tearDown(() => f.dispose());
 
       test(
         'when launch is attempted then onLaunchFailed fires and onReady does not',
         () async {
-          await manager.launch(app.id);
+          await f.manager.launch('project');
 
           // This future only completes when the app exits during the build and
           // the `onLaunchFailed` callback is invoked.
@@ -581,100 +567,56 @@ serverpod:
             const Duration(seconds: 30),
           );
 
-          expect(failedApp.id, app.id);
+          expect(failedApp.id, 'project');
           expect(readyCalls, 0);
-          expect(manager.isRunning(app.id), isFalse);
-          expect(manager.isLaunching(app.id), isFalse);
+          expect(f.manager.isRunning('project'), isFalse);
+          expect(f.manager.isLaunching('project'), isFalse);
         },
       );
     },
   );
 
   group('Given an initialized FlutterAppManager', () {
-    late Directory tempDir;
-    late Directory serverDir;
-    late FlutterAppManager manager;
-    late File serverPubspecFile;
+    late _ManagerFixture f;
 
     setUp(() async {
-      tempDir = await Directory.systemTemp.createTemp('flutter_mgr_reload_');
-      serverDir = Directory(p.join(tempDir.path, 'project_server'))
-        ..createSync(recursive: true);
-      final flutterDirA = Directory(p.join(tempDir.path, 'app_a_flutter'))
-        ..createSync(recursive: true);
-      final flutterDirB = Directory(p.join(tempDir.path, 'app_b_flutter'))
-        ..createSync(recursive: true);
-
-      for (final dir in [flutterDirA, flutterDirB]) {
-        File(p.join(dir.path, 'pubspec.yaml')).writeAsStringSync('''
-name: ${p.basename(dir.path)}
-dependencies:
-  flutter:
-    sdk: flutter
-''');
-      }
-
-      serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
-      serverPubspecFile.writeAsStringSync('''
-name: server
-serverpod:
-  flutter_apps:
-    app-a:
-      path: ../app_a_flutter
-    app-b:
-      path: ../app_b_flutter
-''');
-
-      manager = FlutterAppManager(
-        projectName: 'project',
-        launchFlutterApp: false,
-        serverPubspecFile: serverPubspecFile,
-        serverpodToolDir: p.join(tempDir.path, '.serverpod'),
-        serverPackageDirectoryPathParts: p.split(serverDir.path),
-        runMode: 'development',
-        onProgress: (_, _) {},
-        onReady: (_, _) {},
-        onStart: (_, _) async {},
-        onStop: (_) {},
-        onLaunchFailed: (_) {},
-        onEnsureAppTab: (_) {},
-        stdoutSinkFor: (_) => stdout,
-        stderrSinkFor: (_) => stderr,
+      f = await _ManagerFixture.create(
+        apps: const [_AppSpec('app-a'), _AppSpec('app-b')],
       );
-      await manager.initialize();
     });
 
-    tearDown(() async {
-      await manager.dispose();
-      await tempDir.delete(recursive: true);
-    });
+    tearDown(() => f.dispose());
 
-    test(
-      'when loadApps is called after removing apps from the config, '
-      'then removed apps are stopped and new list is reflected',
-      () async {
-        serverPubspecFile.writeAsStringSync('''
-name: server
+    group('with an app removed from the flutter_apps config', () {
+      setUp(() {
+        f.serverPubspecFile.writeAsStringSync('''
+name: project_server
 serverpod:
   flutter_apps:
     app-a:
       path: ../app_a_flutter
 ''');
+      });
 
-        expect(manager.apps.length, 2);
-        await manager.loadApps();
-        expect(manager.isRunning('app-b'), isFalse);
-        expect(manager.apps.length, 1);
-        expect(manager.apps.first.id, 'app-a');
-      },
-    );
+      test(
+        'when loadApps is called '
+        'then the removed app is stopped and dropped from the app list',
+        () async {
+          expect(f.manager.apps.length, 2);
 
-    test(
-      'when loadApps is called after adding additional apps to the config, '
-      'then new apps are added and old ones remain',
-      () async {
-        serverPubspecFile.writeAsStringSync('''
-name: server
+          await f.manager.loadApps();
+
+          expect(f.manager.isRunning('app-b'), isFalse);
+          expect(f.manager.apps.length, 1);
+          expect(f.manager.apps.first.id, 'app-a');
+        },
+      );
+    });
+
+    group('with an additional app in the flutter_apps config', () {
+      setUp(() {
+        f.serverPubspecFile.writeAsStringSync('''
+name: project_server
 serverpod:
   flutter_apps:
     app-a:
@@ -684,35 +626,38 @@ serverpod:
     app-c:
       path: ../app_c_flutter
 ''');
+        f.addFlutterPackage('app_c_flutter');
+      });
 
-        final flutterDirC = Directory(p.join(tempDir.path, 'app_c_flutter'))
-          ..createSync(recursive: true);
-        File(p.join(flutterDirC.path, 'pubspec.yaml')).writeAsStringSync('''
-name: app_c
-dependencies:
-  flutter:
-    sdk: flutter
-''');
+      test(
+        'when loadApps is called '
+        'then the new app is added and existing ones remain',
+        () async {
+          expect(f.manager.apps.length, 2);
 
-        expect(manager.apps.length, 2);
-        await manager.loadApps();
+          await f.manager.loadApps();
 
-        expect(manager.apps.length, 3);
-        expect(
-          manager.apps.map((a) => a.id),
-          containsAll(['app-a', 'app-b', 'app-c']),
-        );
-      },
-    );
+          expect(f.manager.apps.length, 3);
+          expect(
+            f.manager.apps.map((a) => a.id),
+            containsAll(['app-a', 'app-b', 'app-c']),
+          );
+        },
+      );
+    });
 
     test(
-      'when loadApps without changing the apps in the config, '
-      'then the app list remains unchanged',
+      'when loadApps is called without config changes '
+      'then the app list is unchanged',
       () async {
-        expect(manager.apps.length, 2);
-        await manager.loadApps();
-        expect(manager.apps.length, 2);
-        expect(manager.apps.map((a) => a.id), containsAll(['app-a', 'app-b']));
+        expect(f.manager.apps.length, 2);
+
+        await f.manager.loadApps();
+
+        expect(
+          f.manager.apps.map((a) => a.id),
+          containsAll(['app-a', 'app-b']),
+        );
       },
     );
   });

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -162,12 +162,12 @@ void main() {
       late FlutterProcess fp;
       late ({HttpServer server, String wsUri}) fake;
       late List<String> progressMessages;
-      late Completer<void> ready;
+      late Completer<void> started;
 
       setUp(() async {
         fake = await _startFakeVmService();
         progressMessages = <String>[];
-        ready = Completer<void>();
+        started = Completer<void>();
 
         fp = FlutterProcess(
           flutterPackageDir: Directory.current.path,
@@ -178,9 +178,9 @@ void main() {
             '--ws=${fake.wsUri}',
             '--web-url=http://localhost:54321',
           ],
-          onProgress: (message) {
-            progressMessages.add(message);
-            if (message == 'ready' && !ready.isCompleted) ready.complete();
+          onProgress: progressMessages.add,
+          onStarted: () {
+            if (!started.isCompleted) started.complete();
           },
         );
 
@@ -197,9 +197,9 @@ void main() {
 
       test(
         'when the shim emits app.progress, app.webLaunchUrl, app.debugPort, app.dtd, app.started '
-        'then onProgress fires, flutterAppUrl is captured, dtdUri is captured, and vmServiceUri is the http form of the daemon\'s wsUri',
+        'then onProgress and onStarted fire, flutterAppUrl is captured, dtdUri is captured, and vmServiceUri is the http form of the daemon\'s wsUri',
         () async {
-          await ready.future.timeout(const Duration(seconds: 20));
+          await started.future.timeout(const Duration(seconds: 20));
 
           expect(
             fp.vmServiceUri,
@@ -209,7 +209,6 @@ void main() {
           expect(fp.dtdUri, equals('ws://127.0.0.1:9100/ws'));
           expect(progressMessages, contains(flutterAppLaunching));
           expect(progressMessages, contains('Launching ...'));
-          expect(progressMessages, contains('ready'));
 
           await fp.stop(timeout: const Duration(seconds: 1));
         },
@@ -415,7 +414,7 @@ void main() {
           ]),
         );
         expect(fp.flutterAppUrl, 'http://localhost:8080');
-        expect(progressMessages, containsAllInOrder(['Compiling', 'ready']));
+        expect(progressMessages, contains('Compiling'));
       },
     );
 
@@ -440,9 +439,10 @@ void main() {
         );
 
         // Desktop devices never publish an app.webLaunchUrl, so this
-        // callback is their only launch-complete signal.
+        // callback is their only launch-complete signal. It replaces the
+        // progress stream for this event - no stage string is emitted.
         expect(startedCalls, 1);
-        expect(progressMessages, ['ready']);
+        expect(progressMessages, isEmpty);
         expect(fp.flutterAppUrl, isNull);
       },
     );

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -420,6 +420,34 @@ void main() {
     );
 
     test(
+      'when app.started arrives then onStarted fires',
+      () {
+        var startedCalls = 0;
+        fp = FlutterProcess(
+          flutterPackageDir: Directory.systemTemp.path,
+          device: 'linux',
+          onProgress: progressMessages.add,
+          onStarted: () => startedCalls++,
+        );
+
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'app.started',
+              'params': <String, Object?>{},
+            },
+          ]),
+        );
+
+        // Desktop devices never publish an app.webLaunchUrl, so this
+        // callback is their only launch-complete signal.
+        expect(startedCalls, 1);
+        expect(progressMessages, ['ready']);
+        expect(fp.flutterAppUrl, isNull);
+      },
+    );
+
+    test(
       'when given app.dtd then dtdUri is captured',
       () {
         fp.handleMachineLine(

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/emits_desktop_machine_events.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/emits_desktop_machine_events.dart
@@ -1,0 +1,46 @@
+// Test shim: emits the `--machine` event sequence of a desktop-device run
+// (e.g. `-d linux`) - progress, debugPort, and started, but no
+// `app.webLaunchUrl` (that event is web-only) - then waits for
+// SIGINT/SIGTERM. `--ws=<uri>` overrides the wsUri in app.debugPort.
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+Future<void> main(List<String> args) async {
+  final wsUri = args
+      .firstWhere(
+        (a) => a.startsWith('--ws='),
+        orElse: () => '--ws=ws://127.0.0.1:0/ws',
+      )
+      .substring('--ws='.length);
+
+  void emit(Map<String, Object?> event) {
+    stdout.writeln(jsonEncode([event]));
+  }
+
+  emit({
+    'event': 'app.progress',
+    'params': {'message': 'Syncing files to device Linux...'},
+  });
+  emit({
+    'event': 'app.debugPort',
+    'params': {'wsUri': wsUri, 'port': Uri.parse(wsUri).port},
+  });
+  emit({
+    'event': 'app.started',
+    'params': {},
+  });
+
+  final stopper = Completer<void>();
+
+  ProcessSignal.sigint.watch().listen((_) {
+    if (!stopper.isCompleted) stopper.complete();
+  });
+  if (!Platform.isWindows) {
+    ProcessSignal.sigterm.watch().listen((_) {
+      if (!stopper.isCompleted) stopper.complete();
+    });
+  }
+
+  await stopper.future;
+}


### PR DESCRIPTION
When `serverpod start` launches a Flutter app on a non-web device (desktop or mobile), the app's tab in the TUI never left the loading state: the spinner froze, the status text kept shimmering forever.

The ready signal (`onReady`, which sets `tab.ready`) only fired when the daemon published a web URL. `flutterAppUrl` comes from the `app.webLaunchUrl` machine event, which only exists for web devices, so on any other device the tab stayed "launching" forever.

This PR signals ready from the daemon's `app.started` event, which fires on every device type:
- `FlutterProcess` gains an `onStarted` callback, invoked on `app.started`.
- `FlutterAppManager` funnels both ready sources through a `_signalReady` helper that fires `onReady` at most once per launch. 
- `isLaunching` is now keyed on the ready signal instead of URL publication.
- New `emits_desktop_machine_events.dart` shim with a manager test asserting `onReady` fires once with a null URL, plus a `FlutterProcess` unit test for `onStarted`.

Fixes #5454 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None