### PR TITLE
feat: Show the device platform in the start TUI Flutter app status line

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -1149,6 +1149,8 @@ Future<void> _runTuiBackend({
         tab.ready = false;
         tab.stopped = false;
         tab.url = null;
+        // Refreshed per launch; the configured device may have changed.
+        tab.device = app.device;
         // Focus the tab only when the launch was initiated from the launch
         // panel (which is open at that point). Apps auto-started by
         // `serverpod start` launch with the panel closed, so the Server logs

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -491,7 +491,9 @@ class MainScreen extends StatelessComponent {
 
     String statusText;
     if (tab.ready) {
-      statusText = tab.url ?? 'App running';
+      final device = tab.device;
+      statusText =
+          tab.url ?? 'Running on device${device == null ? '' : ' $device'}';
     } else if (tab.stopped) {
       statusText = 'App stopped';
     } else {

--- a/tools/serverpod_cli/lib/src/commands/start/tui/tab_model.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/tab_model.dart
@@ -48,6 +48,7 @@ class AppLogTab implements PaneTab {
     this.ready = false,
     this.stopped = false,
     this.url,
+    this.device,
     this.startupStage,
   }) : lines = lines ?? BoundedQueueList<String>(maxLogEntries),
        logHistory = logHistory ?? BoundedQueueList<Object>(maxLogEntries),
@@ -72,6 +73,10 @@ class AppLogTab implements PaneTab {
 
   /// HTTP URL the Flutter app is served at.
   String? url;
+
+  /// Configured launch device from [FlutterAppConfig.device], or null for
+  /// the default web device.
+  String? device;
 
   /// Latest `app.progress` message from the Flutter daemon.
   String? startupStage;

--- a/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
@@ -313,51 +313,49 @@ void main() {
     );
   });
 
-  group('Given a ready Flutter app tab', () {
-    test(
-      'when it has a configured device '
-      'then the status line names it',
-      () async {
-        final tester = await _pumpReadyAppTab(device: 'emulator-5554');
+  group('Given a ready Flutter app tab with a configured device', () {
+    late NoctermTester tester;
 
-        expect(
-          tester.terminalState.containsText('Running on device emulator-5554'),
-          isTrue,
-        );
-      },
-    );
+    setUp(() async {
+      tester = await _pumpReadyAppTab(device: 'emulator-5554');
+    });
 
-    test(
-      'when it has no configured device '
-      'then the status line shows the generic running label',
-      () async {
-        final tester = await _pumpReadyAppTab();
+    test('then the status line names the device', () {
+      expect(
+        tester.terminalState.containsText('Running on device emulator-5554'),
+        isTrue,
+      );
+    });
+  });
 
-        expect(
-          tester.terminalState.containsText('Running on device'),
-          isTrue,
-        );
-      },
-    );
+  group('Given a ready Flutter app tab without a configured device', () {
+    late NoctermTester tester;
 
-    test(
-      'when a URL is published '
-      'then the status line shows the URL, not the device',
-      () async {
-        final tester = await _pumpReadyAppTab(
-          device: 'chrome',
-          url: 'http://localhost:8080',
-        );
+    setUp(() async {
+      tester = await _pumpReadyAppTab();
+    });
 
-        expect(
-          tester.terminalState.containsText('http://localhost:8080'),
-          isTrue,
-        );
-        expect(
-          tester.terminalState.containsText('Running on device'),
-          isFalse,
-        );
-      },
-    );
+    test('then the status line shows the generic running label', () {
+      expect(tester.terminalState.containsText('Running on device'), isTrue);
+    });
+  });
+
+  group('Given a ready Flutter app tab with a published URL', () {
+    late NoctermTester tester;
+
+    setUp(() async {
+      tester = await _pumpReadyAppTab(
+        device: 'chrome',
+        url: 'http://localhost:8080',
+      );
+    });
+
+    test('then the status line shows the URL, not the device', () {
+      expect(
+        tester.terminalState.containsText('http://localhost:8080'),
+        isTrue,
+      );
+      expect(tester.terminalState.containsText('Running on device'), isFalse);
+    });
   });
 }

--- a/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
@@ -90,6 +90,27 @@ Future<NoctermTester> _pumpLaunchPanel({
   return _pump(state, const Size(120, 24));
 }
 
+/// Builds a single ready app tab with [device] and [url], then pumps it.
+Future<NoctermTester> _pumpReadyAppTab({String? device, String? url}) async {
+  final state = ServerWatchState();
+  state.showSplash = false;
+  state.serverReady = true;
+  state.launchableApps = [
+    const FlutterAppConfig(
+      id: 'app',
+      name: 'App',
+      relativePathParts: ['..', 'app'],
+      serverPackageDirectoryPathParts: [],
+    ),
+  ];
+  final tab = state.getOrCreateAppLogTab(appId: 'app', label: 'App');
+  tab.ready = true;
+  tab.device = device;
+  tab.url = url;
+  state.tabs.focusTab(tab);
+  return _pump(state, const Size(200, 30));
+}
+
 /// Pumps [state] at [size] and returns the tester, disposing it on teardown.
 Future<NoctermTester> _pump(ServerWatchState state, Size size) async {
   final holder = StartAppStateHolder(state);
@@ -288,6 +309,54 @@ void main() {
         );
 
         expect(launchingMarker.style.color, isNot(runningMarker.style.color));
+      },
+    );
+  });
+
+  group('Given a ready Flutter app tab', () {
+    test(
+      'when it has a configured device '
+      'then the status line names it',
+      () async {
+        final tester = await _pumpReadyAppTab(device: 'emulator-5554');
+
+        expect(
+          tester.terminalState.containsText('Running on device emulator-5554'),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'when it has no configured device '
+      'then the status line shows the generic running label',
+      () async {
+        final tester = await _pumpReadyAppTab();
+
+        expect(
+          tester.terminalState.containsText('Running on device'),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'when a URL is published '
+      'then the status line shows the URL, not the device',
+      () async {
+        final tester = await _pumpReadyAppTab(
+          device: 'chrome',
+          url: 'http://localhost:8080',
+        );
+
+        expect(
+          tester.terminalState.containsText('http://localhost:8080'),
+          isTrue,
+        );
+        expect(
+          tester.terminalState.containsText('Running on device'),
+          isFalse,
+        );
       },
     );
   });


### PR DESCRIPTION
For non-web Flutter apps, the `serverpod start` TUI status line previously showed a generic `App running` once the app was up. It now shows which platform the app is running on:

The daemon's `app.start` event carries the resolved `deviceId`:
- Desktop ids name their platform directly (`windows`, `macos`, `linux`)
- Mobile ids are opaque serials (`emulator-5554`, iOS UDIDs), so they are matched against a `device.getDevices` daemon request and mapped via the device's `platformType`.

Resolution is best-effort: on any failure the status line just keeps the generic `Running on device` label. Web devices are not mapped since their status line always shows the published URL.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None