### PR TITLE
feat: Add structured Flutter logs to `serverpod start`

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/providers/firebase/models/firebase_email_not_verified_exception.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/lib/src/protocol/providers/firebase/models/firebase_email_not_verified_exception.dart
@@ -20,7 +20,10 @@ import 'package:serverpod_client/serverpod_client.dart' as _i1;
 /// throws it). Clients can catch this to prompt the user to verify their
 /// email address.
 abstract class FirebaseEmailNotVerifiedException
-    implements _i1.SerializableException, _i1.SerializableModel {
+    implements
+        _i1.SerializableException,
+        _i1.SerializableModel,
+        _i1.ProtocolSerialization {
   FirebaseEmailNotVerifiedException._();
 
   factory FirebaseEmailNotVerifiedException() =
@@ -38,6 +41,13 @@ abstract class FirebaseEmailNotVerifiedException
   FirebaseEmailNotVerifiedException copyWith();
   @override
   Map<String, dynamic> toJson() {
+    return {
+      '__className__': 'serverpod_auth_idp.FirebaseEmailNotVerifiedException',
+    };
+  }
+
+  @override
+  Map<String, dynamic> toJsonForProtocol() {
     return {
       '__className__': 'serverpod_auth_idp.FirebaseEmailNotVerifiedException',
     };

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -42,6 +42,7 @@ import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
 import 'package:serverpod_cli/src/vm_proxy/serverpod_hooks.dart';
 import 'package:serverpod_logging_cli/serverpod_logging_cli.dart';
+import 'package:serverpod_shared/log.dart' as structured_log;
 import 'package:serverpod_shared/serverpod_shared.dart' hide ExitException;
 import 'package:serverpod_tui/serverpod_tui.dart';
 import 'package:stream_transform/stream_transform.dart';
@@ -1109,11 +1110,21 @@ Future<void> _runTuiBackend({
       serverStderrSink: stderrSink,
       flutterStdoutSinkFor: (app) => TuiLogSink(
         holder,
-        addLine: (line) => holder.state.appLogTabFor(app.id)?.lines.add(line),
+        addLine: (line) => handleFlutterOutput(
+          holder,
+          app.id,
+          line,
+          level: structured_log.LogLevel.info,
+        ),
       ),
       flutterStderrSinkFor: (app) => TuiLogSink(
         holder,
-        addLine: (line) => holder.state.appLogTabFor(app.id)?.lines.add(line),
+        addLine: (line) => handleFlutterOutput(
+          holder,
+          app.id,
+          line,
+          level: structured_log.LogLevel.error,
+        ),
       ),
       onEnsureFlutterAppTab: (app) {
         final tab = holder.state.getOrCreateAppLogTab(
@@ -1178,7 +1189,7 @@ Future<void> _runTuiBackend({
         if (vmService == null) return;
         await vmService.streamListen('Extension');
         vmService.onExtensionEvent.listen(
-          (event) => handleServerLogEvent(holder, event),
+          (event) => handleFlutterExtensionEvent(holder, app.id, event),
         );
       },
       onFlutterStop: (app) {

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -13,6 +13,7 @@ import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_app_manager.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_log_event.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
 import 'package:serverpod_cli/src/commands/start/mcp_server.dart';
@@ -42,7 +43,6 @@ import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
 import 'package:serverpod_cli/src/vm_proxy/serverpod_hooks.dart';
 import 'package:serverpod_logging_cli/serverpod_logging_cli.dart';
-import 'package:serverpod_shared/log.dart' as structured_log;
 import 'package:serverpod_shared/serverpod_shared.dart' hide ExitException;
 import 'package:serverpod_tui/serverpod_tui.dart';
 import 'package:stream_transform/stream_transform.dart';
@@ -377,6 +377,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   IOSink Function(FlutterAppConfig app)? flutterStderrSinkFor,
   void Function(FlutterAppConfig app)? onEnsureFlutterAppTab,
   void Function(FlutterAppConfig app, String stage)? onFlutterProgress,
+  void Function(FlutterAppConfig app, FlutterLogEvent event)? onFlutterLog,
   void Function(FlutterAppConfig app, String? url)? onFlutterReady,
   void Function(FlutterAppConfig app)? onFlutterLaunchFailed,
   void Function(FlutterAppConfig app)? onFlutterStop,
@@ -597,6 +598,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     onStop: (app) => onFlutterStop?.call(app),
     onLaunchFailed: (app) => onFlutterLaunchFailed?.call(app),
     onEnsureAppTab: (app) => onEnsureFlutterAppTab?.call(app),
+    onLog: (app, event) => onFlutterLog?.call(app, event),
     stdoutSinkFor: (app) => flutterStdoutSinkFor?.call(app) ?? stdout,
     stderrSinkFor: (app) => flutterStderrSinkFor?.call(app) ?? stderr,
   );
@@ -1110,22 +1112,14 @@ Future<void> _runTuiBackend({
       serverStderrSink: stderrSink,
       flutterStdoutSinkFor: (app) => TuiLogSink(
         holder,
-        addLine: (line) => handleFlutterOutput(
-          holder,
-          app.id,
-          line,
-          level: structured_log.LogLevel.info,
-        ),
+        addLine: (line) => handleFlutterOutput(holder, app.id, line),
       ),
       flutterStderrSinkFor: (app) => TuiLogSink(
         holder,
-        addLine: (line) => handleFlutterOutput(
-          holder,
-          app.id,
-          line,
-          level: structured_log.LogLevel.error,
-        ),
+        addLine: (line) => handleFlutterOutput(holder, app.id, line),
       ),
+      onFlutterLog: (app, event) =>
+          handleFlutterLogEvent(holder, app.id, event),
       onEnsureFlutterAppTab: (app) {
         final tab = holder.state.getOrCreateAppLogTab(
           appId: app.id,

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/flutter_dependency_tracker.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_log_event.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
 import 'package:serverpod_cli/src/config/flutter_app_config.dart';
@@ -44,6 +45,7 @@ class FlutterAppManager {
     required this.onStop,
     required this.onLaunchFailed,
     required this.onEnsureAppTab,
+    required this.onLog,
     required this.stdoutSinkFor,
     required this.stderrSinkFor,
     required this.serverPubspecFile,
@@ -93,6 +95,7 @@ class FlutterAppManager {
   final void Function(FlutterAppConfig app) onStop;
   final void Function(FlutterAppConfig app) onLaunchFailed;
   final void Function(FlutterAppConfig app) onEnsureAppTab;
+  final void Function(FlutterAppConfig app, FlutterLogEvent event) onLog;
   final IOSink Function(FlutterAppConfig app) stdoutSinkFor;
   final IOSink Function(FlutterAppConfig app) stderrSinkFor;
 
@@ -244,6 +247,7 @@ class FlutterAppManager {
       machineArgsOverride: argsOverrideForTesting?.call(runtime.app),
       stdoutSink: stdoutSinkFor(runtime.app),
       stderrSink: stderrSinkFor(runtime.app),
+      onLog: (event) => onLog(runtime.app, event),
       onProgress: (stage) {
         onProgress(runtime.app, stage);
         log.info('  ${runtime.app.name}: $stage');

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_log_event.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_log_event.dart
@@ -25,6 +25,7 @@ class FlutterLogEvent {
     this.metadata,
     this.levelIsInferred = false,
     this.timestampIsInferred = false,
+    this.canCoalesce = false,
   });
 
   final DateTime time;
@@ -43,4 +44,10 @@ class FlutterLogEvent {
   /// Whether [time] records when the CLI received the event because the source
   /// did not supply a timestamp.
   final bool timestampIsInferred;
+
+  /// Whether adjacent events from the same raw source may be combined.
+  ///
+  /// This is false for transports that already provide semantic event
+  /// boundaries, even when their level or timestamp is inferred.
+  final bool canCoalesce;
 }

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_log_event.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_log_event.dart
@@ -1,0 +1,46 @@
+import 'package:serverpod_shared/log.dart' show LogLevel;
+
+/// Transport that produced a Flutter log event.
+enum FlutterLogSource {
+  appLog,
+  daemon,
+  vmLogging,
+  vmStdout,
+  vmStderr,
+  processStdout,
+  processStderr,
+  flutterError,
+}
+
+/// A Flutter log before it is flattened into terminal output.
+class FlutterLogEvent {
+  const FlutterLogEvent({
+    required this.time,
+    required this.level,
+    required this.message,
+    required this.source,
+    this.loggerName,
+    this.error,
+    this.stackTrace,
+    this.metadata,
+    this.levelIsInferred = false,
+    this.timestampIsInferred = false,
+  });
+
+  final DateTime time;
+  final LogLevel level;
+  final String message;
+  final FlutterLogSource source;
+  final String? loggerName;
+  final String? error;
+  final String? stackTrace;
+  final Map<String, Object?>? metadata;
+
+  /// Whether [level] was derived from a stream or boolean error marker rather
+  /// than supplied as a real severity by the source.
+  final bool levelIsInferred;
+
+  /// Whether [time] records when the CLI received the event because the source
+  /// did not supply a timestamp.
+  final bool timestampIsInferred;
+}

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -5,12 +5,14 @@ import 'dart:io';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/messages.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_log_event.dart';
 import 'package:serverpod_cli/src/commands/start/server_process.dart'
     show vmServiceWsUri;
 import 'package:serverpod_cli/src/util/browser_launcher.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vendored/flutter_daemon_protocol.dart';
 import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
+import 'package:serverpod_shared/log.dart' show LogLevel;
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
 
@@ -45,6 +47,7 @@ class FlutterProcess {
   final List<String> _extraArgs;
   final IOSink _stdout;
   final IOSink _stderr;
+  final void Function(FlutterLogEvent event)? _onLog;
 
   /// IDE-facing proxy. When non-null, the process binds upstream on
   /// VM-service connect and unbinds on shutdown so the IDE sees a
@@ -108,6 +111,7 @@ class FlutterProcess {
     VmServiceProxy? flutterProxy,
     void Function(String stage)? onProgress,
     void Function()? onStarted,
+    void Function(FlutterLogEvent event)? onLog,
     IOSink? stdoutSink,
     IOSink? stderrSink,
     List<String>? machineArgsOverride,
@@ -120,6 +124,7 @@ class FlutterProcess {
        _flutterProxy = flutterProxy,
        _onProgress = onProgress,
        _onStarted = onStarted,
+       _onLog = onLog,
        _stdout = stdoutSink ?? stdout,
        _stderr = stderrSink ?? stderr,
        _launchBrowser = device == flutterDeviceWebServerWithBrowser,
@@ -200,6 +205,16 @@ class FlutterProcess {
       if (line.startsWith('[')) {
         stdoutLines.add(line);
       } else if (line.isNotEmpty) {
+        _emitLog(
+          FlutterLogEvent(
+            time: DateTime.now(),
+            level: LogLevel.info,
+            message: line,
+            source: FlutterLogSource.processStdout,
+            levelIsInferred: true,
+            timestampIsInferred: true,
+          ),
+        );
         _stdout.writeln(line);
       }
     }
@@ -224,7 +239,42 @@ class FlutterProcess {
       },
     );
     _machineLinesSub = stdoutLines.stream.listen(handleMachineLine);
-    _stderrBytesSub = process.stderr.listen(_stderr.add);
+    final stderrLineBuffer = StringBuffer();
+    void routeStderrLine(String line) {
+      if (line.isEmpty) return;
+      _emitLog(
+        FlutterLogEvent(
+          time: DateTime.now(),
+          level: LogLevel.error,
+          message: line,
+          source: FlutterLogSource.processStderr,
+          levelIsInferred: true,
+          timestampIsInferred: true,
+        ),
+      );
+    }
+
+    _stderrBytesSub = process.stderr.listen(
+      (data) {
+        _stderr.add(data);
+        stderrLineBuffer.write(utf8.decode(data, allowMalformed: true));
+        final bufferStr = stderrLineBuffer.toString();
+        final lastNewline = bufferStr.lastIndexOf('\n');
+        if (lastNewline == -1) return;
+        final ready = bufferStr.substring(0, lastNewline);
+        stderrLineBuffer.clear();
+        stderrLineBuffer.write(bufferStr.substring(lastNewline + 1));
+        lineSplitter.convert(ready).forEach(routeStderrLine);
+      },
+      onDone: () {
+        if (stderrLineBuffer.isNotEmpty) {
+          lineSplitter
+              .convert(stderrLineBuffer.toString())
+              .forEach(routeStderrLine);
+          stderrLineBuffer.clear();
+        }
+      },
+    );
 
     unawaited(
       process.exitCode.then((code) async {
@@ -354,32 +404,76 @@ class FlutterProcess {
     }
 
     if (await tryListen('Logging')) {
-      const severeLevel = 1000;
       _loggingSub = vmService.onLoggingEvent.listen((event) {
         final record = event.logRecord;
-        final message = record?.message?.valueAsString;
+        final message = _instanceValue(record?.message);
         if (message == null || message.isEmpty) return;
-        final name = record?.loggerName?.valueAsString ?? '';
+        final name = _instanceValue(record?.loggerName) ?? '';
         final line = name.isEmpty ? message : '[$name] $message';
-        final sink = (record?.level ?? 0) >= severeLevel ? _stderr : _stdout;
+        final vmLevel = record?.level;
+        final hasVmLevel = vmLevel != null && vmLevel >= 0;
+        final level = _logLevelFromVmLevel(
+          hasVmLevel ? vmLevel : null,
+        );
+        final sink = switch (level) {
+          LogLevel.warning || LogLevel.error || LogLevel.fatal => _stderr,
+          _ => _stdout,
+        };
+        final recordTime = record?.time;
+        final hasRecordTime = recordTime != null && recordTime >= 0;
+        _emitLog(
+          FlutterLogEvent(
+            time: hasRecordTime
+                ? DateTime.fromMillisecondsSinceEpoch(recordTime)
+                : DateTime.now(),
+            level: level,
+            message: message,
+            source: FlutterLogSource.vmLogging,
+            loggerName: name.isEmpty ? null : name,
+            error: _instanceValue(record?.error),
+            stackTrace: _instanceValue(record?.stackTrace),
+            metadata: {
+              'vmLevel': ?(hasVmLevel ? vmLevel : null),
+              'sequenceNumber': ?record?.sequenceNumber,
+              'zone': ?_instanceValue(record?.zone),
+            },
+            levelIsInferred: !hasVmLevel,
+            timestampIsInferred: !hasRecordTime,
+          ),
+        );
         sink.writeln(line);
       });
     }
 
     if (await tryListen('Stdout')) {
       _stdoutEventSub = vmService.onStdoutEvent.listen(
-        (e) => _writeVmStreamEvent(_stdout, e),
+        (e) => _writeVmStreamEvent(
+          _stdout,
+          e,
+          level: LogLevel.info,
+          source: FlutterLogSource.vmStdout,
+        ),
       );
     }
     if (await tryListen('Stderr')) {
       _stderrEventSub = vmService.onStderrEvent.listen(
-        (e) => _writeVmStreamEvent(_stderr, e),
+        (e) => _writeVmStreamEvent(
+          _stderr,
+          e,
+          level: LogLevel.error,
+          source: FlutterLogSource.vmStderr,
+        ),
       );
     }
   }
 
   /// Decodes a VM service [event] and writes its text to [sink]
-  static void _writeVmStreamEvent(IOSink sink, Event event) {
+  void _writeVmStreamEvent(
+    IOSink sink,
+    Event event, {
+    required LogLevel level,
+    required FlutterLogSource source,
+  }) {
     final bytes = event.bytes;
     String text;
     if (bytes != null) {
@@ -393,6 +487,19 @@ class FlutterProcess {
       return;
     }
     if (text.isEmpty) return;
+    final message = _withoutTrailingNewline(text);
+    if (message.isNotEmpty) {
+      _emitLog(
+        FlutterLogEvent(
+          time: DateTime.now(),
+          level: level,
+          message: message,
+          source: source,
+          levelIsInferred: true,
+          timestampIsInferred: true,
+        ),
+      );
+    }
     sink.write(text);
   }
 
@@ -565,14 +672,18 @@ class FlutterProcess {
           _forwardMachineLog(
             paramMap,
             messageKey: 'log',
-            isError: paramMap['error'] == true,
+            level: paramMap['error'] == true ? LogLevel.error : LogLevel.info,
+            source: FlutterLogSource.appLog,
+            levelIsInferred: true,
           );
         case 'daemon.logMessage':
-          final level = paramMap['level'];
+          final daemonLevel = paramMap['level'];
           _forwardMachineLog(
             paramMap,
             messageKey: 'message',
-            isError: level == 'error' || level == 'warning',
+            level: _logLevelFromDaemonLevel(daemonLevel),
+            source: FlutterLogSource.daemon,
+            levelIsInferred: !_isKnownDaemonLevel(daemonLevel),
           );
       }
     }
@@ -581,20 +692,97 @@ class FlutterProcess {
   void _forwardMachineLog(
     Map<dynamic, dynamic> params, {
     required String messageKey,
-    required bool isError,
+    required LogLevel level,
+    required FlutterLogSource source,
+    bool levelIsInferred = false,
   }) {
     final message = params[messageKey];
     if (message is! String || message.isEmpty) return;
 
-    final sink = isError ? _stderr : _stdout;
+    final stackTrace = params['stackTrace'];
+    _emitLog(
+      FlutterLogEvent(
+        time: DateTime.now(),
+        level: level,
+        message: message,
+        source: source,
+        stackTrace: stackTrace is String && stackTrace.isNotEmpty
+            ? stackTrace
+            : null,
+        metadata: source == FlutterLogSource.daemon
+            ? {'daemonLevel': params['level']}
+            : source == FlutterLogSource.appLog
+            ? {'error': params['error'] == true}
+            : null,
+        levelIsInferred: levelIsInferred,
+        timestampIsInferred: true,
+      ),
+    );
+
+    final sink = switch (level) {
+      LogLevel.warning || LogLevel.error || LogLevel.fatal => _stderr,
+      _ => _stdout,
+    };
     sink.write(message);
     if (!message.endsWith('\n')) sink.writeln();
 
-    final stackTrace = params['stackTrace'];
     if (stackTrace is String && stackTrace.isNotEmpty) {
       sink.write(stackTrace);
       if (!stackTrace.endsWith('\n')) sink.writeln();
     }
+  }
+
+  void _emitLog(FlutterLogEvent event) {
+    try {
+      _onLog?.call(event);
+    } catch (error, stackTrace) {
+      log.warning('Flutter log listener failed: $error\n$stackTrace');
+    }
+  }
+
+  static LogLevel _logLevelFromDaemonLevel(Object? level) {
+    return switch (level) {
+      'trace' || 'debug' => LogLevel.debug,
+      'status' || 'info' => LogLevel.info,
+      'warning' || 'warn' => LogLevel.warning,
+      'error' => LogLevel.error,
+      'fatal' => LogLevel.fatal,
+      _ => LogLevel.info,
+    };
+  }
+
+  static bool _isKnownDaemonLevel(Object? level) {
+    return const {
+      'trace',
+      'debug',
+      'status',
+      'info',
+      'warning',
+      'warn',
+      'error',
+      'fatal',
+    }.contains(level);
+  }
+
+  static LogLevel _logLevelFromVmLevel(int? level) {
+    final value = level ?? 800;
+    if (value >= 1200) return LogLevel.fatal;
+    if (value >= 1000) return LogLevel.error;
+    if (value >= 900) return LogLevel.warning;
+    if (value >= 800) return LogLevel.info;
+    return LogLevel.debug;
+  }
+
+  static String _withoutTrailingNewline(String text) {
+    var end = text.length;
+    if (end > 0 && text.codeUnitAt(end - 1) == 10) end--;
+    if (end > 0 && text.codeUnitAt(end - 1) == 13) end--;
+    return text.substring(0, end);
+  }
+
+  static String? _instanceValue(InstanceRef? instance) {
+    if (instance == null || instance.kind == InstanceKind.kNull) return null;
+    return instance.valueAsString;
   }
 
   Future<void> _openBrowser(Uri url) async {

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -87,6 +87,8 @@ class FlutterProcess {
   StreamSubscription<Event>? _stdoutEventSub;
   StreamSubscription<Event>? _stderrEventSub;
   Timer? _vmServiceHeartbeat;
+  Timer? _logCoalesceTimer;
+  _PendingFlutterLog? _pendingLog;
 
   String? _appId;
   FlutterDaemonProtocol? _daemon;
@@ -213,6 +215,7 @@ class FlutterProcess {
             source: FlutterLogSource.processStdout,
             levelIsInferred: true,
             timestampIsInferred: true,
+            canCoalesce: true,
           ),
         );
         _stdout.writeln(line);
@@ -250,6 +253,7 @@ class FlutterProcess {
           source: FlutterLogSource.processStderr,
           levelIsInferred: true,
           timestampIsInferred: true,
+          canCoalesce: true,
         ),
       );
     }
@@ -497,6 +501,7 @@ class FlutterProcess {
           source: source,
           levelIsInferred: true,
           timestampIsInferred: true,
+          canCoalesce: true,
         ),
       );
     }
@@ -733,6 +738,41 @@ class FlutterProcess {
   }
 
   void _emitLog(FlutterLogEvent event) {
+    if (_onLog == null) return;
+
+    final canCoalesce =
+        event.canCoalesce && event.levelIsInferred && event.timestampIsInferred;
+    if (!canCoalesce) {
+      _flushPendingLog();
+      _dispatchLog(event);
+      return;
+    }
+
+    final pending = _pendingLog;
+    if (pending == null || !pending.canAppend(event)) {
+      _flushPendingLog();
+      _pendingLog = _PendingFlutterLog(event);
+    } else {
+      pending.append(event);
+    }
+
+    _logCoalesceTimer?.cancel();
+    _logCoalesceTimer = Timer(
+      const Duration(milliseconds: 50),
+      _flushPendingLog,
+    );
+  }
+
+  void _flushPendingLog() {
+    _logCoalesceTimer?.cancel();
+    _logCoalesceTimer = null;
+    final pending = _pendingLog;
+    if (pending == null) return;
+    _pendingLog = null;
+    _dispatchLog(pending.toEvent());
+  }
+
+  void _dispatchLog(FlutterLogEvent event) {
     try {
       _onLog?.call(event);
     } catch (error, stackTrace) {
@@ -834,6 +874,7 @@ class FlutterProcess {
       await _loggingSub?.cancel();
       await _stdoutEventSub?.cancel();
       await _stderrEventSub?.cancel();
+      _flushPendingLog();
       _vmServiceHeartbeat?.cancel();
       _stdoutBytesSub = null;
       _stderrBytesSub = null;
@@ -926,4 +967,53 @@ class FlutterProcess {
     if (path.endsWith('/ws')) path = path.substring(0, path.length - 3);
     return uri.replace(scheme: scheme, path: path).toString();
   }
+}
+
+class _PendingFlutterLog {
+  _PendingFlutterLog(this.first)
+    : _message = StringBuffer(first.message),
+      _lineCount = _countLines(first.message);
+
+  static const maxLines = 100;
+  static const maxCharacters = 64 * 1024;
+
+  final FlutterLogEvent first;
+  final StringBuffer _message;
+  int _lineCount;
+
+  bool canAppend(FlutterLogEvent event) {
+    if (event.source != first.source || event.level != first.level) {
+      return false;
+    }
+    final additionalLines = _countLines(event.message);
+    return _lineCount + additionalLines <= maxLines &&
+        _message.length + event.message.length + 1 <= maxCharacters;
+  }
+
+  void append(FlutterLogEvent event) {
+    if (_message.isNotEmpty) _message.writeln();
+    _message.write(event.message);
+    _lineCount += _countLines(event.message);
+  }
+
+  FlutterLogEvent toEvent() {
+    return FlutterLogEvent(
+      time: first.time,
+      level: first.level,
+      message: _message.toString(),
+      source: first.source,
+      loggerName: first.loggerName,
+      error: first.error,
+      stackTrace: first.stackTrace,
+      metadata: {
+        ...?first.metadata,
+        'coalesced': _lineCount > _countLines(first.message),
+        'lineCount': _lineCount,
+      },
+      levelIsInferred: first.levelIsInferred,
+      timestampIsInferred: first.timestampIsInferred,
+    );
+  }
+
+  static int _countLines(String message) => '\n'.allMatches(message).length + 1;
 }

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -88,6 +88,8 @@ class FlutterProcess {
   Timer? _vmServiceHeartbeat;
   Timer? _logCoalesceTimer;
   _PendingFlutterLog? _pendingLog;
+  _Utf8LineDecoder? _vmStdoutDecoder;
+  _Utf8LineDecoder? _vmStderrDecoder;
 
   String? _appId;
   FlutterDaemonProtocol? _daemon;
@@ -418,62 +420,66 @@ class FlutterProcess {
     }
 
     if (await tryListen('Stdout')) {
-      _stdoutEventSub = vmService.onStdoutEvent.listen(
-        (e) => _writeVmStreamEvent(
+      _vmStdoutDecoder = _Utf8LineDecoder(
+        (line) => _forwardVmStreamLine(
           _stdout,
-          e,
+          line,
           level: LogLevel.info,
           source: FlutterLogSource.vmStdout,
         ),
       );
+      _stdoutEventSub = vmService.onStdoutEvent.listen(
+        (event) => _writeVmStreamEvent(_vmStdoutDecoder!, event),
+      );
     }
     if (await tryListen('Stderr')) {
-      _stderrEventSub = vmService.onStderrEvent.listen(
-        (e) => _writeVmStreamEvent(
+      _vmStderrDecoder = _Utf8LineDecoder(
+        (line) => _forwardVmStreamLine(
           _stderr,
-          e,
+          line,
           level: LogLevel.error,
           source: FlutterLogSource.vmStderr,
         ),
       );
+      _stderrEventSub = vmService.onStderrEvent.listen(
+        (event) => _writeVmStreamEvent(_vmStderrDecoder!, event),
+      );
     }
   }
 
-  /// Decodes a VM service [event] and writes its text to [sink]
-  void _writeVmStreamEvent(
+  /// Adds a VM service stream [event] to its UTF-8 line decoder.
+  void _writeVmStreamEvent(_Utf8LineDecoder decoder, Event event) {
+    final encodedBytes = event.bytes;
+    if (encodedBytes == null) return;
+    try {
+      decoder.add(base64.decode(encodedBytes));
+    } catch (_) {
+      // Ignore malformed VM service payloads.
+    }
+  }
+
+  void _forwardVmStreamLine(
     IOSink sink,
-    Event event, {
+    String line, {
     required LogLevel level,
     required FlutterLogSource source,
   }) {
-    final bytes = event.bytes;
-    String text;
-    if (bytes != null) {
-      try {
-        text = utf8.decode(base64.decode(bytes), allowMalformed: true);
-      } catch (_) {
-        return;
-      }
-    } else {
-      // No bytes payload on this VM build
+    if (line.isEmpty) {
+      sink.writeln();
       return;
     }
-    if (text.isEmpty) return;
-    final message = _withoutTrailingNewline(text);
-    if (message.isNotEmpty) {
-      _emitLog(
-        FlutterLogEvent(
-          time: DateTime.now(),
-          level: level,
-          message: message,
-          source: source,
-          levelIsInferred: true,
-          timestampIsInferred: true,
-          canCoalesce: true,
-        ),
-      );
-    }
-    sink.write(text);
+    final accepted = _emitLog(
+      FlutterLogEvent(
+        time: DateTime.now(),
+        level: level,
+        message: line,
+        source: source,
+        levelIsInferred: true,
+        timestampIsInferred: true,
+        canCoalesce: true,
+      ),
+    );
+    if (accepted) sink.writeln(line);
   }
 
   /// Hot reload. Daemon-reported success; never throws.
@@ -781,13 +787,6 @@ class FlutterProcess {
     return LogLevel.debug;
   }
 
-  static String _withoutTrailingNewline(String text) {
-    var end = text.length;
-    if (end > 0 && text.codeUnitAt(end - 1) == 10) end--;
-    if (end > 0 && text.codeUnitAt(end - 1) == 13) end--;
-    return text.substring(0, end);
-  }
-
   static String? _instanceValue(InstanceRef? instance) {
     if (instance == null || instance.kind == InstanceKind.kNull) return null;
     return instance.valueAsString;
@@ -841,6 +840,8 @@ class FlutterProcess {
       await _loggingSub?.cancel();
       await _stdoutEventSub?.cancel();
       await _stderrEventSub?.cancel();
+      _vmStdoutDecoder?.close();
+      _vmStderrDecoder?.close();
       _flushPendingLog();
       _vmServiceHeartbeat?.cancel();
       _stdoutLinesSub = null;
@@ -849,6 +850,8 @@ class FlutterProcess {
       _loggingSub = null;
       _stdoutEventSub = null;
       _stderrEventSub = null;
+      _vmStdoutDecoder = null;
+      _vmStderrDecoder = null;
       _vmServiceHeartbeat = null;
 
       await _vmService?.dispose();
@@ -982,4 +985,32 @@ class _PendingFlutterLog {
   }
 
   static int _countLines(String message) => '\n'.allMatches(message).length + 1;
+}
+
+class _Utf8LineDecoder {
+  _Utf8LineDecoder(void Function(String line) onLine) {
+    _sink = const Utf8Decoder(allowMalformed: true).startChunkedConversion(
+      const LineSplitter().startChunkedConversion(
+        _CallbackSink<String>(onLine),
+      ),
+    );
+  }
+
+  late final ByteConversionSink _sink;
+
+  void add(List<int> bytes) => _sink.add(bytes);
+
+  void close() => _sink.close();
+}
+
+class _CallbackSink<T> implements Sink<T> {
+  const _CallbackSink(this._onData);
+
+  final void Function(T data) _onData;
+
+  @override
+  void add(T data) => _onData(data);
+
+  @override
+  void close() {}
 }

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -80,9 +80,8 @@ class FlutterProcess {
 
   Process? _process;
   StreamSubscription<ProcessSignal>? _sigtermSub;
-  StreamSubscription<List<int>>? _stdoutBytesSub;
-  StreamSubscription<List<int>>? _stderrBytesSub;
-  StreamSubscription<String>? _machineLinesSub;
+  StreamSubscription<String>? _stdoutLinesSub;
+  StreamSubscription<String>? _stderrLinesSub;
   StreamSubscription<Event>? _loggingSub;
   StreamSubscription<Event>? _stdoutEventSub;
   StreamSubscription<Event>? _stderrEventSub;
@@ -200,14 +199,11 @@ class FlutterProcess {
     }
 
     // `[`-prefixed lines -> machine parser; rest -> _stdout as text.
-    final stdoutLines = StreamController<String>();
-    const lineSplitter = LineSplitter();
-    final lineBuffer = StringBuffer();
     void routeLine(String line) {
       if (line.startsWith('[')) {
-        stdoutLines.add(line);
+        handleMachineLine(line);
       } else if (line.isNotEmpty) {
-        _emitLog(
+        final accepted = _emitLog(
           FlutterLogEvent(
             time: DateTime.now(),
             level: LogLevel.info,
@@ -218,34 +214,21 @@ class FlutterProcess {
             canCoalesce: true,
           ),
         );
-        _stdout.writeln(line);
+        if (accepted) _stdout.writeln(line);
       }
     }
 
-    _stdoutBytesSub = process.stdout.listen(
-      (data) {
-        lineBuffer.write(utf8.decode(data, allowMalformed: true));
-        final bufferStr = lineBuffer.toString();
-        final lastNewline = bufferStr.lastIndexOf('\n');
-        if (lastNewline == -1) return;
-        final ready = bufferStr.substring(0, lastNewline);
-        lineBuffer.clear();
-        lineBuffer.write(bufferStr.substring(lastNewline + 1));
-        lineSplitter.convert(ready).forEach(routeLine);
-      },
-      onDone: () {
-        if (lineBuffer.isNotEmpty) {
-          lineSplitter.convert(lineBuffer.toString()).forEach(routeLine);
-          lineBuffer.clear();
-        }
-        stdoutLines.close();
-      },
-    );
-    _machineLinesSub = stdoutLines.stream.listen(handleMachineLine);
-    final stderrLineBuffer = StringBuffer();
+    _stdoutLinesSub = process.stdout
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .transform(const LineSplitter())
+        .listen(routeLine);
+
     void routeStderrLine(String line) {
-      if (line.isEmpty) return;
-      _emitLog(
+      if (line.isEmpty) {
+        _stderr.writeln();
+        return;
+      }
+      final accepted = _emitLog(
         FlutterLogEvent(
           time: DateTime.now(),
           level: LogLevel.error,
@@ -256,29 +239,13 @@ class FlutterProcess {
           canCoalesce: true,
         ),
       );
+      if (accepted) _stderr.writeln(line);
     }
 
-    _stderrBytesSub = process.stderr.listen(
-      (data) {
-        _stderr.add(data);
-        stderrLineBuffer.write(utf8.decode(data, allowMalformed: true));
-        final bufferStr = stderrLineBuffer.toString();
-        final lastNewline = bufferStr.lastIndexOf('\n');
-        if (lastNewline == -1) return;
-        final ready = bufferStr.substring(0, lastNewline);
-        stderrLineBuffer.clear();
-        stderrLineBuffer.write(bufferStr.substring(lastNewline + 1));
-        lineSplitter.convert(ready).forEach(routeStderrLine);
-      },
-      onDone: () {
-        if (stderrLineBuffer.isNotEmpty) {
-          lineSplitter
-              .convert(stderrLineBuffer.toString())
-              .forEach(routeStderrLine);
-          stderrLineBuffer.clear();
-        }
-      },
-    );
+    _stderrLinesSub = process.stderr
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .transform(const LineSplitter())
+        .listen(routeStderrLine);
 
     unawaited(
       process.exitCode.then((code) async {
@@ -868,18 +835,16 @@ class FlutterProcess {
 
     try {
       _process = null;
-      await _stdoutBytesSub?.cancel();
-      await _stderrBytesSub?.cancel();
-      await _machineLinesSub?.cancel();
+      await _stdoutLinesSub?.cancel();
+      await _stderrLinesSub?.cancel();
       await _sigtermSub?.cancel();
       await _loggingSub?.cancel();
       await _stdoutEventSub?.cancel();
       await _stderrEventSub?.cancel();
       _flushPendingLog();
       _vmServiceHeartbeat?.cancel();
-      _stdoutBytesSub = null;
-      _stderrBytesSub = null;
-      _machineLinesSub = null;
+      _stdoutLinesSub = null;
+      _stderrLinesSub = null;
       _sigtermSub = null;
       _loggingSub = null;
       _stdoutEventSub = null;

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -14,6 +14,7 @@ import 'package:serverpod_cli/src/util/strip_ansi.dart';
 import 'package:serverpod_cli/src/vendored/flutter_daemon_protocol.dart';
 import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
 import 'package:serverpod_shared/log.dart' show LogLevel;
+import 'package:serverpod_tui/serverpod_tui.dart' show BoundedQueueList;
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
 
@@ -43,6 +44,7 @@ class FlutterNotInstalledException implements Exception {
 /// reload/restart go via [FlutterDaemonProtocol] over daemon stdin.
 class FlutterProcess {
   static const _rawLogDeduplicationWindow = Duration(seconds: 5);
+  static const _maxRecentRawLogLines = 1000;
 
   final String _flutterPackageDir;
   final String _flutterExecutable;
@@ -94,7 +96,9 @@ class FlutterProcess {
   _Utf8LineDecoder? _vmStdoutDecoder;
   _Utf8LineDecoder? _vmStderrDecoder;
   final Stopwatch _logClock = Stopwatch()..start();
-  final List<_RecentRawLogLine> _recentRawLogLines = [];
+  final _recentRawLogLines = BoundedQueueList<_RecentRawLogLine>(
+    _maxRecentRawLogLines,
+  );
 
   String? _appId;
   FlutterDaemonProtocol? _daemon;
@@ -799,7 +803,7 @@ class FlutterProcess {
 
     if (unmatchedMessages.isNotEmpty) {
       for (final message in unmatchedMessages) {
-        _rememberRawLogLine(
+        _recentRawLogLines.add(
           _RecentRawLogLine(
             channel: channel,
             message: message,
@@ -815,14 +819,6 @@ class FlutterProcess {
       _recentRawLogLines[index].duplicateSources.add(event.source);
     }
     return true;
-  }
-
-  void _rememberRawLogLine(_RecentRawLogLine line) {
-    const maxRecentLines = 1000;
-    _recentRawLogLines.add(line);
-    if (_recentRawLogLines.length > maxRecentLines) {
-      _recentRawLogLines.removeAt(0);
-    }
   }
 
   static _RawLogChannel? _rawLogChannel(FlutterLogEvent event) {

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -559,10 +559,41 @@ class FlutterProcess {
         case 'app.stop':
           log.debug('Flutter daemon emitted app.stop; tearing down.');
           unawaited(_onAppStop());
+        case 'app.log':
+          // Native devices report application and platform output here. Keep
+          // this alongside the VM streams, which are required for web targets.
+          _forwardMachineLog(
+            paramMap,
+            messageKey: 'log',
+            isError: paramMap['error'] == true,
+          );
         case 'daemon.logMessage':
-          final message = paramMap['message'];
-          if (message is String) log.debug('flutter[daemon] $message');
+          final level = paramMap['level'];
+          _forwardMachineLog(
+            paramMap,
+            messageKey: 'message',
+            isError: level == 'error' || level == 'warning',
+          );
       }
+    }
+  }
+
+  void _forwardMachineLog(
+    Map<dynamic, dynamic> params, {
+    required String messageKey,
+    required bool isError,
+  }) {
+    final message = params[messageKey];
+    if (message is! String || message.isEmpty) return;
+
+    final sink = isError ? _stderr : _stdout;
+    sink.write(message);
+    if (!message.endsWith('\n')) sink.writeln();
+
+    final stackTrace = params['stackTrace'];
+    if (stackTrace is String && stackTrace.isNotEmpty) {
+      sink.write(stackTrace);
+      if (!stackTrace.endsWith('\n')) sink.writeln();
     }
   }
 

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -91,7 +91,7 @@ class FlutterProcess {
   _PendingFlutterLog? _pendingLog;
   _Utf8LineDecoder? _vmStdoutDecoder;
   _Utf8LineDecoder? _vmStderrDecoder;
-  final Stopwatch _logDeduplicationClock = Stopwatch()..start();
+  final Stopwatch _logClock = Stopwatch()..start();
   final List<_RecentRawLogLine> _recentRawLogLines = [];
 
   String? _appId;
@@ -729,9 +729,17 @@ class FlutterProcess {
     }
 
     final pending = _pendingLog;
-    if (pending == null || !pending.canAppend(event)) {
+    final receivedAtMilliseconds = _logClock.elapsedMilliseconds;
+    if (pending == null ||
+        !pending.canAppend(
+          event,
+          receivedAtMilliseconds: receivedAtMilliseconds,
+        )) {
       _flushPendingLog();
-      _pendingLog = _PendingFlutterLog(event);
+      _pendingLog = _PendingFlutterLog(
+        event,
+        receivedAtMilliseconds: receivedAtMilliseconds,
+      );
     } else {
       pending.append(event);
     }
@@ -748,7 +756,7 @@ class FlutterProcess {
     final channel = _rawLogChannel(event);
     if (channel == null) return false;
 
-    final now = _logDeduplicationClock.elapsedMilliseconds;
+    final now = _logClock.elapsedMilliseconds;
     _recentRawLogLines.removeWhere(
       (line) => now - line.receivedAtMilliseconds > 1000,
     );
@@ -1031,19 +1039,30 @@ class FlutterProcess {
 }
 
 class _PendingFlutterLog {
-  _PendingFlutterLog(this.first)
-    : _message = StringBuffer(first.message),
-      _lineCount = _countLines(first.message);
+  _PendingFlutterLog(
+    this.first, {
+    required this.receivedAtMilliseconds,
+  }) : _message = StringBuffer(first.message),
+       _lineCount = _countLines(first.message);
 
   static const maxLines = 100;
   static const maxCharacters = 64 * 1024;
+  static const maxAge = Duration(milliseconds: 250);
 
   final FlutterLogEvent first;
+  final int receivedAtMilliseconds;
   final StringBuffer _message;
   int _lineCount;
 
-  bool canAppend(FlutterLogEvent event) {
+  bool canAppend(
+    FlutterLogEvent event, {
+    required int receivedAtMilliseconds,
+  }) {
     if (event.source != first.source || event.level != first.level) {
+      return false;
+    }
+    if (receivedAtMilliseconds - this.receivedAtMilliseconds >=
+        maxAge.inMilliseconds) {
       return false;
     }
     final additionalLines = _countLines(event.message);

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -10,6 +10,7 @@ import 'package:serverpod_cli/src/commands/start/server_process.dart'
     show vmServiceWsUri;
 import 'package:serverpod_cli/src/util/browser_launcher.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:serverpod_cli/src/util/strip_ansi.dart';
 import 'package:serverpod_cli/src/vendored/flutter_daemon_protocol.dart';
 import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
 import 'package:serverpod_shared/log.dart' show LogLevel;
@@ -90,6 +91,8 @@ class FlutterProcess {
   _PendingFlutterLog? _pendingLog;
   _Utf8LineDecoder? _vmStdoutDecoder;
   _Utf8LineDecoder? _vmStderrDecoder;
+  final Stopwatch _logDeduplicationClock = Stopwatch()..start();
+  final List<_RecentRawLogLine> _recentRawLogLines = [];
 
   String? _appId;
   FlutterDaemonProtocol? _daemon;
@@ -679,7 +682,7 @@ class FlutterProcess {
     if (message is! String || message.isEmpty) return;
 
     final stackTrace = params['stackTrace'];
-    _emitLog(
+    final accepted = _emitLog(
       FlutterLogEvent(
         time: DateTime.now(),
         level: level,
@@ -697,6 +700,7 @@ class FlutterProcess {
         timestampIsInferred: true,
       ),
     );
+    if (!accepted) return;
 
     final sink = switch (level) {
       LogLevel.warning || LogLevel.error || LogLevel.fatal => _stderr,
@@ -711,15 +715,17 @@ class FlutterProcess {
     }
   }
 
-  void _emitLog(FlutterLogEvent event) {
-    if (_onLog == null) return;
+  /// Returns whether [event] was accepted for structured and raw forwarding.
+  bool _emitLog(FlutterLogEvent event) {
+    if (_isDuplicateRawLog(event)) return false;
+    if (_onLog == null) return true;
 
     final canCoalesce =
         event.canCoalesce && event.levelIsInferred && event.timestampIsInferred;
     if (!canCoalesce) {
       _flushPendingLog();
       _dispatchLog(event);
-      return;
+      return true;
     }
 
     final pending = _pendingLog;
@@ -735,6 +741,86 @@ class FlutterProcess {
       const Duration(milliseconds: 50),
       _flushPendingLog,
     );
+    return true;
+  }
+
+  bool _isDuplicateRawLog(FlutterLogEvent event) {
+    final channel = _rawLogChannel(event);
+    if (channel == null) return false;
+
+    final now = _logDeduplicationClock.elapsedMilliseconds;
+    _recentRawLogLines.removeWhere(
+      (line) => now - line.receivedAtMilliseconds > 1000,
+    );
+
+    final lines = stripAnsi(event.message)
+        .split('\n')
+        .map(
+          (line) =>
+              line.endsWith('\r') ? line.substring(0, line.length - 1) : line,
+        )
+        .where((line) => line.isNotEmpty)
+        .toList();
+    if (lines.isEmpty) return false;
+
+    final matchedIndexes = <int>[];
+    for (final message in lines) {
+      var matchIndex = -1;
+      for (var index = 0; index < _recentRawLogLines.length; index++) {
+        final line = _recentRawLogLines[index];
+        if (!matchedIndexes.contains(index) &&
+            line.channel == channel &&
+            line.message == message &&
+            line.source != event.source &&
+            !line.duplicateSources.contains(event.source)) {
+          matchIndex = index;
+          break;
+        }
+      }
+      if (matchIndex == -1) {
+        for (final message in lines) {
+          _rememberRawLogLine(
+            _RecentRawLogLine(
+              channel: channel,
+              message: message,
+              source: event.source,
+              receivedAtMilliseconds: now,
+            ),
+          );
+        }
+        return false;
+      }
+      matchedIndexes.add(matchIndex);
+    }
+
+    for (final index in matchedIndexes) {
+      _recentRawLogLines[index].duplicateSources.add(event.source);
+    }
+    return true;
+  }
+
+  void _rememberRawLogLine(_RecentRawLogLine line) {
+    const maxRecentLines = 1000;
+    _recentRawLogLines.add(line);
+    if (_recentRawLogLines.length > maxRecentLines) {
+      _recentRawLogLines.removeAt(0);
+    }
+  }
+
+  static _RawLogChannel? _rawLogChannel(FlutterLogEvent event) {
+    return switch (event.source) {
+      FlutterLogSource.processStdout ||
+      FlutterLogSource.vmStdout => _RawLogChannel.stdout,
+      FlutterLogSource.processStderr ||
+      FlutterLogSource.vmStderr => _RawLogChannel.stderr,
+      FlutterLogSource.appLog => switch (event.level) {
+        LogLevel.warning ||
+        LogLevel.error ||
+        LogLevel.fatal => _RawLogChannel.stderr,
+        _ => _RawLogChannel.stdout,
+      },
+      _ => null,
+    };
   }
 
   void _flushPendingLog() {
@@ -985,6 +1071,23 @@ class _PendingFlutterLog {
   }
 
   static int _countLines(String message) => '\n'.allMatches(message).length + 1;
+}
+
+enum _RawLogChannel { stdout, stderr }
+
+class _RecentRawLogLine {
+  _RecentRawLogLine({
+    required this.channel,
+    required this.message,
+    required this.source,
+    required this.receivedAtMilliseconds,
+  });
+
+  final _RawLogChannel channel;
+  final String message;
+  final FlutterLogSource source;
+  final int receivedAtMilliseconds;
+  final Set<FlutterLogSource> duplicateSources = {};
 }
 
 class _Utf8LineDecoder {

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -764,6 +764,7 @@ class FlutterProcess {
     if (lines.isEmpty) return false;
 
     final matchedIndexes = <int>[];
+    final unmatchedMessages = <String>[];
     for (final message in lines) {
       var matchIndex = -1;
       for (var index = 0; index < _recentRawLogLines.length; index++) {
@@ -778,19 +779,24 @@ class FlutterProcess {
         }
       }
       if (matchIndex == -1) {
-        for (final message in lines) {
-          _rememberRawLogLine(
-            _RecentRawLogLine(
-              channel: channel,
-              message: message,
-              source: event.source,
-              receivedAtMilliseconds: now,
-            ),
-          );
-        }
-        return false;
+        unmatchedMessages.add(message);
+      } else {
+        matchedIndexes.add(matchIndex);
       }
-      matchedIndexes.add(matchIndex);
+    }
+
+    if (unmatchedMessages.isNotEmpty) {
+      for (final message in unmatchedMessages) {
+        _rememberRawLogLine(
+          _RecentRawLogLine(
+            channel: channel,
+            message: message,
+            source: event.source,
+            receivedAtMilliseconds: now,
+          ),
+        );
+      }
+      return false;
     }
 
     for (final index in matchedIndexes) {

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -42,6 +42,8 @@ class FlutterNotInstalledException implements Exception {
 /// vm-service URI and the `flutter-vm-service-info.json` file);
 /// reload/restart go via [FlutterDaemonProtocol] over daemon stdin.
 class FlutterProcess {
+  static const _rawLogDeduplicationWindow = Duration(seconds: 5);
+
   final String _flutterPackageDir;
   final String _flutterExecutable;
   final String _device;
@@ -758,7 +760,9 @@ class FlutterProcess {
 
     final now = _logClock.elapsedMilliseconds;
     _recentRawLogLines.removeWhere(
-      (line) => now - line.receivedAtMilliseconds > 1000,
+      (line) =>
+          now - line.receivedAtMilliseconds >
+          _rawLogDeduplicationWindow.inMilliseconds,
     );
 
     final lines = stripAnsi(event.message)

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -415,7 +415,8 @@ class FlutterProcess {
         final name = _instanceValue(record?.loggerName) ?? '';
         final line = name.isEmpty ? message : '[$name] $message';
         final vmLevel = record?.level;
-        final hasVmLevel = vmLevel != null && vmLevel >= 0;
+        // Level 0 is dart:developer's default "unspecified" value.
+        final hasVmLevel = vmLevel != null && vmLevel > 0;
         final level = _logLevelFromVmLevel(
           hasVmLevel ? vmLevel : null,
         );

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -433,7 +433,8 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
     }
 
     final focusedTab = state.tabs.focusedTab;
-    if (event.logicalKey == LogicalKey.keyE && focusedTab is ServerLogTab) {
+    if (event.logicalKey == LogicalKey.keyE &&
+        (focusedTab is ServerLogTab || focusedTab is AppLogTab)) {
       state.expandStackTraces = !state.expandStackTraces;
       _rebuild();
       return true;

--- a/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
@@ -90,7 +90,7 @@ void handleFlutterExtensionEvent(
         level: LogLevel.error,
         message: message,
         source: FlutterLogSource.flutterError,
-        metadata: {'errorsSinceReload': data['errorsSinceReload']},
+        metadata: {'errorsSinceReload': ?data['errorsSinceReload']},
         timestampIsInferred: !hasEventTimestamp,
       );
       handleFlutterLogEvent(holder, appId, flutterEvent);

--- a/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
@@ -3,6 +3,7 @@ import 'package:serverpod_tui/serverpod_tui.dart';
 import 'package:vm_service/vm_service.dart' show Event;
 
 import '../../../util/serverpod_cli_logger.dart';
+import '../../../util/strip_ansi.dart';
 import '../flutter_log_event.dart';
 import 'app.dart';
 import 'tab_model.dart';
@@ -141,18 +142,21 @@ void handleFlutterLogEvent(
   if (tab == null) return;
 
   final loggerName = event.loggerName;
+  final message = loggerName == null
+      ? event.message
+      : '[$loggerName] ${event.message}';
+  final error = event.error;
+  final stackTrace = event.stackTrace;
   tab.logHistory.add(
     LogEntry(
       level: event.level,
       time: event.time,
-      message: loggerName == null
-          ? event.message
-          : '[$loggerName] ${event.message}',
+      message: stripAnsi(message),
       scope: LogScope.root(appId),
-      error: event.error,
-      stackTrace: event.stackTrace == null || event.stackTrace!.isEmpty
+      error: error == null ? null : stripAnsi(error),
+      stackTrace: stackTrace == null || stackTrace.isEmpty
           ? null
-          : StackTrace.fromString(event.stackTrace!),
+          : StackTrace.fromString(stripAnsi(stackTrace)),
       metadata: {
         ...?event.metadata,
         'source': event.source.name,
@@ -202,7 +206,7 @@ void _addRawFlutterEntry(AppLogTab tab, LogEntry entry) {
     if (raw.isNotEmpty) raw.writeln();
     raw.write(entry.stackTrace);
   }
-  tab.lines.addAll(raw.toString().split('\n'));
+  tab.lines.addAll(stripAnsi(raw.toString()).split('\n'));
 }
 
 /// Runs an async action as a tracked operation with spinner in the TUI.

--- a/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
@@ -3,6 +3,7 @@ import 'package:serverpod_tui/serverpod_tui.dart';
 import 'package:vm_service/vm_service.dart' show Event;
 
 import '../../../util/serverpod_cli_logger.dart';
+import '../flutter_log_event.dart';
 import 'app.dart';
 import 'tab_model.dart';
 
@@ -79,17 +80,26 @@ void handleFlutterExtensionEvent(
     case 'Flutter.Error':
       final message = data['renderedErrorText'];
       if (message is! String || message.isEmpty) return;
-      _addFlutterEntry(
+      final eventTimestamp = event.timestamp;
+      final hasEventTimestamp = eventTimestamp != null && eventTimestamp >= 0;
+      final flutterEvent = FlutterLogEvent(
+        time: hasEventTimestamp
+            ? DateTime.fromMillisecondsSinceEpoch(eventTimestamp)
+            : DateTime.now(),
+        level: LogLevel.error,
+        message: message,
+        source: FlutterLogSource.flutterError,
+        metadata: {'errorsSinceReload': data['errorsSinceReload']},
+        timestampIsInferred: !hasEventTimestamp,
+      );
+      handleFlutterLogEvent(holder, appId, flutterEvent);
+      _addRawFlutterEntry(
         tab,
         LogEntry(
           level: LogLevel.error,
-          time: DateTime.now(),
+          time: flutterEvent.time,
           message: message,
           scope: LogScope.root(appId),
-          metadata: {
-            'source': 'Flutter.Error',
-            'errorsSinceReload': data['errorsSinceReload'],
-          },
         ),
       );
     case 'ext.serverpod.log':
@@ -105,29 +115,53 @@ void handleFlutterExtensionEvent(
   holder.markDirty();
 }
 
-/// Adds an unstructured Flutter stdout/stderr line to both the raw history
-/// used by MCP and the structured history rendered by the TUI.
+/// Adds a raw Flutter stdout/stderr line to the history used by MCP.
+///
+/// The corresponding structured entry arrives separately through
+/// [handleFlutterLogEvent], before the process flattens it into this stream.
 void handleFlutterOutput(
   StartAppStateHolder holder,
   String appId,
-  String line, {
-  required LogLevel level,
-}) {
+  String line,
+) {
   final tab = holder.state.appLogTabFor(appId);
   if (tab == null) return;
 
   tab.lines.add(line);
-  if (line.isNotEmpty) {
-    tab.logHistory.add(
-      LogEntry(
-        level: level,
-        time: DateTime.now(),
-        message: line,
-        scope: LogScope.root(appId),
-        metadata: const {'source': 'stdio'},
-      ),
-    );
-  }
+  holder.markDirty();
+}
+
+/// Adds a Flutter event with the structure supplied by its original source.
+void handleFlutterLogEvent(
+  StartAppStateHolder holder,
+  String appId,
+  FlutterLogEvent event,
+) {
+  final tab = holder.state.appLogTabFor(appId);
+  if (tab == null) return;
+
+  final loggerName = event.loggerName;
+  tab.logHistory.add(
+    LogEntry(
+      level: event.level,
+      time: event.time,
+      message: loggerName == null
+          ? event.message
+          : '[$loggerName] ${event.message}',
+      scope: LogScope.root(appId),
+      error: event.error,
+      stackTrace: event.stackTrace == null || event.stackTrace!.isEmpty
+          ? null
+          : StackTrace.fromString(event.stackTrace!),
+      metadata: {
+        ...?event.metadata,
+        'source': event.source.name,
+        'loggerName': ?loggerName,
+        'levelIsInferred': event.levelIsInferred,
+        'timestampIsInferred': event.timestampIsInferred,
+      },
+    ),
+  );
   holder.markDirty();
 }
 
@@ -155,6 +189,10 @@ LogEntry _logEntryFromData(
 void _addFlutterEntry(AppLogTab tab, LogEntry entry) {
   tab.logHistory.add(entry);
 
+  _addRawFlutterEntry(tab, entry);
+}
+
+void _addRawFlutterEntry(AppLogTab tab, LogEntry entry) {
   final raw = StringBuffer(entry.message);
   if (entry.error != null) {
     if (raw.isNotEmpty) raw.writeln();

--- a/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
@@ -4,6 +4,7 @@ import 'package:vm_service/vm_service.dart' show Event;
 
 import '../../../util/serverpod_cli_logger.dart';
 import 'app.dart';
+import 'tab_model.dart';
 
 int _actionCounter = 0;
 
@@ -17,30 +18,15 @@ void handleServerLogEvent(TuiAppStateHolder holder, Event event) {
   final type = data['type'] as String?;
   switch (type) {
     case 'log':
-      final stackTrace = data['stackTrace'] as String?;
-      final message = data['message'] as String? ?? '';
-      final time =
-          DateTime.tryParse(data['timestamp'] as String? ?? '') ??
-          DateTime.now();
-      state.logHistory.add(
-        LogEntry(
-          level: parseLogLevel(data['level'] as String? ?? 'info'),
-          time: time,
-          message: message,
-          scope: LogScope.root('server'),
-          error: data['error']?.toString(),
-          stackTrace: stackTrace != null && stackTrace.isNotEmpty
-              ? StackTrace.fromString(stackTrace)
-              : null,
-        ),
-      );
+      final entry = _logEntryFromData(data, scopeLabel: 'server');
+      state.logHistory.add(entry);
 
       // An alert carries `metadata: {'alert': true}`. AlertMessage.parse
       // strips any `<...>` copy markup for display; the raw log line above
       // keeps the markup.
       final metadata = data['metadata'];
       if (metadata is Map && metadata['alert'] == true) {
-        holder.showAlert(AlertMessage.parse(message), time: time);
+        holder.showAlert(AlertMessage.parse(entry.message), time: entry.time);
       }
 
     case 'scope_start':
@@ -71,6 +57,114 @@ void handleServerLogEvent(TuiAppStateHolder holder, Event event) {
       }
   }
   holder.markDirty();
+}
+
+/// Dispatches Flutter VM extension events to the matching app log tab.
+///
+/// Flutter framework assertions are emitted as `Flutter.Error` events when
+/// structured errors are enabled. In that mode Flutter intentionally does not
+/// repeat the error on stderr, so this stream is the authoritative source.
+void handleFlutterExtensionEvent(
+  StartAppStateHolder holder,
+  String appId,
+  Event event,
+) {
+  final tab = holder.state.appLogTabFor(appId);
+  if (tab == null) return;
+
+  final data = event.extensionData?.data;
+  if (data == null) return;
+
+  switch (event.extensionKind) {
+    case 'Flutter.Error':
+      final message = data['renderedErrorText'];
+      if (message is! String || message.isEmpty) return;
+      _addFlutterEntry(
+        tab,
+        LogEntry(
+          level: LogLevel.error,
+          time: DateTime.now(),
+          message: message,
+          scope: LogScope.root(appId),
+          metadata: {
+            'source': 'Flutter.Error',
+            'errorsSinceReload': data['errorsSinceReload'],
+          },
+        ),
+      );
+    case 'ext.serverpod.log':
+      if (data['type'] != 'log') return;
+      _addFlutterEntry(
+        tab,
+        _logEntryFromData(data, scopeLabel: appId),
+      );
+    default:
+      return;
+  }
+
+  holder.markDirty();
+}
+
+/// Adds an unstructured Flutter stdout/stderr line to both the raw history
+/// used by MCP and the structured history rendered by the TUI.
+void handleFlutterOutput(
+  StartAppStateHolder holder,
+  String appId,
+  String line, {
+  required LogLevel level,
+}) {
+  final tab = holder.state.appLogTabFor(appId);
+  if (tab == null) return;
+
+  tab.lines.add(line);
+  if (line.isNotEmpty) {
+    tab.logHistory.add(
+      LogEntry(
+        level: level,
+        time: DateTime.now(),
+        message: line,
+        scope: LogScope.root(appId),
+        metadata: const {'source': 'stdio'},
+      ),
+    );
+  }
+  holder.markDirty();
+}
+
+LogEntry _logEntryFromData(
+  Map<String, dynamic> data, {
+  required String scopeLabel,
+}) {
+  final stackTrace = data['stackTrace'] as String?;
+  return LogEntry(
+    level: parseLogLevel(data['level'] as String? ?? 'info'),
+    time:
+        DateTime.tryParse(data['timestamp'] as String? ?? '') ?? DateTime.now(),
+    message: data['message'] as String? ?? '',
+    scope: LogScope.root(scopeLabel),
+    error: data['error']?.toString(),
+    stackTrace: stackTrace != null && stackTrace.isNotEmpty
+        ? StackTrace.fromString(stackTrace)
+        : null,
+    metadata: data['metadata'] is Map
+        ? Map<String, Object?>.from(data['metadata'] as Map)
+        : null,
+  );
+}
+
+void _addFlutterEntry(AppLogTab tab, LogEntry entry) {
+  tab.logHistory.add(entry);
+
+  final raw = StringBuffer(entry.message);
+  if (entry.error != null) {
+    if (raw.isNotEmpty) raw.writeln();
+    raw.write(entry.error);
+  }
+  if (entry.stackTrace != null) {
+    if (raw.isNotEmpty) raw.writeln();
+    raw.write(entry.stackTrace);
+  }
+  tab.lines.addAll(raw.toString().split('\n'));
 }
 
 /// Runs an async action as a tracked operation with spinner in the TUI.

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -454,12 +454,18 @@ class MainScreen extends StatelessComponent {
 
   Component _buildTabContent(ServerpodThemeData st, PaneTab tab) {
     return switch (tab) {
-      ServerLogTab() => _buildStructuredLogView(tab.scrollController),
+      ServerLogTab() => _buildStructuredLogView(
+        state.logHistory,
+        tab.scrollController,
+      ),
       AppLogTab appTab => Column(
         children: [
           ?_buildFlutterStatusLine(st, appTab),
           Expanded(
-            child: _buildRawOutputView(appTab.lines, appTab.scrollController),
+            child: _buildStructuredLogView(
+              appTab.logHistory,
+              appTab.scrollController,
+            ),
           ),
         ],
       ),
@@ -606,9 +612,10 @@ class MainScreen extends StatelessComponent {
     );
   }
 
-  Component _buildStructuredLogView(ScrollController logScrollController) {
-    final items = state.logHistory;
-
+  Component _buildStructuredLogView(
+    List<Object> items,
+    ScrollController logScrollController,
+  ) {
     return Padding(
       padding: const EdgeInsets.only(left: 1),
       child: SelectionArea(

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -179,6 +179,7 @@ class ServerWatchState extends TuiState {
     for (final tab in appsTabArea?.tabs ?? []) {
       if (tab is AppLogTab) {
         tab.lines.clear();
+        tab.logHistory.clear();
       }
     }
   }

--- a/tools/serverpod_cli/lib/src/commands/start/tui/tab_model.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/tab_model.dart
@@ -43,16 +43,18 @@ class AppLogTab implements PaneTab {
     required this.appId,
     required this.label,
     BoundedQueueList<String>? lines,
+    BoundedQueueList<Object>? logHistory,
     ScrollController? scrollController,
     this.ready = false,
     this.stopped = false,
     this.url,
     this.startupStage,
-  }) : lines = lines ?? BoundedQueueList<String>(maxRawLines),
+  }) : lines = lines ?? BoundedQueueList<String>(maxLogEntries),
+       logHistory = logHistory ?? BoundedQueueList<Object>(maxLogEntries),
        scrollController = scrollController ?? ScrollController();
 
-  /// Maximum number of raw lines to keep.
-  static const maxRawLines = 10000;
+  /// Maximum number of raw lines and structured entries to keep.
+  static const maxLogEntries = 10000;
 
   /// Stable app identifier from [FlutterAppConfig.id].
   final String appId;
@@ -79,6 +81,9 @@ class AppLogTab implements PaneTab {
 
   /// Raw stdout/stderr lines for this app.
   final BoundedQueueList<String> lines;
+
+  /// Structured entries rendered in this app's log tab.
+  final BoundedQueueList<Object> logHistory;
 
   @override
   final ScrollController scrollController;

--- a/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
@@ -4,7 +4,9 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/flutter_app_manager.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_log_event.dart';
 import 'package:serverpod_cli/src/config/flutter_app_config.dart';
+import 'package:serverpod_shared/log.dart' show LogLevel;
 import 'package:test/test.dart';
 
 String _shimPath(String name) => p.join(
@@ -100,6 +102,7 @@ class _ManagerFixture {
     void Function(FlutterAppConfig app)? onStop,
     void Function(FlutterAppConfig app)? onLaunchFailed,
     void Function(FlutterAppConfig app)? onEnsureAppTab,
+    void Function(FlutterAppConfig app, FlutterLogEvent event)? onLog,
     IOSink Function(FlutterAppConfig app)? stdoutSinkFor,
     IOSink Function(FlutterAppConfig app)? stderrSinkFor,
   }) async {
@@ -146,6 +149,7 @@ $appEntries''');
       onStop: onStop ?? (_) {},
       onLaunchFailed: onLaunchFailed ?? (_) {},
       onEnsureAppTab: onEnsureAppTab ?? (_) {},
+      onLog: onLog ?? (_, _) {},
       stdoutSinkFor: stdoutSinkFor ?? (_) => stdout,
       stderrSinkFor: stderrSinkFor ?? (_) => stderr,
       flutterExecutableForTesting: shim == null ? null : _dartExecutable(),
@@ -543,14 +547,17 @@ void main() {
       late _ManagerFixture f;
       late Completer<FlutterAppConfig> launchFailed;
       late int readyCalls;
+      late List<(String, FlutterLogEvent)> logEvents;
 
       setUp(() async {
         readyCalls = 0;
+        logEvents = [];
         launchFailed = Completer<FlutterAppConfig>();
         f = await _ManagerFixture.create(
           shim: 'exits_during_build.dart',
           onReady: (_, _) => readyCalls++,
           onLaunchFailed: (app) => launchFailed.complete(app),
+          onLog: (app, event) => logEvents.add((app.id, event)),
         );
       });
 
@@ -571,6 +578,25 @@ void main() {
           expect(readyCalls, 0);
           expect(f.manager.isRunning('project'), isFalse);
           expect(f.manager.isLaunching('project'), isFalse);
+        },
+      );
+
+      test(
+        'when stderr is emitted then its typed log event keeps the app identity',
+        () async {
+          await f.manager.launch('project');
+          await launchFailed.future.timeout(const Duration(seconds: 30));
+
+          expect(logEvents, hasLength(1));
+          final (appId, event) = logEvents.single;
+          expect(appId, 'project');
+          expect(event.level, LogLevel.error);
+          expect(event.source, FlutterLogSource.processStderr);
+          expect(event.levelIsInferred, isTrue);
+          expect(
+            event.message,
+            'Error: unable to find asset declared in pubspec.yaml.',
+          );
         },
       );
     },

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -1044,6 +1044,99 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
   );
 
   group(
+    'Given two identical VM lines with app.log mirrors and one additional app.log line, '
+    'when both transports forward them,',
+    () {
+      late FlutterProcess fp;
+      late ({HttpServer server, String wsUri}) fake;
+      late List<FlutterLogEvent> receivedEvents;
+      late StringBuffer stdoutBuffer;
+      late StreamController<List<int>> stdoutController;
+      late IOSink stdoutSink;
+
+      setUp(() async {
+        fake = await _startFakeLoggingVmService(
+          loggingLevel: null,
+          stdoutChunks: [utf8.encode('hello\n'), utf8.encode('hello\n')],
+          stdoutChunkInterval: const Duration(milliseconds: 75),
+        );
+        receivedEvents = [];
+        stdoutBuffer = StringBuffer();
+        stdoutController = StreamController<List<int>>();
+        stdoutController.stream
+            .transform(utf8.decoder)
+            .listen(stdoutBuffer.write);
+        stdoutSink = IOSink(stdoutController.sink);
+        final twoVmEvents = Completer<void>();
+        final additionalAppLogEvent = Completer<void>();
+        fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          device: 'linux',
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [
+            _shimPath('emits_machine_events.dart'),
+            '--ws=${fake.wsUri}',
+          ],
+          stdoutSink: stdoutSink,
+          onLog: (event) {
+            receivedEvents.add(event);
+            if (receivedEvents.length == 2 && !twoVmEvents.isCompleted) {
+              twoVmEvents.complete();
+            }
+            if (receivedEvents.length == 3 &&
+                !additionalAppLogEvent.isCompleted) {
+              additionalAppLogEvent.complete();
+            }
+          },
+        );
+
+        await fp.start();
+        await fp.launched;
+        await fp.connectToVmService();
+        await twoVmEvents.future.timeout(const Duration(seconds: 5));
+        for (var index = 0; index < 3; index++) {
+          fp.handleMachineLine(
+            jsonEncode([
+              {
+                'event': 'app.log',
+                'params': {'log': 'hello', 'error': false},
+              },
+            ]),
+          );
+        }
+        await additionalAppLogEvent.future.timeout(const Duration(seconds: 5));
+        await stdoutSink.flush();
+        await Future<void>.delayed(Duration.zero);
+      });
+
+      tearDown(() async {
+        await fp.stop(timeout: const Duration(milliseconds: 100));
+        await fake.server.close(force: true);
+        await stdoutSink.close();
+      });
+
+      test(
+        'then the mirrors are suppressed and the additional line is retained.',
+        () {
+          expect(
+            receivedEvents.map((event) => event.source),
+            [
+              FlutterLogSource.vmStdout,
+              FlutterLogSource.vmStdout,
+              FlutterLogSource.appLog,
+            ],
+          );
+          expect(
+            receivedEvents.map((event) => event.message),
+            everyElement('hello'),
+          );
+          expect(stdoutBuffer.toString(), 'hello\nhello\nhello\n');
+        },
+      );
+    },
+  );
+
+  group(
     'Given a partially mirrored multi-line app log followed by a repeated line, '
     'when both transports forward the output,',
     () {
@@ -1294,6 +1387,56 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
             receivedEvents.expand((event) => event.message.split('\n')),
             [for (var index = 1; index <= 20; index++) 'Line $index'],
           );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a Flutter process rapidly emitting identical inferred stderr lines, '
+    'when its log events are forwarded,',
+    () {
+      late FlutterProcess fp;
+      late FlutterLogEvent receivedEvent;
+
+      setUp(() async {
+        final eventCompleter = Completer<FlutterLogEvent>();
+        fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          device: 'web-server',
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [
+            _shimPath('emits_identical_raw_log_burst.dart'),
+          ],
+          onLog: (event) {
+            if (!eventCompleter.isCompleted) eventCompleter.complete(event);
+          },
+        );
+
+        await fp.start();
+        await fp.exitCode;
+        receivedEvent = await eventCompleter.future.timeout(
+          const Duration(seconds: 5),
+        );
+      });
+
+      tearDown(() async {
+        await fp.stop();
+      });
+
+      test(
+        'then they are grouped into one structured entry.',
+        () {
+          expect(
+            receivedEvent.message,
+            'Repeated diagnostic.\n'
+            'Repeated diagnostic.\n'
+            'Repeated diagnostic.',
+          );
+          expect(receivedEvent.metadata, {
+            'coalesced': true,
+            'lineCount': 3,
+          });
         },
       );
     },

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -40,7 +40,10 @@ Future<({HttpServer server, String wsUri})> _startFakeVmService() async {
   );
 }
 
-Future<({HttpServer server, String wsUri})> _startFakeLoggingVmService() async {
+Future<({HttpServer server, String wsUri})> _startFakeLoggingVmService({
+  int? loggingLevel = 800,
+  List<List<int>> stdoutChunks = const [],
+}) async {
   final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
   server.transform(WebSocketTransformer()).listen((socket) {
     socket.listen((data) {
@@ -60,58 +63,77 @@ Future<({HttpServer server, String wsUri})> _startFakeLoggingVmService() async {
 
       final params = request['params'];
       if (request['method'] != 'streamListen' ||
-          params is! Map<String, dynamic> ||
-          params['streamId'] != 'Logging') {
+          params is! Map<String, dynamic>) {
         return;
       }
 
+      final streamId = params['streamId'];
       Timer(const Duration(milliseconds: 20), () {
         if (socket.readyState != WebSocket.open) return;
-        socket.add(
-          jsonEncode({
-            'jsonrpc': '2.0',
-            'method': 'streamNotify',
-            'params': {
-              'streamId': 'Logging',
-              'event': {
-                'type': 'Event',
-                'kind': 'Logging',
-                'timestamp': 1783997898247,
-                'logRecord': {
-                  'type': 'LogRecord',
-                  'message': {
-                    'type': '@Instance',
-                    'kind': 'String',
-                    'valueAsString': 'Using WidgetsApp configuration',
-                  },
-                  'time': 1783997898247,
-                  'level': 800,
-                  'sequenceNumber': 1,
-                  'loggerName': {
-                    'type': '@Instance',
-                    'kind': 'String',
-                    'valueAsString': 'GoRouter',
-                  },
-                  'zone': {
-                    'type': '@Instance',
-                    'kind': 'Null',
-                    'valueAsString': 'null',
-                  },
-                  'error': {
-                    'type': '@Instance',
-                    'kind': 'Null',
-                    'valueAsString': 'null',
-                  },
-                  'stackTrace': {
-                    'type': '@Instance',
-                    'kind': 'Null',
-                    'valueAsString': 'null',
+        if (streamId == 'Logging' && loggingLevel != null) {
+          socket.add(
+            jsonEncode({
+              'jsonrpc': '2.0',
+              'method': 'streamNotify',
+              'params': {
+                'streamId': 'Logging',
+                'event': {
+                  'type': 'Event',
+                  'kind': 'Logging',
+                  'timestamp': 1783997898247,
+                  'logRecord': {
+                    'type': 'LogRecord',
+                    'message': {
+                      'type': '@Instance',
+                      'kind': 'String',
+                      'valueAsString': 'Using WidgetsApp configuration',
+                    },
+                    'time': 1783997898247,
+                    'level': loggingLevel,
+                    'sequenceNumber': 1,
+                    'loggerName': {
+                      'type': '@Instance',
+                      'kind': 'String',
+                      'valueAsString': 'GoRouter',
+                    },
+                    'zone': {
+                      'type': '@Instance',
+                      'kind': 'Null',
+                      'valueAsString': 'null',
+                    },
+                    'error': {
+                      'type': '@Instance',
+                      'kind': 'Null',
+                      'valueAsString': 'null',
+                    },
+                    'stackTrace': {
+                      'type': '@Instance',
+                      'kind': 'Null',
+                      'valueAsString': 'null',
+                    },
                   },
                 },
               },
-            },
-          }),
-        );
+            }),
+          );
+        } else if (streamId == 'Stdout') {
+          for (final chunk in stdoutChunks) {
+            socket.add(
+              jsonEncode({
+                'jsonrpc': '2.0',
+                'method': 'streamNotify',
+                'params': {
+                  'streamId': 'Stdout',
+                  'event': {
+                    'type': 'Event',
+                    'kind': 'WriteEvent',
+                    'bytes': base64Encode(chunk),
+                  },
+                },
+              }),
+            );
+          }
+        }
       });
     }, onDone: socket.close);
   });
@@ -826,6 +848,57 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
             'vmLevel': 800,
             'sequenceNumber': 1,
           });
+        },
+      );
+    },
+  );
+
+  group(
+    'Given VM logging with an unspecified level, '
+    'when the record is forwarded,',
+    () {
+      late FlutterProcess fp;
+      late ({HttpServer server, String wsUri}) fake;
+      late FlutterLogEvent loggingEvent;
+
+      setUp(() async {
+        fake = await _startFakeLoggingVmService(loggingLevel: 0);
+        final loggingCompleter = Completer<FlutterLogEvent>();
+        fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          device: 'web-server',
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [
+            _shimPath('emits_machine_events.dart'),
+            '--ws=${fake.wsUri}',
+          ],
+          onLog: (event) {
+            if (event.source == FlutterLogSource.vmLogging &&
+                !loggingCompleter.isCompleted) {
+              loggingCompleter.complete(event);
+            }
+          },
+        );
+
+        await fp.start();
+        await fp.launched;
+        await fp.connectToVmService();
+        loggingEvent = await loggingCompleter.future.timeout(
+          const Duration(seconds: 5),
+        );
+      });
+
+      tearDown(() async {
+        await fp.stop(timeout: const Duration(milliseconds: 100));
+        await fake.server.close(force: true);
+      });
+
+      test(
+        'then it is represented as inferred info.',
+        () {
+          expect(loggingEvent.level, LogLevel.info);
+          expect(loggingEvent.levelIsInferred, isTrue);
+          expect(loggingEvent.metadata, {'sequenceNumber': 1});
         },
       );
     },

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -43,6 +43,7 @@ Future<({HttpServer server, String wsUri})> _startFakeVmService() async {
 Future<({HttpServer server, String wsUri})> _startFakeLoggingVmService({
   int? loggingLevel = 800,
   List<List<int>> stdoutChunks = const [],
+  Duration stdoutChunkInterval = Duration.zero,
 }) async {
   final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
   server.transform(WebSocketTransformer()).listen((socket) {
@@ -68,7 +69,7 @@ Future<({HttpServer server, String wsUri})> _startFakeLoggingVmService({
       }
 
       final streamId = params['streamId'];
-      Timer(const Duration(milliseconds: 20), () {
+      Timer(const Duration(milliseconds: 20), () async {
         if (socket.readyState != WebSocket.open) return;
         if (streamId == 'Logging' && loggingLevel != null) {
           socket.add(
@@ -117,7 +118,8 @@ Future<({HttpServer server, String wsUri})> _startFakeLoggingVmService({
             }),
           );
         } else if (streamId == 'Stdout') {
-          for (final chunk in stdoutChunks) {
+          for (var index = 0; index < stdoutChunks.length; index++) {
+            final chunk = stdoutChunks[index];
             socket.add(
               jsonEncode({
                 'jsonrpc': '2.0',
@@ -132,6 +134,10 @@ Future<({HttpServer server, String wsUri})> _startFakeLoggingVmService({
                 },
               }),
             );
+            if (index < stdoutChunks.length - 1 &&
+                stdoutChunkInterval > Duration.zero) {
+              await Future<void>.delayed(stdoutChunkInterval);
+            }
           }
         }
       });
@@ -1031,6 +1037,94 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
           expect(receivedEvents, hasLength(1));
           expect(receivedEvents.single.source, FlutterLogSource.vmStdout);
           expect(stdoutBuffer.toString(), 'A native application message\n');
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a partially mirrored multi-line app log followed by a repeated line, '
+    'when both transports forward the output,',
+    () {
+      late FlutterProcess fp;
+      late ({HttpServer server, String wsUri}) fake;
+      late List<FlutterLogEvent> receivedEvents;
+      late StringBuffer stdoutBuffer;
+      late StreamController<List<int>> stdoutController;
+      late IOSink stdoutSink;
+
+      setUp(() async {
+        fake = await _startFakeLoggingVmService(
+          loggingLevel: null,
+          stdoutChunks: [utf8.encode('A\n'), utf8.encode('A\n')],
+          stdoutChunkInterval: const Duration(milliseconds: 150),
+        );
+        receivedEvents = [];
+        stdoutBuffer = StringBuffer();
+        stdoutController = StreamController<List<int>>();
+        stdoutController.stream
+            .transform(utf8.decoder)
+            .listen(stdoutBuffer.write);
+        stdoutSink = IOSink(stdoutController.sink);
+        final firstVmEvent = Completer<void>();
+        fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          device: 'linux',
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [
+            _shimPath('emits_machine_events.dart'),
+            '--ws=${fake.wsUri}',
+          ],
+          stdoutSink: stdoutSink,
+          onLog: (event) {
+            receivedEvents.add(event);
+            if (event.source == FlutterLogSource.vmStdout &&
+                !firstVmEvent.isCompleted) {
+              firstVmEvent.complete();
+            }
+          },
+        );
+
+        await fp.start();
+        await fp.launched;
+        await fp.connectToVmService();
+        await firstVmEvent.future.timeout(const Duration(seconds: 5));
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'app.log',
+              'params': {'log': 'A\nB', 'error': false},
+            },
+          ]),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'app.log',
+              'params': {'log': 'A', 'error': false},
+            },
+          ]),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        await stdoutSink.flush();
+        await Future<void>.delayed(Duration.zero);
+      });
+
+      tearDown(() async {
+        await fp.stop(timeout: const Duration(milliseconds: 100));
+        await fake.server.close(force: true);
+        await stdoutSink.close();
+      });
+
+      test(
+        'then the repeated line is retained once.',
+        () {
+          expect(
+            receivedEvents.map((event) => event.message),
+            ['A', 'A\nB', 'A'],
+          );
+          expect(stdoutBuffer.toString(), 'A\nA\nB\nA\n');
         },
       );
     },

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -961,6 +961,82 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
   );
 
   group(
+    'Given the same app line from a VM stream and app.log, '
+    'when both transports forward it,',
+    () {
+      late FlutterProcess fp;
+      late ({HttpServer server, String wsUri}) fake;
+      late List<FlutterLogEvent> receivedEvents;
+      late StringBuffer stdoutBuffer;
+      late StreamController<List<int>> stdoutController;
+      late IOSink stdoutSink;
+
+      setUp(() async {
+        const message = 'A native application message';
+        fake = await _startFakeLoggingVmService(
+          loggingLevel: null,
+          stdoutChunks: [utf8.encode('$message\n')],
+        );
+        receivedEvents = [];
+        stdoutBuffer = StringBuffer();
+        stdoutController = StreamController<List<int>>();
+        stdoutController.stream
+            .transform(utf8.decoder)
+            .listen(stdoutBuffer.write);
+        stdoutSink = IOSink(stdoutController.sink);
+        final vmEvent = Completer<void>();
+        fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          device: 'linux',
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [
+            _shimPath('emits_machine_events.dart'),
+            '--ws=${fake.wsUri}',
+          ],
+          stdoutSink: stdoutSink,
+          onLog: (event) {
+            receivedEvents.add(event);
+            if (event.source == FlutterLogSource.vmStdout &&
+                !vmEvent.isCompleted) {
+              vmEvent.complete();
+            }
+          },
+        );
+
+        await fp.start();
+        await fp.launched;
+        await fp.connectToVmService();
+        await vmEvent.future.timeout(const Duration(seconds: 5));
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'app.log',
+              'params': {'log': message, 'error': false},
+            },
+          ]),
+        );
+        await stdoutSink.flush();
+        await Future<void>.delayed(Duration.zero);
+      });
+
+      tearDown(() async {
+        await fp.stop(timeout: const Duration(milliseconds: 100));
+        await fake.server.close(force: true);
+        await stdoutSink.close();
+      });
+
+      test(
+        'then one structured entry and one raw line are retained.',
+        () {
+          expect(receivedEvents, hasLength(1));
+          expect(receivedEvents.single.source, FlutterLogSource.vmStdout);
+          expect(stdoutBuffer.toString(), 'A native application message\n');
+        },
+      );
+    },
+  );
+
+  group(
     'Given a Flutter process whose UTF-8 stderr character spans byte chunks, '
     'when stderr is forwarded,',
     () {

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -830,4 +830,63 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
       );
     },
   );
+
+  group(
+    'Given a Flutter process emitting inferred stderr lines in two bursts, '
+    'when its log events are forwarded,',
+    () {
+      late FlutterProcess fp;
+      late List<FlutterLogEvent> receivedEvents;
+
+      setUp(() async {
+        receivedEvents = [];
+        final twoEvents = Completer<void>();
+        fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          device: 'web-server',
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [
+            _shimPath('emits_raw_log_bursts.dart'),
+          ],
+          onLog: (event) {
+            receivedEvents.add(event);
+            if (receivedEvents.length == 2 && !twoEvents.isCompleted) {
+              twoEvents.complete();
+            }
+          },
+        );
+
+        await fp.start();
+        await fp.exitCode;
+        await twoEvents.future.timeout(const Duration(seconds: 5));
+      });
+
+      tearDown(() async {
+        await fp.stop();
+      });
+
+      test(
+        'then adjacent lines are grouped and the idle boundary starts a new entry.',
+        () {
+          expect(receivedEvents, hasLength(2));
+          expect(
+            receivedEvents.first.message,
+            'First line of one diagnostic.\n'
+            'Second line of one diagnostic.',
+          );
+          expect(receivedEvents.first.metadata, {
+            'coalesced': true,
+            'lineCount': 2,
+          });
+          expect(receivedEvents.first.levelIsInferred, isTrue);
+          expect(receivedEvents.first.timestampIsInferred, isTrue);
+          expect(receivedEvents.last.message, 'A later diagnostic.');
+          expect(receivedEvents.last.metadata, {
+            'coalesced': false,
+            'lineCount': 1,
+          });
+        },
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -905,6 +905,62 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
   );
 
   group(
+    'Given VM stdout split across partial writes, '
+    'when the stream is forwarded,',
+    () {
+      late FlutterProcess fp;
+      late ({HttpServer server, String wsUri}) fake;
+      late FlutterLogEvent stdoutEvent;
+
+      setUp(() async {
+        fake = await _startFakeLoggingVmService(
+          loggingLevel: null,
+          stdoutChunks: [utf8.encode('Progress: '), utf8.encode('50%\n')],
+        );
+        final stdoutCompleter = Completer<FlutterLogEvent>();
+        fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          device: 'web-server',
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [
+            _shimPath('emits_machine_events.dart'),
+            '--ws=${fake.wsUri}',
+          ],
+          onLog: (event) {
+            if (event.source == FlutterLogSource.vmStdout &&
+                !stdoutCompleter.isCompleted) {
+              stdoutCompleter.complete(event);
+            }
+          },
+        );
+
+        await fp.start();
+        await fp.launched;
+        await fp.connectToVmService();
+        stdoutEvent = await stdoutCompleter.future.timeout(
+          const Duration(seconds: 5),
+        );
+      });
+
+      tearDown(() async {
+        await fp.stop(timeout: const Duration(milliseconds: 100));
+        await fake.server.close(force: true);
+      });
+
+      test(
+        'then one complete structured line is emitted.',
+        () {
+          expect(stdoutEvent.message, 'Progress: 50%');
+          expect(stdoutEvent.metadata, {
+            'coalesced': false,
+            'lineCount': 1,
+          });
+        },
+      );
+    },
+  );
+
+  group(
     'Given a Flutter process whose UTF-8 stderr character spans byte chunks, '
     'when stderr is forwarded,',
     () {

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -4,8 +4,10 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/messages.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_log_event.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
+import 'package:serverpod_shared/log.dart' show LogLevel;
 import 'package:test/test.dart';
 
 /// Path of a Dart shim under `test/commands/start/flutter_shims/`.
@@ -31,6 +33,87 @@ Future<({HttpServer server, String wsUri})> _startFakeVmService() async {
       (data) {},
       onDone: () => socket.close(),
     );
+  });
+  return (
+    server: server,
+    wsUri: 'ws://127.0.0.1:${server.port}/ws',
+  );
+}
+
+Future<({HttpServer server, String wsUri})> _startFakeLoggingVmService() async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  server.transform(WebSocketTransformer()).listen((socket) {
+    socket.listen((data) {
+      if (data is! String) return;
+      final request = jsonDecode(data);
+      if (request is! Map<String, dynamic>) return;
+
+      final id = request['id'];
+      if (id == null) return;
+      socket.add(
+        jsonEncode({
+          'jsonrpc': '2.0',
+          'id': id,
+          'result': {'type': 'Success'},
+        }),
+      );
+
+      final params = request['params'];
+      if (request['method'] != 'streamListen' ||
+          params is! Map<String, dynamic> ||
+          params['streamId'] != 'Logging') {
+        return;
+      }
+
+      Timer(const Duration(milliseconds: 20), () {
+        if (socket.readyState != WebSocket.open) return;
+        socket.add(
+          jsonEncode({
+            'jsonrpc': '2.0',
+            'method': 'streamNotify',
+            'params': {
+              'streamId': 'Logging',
+              'event': {
+                'type': 'Event',
+                'kind': 'Logging',
+                'timestamp': 1783997898247,
+                'logRecord': {
+                  'type': 'LogRecord',
+                  'message': {
+                    'type': '@Instance',
+                    'kind': 'String',
+                    'valueAsString': 'Using WidgetsApp configuration',
+                  },
+                  'time': 1783997898247,
+                  'level': 800,
+                  'sequenceNumber': 1,
+                  'loggerName': {
+                    'type': '@Instance',
+                    'kind': 'String',
+                    'valueAsString': 'GoRouter',
+                  },
+                  'zone': {
+                    'type': '@Instance',
+                    'kind': 'Null',
+                    'valueAsString': 'null',
+                  },
+                  'error': {
+                    'type': '@Instance',
+                    'kind': 'Null',
+                    'valueAsString': 'null',
+                  },
+                  'stackTrace': {
+                    'type': '@Instance',
+                    'kind': 'Null',
+                    'valueAsString': 'null',
+                  },
+                },
+              },
+            },
+          }),
+        );
+      });
+    }, onDone: socket.close);
   });
   return (
     server: server,
@@ -353,6 +436,7 @@ void main() {
     late StreamController<List<int>> stderrController;
     late IOSink stdoutSink;
     late IOSink stderrSink;
+    late List<FlutterLogEvent> logEvents;
 
     setUp(() async {
       progressMessages = <String>[];
@@ -368,6 +452,7 @@ void main() {
           .listen(stderrBuffer.write);
       stdoutSink = IOSink(stdoutController.sink);
       stderrSink = IOSink(stderrController.sink);
+      logEvents = [];
 
       /// FlutterProcess wired only enough to push synthetic lines through
       /// `handleMachineLine` and assert side effects.
@@ -377,6 +462,7 @@ void main() {
         onProgress: progressMessages.add,
         stdoutSink: stdoutSink,
         stderrSink: stderrSink,
+        onLog: logEvents.add,
       );
     });
 
@@ -407,6 +493,11 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
 
         expect(stdoutBuffer.toString(), '$exception\n');
         expect(stderrBuffer.toString(), isEmpty);
+        expect(logEvents, hasLength(1));
+        expect(logEvents.single.level, LogLevel.info);
+        expect(logEvents.single.source, FlutterLogSource.appLog);
+        expect(logEvents.single.message, exception);
+        expect(logEvents.single.levelIsInferred, isTrue);
       },
     );
 
@@ -431,6 +522,9 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
 
         expect(stderrBuffer.toString(), '$warning\n');
         expect(stdoutBuffer.toString(), isEmpty);
+        expect(logEvents.single.level, LogLevel.error);
+        expect(logEvents.single.source, FlutterLogSource.appLog);
+        expect(logEvents.single.levelIsInferred, isTrue);
       },
     );
 
@@ -458,6 +552,10 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
           'Flutter tool warning\nfirst frame\nsecond frame\n',
         );
         expect(stdoutBuffer.toString(), isEmpty);
+        expect(logEvents.single.level, LogLevel.warning);
+        expect(logEvents.single.source, FlutterLogSource.daemon);
+        expect(logEvents.single.stackTrace, 'first frame\nsecond frame\n');
+        expect(logEvents.single.levelIsInferred, isFalse);
       },
     );
 
@@ -481,6 +579,9 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
 
         expect(stdoutBuffer.toString(), 'Building Linux application...\n');
         expect(stderrBuffer.toString(), isEmpty);
+        expect(logEvents.single.level, LogLevel.info);
+        expect(logEvents.single.source, FlutterLogSource.daemon);
+        expect(logEvents.single.levelIsInferred, isFalse);
       },
     );
 
@@ -675,4 +776,58 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
       },
     );
   });
+
+  group(
+    'Given a VM Logging record whose optional values are Null instances, '
+    'when the record is received,',
+    () {
+      late FlutterProcess fp;
+      late ({HttpServer server, String wsUri}) fake;
+      late FlutterLogEvent receivedEvent;
+
+      setUp(() async {
+        fake = await _startFakeLoggingVmService();
+        final eventCompleter = Completer<FlutterLogEvent>();
+        fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          device: 'web-server',
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [
+            _shimPath('emits_machine_events.dart'),
+            '--ws=${fake.wsUri}',
+          ],
+          onLog: (event) {
+            if (event.source == FlutterLogSource.vmLogging &&
+                !eventCompleter.isCompleted) {
+              eventCompleter.complete(event);
+            }
+          },
+        );
+
+        await fp.start();
+        await fp.launched;
+        await fp.connectToVmService();
+        receivedEvent = await eventCompleter.future.timeout(
+          const Duration(seconds: 5),
+        );
+      });
+
+      tearDown(() async {
+        await fp.stop(timeout: const Duration(milliseconds: 100));
+        await fake.server.close(force: true);
+      });
+
+      test(
+        'then no error, stack trace, or null-valued metadata is emitted.',
+        () {
+          expect(receivedEvent.error, isNull);
+          expect(receivedEvent.stackTrace, isNull);
+          expect(receivedEvent.metadata, {
+            'vmLevel': 800,
+            'sequenceNumber': 1,
+          });
+        },
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -967,7 +967,7 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
   );
 
   group(
-    'Given the same app line from a VM stream and app.log, '
+    'Given the same app line from a VM stream and delayed app.log, '
     'when both transports forward it,',
     () {
       late FlutterProcess fp;
@@ -1013,6 +1013,7 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
         await fp.launched;
         await fp.connectToVmService();
         await vmEvent.future.timeout(const Duration(seconds: 5));
+        await Future<void>.delayed(const Duration(milliseconds: 1250));
         fp.handleMachineLine(
           jsonEncode([
             {

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -1246,4 +1246,55 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
       );
     },
   );
+
+  group(
+    'Given a Flutter process continuously emitting inferred stderr lines, '
+    'when its log events are forwarded,',
+    () {
+      late FlutterProcess fp;
+      late List<FlutterLogEvent> receivedEvents;
+
+      setUp(() async {
+        receivedEvents = [];
+        final allLinesForwarded = Completer<void>();
+        fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          device: 'web-server',
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [
+            _shimPath('emits_raw_log_trickle.dart'),
+          ],
+          onLog: (event) {
+            receivedEvents.add(event);
+            final lineCount = receivedEvents.fold<int>(
+              0,
+              (count, event) => count + event.message.split('\n').length,
+            );
+            if (lineCount == 20 && !allLinesForwarded.isCompleted) {
+              allLinesForwarded.complete();
+            }
+          },
+        );
+
+        await fp.start();
+        await fp.exitCode;
+        await allLinesForwarded.future.timeout(const Duration(seconds: 5));
+      });
+
+      tearDown(() async {
+        await fp.stop();
+      });
+
+      test(
+        'then the pending entry is flushed before the output becomes idle.',
+        () {
+          expect(receivedEvents, hasLength(greaterThan(1)));
+          expect(
+            receivedEvents.expand((event) => event.message.split('\n')),
+            [for (var index = 1; index <= 20; index++) 'Line $index'],
+          );
+        },
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -347,9 +347,27 @@ void main() {
   group('Given a FlutterProcess receiving machine protocol lines', () {
     late FlutterProcess fp;
     late List<String> progressMessages;
+    late StringBuffer stdoutBuffer;
+    late StringBuffer stderrBuffer;
+    late StreamController<List<int>> stdoutController;
+    late StreamController<List<int>> stderrController;
+    late IOSink stdoutSink;
+    late IOSink stderrSink;
 
     setUp(() async {
       progressMessages = <String>[];
+      stdoutBuffer = StringBuffer();
+      stderrBuffer = StringBuffer();
+      stdoutController = StreamController<List<int>>();
+      stderrController = StreamController<List<int>>();
+      stdoutController.stream
+          .transform(utf8.decoder)
+          .listen(stdoutBuffer.write);
+      stderrController.stream
+          .transform(utf8.decoder)
+          .listen(stderrBuffer.write);
+      stdoutSink = IOSink(stdoutController.sink);
+      stderrSink = IOSink(stderrController.sink);
 
       /// FlutterProcess wired only enough to push synthetic lines through
       /// `handleMachineLine` and assert side effects.
@@ -357,8 +375,114 @@ void main() {
         flutterPackageDir: Directory.systemTemp.path,
         device: 'web-server',
         onProgress: progressMessages.add,
+        stdoutSink: stdoutSink,
+        stderrSink: stderrSink,
       );
     });
+
+    tearDown(() async {
+      await stdoutSink.close();
+      await stderrSink.close();
+    });
+
+    test(
+      'when a Flutter application log event contains a framework exception, '
+      'then the complete exception is forwarded to stdout.',
+      () async {
+        const exception = '''
+══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞══
+Multiple widgets used the same GlobalKey.
+The key [GlobalKey#1d408] was used by multiple widgets.''';
+
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'app.log',
+              'params': {'log': exception, 'error': false},
+            },
+          ]),
+        );
+        await stdoutSink.flush();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(stdoutBuffer.toString(), '$exception\n');
+        expect(stderrBuffer.toString(), isEmpty);
+      },
+    );
+
+    test(
+      'when a Flutter application log event is marked as an error, '
+      'then the complete log is forwarded to stderr.',
+      () async {
+        const warning =
+            '** (serverpod_app:564071): WARNING **: '
+            'Timed out waiting for OpenGL frame';
+
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'app.log',
+              'params': {'log': warning, 'error': true},
+            },
+          ]),
+        );
+        await stderrSink.flush();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(stderrBuffer.toString(), '$warning\n');
+        expect(stdoutBuffer.toString(), isEmpty);
+      },
+    );
+
+    test(
+      'when a Flutter tool warning contains a stack trace, '
+      'then the message and stack trace are forwarded to stderr.',
+      () async {
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'daemon.logMessage',
+              'params': {
+                'level': 'warning',
+                'message': 'Flutter tool warning',
+                'stackTrace': 'first frame\nsecond frame\n',
+              },
+            },
+          ]),
+        );
+        await stderrSink.flush();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          stderrBuffer.toString(),
+          'Flutter tool warning\nfirst frame\nsecond frame\n',
+        );
+        expect(stdoutBuffer.toString(), isEmpty);
+      },
+    );
+
+    test(
+      'when a Flutter tool status message is received, '
+      'then the message is forwarded to stdout.',
+      () async {
+        fp.handleMachineLine(
+          jsonEncode([
+            {
+              'event': 'daemon.logMessage',
+              'params': {
+                'level': 'status',
+                'message': 'Building Linux application...',
+              },
+            },
+          ]),
+        );
+        await stdoutSink.flush();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(stdoutBuffer.toString(), 'Building Linux application...\n');
+        expect(stderrBuffer.toString(), isEmpty);
+      },
+    );
 
     test(
       'when given a line that does not start with [ '

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -905,6 +905,64 @@ The key [GlobalKey#1d408] was used by multiple widgets.''';
   );
 
   group(
+    'Given a Flutter process whose UTF-8 stderr character spans byte chunks, '
+    'when stderr is forwarded,',
+    () {
+      late FlutterProcess fp;
+      late FlutterLogEvent receivedEvent;
+      late StringBuffer stderrBuffer;
+      late StreamController<List<int>> stderrController;
+      late IOSink stderrSink;
+
+      setUp(() async {
+        final eventCompleter = Completer<FlutterLogEvent>();
+        stderrBuffer = StringBuffer();
+        stderrController = StreamController<List<int>>();
+        stderrController.stream
+            .transform(utf8.decoder)
+            .listen(stderrBuffer.write);
+        stderrSink = IOSink(stderrController.sink);
+        fp = FlutterProcess(
+          flutterPackageDir: Directory.current.path,
+          device: 'web-server',
+          flutterExecutable: _dartExecutable(),
+          argsOverrideForTesting: [
+            _shimPath('emits_split_utf8_stderr.dart'),
+          ],
+          stderrSink: stderrSink,
+          onLog: (event) {
+            if (event.source == FlutterLogSource.processStderr &&
+                !eventCompleter.isCompleted) {
+              eventCompleter.complete(event);
+            }
+          },
+        );
+
+        await fp.start();
+        await fp.exitCode;
+        receivedEvent = await eventCompleter.future.timeout(
+          const Duration(seconds: 5),
+        );
+        await stderrSink.flush();
+        await Future<void>.delayed(Duration.zero);
+      });
+
+      tearDown(() async {
+        await fp.stop();
+        await stderrSink.close();
+      });
+
+      test(
+        'then the structured entry and raw line preserve the character.',
+        () {
+          expect(receivedEvent.message, 'Falha: conexão');
+          expect(stderrBuffer.toString(), 'Falha: conexão\n');
+        },
+      );
+    },
+  );
+
+  group(
     'Given a Flutter process emitting inferred stderr lines in two bursts, '
     'when its log events are forwarded,',
     () {

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/emits_identical_raw_log_burst.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/emits_identical_raw_log_burst.dart
@@ -1,0 +1,8 @@
+import 'dart:io';
+
+Future<void> main() async {
+  for (var index = 0; index < 3; index++) {
+    stderr.writeln('Repeated diagnostic.');
+  }
+  await stderr.flush();
+}

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/emits_raw_log_bursts.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/emits_raw_log_bursts.dart
@@ -1,0 +1,13 @@
+import 'dart:async';
+import 'dart:io';
+
+Future<void> main() async {
+  stderr.writeln('First line of one diagnostic.');
+  stderr.writeln('Second line of one diagnostic.');
+  await stderr.flush();
+
+  await Future<void>.delayed(const Duration(milliseconds: 100));
+
+  stderr.writeln('A later diagnostic.');
+  await stderr.flush();
+}

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/emits_raw_log_trickle.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/emits_raw_log_trickle.dart
@@ -1,0 +1,10 @@
+import 'dart:async';
+import 'dart:io';
+
+Future<void> main() async {
+  for (var index = 1; index <= 20; index++) {
+    stderr.writeln('Line $index');
+    await stderr.flush();
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+  }
+}

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/emits_split_utf8_stderr.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/emits_split_utf8_stderr.dart
@@ -1,0 +1,14 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+Future<void> main() async {
+  final bytes = utf8.encode('Falha: conexão\n');
+  final splitAt = bytes.indexOf(0xc3) + 1;
+
+  stderr.add(bytes.sublist(0, splitAt));
+  await stderr.flush();
+  await Future<void>.delayed(const Duration(milliseconds: 50));
+  stderr.add(bytes.sublist(splitAt));
+  await stderr.flush();
+}

--- a/tools/serverpod_cli/test/commands/start/tui/app_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/app_test.dart
@@ -99,18 +99,6 @@ void main() {
       expect(state.expandStackTraces, isFalse);
     });
 
-    test(
-      'when e is pressed on an app log tab then traces do not toggle',
-      () async {
-        state.getOrCreateAppLogTab(appId: 'app', label: 'App');
-        state.tabs.focusedAreaIndex = 1;
-
-        await _sendKey(tester, LogicalKey.keyE);
-
-        expect(state.expandStackTraces, isFalse);
-      },
-    );
-
     test('when backtick is pressed then the raw server logs open', () async {
       expect(state.showRawServerLogs, isFalse);
 
@@ -130,6 +118,36 @@ void main() {
       await _sendKey(tester, LogicalKey.keyS);
       expect(state.showRawServerLogs, isFalse);
     });
+  });
+
+  group('Given a Flutter app log tab with a stack-traced error entry,', () {
+    setUp(() {
+      final appTab = state.getOrCreateAppLogTab(appId: 'app', label: 'App');
+      appTab.logHistory.add(
+        LogEntry(
+          time: DateTime(2026),
+          level: LogLevel.error,
+          message: 'Flutter framework error',
+          scope: LogScope.root('app'),
+          stackTrace: StackTrace.fromString('#0 a\n#1 b'),
+        ),
+      );
+      state.tabs.focusTab(appTab);
+    });
+
+    test(
+      'when e is pressed, '
+      'then the app stack traces expand and collapse.',
+      () async {
+        expect(state.expandStackTraces, isFalse);
+
+        await _sendKey(tester, LogicalKey.keyE);
+        expect(state.expandStackTraces, isTrue);
+
+        await _sendKey(tester, LogicalKey.keyE);
+        expect(state.expandStackTraces, isFalse);
+      },
+    );
   });
 
   group('Given the raw server logs overlay is open', () {

--- a/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
@@ -390,6 +390,24 @@ void main() {
         expect(appTab.lines, isEmpty);
       },
     );
+
+    test(
+      'when the error text contains ANSI styling, '
+      'then both structured and raw histories contain plain text.',
+      () {
+        handleFlutterExtensionEvent(
+          holder,
+          'serverpod-app',
+          _flutterErrorEvent({
+            'renderedErrorText': '\x1b[31mA framework error\x1b[0m',
+          }),
+        );
+
+        final entry = appTab.logHistory.single as LogEntry;
+        expect(entry.message, 'A framework error');
+        expect(appTab.lines, ['A framework error']);
+      },
+    );
   });
 
   group('Given a Flutter app tab and a structured application log event,', () {
@@ -500,6 +518,31 @@ void main() {
           'levelIsInferred': false,
           'timestampIsInferred': false,
         });
+      },
+    );
+
+    test(
+      'when the event contains ANSI styling, '
+      'then the rendered message, error, and stack trace contain plain text.',
+      () {
+        handleFlutterLogEvent(
+          holder,
+          'serverpod-app',
+          FlutterLogEvent(
+            time: DateTime.utc(2026, 7, 14, 3),
+            level: LogLevel.error,
+            message: '\x1b[31mFailed\x1b[0m',
+            source: FlutterLogSource.processStderr,
+            loggerName: '\x1b[33mflutter\x1b[0m',
+            error: '\x1b[31mBad state\x1b[0m',
+            stackTrace: '\x1b[2m#0 main (app.dart:1)\x1b[0m',
+          ),
+        );
+
+        final entry = appTab.logHistory.single as LogEntry;
+        expect(entry.message, '[flutter] Failed');
+        expect(entry.error, 'Bad state');
+        expect(entry.stackTrace.toString(), '#0 main (app.dart:1)');
       },
     );
   });

--- a/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
@@ -473,6 +473,36 @@ void main() {
     );
   });
 
+  group('Given a Flutter app tab and a framework error without a count,', () {
+    late AppLogTab appTab;
+
+    setUp(() {
+      appTab = state.getOrCreateAppLogTab(
+        appId: 'serverpod-app',
+        label: 'Serverpod app',
+      );
+    });
+
+    test(
+      'when the event is dispatched, '
+      'then its metadata does not contain a null value.',
+      () {
+        handleFlutterExtensionEvent(
+          holder,
+          'serverpod-app',
+          _flutterErrorEvent({'renderedErrorText': 'A framework error'}),
+        );
+
+        final entry = appTab.logHistory.single as LogEntry;
+        expect(entry.metadata, {
+          'source': 'flutterError',
+          'levelIsInferred': false,
+          'timestampIsInferred': false,
+        });
+      },
+    );
+  });
+
   group('Given a Flutter app tab receiving a source-structured log event,', () {
     late AppLogTab appTab;
 

--- a/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:nocterm/nocterm.dart' show ClipboardManager;
+import 'package:serverpod_cli/src/commands/start/flutter_log_event.dart';
 import 'package:serverpod_cli/src/commands/start/tui/app.dart';
 import 'package:serverpod_cli/src/commands/start/tui/event_handler.dart';
 import 'package:serverpod_cli/src/commands/start/tui/state.dart';
@@ -362,7 +363,14 @@ void main() {
         expect(appTab.logHistory, hasLength(1));
         final entry = appTab.logHistory.single as LogEntry;
         expect(entry.level, LogLevel.error);
+        expect(entry.time, DateTime.fromMillisecondsSinceEpoch(0));
         expect(entry.message, error);
+        expect(entry.metadata, {
+          'errorsSinceReload': 0,
+          'source': 'flutterError',
+          'levelIsInferred': false,
+          'timestampIsInferred': false,
+        });
         expect(appTab.lines, error.split('\n'));
         expect(state.logHistory, isEmpty);
       },
@@ -431,21 +439,67 @@ void main() {
 
     test(
       'when an stderr line is received, '
-      'then it is retained and rendered as a structured error entry.',
+      'then it is retained without inventing a second structured entry.',
       () {
         handleFlutterOutput(
           holder,
           'serverpod-app',
           'libEGL warning: failed to create dri2 screen',
-          level: LogLevel.error,
         );
 
         expect(appTab.lines, [
           'libEGL warning: failed to create dri2 screen',
         ]);
+        expect(appTab.logHistory, isEmpty);
+      },
+    );
+  });
+
+  group('Given a Flutter app tab receiving a source-structured log event,', () {
+    late AppLogTab appTab;
+
+    setUp(() {
+      appTab = state.getOrCreateAppLogTab(
+        appId: 'serverpod-app',
+        label: 'Serverpod app',
+      );
+    });
+
+    test(
+      'when the event is dispatched, '
+      'then its severity, timestamp, logger, error, and stack trace are preserved.',
+      () {
+        final time = DateTime.utc(2026, 7, 14, 3);
+
+        handleFlutterLogEvent(
+          holder,
+          'serverpod-app',
+          FlutterLogEvent(
+            time: time,
+            level: LogLevel.warning,
+            message: 'Connection is slow',
+            source: FlutterLogSource.vmLogging,
+            loggerName: 'sync',
+            error: 'TimeoutException',
+            stackTrace: '#0 sync (package:app/sync.dart:10:3)',
+          ),
+        );
+
         final entry = appTab.logHistory.single as LogEntry;
-        expect(entry.level, LogLevel.error);
-        expect(entry.message, 'libEGL warning: failed to create dri2 screen');
+        expect(entry.level, LogLevel.warning);
+        expect(entry.time, time);
+        expect(entry.message, '[sync] Connection is slow');
+        expect(entry.error, 'TimeoutException');
+        expect(
+          entry.stackTrace.toString(),
+          '#0 sync (package:app/sync.dart:10:3)',
+        );
+        expect(entry.metadata, {
+          'source': 'vmLogging',
+          'loggerName': 'sync',
+          'levelIsInferred': false,
+          'timestampIsInferred': false,
+        });
       },
     );
   });

--- a/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
@@ -4,6 +4,7 @@ import 'package:nocterm/nocterm.dart' show ClipboardManager;
 import 'package:serverpod_cli/src/commands/start/tui/app.dart';
 import 'package:serverpod_cli/src/commands/start/tui/event_handler.dart';
 import 'package:serverpod_cli/src/commands/start/tui/state.dart';
+import 'package:serverpod_cli/src/commands/start/tui/tab_model.dart';
 import 'package:serverpod_shared/log.dart';
 import 'package:serverpod_tui/serverpod_tui.dart';
 import 'package:test/test.dart';
@@ -14,6 +15,15 @@ Event _logEvent(Map<String, Object?> data) {
     kind: EventKind.kExtension,
     timestamp: 0,
     extensionKind: 'ext.serverpod.log',
+    extensionData: ExtensionData.parse(data),
+  );
+}
+
+Event _flutterErrorEvent(Map<String, Object?> data) {
+  return Event(
+    kind: EventKind.kExtension,
+    timestamp: 0,
+    extensionKind: 'Flutter.Error',
     extensionData: ExtensionData.parse(data),
   );
 }
@@ -319,6 +329,125 @@ void main() {
 
       expect(state.logHistory, isEmpty);
     });
+  });
+
+  group('Given a Flutter app tab and a framework error event,', () {
+    late AppLogTab appTab;
+
+    setUp(() {
+      appTab = state.getOrCreateAppLogTab(
+        appId: 'serverpod-app',
+        label: 'Serverpod app',
+      );
+    });
+
+    test(
+      'when the event is dispatched, '
+      'then the complete error is added to the app as one structured entry.',
+      () {
+        const error =
+            "'package:flutter/src/widgets/framework.dart': Failed assertion: "
+            "line 2168 pos 12: '_elements.contains(element)': is not true.\n"
+            'See also: https://docs.flutter.dev/testing/errors';
+
+        handleFlutterExtensionEvent(
+          holder,
+          'serverpod-app',
+          _flutterErrorEvent({
+            'errorsSinceReload': 0,
+            'renderedErrorText': error,
+          }),
+        );
+
+        expect(appTab.logHistory, hasLength(1));
+        final entry = appTab.logHistory.single as LogEntry;
+        expect(entry.level, LogLevel.error);
+        expect(entry.message, error);
+        expect(appTab.lines, error.split('\n'));
+        expect(state.logHistory, isEmpty);
+      },
+    );
+
+    test(
+      'when a Flutter error event has no rendered error text, '
+      'then it is ignored.',
+      () {
+        handleFlutterExtensionEvent(
+          holder,
+          'serverpod-app',
+          _flutterErrorEvent({'errorsSinceReload': 0}),
+        );
+
+        expect(appTab.logHistory, isEmpty);
+        expect(appTab.lines, isEmpty);
+      },
+    );
+  });
+
+  group('Given a Flutter app tab and a structured application log event,', () {
+    late AppLogTab appTab;
+
+    setUp(() {
+      appTab = state.getOrCreateAppLogTab(
+        appId: 'serverpod-app',
+        label: 'Serverpod app',
+      );
+    });
+
+    test(
+      'when the event is dispatched, '
+      'then it is added to the app instead of the server log.',
+      () {
+        handleFlutterExtensionEvent(
+          holder,
+          'serverpod-app',
+          _logEvent({
+            'type': 'log',
+            'level': 'warning',
+            'message': 'Application warning',
+            'timestamp': '2026-07-14T03:00:00.000Z',
+          }),
+        );
+
+        expect(appTab.logHistory, hasLength(1));
+        final entry = appTab.logHistory.single as LogEntry;
+        expect(entry.level, LogLevel.warning);
+        expect(entry.message, 'Application warning');
+        expect(appTab.lines, ['Application warning']);
+        expect(state.logHistory, isEmpty);
+      },
+    );
+  });
+
+  group('Given a Flutter app tab receiving unstructured output,', () {
+    late AppLogTab appTab;
+
+    setUp(() {
+      appTab = state.getOrCreateAppLogTab(
+        appId: 'serverpod-app',
+        label: 'Serverpod app',
+      );
+    });
+
+    test(
+      'when an stderr line is received, '
+      'then it is retained and rendered as a structured error entry.',
+      () {
+        handleFlutterOutput(
+          holder,
+          'serverpod-app',
+          'libEGL warning: failed to create dri2 screen',
+          level: LogLevel.error,
+        );
+
+        expect(appTab.lines, [
+          'libEGL warning: failed to create dri2 screen',
+        ]);
+        final entry = appTab.logHistory.single as LogEntry;
+        expect(entry.level, LogLevel.error);
+        expect(entry.message, 'libEGL warning: failed to create dri2 screen');
+      },
+    );
   });
 
   group('Given parseLogLevel', () {

--- a/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
@@ -35,10 +35,27 @@ Future<NoctermTester> _pumpAppsLayout(Size size) async {
   ];
   final admin = state.getOrCreateAppLogTab(appId: 'admin', label: 'Admin');
   admin.lines.add('admin-log-line');
-  state
-      .getOrCreateAppLogTab(appId: 'portal', label: 'Portal')
-      .lines
-      .add('portal-log-line');
+  admin.logHistory.add(
+    LogEntry(
+      time: DateTime(2026),
+      level: LogLevel.info,
+      message: 'admin-log-line',
+      scope: LogScope.root('admin'),
+    ),
+  );
+  final portal = state.getOrCreateAppLogTab(
+    appId: 'portal',
+    label: 'Portal',
+  );
+  portal.lines.add('portal-log-line');
+  portal.logHistory.add(
+    LogEntry(
+      time: DateTime(2026),
+      level: LogLevel.info,
+      message: 'portal-log-line',
+      scope: LogScope.root('portal'),
+    ),
+  );
   state.tabs.focusTab(admin);
 
   return _pump(state, size);

--- a/tools/serverpod_cli/test/commands/start/tui/state_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/state_test.dart
@@ -33,6 +33,7 @@ void main() {
       state.logHistory.add('server entry');
       state.rawLines.add('raw server line');
       appTab.lines.add('raw flutter line');
+      appTab.logHistory.add('structured flutter entry');
     });
 
     test('when clearLogs is called then every log buffer is emptied', () {
@@ -41,6 +42,7 @@ void main() {
       expect(state.logHistory, isEmpty);
       expect(state.rawLines, isEmpty);
       expect(appTab.lines, isEmpty);
+      expect(appTab.logHistory, isEmpty);
     });
   });
 

--- a/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_loop_test.dart
@@ -190,6 +190,7 @@ void main() {
         onStop: (_) {},
         onLaunchFailed: (_) {},
         onEnsureAppTab: (_) {},
+        onLog: (_, _) {},
         stdoutSinkFor: (_) => stdout,
         stderrSinkFor: (_) => stderr,
       );

--- a/tools/serverpod_cli/test/commands/start/watch_session_test.dart
+++ b/tools/serverpod_cli/test/commands/start/watch_session_test.dart
@@ -240,6 +240,7 @@ serverpod:
     onStop: (_) {},
     onLaunchFailed: (_) {},
     onEnsureAppTab: (_) {},
+    onLog: (_, _) {},
     stdoutSinkFor: (_) => stdout,
     stderrSinkFor: (_) => stderr,
   );
@@ -299,6 +300,7 @@ serverpod:
     onStop: (_) {},
     onLaunchFailed: (_) {},
     onEnsureAppTab: (_) {},
+    onLog: (_, _) {},
     stdoutSinkFor: (_) => stdout,
     stderrSinkFor: (_) => stderr,
   );


### PR DESCRIPTION
Closes: #5169

This PR started as a fix for missing important Flutter log events, such as rendering errors or non-initialized providers. But, since such messages were structured, the PR evolved into making all Flutter logs structured. Now, all app tabs show the logs with the same format as the Server logs.

Important to mention that, since stdout/stderr are not structured, they are heuristically grouped into structured entries, with an inferred log level based on the channel (stdout -> info, stderr -> error). Grouping is done by coalescing adjacent raw lines that arrive in a very short time interval (~25ms) with no other messages in between.

We acknowledge that this is not perfect, but it provides a greatly improved UX over the raw logs, and the worst side-effect that can happen is a message being bundled on the wrong group.

<img width="1796" height="705" alt="image" src="https://github.com/user-attachments/assets/48b56773-b337-4a17-8857-11cde4fb4c66" />

<img width="1785" height="867" alt="image" src="https://github.com/user-attachments/assets/064df96c-5de0-4ea8-9256-0b6e1fec8539" />


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.