### PR TITLE
fix(cli): validate relation database actions

### DIFF
--- a/tools/serverpod_cli/CHANGELOG.md
+++ b/tools/serverpod_cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 - feat: Adds support for creating server only projects.
 - fix: Fixes `upsert` with `updateWhere` throwing on SQLite when conflicts are filtered out.
 - fix: Adds missing export of `DeepCollectionEquality` for shared models. Backported to 3.4.11.
+- fix: Validates `SetNull` and `SetDefault` relation actions against foreign key column constraints.
 - fix: Prevents the creation of orphaned images on subsequent IDP logins. Backported to 3.4.11.
 - refactor: Refines the serverpod start TUI app status, stop/close, and launcher.
 - chore: Changes the template to serve the Flutter web app under root if website is not enabled.

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -537,9 +537,10 @@ class Restrictions {
     var definition = documentDefinition;
     if (definition is! ClassDefinition) return [];
 
-    var field = definition.findField(parentNodeName);
+    var relationField = definition.findField(parentNodeName);
+    var relation = relationField?.relation;
 
-    if (field?.relation?.isForeignKeyOrigin == false) {
+    if (relation?.isForeignKeyOrigin == false) {
       return [
         SourceSpanSeverityException(
           'The "$key" property can only be set on the side holding the foreign key.',
@@ -548,7 +549,82 @@ class Restrictions {
       ];
     }
 
+    var foreignKeyField = _resolveForeignKeyField(
+      definition,
+      relationField,
+    );
+    var foreignKeyRelation = foreignKeyField?.relation;
+    if (foreignKeyRelation is! ForeignRelationDefinition) return [];
+
+    var action = switch (key) {
+      Keyword.onDelete => foreignKeyRelation.onDelete,
+      Keyword.onUpdate => foreignKeyRelation.onUpdate,
+      _ => null,
+    };
+
+    if (action == ForeignKeyAction.setNull) {
+      return _validateSetNullAction(key, foreignKeyField!, span);
+    }
+
+    if (action == ForeignKeyAction.setDefault) {
+      return _validateSetDefaultAction(key, foreignKeyField!, span);
+    }
+
     return [];
+  }
+
+  SerializableModelFieldDefinition? _resolveForeignKeyField(
+    ClassDefinition definition,
+    SerializableModelFieldDefinition? relationField,
+  ) {
+    var relation = relationField?.relation;
+
+    if (relation is ForeignRelationDefinition) {
+      return relationField;
+    }
+
+    if (relation is ObjectRelationDefinition) {
+      return definition.findField(relation.fieldName);
+    }
+
+    return null;
+  }
+
+  List<SourceSpanSeverityException> _validateSetNullAction(
+    String key,
+    SerializableModelFieldDefinition foreignKeyField,
+    SourceSpan? span,
+  ) {
+    var isNullableDatabaseColumn =
+        foreignKeyField.name != defaultPrimaryKeyName &&
+        foreignKeyField.type.nullable;
+    if (isNullableDatabaseColumn) return [];
+
+    return [
+      SourceSpanSeverityException(
+        'The foreign key field "${foreignKeyField.name}" must be nullable in '
+        'the database when "$key" is set to "SetNull".',
+        span,
+      ),
+    ];
+  }
+
+  List<SourceSpanSeverityException> _validateSetDefaultAction(
+    String key,
+    SerializableModelFieldDefinition foreignKeyField,
+    SourceSpan? span,
+  ) {
+    if (foreignKeyField.defaultPersistValue != null) return [];
+
+    return [
+      SourceSpanSeverityException(
+        'The foreign key field "${foreignKeyField.name}" must define a '
+        'database default using "default" or "defaultPersist" when "$key" is '
+        'set to "SetDefault". "defaultModel" only initializes Dart objects '
+        'and is not applied by the database.',
+        span,
+      ),
+    ];
   }
 
   List<SourceSpanSeverityException> validateOptionalKey(

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -2717,6 +2717,10 @@ class Restrictions {
       );
     }
 
+    errors.addAll(
+      _validateDefaultOnRelationField(field, Keyword.defaultKey, span),
+    );
+
     if ((definition is ModelClassDefinition) &&
         (definition.tableName != null) &&
         (parentNodeName == defaultPrimaryKeyName)) {
@@ -2782,6 +2786,13 @@ class Restrictions {
       );
     }
 
+    var relationErrors = _validateDefaultOnRelationField(
+      field,
+      Keyword.defaultPersistKey,
+      span,
+    );
+    errors.addAll(relationErrors);
+
     if (field.hasOnlyDatabaseDefaults && !field.type.nullable) {
       errors.add(
         SourceSpanSeverityException(
@@ -2794,7 +2805,7 @@ class Restrictions {
     /// We perform this check here instead of using [mutuallyExclusiveKeys] because our
     /// concern is specifically whether the field should be persisted in the database.
     /// Using "persist" is allowed, while using "!persist" is not allowed.
-    if (!field.shouldPersist) {
+    if (relationErrors.isEmpty && !field.shouldPersist) {
       errors.add(
         SourceSpanSeverityException(
           'The "defaultPersist" property is mutually exclusive with the "!persist" property.',
@@ -2804,6 +2815,23 @@ class Restrictions {
     }
 
     return errors;
+  }
+
+  List<SourceSpanSeverityException> _validateDefaultOnRelationField(
+    SerializableModelFieldDefinition field,
+    String key,
+    SourceSpan? span,
+  ) {
+    var relation = field.relation;
+    if (relation == null || relation is ForeignRelationDefinition) return [];
+
+    return [
+      SourceSpanSeverityException(
+        'The "$key" property can only be used on persisted fields or on id '
+        'fields that define the foreign key relation.',
+        span,
+      ),
+    ];
   }
 
   Map<dynamic, int> _duplicatesCount(List<dynamic> list) {

--- a/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/class_yaml_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/yaml_definitions/class_yaml_definition.dart
@@ -99,11 +99,7 @@ class ClassYamlDefinition {
                 valueRestriction:
                     restrictions.validateRelationInterdependencies,
                 allowEmptyNestedValue: true,
-                mutuallyExclusiveKeys: {
-                  Keyword.defaultKey,
-                  Keyword.defaultModelKey,
-                  Keyword.defaultPersistKey,
-                },
+                mutuallyExclusiveKeys: {Keyword.defaultModelKey},
                 nested: {
                   ValidateNode(
                     Keyword.parent,
@@ -196,9 +192,6 @@ class ClassYamlDefinition {
                   Keyword.defaultKey,
                   restrictions.documentDefinition,
                 ).validate,
-                mutuallyExclusiveKeys: {
-                  Keyword.relation,
-                },
               ),
               ValidateNode(
                 Keyword.defaultModelKey,
@@ -218,9 +211,6 @@ class ClassYamlDefinition {
                   Keyword.defaultPersistKey,
                   restrictions.documentDefinition,
                 ).validate,
-                mutuallyExclusiveKeys: {
-                  Keyword.relation,
-                },
               ),
               ValidateNode(
                 Keyword.columnKey,

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_database_action_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_database_action_test.dart
@@ -254,6 +254,70 @@ fields:
         expect(collector.errors, isEmpty);
       });
 
+      test('then defaultPersist on a direct id relation is accepted.', () {
+        var collector = analyzeSingleModel(
+          '''
+class: Example
+table: example
+fields:
+  exampleId: int?, defaultPersist=1, relation(parent=example, $actionKey=SetDefault)
+''',
+        );
+
+        expect(collector.errors, isEmpty);
+      });
+
+      test('then a shared default on a direct id relation is accepted.', () {
+        var collector = analyzeSingleModel(
+          '''
+class: Example
+table: example
+fields:
+  exampleId: int, default=1, relation(parent=example, $actionKey=SetDefault)
+''',
+        );
+
+        expect(collector.errors, isEmpty);
+      });
+
+      test('then a default on an object relation field is rejected.', () {
+        var collector = analyzeSingleModel(
+          '''
+class: Example
+table: example
+fields:
+  example: Example?, default=1, relation($actionKey=SetDefault, optional)
+''',
+        );
+
+        expect(
+          collector.errors.map((error) => error.message),
+          contains(
+            'The "default" property can only be used on persisted fields or on '
+            'id fields that define the foreign key relation.',
+          ),
+        );
+      });
+
+      test('then defaultPersist on an object relation field is rejected.', () {
+        var collector = analyzeSingleModel(
+          '''
+class: Example
+table: example
+fields:
+  example: Example?, defaultPersist=1, relation($actionKey=SetDefault, optional)
+''',
+        );
+
+        expect(
+          collector.errors.map((error) => error.message),
+          contains(
+            'The "defaultPersist" property can only be used on persisted fields '
+            'or on id fields that define the foreign key relation.',
+          ),
+        );
+      });
+
       test('then an implicit foreign key is rejected.', () {
         var collector = analyzeSingleModel(
           '''

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_database_action_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_database_action_test.dart
@@ -10,6 +10,16 @@ import '../../../../../test_util/builders/model_source_builder.dart';
 void main() {
   var config = GeneratorConfigBuilder().build();
 
+  CodeGenerationCollector analyzeSingleModel(String yaml) {
+    var collector = CodeGenerationCollector();
+    StatefulAnalyzer(
+      config,
+      [ModelSourceBuilder().withYaml(yaml).build()],
+      onErrorsCollector(collector),
+    ).validateAll();
+    return collector;
+  }
+
   var databaseActions = [
     'Cascade',
     'NoAction',
@@ -28,7 +38,8 @@ void main() {
         class: Example
         table: example
         fields:
-          example: Example?, relation(onUpdate=$action)
+          exampleId: int?, default=1
+          example: Example?, relation(field=exampleId, onUpdate=$action)
         ''',
           ).build(),
         ];
@@ -72,7 +83,8 @@ void main() {
         class: Example
         table: example
         fields:
-          example: Example?, relation(onDelete=$action)
+          exampleId: int?, default=1
+          example: Example?, relation(field=exampleId, onDelete=$action)
         ''',
           ).build(),
         ];
@@ -103,6 +115,162 @@ void main() {
         }, skip: noneFieldRelation);
       },
     );
+  }
+
+  for (var actionKey in ['onDelete', 'onUpdate']) {
+    group('Given $actionKey=SetNull', () {
+      test('then a non-nullable explicit foreign key is rejected.', () {
+        var collector = analyzeSingleModel(
+          '''
+class: Example
+table: example
+fields:
+  exampleId: int
+  example: Example?, relation(field=exampleId, $actionKey=SetNull)
+''',
+        );
+
+        expect(collector.errors, hasLength(1));
+        expect(
+          collector.errors.single.message,
+          'The foreign key field "exampleId" must be nullable in the database '
+          'when "$actionKey" is set to "SetNull".',
+        );
+        expect(collector.errors.single.span?.text, actionKey);
+      });
+
+      test('then a nullable explicit foreign key is accepted.', () {
+        var collector = analyzeSingleModel(
+          '''
+class: Example
+table: example
+fields:
+  exampleId: int?
+  example: Example?, relation(field=exampleId, $actionKey=SetNull)
+''',
+        );
+
+        expect(collector.errors, isEmpty);
+      });
+
+      test('then a non-optional implicit foreign key is rejected.', () {
+        var collector = analyzeSingleModel(
+          '''
+class: Example
+table: example
+fields:
+  example: Example?, relation($actionKey=SetNull)
+''',
+        );
+
+        expect(collector.errors, hasLength(1));
+        expect(
+          collector.errors.single.message,
+          'The foreign key field "exampleId" must be nullable in the database '
+          'when "$actionKey" is set to "SetNull".',
+        );
+      });
+
+      test('then an optional implicit foreign key is accepted.', () {
+        var collector = analyzeSingleModel(
+          '''
+class: Example
+table: example
+fields:
+  example: Example?, relation($actionKey=SetNull, optional)
+''',
+        );
+
+        expect(collector.errors, isEmpty);
+      });
+    });
+
+    group('Given $actionKey=SetDefault', () {
+      test('then a foreign key without a database default is rejected.', () {
+        var collector = analyzeSingleModel(
+          '''
+class: Example
+table: example
+fields:
+  exampleId: int
+  example: Example?, relation(field=exampleId, $actionKey=SetDefault)
+''',
+        );
+
+        expect(collector.errors, hasLength(1));
+        expect(
+          collector.errors.single.message,
+          'The foreign key field "exampleId" must define a database default '
+          'using "default" or "defaultPersist" when "$actionKey" is set to '
+          '"SetDefault". "defaultModel" only initializes Dart objects and is '
+          'not applied by the database.',
+        );
+        expect(collector.errors.single.span?.text, actionKey);
+      });
+
+      test('then defaultModel alone is rejected.', () {
+        var collector = analyzeSingleModel(
+          '''
+class: Example
+table: example
+fields:
+  exampleId: int, defaultModel=1
+  example: Example?, relation(field=exampleId, $actionKey=SetDefault)
+''',
+        );
+
+        expect(collector.errors, hasLength(1));
+        expect(
+          collector.errors.single.message,
+          contains('"defaultModel" only initializes Dart objects'),
+        );
+      });
+
+      test('then defaultPersist is accepted.', () {
+        var collector = analyzeSingleModel(
+          '''
+class: Example
+table: example
+fields:
+  exampleId: int?, defaultPersist=1
+  example: Example?, relation(field=exampleId, $actionKey=SetDefault)
+''',
+        );
+
+        expect(collector.errors, isEmpty);
+      });
+
+      test('then a shared default is accepted.', () {
+        var collector = analyzeSingleModel(
+          '''
+class: Example
+table: example
+fields:
+  exampleId: int, default=1
+  example: Example?, relation(field=exampleId, $actionKey=SetDefault)
+''',
+        );
+
+        expect(collector.errors, isEmpty);
+      });
+
+      test('then an implicit foreign key is rejected.', () {
+        var collector = analyzeSingleModel(
+          '''
+class: Example
+table: example
+fields:
+  example: Example?, relation($actionKey=SetDefault)
+''',
+        );
+
+        expect(collector.errors, hasLength(1));
+        expect(
+          collector.errors.single.message,
+          contains('must define a database default'),
+        );
+      });
+    });
   }
 
   group('Given a class with no database action explicitly set', () {


### PR DESCRIPTION
Validates relation database actions against the resolved foreign-key column before migrations are generated.

For `SetNull`, the foreign-key database column must be nullable. For `SetDefault`, it must have a database-level default from `default` or `defaultPersist`; `defaultModel` alone is not sufficient because it only initializes Dart objects.

The validation resolves both explicit and implicitly generated foreign-key fields and covers `onDelete` and `onUpdate`. Database defaults are supported on direct foreign-key id relations, while remaining invalid on non-persisted object and list relation fields.

Fixes #5401

## Validation

- `dart format --output=none --set-exit-if-changed` on the changed Dart files
- `dart analyze` in `tools/serverpod_cli`
- `dart test test/analyzer/models/stateful_analyzer/model_validation/relation/relation_database_action_test.dart`
- `dart test test/analyzer/models/stateful_analyzer/model_validation/relation`
- `git diff --check`

## Pre-launch Checklist

- [x] I read the contribution guidelines and kept the change focused on one bug.
- [x] The code follows Dart formatting and style conventions.
- [x] The PR references the issue it fixes.
- [x] Relevant regression tests were added.
- [x] Existing and new relation analyzer tests pass.
- [x] No breaking API changes are introduced.

## Breaking changes

None.