### PR TITLE
fix: Fix watch-mode feedback loops and Flutter build disk I/O

### DIFF
--- a/tests/serverpod_cli_e2e_test/test/generate_watch_test.dart
+++ b/tests/serverpod_cli_e2e_test/test/generate_watch_test.dart
@@ -156,6 +156,7 @@ fields:
         reason:
             'Incremental code generation did not complete before timeout was reached.',
       );
+      await waitForFileDeletion(entityFile);
 
       entityFiles = entityDirectory.listSync();
       expect(
@@ -306,6 +307,7 @@ fields:
           reason:
               'Incremental code generation did not complete before timeout was reached.',
         );
+        await waitForFileDeletion(entityFile);
 
         entityFiles = entityDirectory.listSync();
         expect(
@@ -913,6 +915,16 @@ String createRandomProjectName() {
   var clientDir = path.join(projectName, '${projectName}_client');
 
   return (serverDir, flutterDir, clientDir);
+}
+
+Future<void> waitForFileDeletion(
+  File file, {
+  Duration timeout = const Duration(seconds: 30),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (file.existsSync() && DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
 }
 
 String createClientModelDirectoryPath(

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -78,7 +78,7 @@ class EndpointsAnalyzer {
         .where((f) => p.isWithin(absoluteIncludedPaths, p.absolute(f)))
         .toSet();
 
-    final erroredBefore = _erroredFiles;
+    final erroredFilesBefore = _erroredFiles;
     final keysBefore = _fileCache.keys.toSet();
 
     await analyze(
@@ -86,7 +86,7 @@ class EndpointsAnalyzer {
       changedFiles: relevantPaths,
     );
 
-    final erroredAfter = _erroredFiles;
+    final erroredFilesAfter = _erroredFiles;
     final keysAfter = _fileCache.keys.toSet();
 
     // Regenerate when the set of endpoint files changed, or when any file's
@@ -97,8 +97,8 @@ class EndpointsAnalyzer {
     // error exists anywhere in the project.
     if (keysBefore.length != keysAfter.length ||
         keysAfter.difference(keysBefore).isNotEmpty ||
-        erroredBefore.length != erroredAfter.length ||
-        erroredAfter.difference(erroredBefore).isNotEmpty) {
+        erroredFilesBefore.length != erroredFilesAfter.length ||
+        erroredFilesAfter.difference(erroredFilesBefore).isNotEmpty) {
       return true;
     }
 

--- a/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/endpoints_analyzer.dart
@@ -60,6 +60,12 @@ class EndpointsAnalyzer {
   /// These are tracked separately since they don't appear in [_fileCache].
   final Map<String, DartDocTemplateRegistry> _nonEndpointTemplateCache = {};
 
+  /// The endpoint files currently cached with errors.
+  Set<String> get _erroredFiles => {
+    for (final entry in _fileCache.entries)
+      if (entry.value.hadErrors) entry.key,
+  };
+
   /// Inform the analyzer that the provided [filePaths] have been updated.
   ///
   /// Refreshes the Dart analysis context for the changed files and returns
@@ -72,7 +78,7 @@ class EndpointsAnalyzer {
         .where((f) => p.isWithin(absoluteIncludedPaths, p.absolute(f)))
         .toSet();
 
-    final errorsBefore = _fileCache.values.any((r) => r.hadErrors);
+    final erroredBefore = _erroredFiles;
     final keysBefore = _fileCache.keys.toSet();
 
     await analyze(
@@ -80,13 +86,19 @@ class EndpointsAnalyzer {
       changedFiles: relevantPaths,
     );
 
-    final errorsAfter = _fileCache.values.any((r) => r.hadErrors);
+    final erroredAfter = _erroredFiles;
     final keysAfter = _fileCache.keys.toSet();
 
-    if (errorsBefore ||
-        errorsAfter ||
-        keysBefore.length != keysAfter.length ||
-        keysAfter.difference(keysBefore).isNotEmpty) {
+    // Regenerate when the set of endpoint files changed, or when any file's
+    // error state flipped (an error appearing or clearing changes the parsed
+    // definitions). A persistently broken file, by contrast, must not turn
+    // every unrelated change - such as watcher echoes of freshly generated
+    // files - into another generation, or generation loops forever while an
+    // error exists anywhere in the project.
+    if (keysBefore.length != keysAfter.length ||
+        keysAfter.difference(keysBefore).isNotEmpty ||
+        erroredBefore.length != erroredAfter.length ||
+        erroredAfter.difference(erroredBefore).isNotEmpty) {
       return true;
     }
 

--- a/tools/serverpod_cli/lib/src/analyzer/dart/future_calls_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/future_calls_analyzer.dart
@@ -73,7 +73,7 @@ class FutureCallsAnalyzer {
         .where((f) => p.isWithin(absoluteIncludedPaths, p.absolute(f)))
         .toSet();
 
-    final erroredBefore = _erroredFiles;
+    final erroredFilesBefore = _erroredFiles;
     final keysBefore = _fileCache.keys.toSet();
 
     await analyze(
@@ -81,7 +81,7 @@ class FutureCallsAnalyzer {
       changedFiles: relevantPaths,
     );
 
-    final erroredAfter = _erroredFiles;
+    final erroredFilesAfter = _erroredFiles;
     final keysAfter = _fileCache.keys.toSet();
 
     // Regenerate when the set of future call files changed, or when any
@@ -93,8 +93,8 @@ class FutureCallsAnalyzer {
     // exists anywhere in the project.
     if (keysBefore.length != keysAfter.length ||
         keysAfter.difference(keysBefore).isNotEmpty ||
-        erroredBefore.length != erroredAfter.length ||
-        erroredAfter.difference(erroredBefore).isNotEmpty) {
+        erroredFilesBefore.length != erroredFilesAfter.length ||
+        erroredFilesAfter.difference(erroredFilesBefore).isNotEmpty) {
       return true;
     }
 

--- a/tools/serverpod_cli/lib/src/analyzer/dart/future_calls_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/future_calls_analyzer.dart
@@ -56,6 +56,12 @@ class FutureCallsAnalyzer {
   /// iteration order when collecting definitions across runs.
   final _fileCache = SplayTreeMap<String, _CachedFutureCallFileResult>();
 
+  /// The future call files currently cached with errors.
+  Set<String> get _erroredFiles => {
+    for (final entry in _fileCache.entries)
+      if (entry.value.hadErrors) entry.key,
+  };
+
   /// Inform the analyzer that the provided [filePaths] have been updated.
   ///
   /// Refreshes the Dart analysis context for the changed files and returns
@@ -67,7 +73,7 @@ class FutureCallsAnalyzer {
         .where((f) => p.isWithin(absoluteIncludedPaths, p.absolute(f)))
         .toSet();
 
-    final errorsBefore = _fileCache.values.any((r) => r.hadErrors);
+    final erroredBefore = _erroredFiles;
     final keysBefore = _fileCache.keys.toSet();
 
     await analyze(
@@ -75,13 +81,20 @@ class FutureCallsAnalyzer {
       changedFiles: relevantPaths,
     );
 
-    final errorsAfter = _fileCache.values.any((r) => r.hadErrors);
+    final erroredAfter = _erroredFiles;
     final keysAfter = _fileCache.keys.toSet();
 
-    if (errorsBefore ||
-        errorsAfter ||
-        keysBefore.length != keysAfter.length ||
-        keysAfter.difference(keysBefore).isNotEmpty) {
+    // Regenerate when the set of future call files changed, or when any
+    // file's error state flipped (an error appearing or clearing changes the
+    // parsed definitions). A persistently broken - or not yet fully analyzed
+    // (see `hadErrors: !hasModels`) - file, by contrast, must not turn every
+    // unrelated change - such as watcher echoes of freshly generated files -
+    // into another generation, or generation loops forever while an error
+    // exists anywhere in the project.
+    if (keysBefore.length != keysAfter.length ||
+        keysAfter.difference(keysBefore).isNotEmpty ||
+        erroredBefore.length != erroredAfter.length ||
+        erroredAfter.difference(erroredBefore).isNotEmpty) {
       return true;
     }
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
@@ -15,6 +15,8 @@ class StatefulAnalyzer {
   final GeneratorConfig config;
   final Map<String, _ModelState> _modelStates = {};
 
+  String _modelStateKey(Uri uri) => p.canonicalize(uri.toFilePath());
+
   /// Returns true if any of the models have severe errors.
   bool get hasSevereErrors => _modelStates.values.any(
     (state) => CodeAnalysisCollector.containsSevereErrors(state.errors),
@@ -28,7 +30,7 @@ class StatefulAnalyzer {
     Function(Uri, CodeGenerationCollector)? onErrorsChangedNotifier,
   ]) {
     for (var yamlSource in sources) {
-      _modelStates[yamlSource.yamlSourceUri.path] = _ModelState(
+      _modelStates[_modelStateKey(yamlSource.yamlSourceUri)] = _ModelState(
         source: yamlSource,
       );
     }
@@ -65,19 +67,19 @@ class StatefulAnalyzer {
       source: yamlSource,
     );
 
-    _modelStates[yamlSource.yamlSourceUri.path] = modelState;
+    _modelStates[_modelStateKey(yamlSource.yamlSourceUri)] = modelState;
   }
 
   /// Checks if a model is registered in the state.
   bool isModelRegistered(Uri uri) {
-    return _modelStates.containsKey(uri.path);
+    return _modelStates.containsKey(_modelStateKey(uri));
   }
 
   /// Removes a model from the state but leaves the responsibility of validating
   /// the new state to the caller. Please note that [validateAll] should be called to
   /// guarantee that all related errors are cleared.
   void removeYamlModel(Uri modelUri) {
-    _modelStates.remove(modelUri.path);
+    _modelStates.remove(_modelStateKey(modelUri));
   }
 
   /// Runs the validation on all models in the state. If no models are
@@ -100,7 +102,7 @@ class StatefulAnalyzer {
   /// state, if not this returns the last validated state.
   /// Errors are reported through the [onErrorsChangedNotifier].
   List<SerializableModelDefinition> validateModel(String yaml, Uri uri) {
-    var state = _modelStates[uri.path];
+    var state = _modelStates[_modelStateKey(uri)];
     if (state == null) return _validProjectModels;
 
     state.source.yaml = yaml;

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -315,14 +315,20 @@ Future<bool> _performGenerateWatch({
     log.info(generatedCodeAlreadyUpToDate, type: TextLogType.success);
   }
 
-  log.debug(initialCodeGenerationComplete);
-
   // Set up file watcher for source directories only (no web or client).
   final watcher = FileWatcher(
     watchPaths: {
       path.absolute(path.joinAll(config.libSourcePathParts)),
       ...config.sharedModelsLibSourcePaths.map(path.absolute),
     },
+  );
+
+  // Announce "Listening for changes" only once the OS watcher is actually
+  // initialized: events that occur before that (the initial directory scan
+  // can take seconds, notably on Windows) are silently dropped. The `ready`
+  // future only starts completing once the stream below has a subscriber.
+  unawaited(
+    watcher.ready.then((_) => log.debug(initialCodeGenerationComplete)),
   );
 
   // The generated dirs live inside the watched lib/ dirs, so generation

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -8,6 +8,7 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
+import 'package:serverpod_cli/src/commands/watcher.dart';
 import 'package:serverpod_cli/src/generated/version.dart';
 import 'package:serverpod_cli/src/generator/analyzers.dart';
 import 'package:serverpod_cli/src/generator/generation_staleness.dart';
@@ -324,12 +325,20 @@ Future<bool> _performGenerateWatch({
     },
   );
 
+  // The generated dirs live inside the watched lib/ dirs, so generation
+  // output shows up as watcher events. Feeding those back into generation
+  // would make every run trigger the next one.
+  final generatedDirPaths = config.generatedDirPaths;
+  bool isGenerated(String filePath) => generatedDirPaths.any(
+    (dir) => path.isWithin(dir, path.absolute(filePath)),
+  );
+
   // Process file change events.
   await for (final event in watcher.onFilesChanged) {
     final affectedPaths = {
       ...event.dartFiles,
       ...event.modelFiles,
-    };
+    }.where((f) => !isGenerated(f)).toSet();
 
     if (affectedPaths.isEmpty) continue;
 

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -786,15 +786,21 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   );
 }
 
-/// The directories the watch-mode [FileWatcher] observes: server/shared/client
+/// The paths the watch-mode [FileWatcher] observes: server/shared/client
 /// source, the server's web dir, each Flutter app's lib and pubspec.yaml, and
-/// the resolution `.dart_tool`(s) carrying `package_config.json` /
-/// `package_graph.json`.
+/// the exact `package_config.json` / `package_graph.json` files of the
+/// resolution `.dart_tool`(s).
 ///
 /// [serverDartToolDir] is the server's resolution `.dart_tool` (workspace root
-/// or the package itself); watching it is what makes a dependency change reload
-/// the server in place. In a workspace it equals each Flutter app's
-/// [FlutterDependencyTracker.dartToolDir] and dedupes to a single watch.
+/// or the package itself); watching its `package_config.json` is what makes a
+/// dependency change reload the server in place. In a workspace it equals each
+/// Flutter app's [FlutterDependencyTracker.dartToolDir].
+///
+/// The pub artifacts are watched as exact files rather than their `.dart_tool`
+/// directories: those directories also hold large, churning build state (e.g.
+/// `flutter_build` intermediates when a Flutter app builds, or the server's
+/// dill), and a recursive directory watch has to scan and re-list that tree on
+/// every build - heavy disk I/O for events that would all be discarded anyway.
 @visibleForTesting
 Set<String> buildWatchPaths({
   required GeneratorConfig config,
@@ -818,16 +824,17 @@ Set<String> buildWatchPaths({
       // full Flutter relaunch.
       p.absolute(p.joinAll([...app.pathParts, 'pubspec.yaml'])),
     ],
-    // The server's resolution .dart_tool, watched for package_config.json
-    // (reloaded into the FES in place) and, in a workspace, the shared
-    // package_graph.json. Dedupes against the Flutter trackers' dirs in a
-    // workspace layout.
-    if (serverDartToolDir != null) p.absolute(serverDartToolDir),
-    // Each Flutter resolution's .dart_tool holds package_graph.json, watched to
-    // detect Flutter dependency changes (workspace root or, in a non-workspace
-    // project, the Flutter package's own .dart_tool).
+    // The server resolution's package_config.json, reloaded into the FES in
+    // place on dependency changes. Watched as an exact file (see above); note
+    // that the single-file watcher stops if the file is deleted (e.g. by a
+    // clean), so dependency tracking then rests until the watcher is rebuilt.
+    if (serverDartToolDir != null)
+      p.absolute(p.join(serverDartToolDir, 'package_config.json')),
+    // Each Flutter resolution's package_graph.json, watched to detect Flutter
+    // dependency changes (workspace root or, in a non-workspace project, the
+    // Flutter package's own .dart_tool).
     for (final tracker in flutterDependencyTrackers)
-      p.absolute(tracker.dartToolDir),
+      p.absolute(p.join(tracker.dartToolDir, 'package_graph.json')),
   };
 }
 

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -12,7 +12,6 @@ import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_app_manager.dart';
-import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_server.dart';
@@ -651,19 +650,16 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     fileChangeSub?.cancel();
     if (!watch) return;
     final currentApps = flutterManager.apps.toList();
-    // One tracker per Flutter app that has a resolved dependency closure. Reused
-    // both to widen the watched directories and to pin the exact pub artifacts
-    // below.
-    final flutterDependencyTrackers = [
+    final flutterPackageGraphPaths = [
       for (final app in currentApps)
-        ?flutterManager.dependencyTrackerFor(app.id),
+        ?flutterManager.packageGraphPathFor(app.id),
     ];
     final watcher = FileWatcher(
       watchPaths: buildWatchPaths(
         config: config,
         flutterApps: currentApps,
         serverDartToolDir: serverDartToolDir,
-        flutterDependencyTrackers: flutterDependencyTrackers,
+        flutterPackageGraphPaths: flutterPackageGraphPaths,
       ),
       // Exact files so a change to one resolution's artifact never triggers the
       // other's action (matters only in a non-workspace layout). The server has
@@ -673,8 +669,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
           ? null
           : p.join(serverDartToolDir, 'package_config.json'),
       packageGraphPaths: {
-        for (final tracker in flutterDependencyTrackers)
-          p.join(tracker.dartToolDir, 'package_graph.json'),
+        ...flutterPackageGraphPaths,
       },
     );
     fileChangeSub = watcher.onFilesChanged
@@ -793,8 +788,8 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
 ///
 /// [serverDartToolDir] is the server's resolution `.dart_tool` (workspace root
 /// or the package itself); watching its `package_config.json` is what makes a
-/// dependency change reload the server in place. In a workspace it equals each
-/// Flutter app's [FlutterDependencyTracker.dartToolDir].
+/// dependency change reload the server in place. [flutterPackageGraphPaths]
+/// contains the resolved or expected graph path for every Flutter app.
 ///
 /// The pub artifacts are watched as exact files rather than their `.dart_tool`
 /// directories: those directories also hold large, churning build state (e.g.
@@ -806,7 +801,7 @@ Set<String> buildWatchPaths({
   required GeneratorConfig config,
   List<FlutterAppConfig> flutterApps = const [],
   String? serverDartToolDir,
-  Iterable<FlutterDependencyTracker> flutterDependencyTrackers = const [],
+  Iterable<String> flutterPackageGraphPaths = const [],
 }) {
   return {
     p.absolute(p.joinAll(config.libSourcePathParts)),
@@ -825,16 +820,14 @@ Set<String> buildWatchPaths({
       p.absolute(p.joinAll([...app.pathParts, 'pubspec.yaml'])),
     ],
     // The server resolution's package_config.json, reloaded into the FES in
-    // place on dependency changes. Watched as an exact file (see above); note
-    // that the single-file watcher stops if the file is deleted (e.g. by a
-    // clean), so dependency tracking then rests until the watcher is rebuilt.
+    // place on dependency changes. The exact-file watcher persists across an
+    // initial absence or deletion without scanning the rest of .dart_tool.
     if (serverDartToolDir != null)
       p.absolute(p.join(serverDartToolDir, 'package_config.json')),
     // Each Flutter resolution's package_graph.json, watched to detect Flutter
     // dependency changes (workspace root or, in a non-workspace project, the
     // Flutter package's own .dart_tool).
-    for (final tracker in flutterDependencyTrackers)
-      p.absolute(p.join(tracker.dartToolDir, 'package_graph.json')),
+    ...flutterPackageGraphPaths.map(p.absolute),
   };
 }
 

--- a/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:async/async.dart';
@@ -50,6 +51,125 @@ bool _isModelFile(String filePath) {
 
 bool _isWithinDartTool(String filePath) {
   return p.split(filePath).contains('.dart_tool');
+}
+
+/// Watches one file across initial absence, deletion, and recreation.
+///
+/// While the file exists, the platform [w.FileWatcher] provides native events.
+/// If it is absent, only that exact path is polled until it appears, avoiding a
+/// recursive watch of its potentially large and frequently changing parent.
+class _PersistentFileWatcher implements w.Watcher {
+  @override
+  final String path;
+
+  final Duration pollingDelay;
+
+  var _readyCompleter = Completer<void>();
+  StreamSubscription<w.WatchEvent>? _fileSubscription;
+  Timer? _pollTimer;
+  bool _isListening = false;
+  bool _isCheckingForFile = false;
+
+  late final StreamController<w.WatchEvent> _eventsController =
+      StreamController<w.WatchEvent>.broadcast(
+        onListen: _start,
+        onCancel: _stop,
+      );
+
+  _PersistentFileWatcher(
+    this.path, {
+    required this.pollingDelay,
+  });
+
+  @override
+  Stream<w.WatchEvent> get events => _eventsController.stream;
+
+  @override
+  bool get isReady => _readyCompleter.isCompleted;
+
+  @override
+  Future<void> get ready => _readyCompleter.future;
+
+  Future<void> _start() async {
+    _isListening = true;
+    await _watchOrPoll();
+    if (!_readyCompleter.isCompleted) _readyCompleter.complete();
+  }
+
+  Future<void> _watchOrPoll() async {
+    if (!_isListening) return;
+    final fileExists = await File(path).exists();
+    if (!_isListening) return;
+    if (!fileExists) {
+      _startPolling();
+      return;
+    }
+
+    try {
+      final fileWatcher = w.FileWatcher(path);
+      late final StreamSubscription<w.WatchEvent> subscription;
+      subscription = fileWatcher.events.listen(
+        (event) {
+          if (_isListening) _eventsController.add(event);
+        },
+        onError: (Object _, StackTrace _) {
+          if (_fileSubscription == subscription) {
+            _fileSubscription = null;
+          }
+          unawaited(subscription.cancel());
+          _startPolling();
+        },
+        onDone: () {
+          if (_fileSubscription == subscription) {
+            _fileSubscription = null;
+          }
+          _startPolling();
+        },
+      );
+      _fileSubscription = subscription;
+      await fileWatcher.ready;
+    } on FileSystemException {
+      _fileSubscription = null;
+      _startPolling();
+    }
+  }
+
+  void _startPolling() {
+    if (!_isListening || _pollTimer != null) return;
+    _pollTimer = Timer.periodic(
+      pollingDelay,
+      (_) => unawaited(_checkForFile()),
+    );
+    unawaited(_checkForFile());
+  }
+
+  Future<void> _checkForFile() async {
+    if (!_isListening || _isCheckingForFile) return;
+    _isCheckingForFile = true;
+    try {
+      final fileExists = await File(path).exists();
+      if (!_isListening || !fileExists) return;
+
+      _pollTimer?.cancel();
+      _pollTimer = null;
+
+      // The underlying watcher cannot report a creation that happened while
+      // the path was absent, so synthesize the change before reattaching it.
+      _eventsController.add(w.WatchEvent(w.ChangeType.MODIFY, path));
+      await _watchOrPoll();
+    } finally {
+      _isCheckingForFile = false;
+    }
+  }
+
+  Future<void> _stop() async {
+    _isListening = false;
+    _pollTimer?.cancel();
+    _pollTimer = null;
+    await _fileSubscription?.cancel();
+    _fileSubscription = null;
+    _readyCompleter = Completer<void>();
+  }
 }
 
 /// Merges multiple buffered [FileChangeEvent]s into a single event.
@@ -106,36 +226,49 @@ class FileWatcher {
   final Set<String> _packageGraphPaths;
 
   final Duration debounceDelay;
+  final Duration missingFilePollingDelay;
 
   /// Creates a file watcher.
   ///
   /// [watchPaths] is the set of directories or files to watch.
   /// [packageConfigPath] and [packageGraphPaths] are the exact pub-artifact
   /// files whose changes map to `packageConfigChanged` / `flutterDependenciesChanged`.
+  /// Missing pub artifacts are checked every [missingFilePollingDelay] until
+  /// they appear, then watched natively.
   FileWatcher({
     required Iterable<String> watchPaths,
     String? packageConfigPath,
     Iterable<String> packageGraphPaths = const [],
     this.debounceDelay = const Duration(milliseconds: 100),
+    this.missingFilePollingDelay = const Duration(milliseconds: 500),
   }) : _watchPaths = watchPaths.map(p.canonicalize).toSet(),
        _packageConfigPath = packageConfigPath == null
            ? null
            : p.canonicalize(packageConfigPath),
        _packageGraphPaths = packageGraphPaths.map(p.canonicalize).toSet();
 
+  late final Set<String> _persistentFilePaths = {
+    ?_packageConfigPath,
+    ..._packageGraphPaths,
+  };
+
   late final List<w.Watcher> _watchers = [
-    for (final watchPath in _watchPaths) ...{
-      if (Directory(watchPath).existsSync())
+    for (final watchPath in _watchPaths)
+      if (_persistentFilePaths.contains(watchPath))
+        _PersistentFileWatcher(
+          watchPath,
+          pollingDelay: missingFilePollingDelay,
+        )
+      else if (Directory(watchPath).existsSync())
         w.DirectoryWatcher(watchPath)
       else if (File(watchPath).existsSync())
         w.FileWatcher(watchPath),
-    },
   ];
 
   /// An immutable view of the paths being watched.
   Set<String> get watchPaths => UnmodifiableSetView(_watchPaths);
 
-  /// Completes when all underlying directory watchers are initialized.
+  /// Completes when all underlying watchers are initialized.
   ///
   /// Subscribers must be listening to [onFilesChanged] before awaiting this,
   /// since watcher initialization only begins when the stream has subscribers.

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -159,12 +159,28 @@ class FlutterAppManager {
   FlutterDependencyTracker? dependencyTrackerFor(String appId) =>
       _runtimes[appId]?.dependencyTracker;
 
+  /// The dependency graph to watch for [appId].
+  ///
+  /// Before the first Flutter run creates a resolution, this returns the
+  /// package-local path that Flutter will create. Once a tracker is available,
+  /// its resolved workspace or package-local `.dart_tool` path is used.
+  String? packageGraphPathFor(String appId) {
+    final runtime = _runtimeFor(appId);
+    if (runtime == null || !runtime.app.hasPackage) return null;
+    final dartToolDir =
+        runtime.dependencyTracker?.dartToolDir ??
+        p.join(p.joinAll(runtime.app.pathParts), '.dart_tool');
+    return p.join(dartToolDir, 'package_graph.json');
+  }
+
   /// Checks dependency changes for [appId].
   PackageDependencyChange checkDependencyChange(String appId) {
     if (dependencyChangeOverrideForTesting != null) {
       return dependencyChangeOverrideForTesting!(appId);
     }
-    return _runtimes[appId]?.dependencyTracker?.refresh() ??
+    final runtime = _runtimes[appId];
+    if (runtime?.dependencyTracker == null) _setupDependencyTracker(appId);
+    return runtime?.dependencyTracker?.refresh() ??
         PackageDependencyChange.none;
   }
 

--- a/tools/serverpod_cli/lib/src/generator/analyzers.dart
+++ b/tools/serverpod_cli/lib/src/generator/analyzers.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:analyzer/file_system/overlay_file_system.dart';
+import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
@@ -24,13 +26,21 @@ class Analyzers {
   final StatefulAnalyzer _models;
   final FutureCallsAnalyzer _futureCalls;
 
+  /// Overlay provider backing the shared analysis context, used to shadow
+  /// `protocol.dart` with a temporary stub during generation without touching
+  /// the file on disk. `null` when the analyzers were constructed around a
+  /// context that is not overlay-backed; the stub is then written to disk.
+  final OverlayResourceProvider? _overlay;
+
   Analyzers({
     required EndpointsAnalyzer endpoints,
     required StatefulAnalyzer models,
     required FutureCallsAnalyzer futureCalls,
+    OverlayResourceProvider? overlay,
   }) : _endpoints = endpoints,
        _models = models,
-       _futureCalls = futureCalls;
+       _futureCalls = futureCalls,
+       _overlay = overlay;
 
   /// Release resources. No-op for local analyzers; overridden by
   /// `IsolatedAnalyzers` to shut down the worker isolate.
@@ -39,7 +49,13 @@ class Analyzers {
   /// Creates the analyzers needed for code generation from [config].
   static Future<Analyzers> create(GeneratorConfig config) async {
     final libDirectory = Directory(p.joinAll(config.libSourcePathParts));
-    final collection = createAnalysisContextCollection(libDirectory);
+    // Overlay-backed so generation can shadow protocol.dart with a temporary
+    // stub in memory instead of writing it to disk (see [performGenerate]).
+    final overlay = OverlayResourceProvider(PhysicalResourceProvider.INSTANCE);
+    final collection = createAnalysisContextCollection(
+      libDirectory,
+      resourceProvider: overlay,
+    );
     final endpointsAnalyzer = EndpointsAnalyzer(
       libDirectory,
       collection: collection,
@@ -60,6 +76,7 @@ class Analyzers {
       endpoints: endpointsAnalyzer,
       models: modelAnalyzer,
       futureCalls: futureCallsAnalyzer,
+      overlay: overlay,
     );
   }
 
@@ -140,9 +157,13 @@ class Analyzers {
   }) async {
     bool success = true;
     String? protocolBackup;
-    var wroteTempProtocol = false;
+    var stubOverlayActive = false;
+    var wroteStubToDisk = false;
     var wroteFullProtocol = false;
     final protocolPath = p.joinAll(config.generatedServerProtocolFilePathParts);
+    // The exact path the analyzer resolves protocol.dart to; overlays must
+    // match it (same normalization as [refreshAnalysisContext]).
+    final analyzerProtocolPath = p.normalize(File(protocolPath).absolute.path);
 
     try {
       log.debug('Analyzing serializable models in the protocol directory.');
@@ -162,16 +183,35 @@ class Analyzers {
       if (requirements.generateModels) {
         log.debug('Generating files for serializable models.');
 
-        final protocolFile = File(protocolPath);
-        if (protocolFile.existsSync()) {
-          protocolBackup = await protocolFile.readAsString();
-        }
-
-        var tempProtocolPath = await _writeTemporaryProtocol(
+        final stubContent = _temporaryProtocolContent(
           models: models,
           config: config,
         );
-        wroteTempProtocol = true;
+        final overlay = _overlay;
+        if (overlay != null) {
+          // Shadow protocol.dart with the stub inside the analyzer only. The
+          // file on disk keeps the previous full protocol, so a generation
+          // whose output is unchanged never touches its timestamp - which
+          // matters because file watchers treat protocol.dart changes as a
+          // reason to recompile (and would otherwise fire on every run).
+          overlay.setOverlay(
+            analyzerProtocolPath,
+            content: stubContent,
+            modificationStamp: DateTime.now().microsecondsSinceEpoch,
+          );
+          stubOverlayActive = true;
+        } else {
+          // No overlay provider backing the analysis context; fall back to
+          // writing the stub to disk and restoring the previous protocol if
+          // the full one never gets written.
+          final protocolFile = File(protocolPath);
+          if (protocolFile.existsSync()) {
+            protocolBackup = await protocolFile.readAsString();
+          }
+          await protocolFile.create(recursive: true);
+          await protocolFile.writeAsString(stubContent, flush: true);
+          wroteStubToDisk = true;
+        }
 
         generatedModelFiles =
             await ServerpodCodeGenerator.generateSerializableModels(
@@ -181,7 +221,7 @@ class Analyzers {
 
         await refreshAnalysisContext(
           _futureCalls.collection,
-          [...generatedModelFiles, tempProtocolPath],
+          [...generatedModelFiles, protocolPath],
         );
       }
 
@@ -257,6 +297,15 @@ class Analyzers {
           );
       wroteFullProtocol = true;
 
+      // The full protocol is on disk now (or was already up to date); retire
+      // the stub overlay so analysis resolves protocol.dart to the real
+      // content from here on.
+      if (stubOverlayActive) {
+        _overlay!.removeOverlay(analyzerProtocolPath);
+        stubOverlayActive = false;
+        await refreshAnalysisContext(_futureCalls.collection, [protocolPath]);
+      }
+
       log.debug('Cleaning old files.');
       final allGeneratedFiles = <String>{
         ...generatedModelFiles,
@@ -292,38 +341,36 @@ class Analyzers {
 
       return (success: success, generatedFiles: allGeneratedFiles);
     } finally {
-      // If model generation overwrote protocol.dart with a temporary stub but
-      // the full protocol was never written (interrupted run, models-only
-      // generation, or an exception), restore the previous protocol.dart so
-      // generated model files that call Protocol() can still compile.
-      if (wroteTempProtocol && !wroteFullProtocol && protocolBackup != null) {
+      // Retire a still-active stub (interrupted run, models-only generation,
+      // or an exception). With an overlay the file on disk was never touched;
+      // just drop the shadow. When the stub was written to disk instead,
+      // restore the previous protocol.dart so generated model files that call
+      // Protocol() can still compile.
+      if (stubOverlayActive) {
+        _overlay!.removeOverlay(analyzerProtocolPath);
+        await refreshAnalysisContext(_futureCalls.collection, [protocolPath]);
+      }
+      if (wroteStubToDisk && !wroteFullProtocol && protocolBackup != null) {
         await File(protocolPath).writeAsString(protocolBackup, flush: true);
       }
     }
   }
 }
 
-/// Writes a temporary protocol.dart that exports all model classes and a stub
-/// [Protocol] class.
+/// Generates the content of a temporary protocol.dart that exports all model
+/// classes and a stub [Protocol] class.
 ///
-/// This allows endpoint and future call files to resolve their
-/// `import 'protocol.dart'` during analysis, and lets generated model files
-/// that call `Protocol()` compile before the full protocol exists. The full
-/// protocol (with endpoint dispatch, etc.) overwrites this later via
-/// [ServerpodCodeGenerator.generateProtocolDefinition].
-Future<String> _writeTemporaryProtocol({
+/// Shadowing protocol.dart with this content allows endpoint and future call
+/// files to resolve their `import 'protocol.dart'` during analysis, and lets
+/// generated model files that call `Protocol()` compile before the full
+/// protocol exists. The full protocol (with endpoint dispatch, etc.) is
+/// written later via [ServerpodCodeGenerator.generateProtocolDefinition].
+String _temporaryProtocolContent({
   required List<SerializableModelDefinition> models,
   required GeneratorConfig config,
-}) async {
-  var generatedTempProtocol = const DartTemporaryProtocolGenerator()
-      .generateSerializableModelsCode(models: models, config: config);
-
-  var protocolPath = generatedTempProtocol.keys.first;
-  var content = generatedTempProtocol.values.first;
-
-  var file = File(protocolPath);
-  await file.create(recursive: true);
-  await file.writeAsString(content, flush: true);
-
-  return protocolPath;
+}) {
+  return const DartTemporaryProtocolGenerator()
+      .generateSerializableModelsCode(models: models, config: config)
+      .values
+      .first;
 }

--- a/tools/serverpod_cli/lib/src/util/analysis_helpers.dart
+++ b/tools/serverpod_cli/lib/src/util/analysis_helpers.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
+import 'package:analyzer/file_system/file_system.dart' show ResourceProvider;
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:path/path.dart' as p;
 
@@ -20,12 +21,17 @@ Future<void> refreshAnalysisContext(
 }
 
 /// Creates an [AnalysisContextCollection] for the given [directory].
+///
+/// Pass [resourceProvider] to back the collection with something other than
+/// the physical file system (e.g. an overlay provider that shadows files
+/// with in-memory content).
 AnalysisContextCollection createAnalysisContextCollection(
-  Directory directory,
-) {
+  Directory directory, {
+  ResourceProvider? resourceProvider,
+}) {
   return AnalysisContextCollection(
     includedPaths: [directory.absolute.path],
-    resourceProvider: PhysicalResourceProvider.INSTANCE,
+    resourceProvider: resourceProvider ?? PhysicalResourceProvider.INSTANCE,
     sdkPath: getSdkPath(),
   );
 }

--- a/tools/serverpod_cli/test/commands/start/file_watcher_test.dart
+++ b/tools/serverpod_cli/test/commands/start/file_watcher_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -102,6 +103,91 @@ void main() {
       );
     },
   );
+
+  group('Given a FileWatcher tracking a missing pub artifact,', () {
+    late File packageGraph;
+    late FileWatcher watcher;
+
+    setUp(() async {
+      final dartToolDir = p.join(tempDir.path, '.dart_tool');
+      await Directory(dartToolDir).create();
+      packageGraph = File(p.join(dartToolDir, 'package_graph.json'));
+      watcher = FileWatcher(
+        watchPaths: [packageGraph.path],
+        packageGraphPaths: [packageGraph.path],
+        debounceDelay: const Duration(milliseconds: 50),
+        missingFilePollingDelay: const Duration(milliseconds: 20),
+      );
+    });
+
+    test(
+      'when the artifact is created, '
+      'then it emits a Flutter dependency change.',
+      () async {
+        final firstEvent = watcher.onFilesChanged.first;
+        await watcher.ready;
+
+        await packageGraph.writeAsString('{"roots":[],"packages":[]}');
+
+        final event = await firstEvent.timeout(const Duration(seconds: 3));
+        expect(event.flutterDependenciesChanged, isTrue);
+      },
+    );
+  });
+
+  group('Given a FileWatcher tracking an existing pub artifact,', () {
+    late File packageGraph;
+    late FileWatcher watcher;
+
+    setUp(() async {
+      final dartToolDir = p.join(tempDir.path, '.dart_tool');
+      await Directory(dartToolDir).create();
+      packageGraph = File(p.join(dartToolDir, 'package_graph.json'));
+      await packageGraph.writeAsString('{"roots":[],"packages":[]}');
+      watcher = FileWatcher(
+        watchPaths: [packageGraph.path],
+        packageGraphPaths: [packageGraph.path],
+        debounceDelay: const Duration(milliseconds: 50),
+        missingFilePollingDelay: const Duration(milliseconds: 20),
+      );
+    });
+
+    test(
+      'when the artifact is deleted and recreated, '
+      'then subsequent changes continue to emit Flutter dependency changes.',
+      () async {
+        final events = StreamIterator(watcher.onFilesChanged);
+        addTearDown(events.cancel);
+        var nextEvent = events.moveNext();
+        await watcher.ready;
+
+        await packageGraph.delete();
+        expect(
+          await nextEvent.timeout(const Duration(seconds: 3)),
+          isTrue,
+        );
+        expect(events.current.flutterDependenciesChanged, isTrue);
+
+        nextEvent = events.moveNext();
+        await packageGraph.writeAsString('{"roots":[],"packages":[]}');
+        expect(
+          await nextEvent.timeout(const Duration(seconds: 3)),
+          isTrue,
+        );
+        expect(events.current.flutterDependenciesChanged, isTrue);
+
+        nextEvent = events.moveNext();
+        await packageGraph.writeAsString(
+          '{"roots":[],"packages":[{"name":"new_dependency"}]}',
+        );
+        expect(
+          await nextEvent.timeout(const Duration(seconds: 3)),
+          isTrue,
+        );
+        expect(events.current.flutterDependenciesChanged, isTrue);
+      },
+    );
+  });
 
   group('Given a FileWatcher watching a .dart_tool directory', () {
     late FileWatcher watcher;

--- a/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/flutter_app_manager.dart';
+import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
 import 'package:serverpod_cli/src/config/flutter_app_config.dart';
 import 'package:test/test.dart';
 
@@ -661,4 +662,48 @@ serverpod:
       },
     );
   });
+
+  group(
+    'Given an initialized FlutterAppManager before the Flutter resolution exists,',
+    () {
+      late _ManagerFixture f;
+
+      setUp(() async {
+        f = await _ManagerFixture.create();
+      });
+
+      tearDown(() => f.dispose());
+
+      test(
+        'when dependency changes are checked after the resolution is created, '
+        'then dependency tracking is initialized.',
+        () {
+          expect(f.manager.dependencyTrackerFor('project'), isNull);
+
+          final flutterDir = f.flutterDir('project');
+          final dartToolDir = Directory(
+            p.join(flutterDir.path, '.dart_tool'),
+          )..createSync();
+          File(
+            p.join(dartToolDir.path, 'package_config.json'),
+          ).writeAsStringSync('''
+{"configVersion":2,"packages":[{"name":"project_flutter","rootUri":"../","packageUri":"lib/"}]}
+''');
+          File(
+            p.join(dartToolDir.path, 'package_graph.json'),
+          ).writeAsStringSync(
+            '''
+{"roots":["project_flutter"],"packages":[{"name":"project_flutter","version":"1.0.0","dependencies":[]}]}
+''',
+          );
+
+          expect(
+            f.manager.checkDependencyChange('project'),
+            PackageDependencyChange.none,
+          );
+          expect(f.manager.dependencyTrackerFor('project'), isNotNull);
+        },
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/commands/start/watch_paths_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_paths_test.dart
@@ -11,7 +11,7 @@ void main() {
 
     test(
       'when there is no Flutter dependency tracker (server-only project), '
-      'then the server resolution .dart_tool is still watched',
+      'then the server resolution package_config.json is still watched',
       () {
         final serverDartTool = p.absolute('some_server', '.dart_tool');
 
@@ -22,13 +22,31 @@ void main() {
 
         // Without this, package_config.json changes are never observed and the
         // server can't pick up a new dependency without a full restart.
-        expect(paths, contains(serverDartTool));
+        expect(paths, contains(p.join(serverDartTool, 'package_config.json')));
+      },
+    );
+
+    test(
+      'when a resolution .dart_tool is provided, '
+      'then only its pub artifacts are watched, not the whole directory',
+      () {
+        final serverDartTool = p.absolute('some_server', '.dart_tool');
+
+        final paths = buildWatchPaths(
+          config: config,
+          serverDartToolDir: serverDartTool,
+        );
+
+        // Watching the directory itself would also watch large, churning
+        // build state (e.g. flutter_build intermediates, the server's dill),
+        // causing heavy disk I/O whenever a build runs.
+        expect(paths, isNot(contains(serverDartTool)));
       },
     );
 
     test(
       'when the server and Flutter resolutions differ (non-workspace layout), '
-      'then both .dart_tool directories are watched',
+      'then both resolutions\' pub artifacts are watched',
       () {
         final serverDartTool = p.absolute('server_pkg', '.dart_tool');
         final flutterDartTool = p.absolute('flutter_pkg', '.dart_tool');
@@ -44,13 +62,21 @@ void main() {
           flutterDependencyTrackers: [tracker],
         );
 
-        expect(paths, containsAll([serverDartTool, flutterDartTool]));
+        expect(
+          paths,
+          containsAll([
+            p.join(serverDartTool, 'package_config.json'),
+            p.join(flutterDartTool, 'package_graph.json'),
+          ]),
+        );
+        expect(paths, isNot(contains(serverDartTool)));
+        expect(paths, isNot(contains(flutterDartTool)));
       },
     );
 
     test(
       'when the server and Flutter share a resolution (workspace layout), '
-      'then the shared .dart_tool is watched exactly once',
+      'then the shared .dart_tool contributes exactly its two pub artifacts',
       () {
         final sharedDartTool = p.absolute('workspace_root', '.dart_tool');
         final tracker = FlutterDependencyTracker(
@@ -65,7 +91,13 @@ void main() {
           flutterDependencyTrackers: [tracker],
         );
 
-        expect(paths.where((path) => path == sharedDartTool), hasLength(1));
+        expect(
+          paths.where((path) => p.isWithin(sharedDartTool, path)),
+          unorderedEquals([
+            p.join(sharedDartTool, 'package_config.json'),
+            p.join(sharedDartTool, 'package_graph.json'),
+          ]),
+        );
       },
     );
   });

--- a/tools/serverpod_cli/test/commands/start/watch_paths_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_paths_test.dart
@@ -1,6 +1,6 @@
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start.dart';
-import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
+import 'package:serverpod_cli/src/config/flutter_app_config.dart';
 import 'package:test/test.dart';
 
 import '../../test_util/builders/generator_config_builder.dart';
@@ -46,20 +46,17 @@ void main() {
 
     test(
       'when the server and Flutter resolutions differ (non-workspace layout), '
-      'then both resolutions\' pub artifacts are watched',
+      "then both resolutions' pub artifacts are watched",
       () {
         final serverDartTool = p.absolute('server_pkg', '.dart_tool');
         final flutterDartTool = p.absolute('flutter_pkg', '.dart_tool');
-        final tracker = FlutterDependencyTracker(
-          dartToolDir: flutterDartTool,
-          flutterPackageName: 'my_flutter',
-          flutterPackageDir: p.absolute('flutter_pkg'),
-        );
 
         final paths = buildWatchPaths(
           config: config,
           serverDartToolDir: serverDartTool,
-          flutterDependencyTrackers: [tracker],
+          flutterPackageGraphPaths: [
+            p.join(flutterDartTool, 'package_graph.json'),
+          ],
         );
 
         expect(
@@ -79,16 +76,13 @@ void main() {
       'then the shared .dart_tool contributes exactly its two pub artifacts',
       () {
         final sharedDartTool = p.absolute('workspace_root', '.dart_tool');
-        final tracker = FlutterDependencyTracker(
-          dartToolDir: sharedDartTool,
-          flutterPackageName: 'my_flutter',
-          flutterPackageDir: p.absolute('workspace_root', 'my_flutter'),
-        );
 
         final paths = buildWatchPaths(
           config: config,
           serverDartToolDir: sharedDartTool,
-          flutterDependencyTrackers: [tracker],
+          flutterPackageGraphPaths: [
+            p.join(sharedDartTool, 'package_graph.json'),
+          ],
         );
 
         expect(
@@ -97,6 +91,34 @@ void main() {
             p.join(sharedDartTool, 'package_config.json'),
             p.join(sharedDartTool, 'package_graph.json'),
           ]),
+        );
+      },
+    );
+
+    test(
+      'when a Flutter app has no dependency tracker yet, '
+      'then its expected local package_graph.json is watched.',
+      () {
+        final serverDir = p.absolute('project_server');
+        final flutterDir = p.absolute('project_flutter');
+        final app = FlutterAppConfig(
+          id: 'project',
+          name: 'project',
+          relativePathParts: p.split(p.relative(flutterDir, from: serverDir)),
+          serverPackageDirectoryPathParts: p.split(serverDir),
+        );
+
+        final paths = buildWatchPaths(
+          config: config,
+          flutterApps: [app],
+          flutterPackageGraphPaths: [
+            p.join(flutterDir, '.dart_tool', 'package_graph.json'),
+          ],
+        );
+
+        expect(
+          paths,
+          contains(p.join(flutterDir, '.dart_tool', 'package_graph.json')),
         );
       },
     );

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
@@ -274,8 +274,7 @@ class ExampleEndpoint extends Endpoint {
   );
 
   group(
-    'Given a tracked and analyzed directory with a persistently invalid dart '
-    'endpoint file',
+    'Given a tracked and analyzed directory with a persistently invalid dart endpoint file',
     () {
       var trackedDirectory = Directory(
         path.join(testProjectDirectory.path, const Uuid().v4()),
@@ -300,25 +299,27 @@ class ExampleEndpoint extends Endpoint {
         await analyzer.analyze(collector: CodeGenerationCollector());
       });
 
-      test('when the file context is updated with an unrelated non-endpoint '
-          'file while the error persists '
-          'then false is returned.', () async {
-        // Regression: a persistent error must not turn every unrelated change
-        // into a regeneration, or watch mode loops forever (each generation
-        // touches generated files, whose events regenerate again).
-        var nonEndpointFile = File(
-          path.join(trackedDirectory.path, 'helper.dart'),
-        );
-        nonEndpointFile.createSync(recursive: true);
-        nonEndpointFile.writeAsStringSync('''
+      test(
+        'when the file context is updated with an unrelated non-endpoint file while the error persists '
+        'then false is returned.',
+        () async {
+          // Regression: a persistent error must not turn every unrelated change
+          // into a regeneration, or watch mode loops forever (each generation
+          // touches generated files, whose events regenerate again).
+          var nonEndpointFile = File(
+            path.join(trackedDirectory.path, 'helper.dart'),
+          );
+          nonEndpointFile.createSync(recursive: true);
+          nonEndpointFile.writeAsStringSync('''
 class HelperClass {}
 ''');
 
-        await expectLater(
-          analyzer.updateFileContexts({nonEndpointFile.path}),
-          completion(false),
-        );
-      });
+          await expectLater(
+            analyzer.updateFileContexts({nonEndpointFile.path}),
+            completion(false),
+          );
+        },
+      );
     },
   );
 

--- a/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/endpoint_validation/update_file_context_test.dart
@@ -274,6 +274,55 @@ class ExampleEndpoint extends Endpoint {
   );
 
   group(
+    'Given a tracked and analyzed directory with a persistently invalid dart '
+    'endpoint file',
+    () {
+      var trackedDirectory = Directory(
+        path.join(testProjectDirectory.path, const Uuid().v4()),
+      );
+
+      late EndpointsAnalyzer analyzer;
+      setUpAll(() async {
+        var endpointFile = File(
+          path.join(trackedDirectory.path, 'endpoint.dart'),
+        );
+        endpointFile.createSync(recursive: true);
+        // Class is missing closing brackets
+        endpointFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello \$name';
+  }
+''');
+        analyzer = EndpointsAnalyzer(trackedDirectory);
+        await analyzer.analyze(collector: CodeGenerationCollector());
+      });
+
+      test('when the file context is updated with an unrelated non-endpoint '
+          'file while the error persists '
+          'then false is returned.', () async {
+        // Regression: a persistent error must not turn every unrelated change
+        // into a regeneration, or watch mode loops forever (each generation
+        // touches generated files, whose events regenerate again).
+        var nonEndpointFile = File(
+          path.join(trackedDirectory.path, 'helper.dart'),
+        );
+        nonEndpointFile.createSync(recursive: true);
+        nonEndpointFile.writeAsStringSync('''
+class HelperClass {}
+''');
+
+        await expectLater(
+          analyzer.updateFileContexts({nonEndpointFile.path}),
+          completion(false),
+        );
+      });
+    },
+  );
+
+  group(
     'Given a tracked and analyzed endpoint file that depends on an invalid dart file',
     () {
       var trackedDirectory = Directory(

--- a/tools/serverpod_cli/test/integration/analyzer/dart/future_call_validation/update_file_context_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/future_call_validation/update_file_context_test.dart
@@ -24,8 +24,7 @@ void main() {
   });
 
   group(
-    'Given a tracked and analyzed directory with a persistently invalid dart '
-    'future call file',
+    'Given a tracked and analyzed directory with a persistently invalid dart future call file',
     () {
       var trackedDirectory = Directory(
         path.join(testProjectDirectory.path, const Uuid().v4()),
@@ -53,31 +52,32 @@ class ExampleFutureCall extends FutureCall {
         );
       });
 
-      test('when the file context is updated with an unrelated non-future-call '
-          'file while the error persists '
-          'then false is returned.', () async {
-        // Regression: a persistent error must not turn every unrelated change
-        // into a regeneration, or watch mode loops forever (each generation
-        // touches generated files, whose events regenerate again).
-        var unrelatedFile = File(
-          path.join(trackedDirectory.path, 'helper.dart'),
-        );
-        unrelatedFile.createSync(recursive: true);
-        unrelatedFile.writeAsStringSync('''
+      test(
+        'when the file context is updated with an unrelated non-future-call file while the error persists '
+        'then false is returned.',
+        () async {
+          // Regression: a persistent error must not turn every unrelated change
+          // into a regeneration, or watch mode loops forever (each generation
+          // touches generated files, whose events regenerate again).
+          var unrelatedFile = File(
+            path.join(trackedDirectory.path, 'helper.dart'),
+          );
+          unrelatedFile.createSync(recursive: true);
+          unrelatedFile.writeAsStringSync('''
 class HelperClass {}
 ''');
 
-        await expectLater(
-          analyzer.updateFileContexts({unrelatedFile.path}),
-          completion(false),
-        );
-      });
+          await expectLater(
+            analyzer.updateFileContexts({unrelatedFile.path}),
+            completion(false),
+          );
+        },
+      );
     },
   );
 
   group(
-    'Given a tracked and analyzed directory with an invalid dart future call '
-    'file',
+    'Given a tracked and analyzed directory with an invalid dart future call file',
     () {
       var trackedDirectory = Directory(
         path.join(testProjectDirectory.path, const Uuid().v4()),
@@ -106,10 +106,11 @@ class ExampleFutureCall extends FutureCall {
         );
       });
 
-      test('when the file context is updated with a fix for the invalid '
-          'future call file '
-          'then true is returned.', () async {
-        futureCallFile.writeAsStringSync('''
+      test(
+        'when the file context is updated with a fix for the invalid future call file '
+        'then true is returned.',
+        () async {
+          futureCallFile.writeAsStringSync('''
 import 'package:serverpod/serverpod.dart';
 
 class ExampleFutureCall extends FutureCall {
@@ -119,17 +120,17 @@ class ExampleFutureCall extends FutureCall {
 }
 ''');
 
-        await expectLater(
-          analyzer.updateFileContexts({futureCallFile.path}),
-          completion(true),
-        );
-      });
+          await expectLater(
+            analyzer.updateFileContexts({futureCallFile.path}),
+            completion(true),
+          );
+        },
+      );
     },
   );
 
   group(
-    'Given a tracked directory with a valid future call file analyzed before '
-    'any models were provided',
+    'Given a tracked directory with a valid future call file analyzed before any models were provided',
     () {
       var trackedDirectory = Directory(
         path.join(testProjectDirectory.path, const Uuid().v4()),
@@ -158,33 +159,38 @@ class ExampleFutureCall extends FutureCall {
         await analyzer.analyze(collector: CodeGenerationCollector());
       });
 
-      test('when the file context is updated with an unrelated non-future-call '
-          'file '
-          'then false is returned.', () async {
-        // Regression: the pending-analysis state is indistinguishable from an
-        // error and used to mark every unrelated change as needing
-        // generation.
-        var unrelatedFile = File(
-          path.join(trackedDirectory.path, 'helper.dart'),
-        );
-        unrelatedFile.createSync(recursive: true);
-        unrelatedFile.writeAsStringSync('''
+      test(
+        'when the file context is updated with an unrelated non-future-call file '
+        'then false is returned.',
+        () async {
+          // Regression: the pending-analysis state is indistinguishable from an
+          // error and used to mark every unrelated change as needing
+          // generation.
+          var unrelatedFile = File(
+            path.join(trackedDirectory.path, 'helper.dart'),
+          );
+          unrelatedFile.createSync(recursive: true);
+          unrelatedFile.writeAsStringSync('''
 class HelperClass {}
 ''');
 
-        await expectLater(
-          analyzer.updateFileContexts({unrelatedFile.path}),
-          completion(false),
-        );
-      });
+          await expectLater(
+            analyzer.updateFileContexts({unrelatedFile.path}),
+            completion(false),
+          );
+        },
+      );
 
-      test('when the file context is updated with the future call file itself '
-          'then true is returned.', () async {
-        await expectLater(
-          analyzer.updateFileContexts({futureCallFile.path}),
-          completion(true),
-        );
-      });
+      test(
+        'when the file context is updated with the future call file itself '
+        'then true is returned.',
+        () async {
+          await expectLater(
+            analyzer.updateFileContexts({futureCallFile.path}),
+            completion(true),
+          );
+        },
+      );
     },
   );
 }

--- a/tools/serverpod_cli/test/integration/analyzer/dart/future_call_validation/update_file_context_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/future_call_validation/update_file_context_test.dart
@@ -1,0 +1,190 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+import 'package:test/test.dart';
+
+import '../../../../test_util/builders/generator_config_builder.dart';
+import '../../../../test_util/endpoint_validation_helpers.dart';
+
+final config = GeneratorConfigBuilder().build();
+
+var testProjectDirectory = Directory.systemTemp.createTempSync('cli_test_');
+
+void main() {
+  setUpAll(() async {
+    await createTestEnvironment(testProjectDirectory);
+  });
+
+  tearDownAll(() {
+    testProjectDirectory.deleteSync(recursive: true);
+  });
+
+  group(
+    'Given a tracked and analyzed directory with a persistently invalid dart '
+    'future call file',
+    () {
+      var trackedDirectory = Directory(
+        path.join(testProjectDirectory.path, const Uuid().v4()),
+      );
+
+      late FutureCallsAnalyzer analyzer;
+      setUpAll(() async {
+        var futureCallFile = File(
+          path.join(trackedDirectory.path, 'future_call.dart'),
+        );
+        futureCallFile.createSync(recursive: true);
+        // Class is missing closing brackets
+        futureCallFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleFutureCall extends FutureCall {
+  Future<void> hello(Session session, String name) async {
+    session.log('Hello \$name');
+  }
+''');
+        analyzer = FutureCallsAnalyzer(directory: trackedDirectory);
+        await analyzer.analyze(
+          collector: CodeGenerationCollector(),
+          analyzedModels: StatefulAnalyzer(config, []).validateAll(),
+        );
+      });
+
+      test('when the file context is updated with an unrelated non-future-call '
+          'file while the error persists '
+          'then false is returned.', () async {
+        // Regression: a persistent error must not turn every unrelated change
+        // into a regeneration, or watch mode loops forever (each generation
+        // touches generated files, whose events regenerate again).
+        var unrelatedFile = File(
+          path.join(trackedDirectory.path, 'helper.dart'),
+        );
+        unrelatedFile.createSync(recursive: true);
+        unrelatedFile.writeAsStringSync('''
+class HelperClass {}
+''');
+
+        await expectLater(
+          analyzer.updateFileContexts({unrelatedFile.path}),
+          completion(false),
+        );
+      });
+    },
+  );
+
+  group(
+    'Given a tracked and analyzed directory with an invalid dart future call '
+    'file',
+    () {
+      var trackedDirectory = Directory(
+        path.join(testProjectDirectory.path, const Uuid().v4()),
+      );
+
+      late File futureCallFile;
+      late FutureCallsAnalyzer analyzer;
+      setUpAll(() async {
+        futureCallFile = File(
+          path.join(trackedDirectory.path, 'future_call.dart'),
+        );
+        futureCallFile.createSync(recursive: true);
+        // Class is missing closing brackets
+        futureCallFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleFutureCall extends FutureCall {
+  Future<void> hello(Session session, String name) async {
+    session.log('Hello \$name');
+  }
+''');
+        analyzer = FutureCallsAnalyzer(directory: trackedDirectory);
+        await analyzer.analyze(
+          collector: CodeGenerationCollector(),
+          analyzedModels: StatefulAnalyzer(config, []).validateAll(),
+        );
+      });
+
+      test('when the file context is updated with a fix for the invalid '
+          'future call file '
+          'then true is returned.', () async {
+        futureCallFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleFutureCall extends FutureCall {
+  Future<void> hello(Session session, String name) async {
+    session.log('Hello \$name');
+  }
+}
+''');
+
+        await expectLater(
+          analyzer.updateFileContexts({futureCallFile.path}),
+          completion(true),
+        );
+      });
+    },
+  );
+
+  group(
+    'Given a tracked directory with a valid future call file analyzed before '
+    'any models were provided',
+    () {
+      var trackedDirectory = Directory(
+        path.join(testProjectDirectory.path, const Uuid().v4()),
+      );
+
+      late File futureCallFile;
+      late FutureCallsAnalyzer analyzer;
+      setUpAll(() async {
+        futureCallFile = File(
+          path.join(trackedDirectory.path, 'future_call.dart'),
+        );
+        futureCallFile.createSync(recursive: true);
+        futureCallFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class ExampleFutureCall extends FutureCall {
+  Future<void> hello(Session session, String name) async {
+    session.log('Hello \$name');
+  }
+}
+''');
+        analyzer = FutureCallsAnalyzer(directory: trackedDirectory);
+        // Analyzed without models: the file is cached as pending full
+        // analysis (hadErrors), the state a fresh up-to-date watch session
+        // starts in before any generation has run.
+        await analyzer.analyze(collector: CodeGenerationCollector());
+      });
+
+      test('when the file context is updated with an unrelated non-future-call '
+          'file '
+          'then false is returned.', () async {
+        // Regression: the pending-analysis state is indistinguishable from an
+        // error and used to mark every unrelated change as needing
+        // generation.
+        var unrelatedFile = File(
+          path.join(trackedDirectory.path, 'helper.dart'),
+        );
+        unrelatedFile.createSync(recursive: true);
+        unrelatedFile.writeAsStringSync('''
+class HelperClass {}
+''');
+
+        await expectLater(
+          analyzer.updateFileContexts({unrelatedFile.path}),
+          completion(false),
+        );
+      });
+
+      test('when the file context is updated with the future call file itself '
+          'then true is returned.', () async {
+        await expectLater(
+          analyzer.updateFileContexts({futureCallFile.path}),
+          completion(true),
+        );
+      });
+    },
+  );
+}

--- a/tools/serverpod_cli/test/integration/generate/unchanged_generation_test.dart
+++ b/tools/serverpod_cli/test/integration/generate/unchanged_generation_test.dart
@@ -1,0 +1,92 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/config/config.dart';
+import 'package:serverpod_cli/src/generator/analyzers.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:test/test.dart';
+
+import '../../test_util/builders/generator_config_builder.dart';
+import '../../test_util/endpoint_validation_helpers.dart';
+
+void main() {
+  group(
+    'Given a project whose code generation already ran, '
+    'when generation runs again with unchanged sources,',
+    () {
+      late Directory projectDir;
+      late GeneratorConfig config;
+      late Analyzers analyzers;
+      late File protocolFile;
+      late String protocolContent;
+      late GenerateResult secondRun;
+
+      // A timestamp no generation run could produce; pinned on protocol.dart
+      // between the runs so any rewrite - even one with identical content -
+      // is detectable regardless of file system timestamp granularity.
+      final mtimeSentinel = DateTime.utc(2020, 1, 1);
+
+      tearDownAll(() => projectDir.deleteIfExists(recursive: true));
+
+      setUpAll(() async {
+        projectDir = Directory.systemTemp.createTempSync('cli_test_');
+        await createTestEnvironment(projectDir);
+
+        File(
+          p.join(projectDir.path, 'lib', 'src', 'protocol', 'item.spy.yaml'),
+        )
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+class: Item
+fields:
+  name: String
+''');
+
+        File(
+          p.join(
+            projectDir.path,
+            'lib',
+            'src',
+            'endpoints',
+            'item_endpoint.dart',
+          ),
+        )
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+import 'package:test_server/src/generated/protocol.dart';
+
+class ItemEndpoint extends Endpoint {
+  Future<Item> getItem(Session session, String name) async {
+    return Item(name: name);
+  }
+}
+''');
+
+        config = buildTestServerConfig(projectDir);
+        analyzers = await Analyzers.create(config);
+        await analyzers.performGenerate(config: config);
+
+        protocolFile = File(
+          p.join(projectDir.path, 'lib', 'src', 'generated', 'protocol.dart'),
+        );
+        protocolContent = protocolFile.readAsStringSync();
+        protocolFile.setLastModifiedSync(mtimeSentinel);
+
+        secondRun = await analyzers.performGenerate(config: config);
+      });
+
+      test('then generation succeeds.', () {
+        expect(secondRun.success, isTrue);
+      });
+
+      test('then protocol.dart is not rewritten.', () {
+        // A rewrite here re-triggers file watchers and compile pipelines on
+        // every generation, even when nothing changed (the temporary analysis
+        // stub must shadow protocol.dart in memory, not on disk).
+        expect(protocolFile.lastModifiedSync().toUtc(), mtimeSentinel);
+        expect(protocolFile.readAsStringSync(), protocolContent);
+      });
+    },
+  );
+}

--- a/tools/serverpod_cli/test/integration/generate/unchanged_generation_test.dart
+++ b/tools/serverpod_cli/test/integration/generate/unchanged_generation_test.dart
@@ -10,39 +10,37 @@ import '../../test_util/builders/generator_config_builder.dart';
 import '../../test_util/endpoint_validation_helpers.dart';
 
 void main() {
-  group(
-    'Given a project whose code generation already ran, '
-    'when generation runs again with unchanged sources,',
-    () {
-      late Directory projectDir;
-      late GeneratorConfig config;
-      late Analyzers analyzers;
-      late File protocolFile;
-      late String protocolContent;
-      late GenerateResult secondRun;
+  group('Given a project whose code generation already ran,', () {
+    late Directory projectDir;
+    late GeneratorConfig config;
+    late Analyzers analyzers;
+    late File protocolFile;
+    late String protocolContent;
 
-      // A timestamp no generation run could produce; pinned on protocol.dart
-      // between the runs so any rewrite - even one with identical content -
-      // is detectable regardless of file system timestamp granularity.
-      final mtimeSentinel = DateTime.utc(2020, 1, 1);
+    // A timestamp no generation run could produce; pinned on protocol.dart
+    // between the runs so any rewrite - even one with identical content -
+    // is detectable regardless of file system timestamp granularity.
+    final mtimeSentinel = DateTime.utc(2020, 1, 1);
 
-      tearDownAll(() => projectDir.deleteIfExists(recursive: true));
+    tearDownAll(() {
+      projectDir.deleteIfExists(recursive: true);
+    });
 
-      setUpAll(() async {
-        projectDir = Directory.systemTemp.createTempSync('cli_test_');
-        await createTestEnvironment(projectDir);
+    setUpAll(() async {
+      projectDir = Directory.systemTemp.createTempSync('cli_test_');
+      await createTestEnvironment(projectDir);
 
-        File(
+      File(
           p.join(projectDir.path, 'lib', 'src', 'protocol', 'item.spy.yaml'),
         )
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
 class: Item
 fields:
   name: String
 ''');
 
-        File(
+      File(
           p.join(
             projectDir.path,
             'lib',
@@ -51,8 +49,8 @@ fields:
             'item_endpoint.dart',
           ),
         )
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
 import 'package:serverpod/serverpod.dart';
 import 'package:test_server/src/generated/protocol.dart';
 
@@ -63,16 +61,21 @@ class ItemEndpoint extends Endpoint {
 }
 ''');
 
-        config = buildTestServerConfig(projectDir);
-        analyzers = await Analyzers.create(config);
-        await analyzers.performGenerate(config: config);
+      config = buildTestServerConfig(projectDir);
+      analyzers = await Analyzers.create(config);
+      await analyzers.performGenerate(config: config);
 
-        protocolFile = File(
-          p.join(projectDir.path, 'lib', 'src', 'generated', 'protocol.dart'),
-        );
-        protocolContent = protocolFile.readAsStringSync();
-        protocolFile.setLastModifiedSync(mtimeSentinel);
+      protocolFile = File(
+        p.join(projectDir.path, 'lib', 'src', 'generated', 'protocol.dart'),
+      );
+      protocolContent = protocolFile.readAsStringSync();
+      protocolFile.setLastModifiedSync(mtimeSentinel);
+    });
 
+    group('when generation runs again with unchanged sources,', () {
+      late GenerateResult secondRun;
+
+      setUpAll(() async {
         secondRun = await analyzers.performGenerate(config: config);
       });
 
@@ -87,6 +90,6 @@ class ItemEndpoint extends Endpoint {
         expect(protocolFile.lastModifiedSync().toUtc(), mtimeSentinel);
         expect(protocolFile.readAsStringSync(), protocolContent);
       });
-    },
-  );
+    });
+  });
 }

--- a/tools/serverpod_cli/test/integration/generate/watch_generated_events_test.dart
+++ b/tools/serverpod_cli/test/integration/generate/watch_generated_events_test.dart
@@ -1,0 +1,181 @@
+@Timeout(Duration(minutes: 10))
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/messages.dart';
+import 'package:test/test.dart';
+
+import '../../test_util/endpoint_validation_helpers.dart';
+
+/// The progress label printed at the start of every watch-mode analysis run.
+const _analysisRunMarker = 'Analyzing changes...';
+
+/// Resolves the CLI entry point so the watch mode under test is the real
+/// `serverpod generate --watch` process, not an in-process approximation.
+Future<String> _cliBinPath() async {
+  final uri = await Isolate.resolvePackageUri(
+    Uri.parse('package:serverpod_cli/analyzer.dart'),
+  );
+  if (uri == null) {
+    throw StateError('Could not resolve package:serverpod_cli');
+  }
+  return p.canonicalize(
+    p.join(uri.toFilePath(), '..', '..', 'bin', 'serverpod_cli.dart'),
+  );
+}
+
+void main() {
+  group(
+    'Given a running generate --watch whose file watcher has processed a '
+    'source model change,',
+    () {
+      late Directory tempDir;
+      late Directory serverDir;
+      late File modelFile;
+      late File generatedProtocolFile;
+      late Process watchProcess;
+      final output = <String>[];
+
+      Future<void> waitForOutput(
+        String needle, {
+        int from = 0,
+        Duration timeout = const Duration(minutes: 4),
+      }) async {
+        final deadline = DateTime.now().add(timeout);
+        while (DateTime.now().isBefore(deadline)) {
+          if (output.skip(from).any((line) => line.contains(needle))) return;
+          await Future<void>.delayed(const Duration(milliseconds: 200));
+        }
+        fail(
+          'Timed out waiting for "$needle" in the CLI output:\n'
+          '${output.join('\n')}',
+        );
+      }
+
+      int analysisRunsSince(int from) =>
+          output.skip(from).where((l) => l.contains(_analysisRunMarker)).length;
+
+      Future<void> touchModelAndAwaitGeneration() async {
+        final from = output.length;
+        modelFile.writeAsStringSync(modelFile.readAsStringSync());
+        await waitForOutput(incrementalCodeGenerationComplete, from: from);
+      }
+
+      tearDownAll(() async {
+        watchProcess.kill();
+        await watchProcess.exitCode.timeout(
+          const Duration(seconds: 10),
+          onTimeout: () {
+            watchProcess.kill(ProcessSignal.sigkill);
+            return watchProcess.exitCode;
+          },
+        );
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      });
+
+      setUpAll(() async {
+        tempDir = Directory.systemTemp.createTempSync('cli_test_');
+        serverDir = Directory(p.join(tempDir.path, 'test_server'));
+        await createTestEnvironment(serverDir);
+
+        // The sibling client package GeneratorConfig.load expects.
+        File(p.join(tempDir.path, 'test_client', 'pubspec.yaml'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+name: test_client
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies: {}
+''');
+
+        modelFile = File(
+          p.join(serverDir.path, 'lib', 'src', 'protocol', 'item.spy.yaml'),
+        )
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+class: Item
+fields:
+  name: String
+''');
+
+        File(
+          p.join(serverDir.path, 'lib', 'src', 'endpoints', 'item_endpoint.dart'),
+        )
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+import 'package:test_server/src/generated/protocol.dart';
+
+class ItemEndpoint extends Endpoint {
+  Future<Item> getItem(Session session, String name) async {
+    return Item(name: name);
+  }
+}
+''');
+
+        generatedProtocolFile = File(
+          p.join(serverDir.path, 'lib', 'src', 'generated', 'protocol.dart'),
+        );
+
+        watchProcess = await Process.start(Platform.resolvedExecutable, [
+          await _cliBinPath(),
+          '--verbose',
+          '--no-analytics',
+          '--no-interactive',
+          'generate',
+          '--watch',
+          '--directory',
+          serverDir.path,
+        ]);
+        for (final stream in [watchProcess.stdout, watchProcess.stderr]) {
+          stream
+              .transform(utf8.decoder)
+              .transform(const LineSplitter())
+              .listen(output.add);
+        }
+
+        await waitForOutput(initialCodeGenerationComplete);
+
+        // Prove the file watcher is live before testing what it ignores:
+        // a source model change must round-trip through a generation run.
+        await touchModelAndAwaitGeneration();
+      });
+
+      test(
+        'when a generated file changes, '
+        'then no generation is triggered by the generated file event.',
+        () async {
+          final from = output.length;
+
+          // A generated file changing on disk is what every generation run
+          // produces; reacting to it would make each run trigger the next.
+          generatedProtocolFile.writeAsStringSync(
+            '${generatedProtocolFile.readAsStringSync()}\n// touched\n',
+          );
+
+          // Long enough for the watcher's debounce (100ms) plus the analysis
+          // progress marker to appear if the event were (wrongly) processed.
+          await Future<void>.delayed(const Duration(seconds: 3));
+          expect(
+            analysisRunsSince(from),
+            0,
+            reason: 'The generated file change must be ignored, '
+                'but an analysis run was triggered.',
+          );
+
+          // Control: the watcher is still alive and processing source events
+          // after having ignored the generated one.
+          await touchModelAndAwaitGeneration();
+          expect(analysisRunsSince(from), 1);
+        },
+      );
+    },
+  );
+}

--- a/tools/serverpod_cli/test/integration/generate/watch_generated_events_test.dart
+++ b/tools/serverpod_cli/test/integration/generate/watch_generated_events_test.dart
@@ -4,89 +4,55 @@ library;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:isolate';
 
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:test/test.dart';
 
 import '../../test_util/endpoint_validation_helpers.dart';
+import '../../test_util/file_system_entity_helpers.dart';
 
 /// The progress label printed at the start of every watch-mode analysis run.
 const _analysisRunMarker = 'Analyzing changes...';
 
-/// Resolves the CLI entry point so the watch mode under test is the real
-/// `serverpod generate --watch` process, not an in-process approximation.
-Future<String> _cliBinPath() async {
-  final uri = await Isolate.resolvePackageUri(
-    Uri.parse('package:serverpod_cli/analyzer.dart'),
-  );
-  if (uri == null) {
-    throw StateError('Could not resolve package:serverpod_cli');
-  }
-  return p.canonicalize(
-    p.join(uri.toFilePath(), '..', '..', 'bin', 'serverpod_cli.dart'),
-  );
-}
-
 void main() {
-  group(
-    'Given a running generate --watch whose file watcher has processed a '
-    'source model change,',
-    () {
-      late Directory tempDir;
-      late Directory serverDir;
-      late File modelFile;
-      late File generatedProtocolFile;
-      late Process watchProcess;
-      final output = <String>[];
+  group('Given a live generate --watch process,', () {
+    Directory? tempDir;
+    Process? watchProcess;
+    late File modelFile;
+    late File generatedProtocolFile;
+    final output = <String>[];
 
-      Future<void> waitForOutput(
-        String needle, {
-        int from = 0,
-        Duration timeout = const Duration(minutes: 4),
-      }) async {
-        final deadline = DateTime.now().add(timeout);
-        while (DateTime.now().isBefore(deadline)) {
-          if (output.skip(from).any((line) => line.contains(needle))) return;
-          await Future<void>.delayed(const Duration(milliseconds: 200));
-        }
-        fail(
-          'Timed out waiting for "$needle" in the CLI output:\n'
-          '${output.join('\n')}',
-        );
-      }
-
-      int analysisRunsSince(int from) =>
-          output.skip(from).where((l) => l.contains(_analysisRunMarker)).length;
-
-      Future<void> touchModelAndAwaitGeneration() async {
-        final from = output.length;
-        modelFile.writeAsStringSync(modelFile.readAsStringSync());
-        await waitForOutput(incrementalCodeGenerationComplete, from: from);
-      }
-
-      tearDownAll(() async {
-        watchProcess.kill();
-        await watchProcess.exitCode.timeout(
+    tearDownAll(() async {
+      final process = watchProcess;
+      if (process != null) {
+        process.kill();
+        await process.exitCode.timeout(
           const Duration(seconds: 10),
           onTimeout: () {
-            watchProcess.kill(ProcessSignal.sigkill);
-            return watchProcess.exitCode;
+            process.kill(ProcessSignal.sigkill);
+            return process.exitCode;
           },
         );
-        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
-      });
+      }
 
-      setUpAll(() async {
-        tempDir = Directory.systemTemp.createTempSync('cli_test_');
-        serverDir = Directory(p.join(tempDir.path, 'test_server'));
-        await createTestEnvironment(serverDir);
+      final directory = tempDir;
+      if (directory != null) {
+        await directory.deleteWithRetry(recursive: true);
+      }
+    });
 
-        // The sibling client package GeneratorConfig.load expects.
-        File(p.join(tempDir.path, 'test_client', 'pubspec.yaml'))
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
+    setUpAll(() async {
+      final directory = Directory.systemTemp.createTempSync('cli_test_');
+      tempDir = directory;
+
+      final serverDir = Directory(p.join(directory.path, 'test_server'));
+      await createTestEnvironment(serverDir);
+
+      // The sibling client package GeneratorConfig.load expects.
+      File(p.join(directory.path, 'test_client', 'pubspec.yaml'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
 name: test_client
 
 environment:
@@ -95,87 +61,133 @@ environment:
 dependencies: {}
 ''');
 
-        modelFile = File(
-          p.join(serverDir.path, 'lib', 'src', 'protocol', 'item.spy.yaml'),
-        )
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
+      modelFile =
+          File(
+              p.join(
+                serverDir.path,
+                'lib',
+                'src',
+                'protocol',
+                'item.spy.yaml',
+              ),
+            )
+            ..createSync(recursive: true)
+            ..writeAsStringSync('''
 class: Item
 fields:
   name: String
 ''');
 
-        File(
-          p.join(serverDir.path, 'lib', 'src', 'endpoints', 'item_endpoint.dart'),
-        )
-          ..createSync(recursive: true)
-          ..writeAsStringSync('''
-import 'package:serverpod/serverpod.dart';
-import 'package:test_server/src/generated/protocol.dart';
+      generatedProtocolFile = File(
+        p.join(serverDir.path, 'lib', 'src', 'generated', 'protocol.dart'),
+      );
 
-class ItemEndpoint extends Endpoint {
-  Future<Item> getItem(Session session, String name) async {
-    return Item(name: name);
-  }
-}
+      final process = await Process.start(Platform.resolvedExecutable, [
+        await resolveServerpodCliEntrypoint(),
+        '--verbose',
+        '--no-analytics',
+        '--no-interactive',
+        'generate',
+        '--watch',
+        '--directory',
+        serverDir.path,
+      ]);
+      watchProcess = process;
+
+      for (final stream in [process.stdout, process.stderr]) {
+        stream
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())
+            .listen(output.add);
+      }
+
+      await _waitForOutput(initialCodeGenerationComplete, output: output);
+
+      // Prove the file watcher is live before testing what it ignores.
+      final outputStart = output.length;
+      modelFile.writeAsStringSync('''
+class: Item
+fields:
+  name: String
+  count: int
 ''');
+      await _waitForOutput(
+        incrementalCodeGenerationComplete,
+        from: outputStart,
+        output: output,
+      );
+    });
 
-        generatedProtocolFile = File(
-          p.join(serverDir.path, 'lib', 'src', 'generated', 'protocol.dart'),
+    group('when a generated file changes,', () {
+      late List<String> outputAfterGeneratedFileChange;
+
+      setUpAll(() async {
+        final outputStart = output.length;
+
+        // This is what every generation run produces. Reacting to the change
+        // would make each generation run trigger the next one.
+        generatedProtocolFile.writeAsStringSync(
+          '${generatedProtocolFile.readAsStringSync()}\n// touched\n',
         );
 
-        watchProcess = await Process.start(Platform.resolvedExecutable, [
-          await _cliBinPath(),
-          '--verbose',
-          '--no-analytics',
-          '--no-interactive',
-          'generate',
-          '--watch',
-          '--directory',
-          serverDir.path,
-        ]);
-        for (final stream in [watchProcess.stdout, watchProcess.stderr]) {
-          stream
-              .transform(utf8.decoder)
-              .transform(const LineSplitter())
-              .listen(output.add);
-        }
+        // Long enough for the watcher's debounce (100ms) plus the analysis
+        // progress marker to appear if the event were processed.
+        await Future<void>.delayed(const Duration(seconds: 3));
+        outputAfterGeneratedFileChange = output.skip(outputStart).toList();
+      });
 
-        await waitForOutput(initialCodeGenerationComplete);
-
-        // Prove the file watcher is live before testing what it ignores:
-        // a source model change must round-trip through a generation run.
-        await touchModelAndAwaitGeneration();
+      test('then the change does not trigger an analysis run.', () {
+        expect(
+          outputAfterGeneratedFileChange.where(
+            (line) => line.contains(_analysisRunMarker),
+          ),
+          isEmpty,
+          reason: 'The generated file change must be ignored.',
+        );
       });
 
       test(
-        'when a generated file changes, '
-        'then no generation is triggered by the generated file event.',
+        'then subsequent source changes still trigger an analysis run.',
         () async {
-          final from = output.length;
-
-          // A generated file changing on disk is what every generation run
-          // produces; reacting to it would make each run trigger the next.
-          generatedProtocolFile.writeAsStringSync(
-            '${generatedProtocolFile.readAsStringSync()}\n// touched\n',
+          final outputStart = output.length;
+          modelFile.writeAsStringSync('''
+class: Item
+fields:
+  name: String
+  count: int
+  description: String
+''');
+          await _waitForOutput(
+            incrementalCodeGenerationComplete,
+            from: outputStart,
+            output: output,
           );
 
-          // Long enough for the watcher's debounce (100ms) plus the analysis
-          // progress marker to appear if the event were (wrongly) processed.
-          await Future<void>.delayed(const Duration(seconds: 3));
           expect(
-            analysisRunsSince(from),
-            0,
-            reason: 'The generated file change must be ignored, '
-                'but an analysis run was triggered.',
+            output
+                .skip(outputStart)
+                .where((line) => line.contains(_analysisRunMarker)),
+            hasLength(1),
           );
-
-          // Control: the watcher is still alive and processing source events
-          // after having ignored the generated one.
-          await touchModelAndAwaitGeneration();
-          expect(analysisRunsSince(from), 1);
         },
       );
-    },
+    });
+  });
+}
+
+Future<void> _waitForOutput(
+  String needle, {
+  required List<String> output,
+  int from = 0,
+  Duration timeout = const Duration(minutes: 4),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (output.skip(from).any((line) => line.contains(needle))) return;
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+  }
+  fail(
+    'Timed out waiting for "$needle" in the CLI output:\n'
+    '${output.join('\n')}',
   );
 }

--- a/tools/serverpod_cli/test/test_util/endpoint_validation_helpers.dart
+++ b/tools/serverpod_cli/test/test_util/endpoint_validation_helpers.dart
@@ -6,7 +6,7 @@ import 'package:path/path.dart' as path;
 /// Resolves the absolute path to the serverpod monorepo root via the test
 /// isolate's package config. The previous `Directory('../..')` approach
 /// breaks when dart_test sandboxes [Directory.current] in concurrent runs.
-Future<String> _resolveServerpodRoot() async {
+Future<String> resolveServerpodRoot() async {
   final uri = await Isolate.resolvePackageUri(
     Uri.parse('package:serverpod_cli/analyzer.dart'),
   );
@@ -19,8 +19,14 @@ Future<String> _resolveServerpodRoot() async {
   );
 }
 
+/// Absolute path to `tools/serverpod_cli/bin/serverpod_cli.dart`.
+Future<String> resolveServerpodCliEntrypoint() async {
+  final root = await resolveServerpodRoot();
+  return path.join(root, 'tools', 'serverpod_cli', 'bin', 'serverpod_cli.dart');
+}
+
 Future createTestEnvironment(Directory testProjectDirectory) async {
-  final pathToServerpodRoot = await _resolveServerpodRoot();
+  final pathToServerpodRoot = await resolveServerpodRoot();
 
   var pubspecFile = File(path.join(testProjectDirectory.path, 'pubspec.yaml'));
   pubspecFile.createSync(recursive: true);


### PR DESCRIPTION
## Summary

Fixes watch-mode feedback loops and excessive disk I/O during Flutter builds, while preserving dependency-change detection across missing, deleted, and recreated pub artifacts.

## Changes

- Excludes generated output paths from generate --watch events before invoking generation, preventing generated files from feeding back into the next analysis pass.

- Avoids touching protocol.dart during unchanged generations. The temporary analysis stub is now applied through an analyzer overlay instead of being written to disk. The existing disk-based approach remains as a fallback, and overlay teardown refreshes the analysis context to prevent stale stub content.

- Regenerates only when the set of files containing analyzer errors changes. Persistent errors no longer cause unrelated file events to trigger generation indefinitely, while introducing or resolving an error still regenerates as expected.

- Watches package_config.json and Flutter package_graph.json as exact files instead of recursively watching .dart_tool. This avoids scanning churning build output such as flutter_build, which caused the disk-I/O spike during cold Flutter desktop builds.

- Makes exact-file watches persistent:
  - Missing artifacts are checked individually every 500 ms.
  - Native file watching takes over once an artifact appears.
  - Deleting and recreating an artifact no longer ends its watch.
  - Expected Flutter graph paths are registered before the first Flutter run.
  - Flutter dependency tracking initializes lazily when the first valid resolution appears.

## Testing

Added regression coverage for:

- Generated events being ignored by generate --watch, with source-change liveness checks.
- Unchanged generation preserving both protocol.dart content and modification time.
- Persistent endpoint and future-call errors not triggering generation for unrelated changes.
- Error appearance and resolution still triggering generation.
- Workspace and non-workspace pub-artifact watch paths.
- Pub artifacts initially being absent.
- Artifact deletion, recreation, and subsequent modification.
- Flutter dependency tracking initialized after the first resolution is created.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.