### PR TITLE
feat: Allow booting the embedded PostgreSQL from the CLI

### DIFF
--- a/packages/serverpod_database/lib/src/adapters/postgres/postgres_pool_manager.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/postgres_pool_manager.dart
@@ -200,6 +200,7 @@ class PostgresPoolManager implements DatabasePoolManager {
           dataDir: dataDir,
           databaseName: config.name,
           username: config.user,
+          transport: UnixTransport(initialPassword: config.password),
           detach: false,
           repairStaleLocks: true,
         ),

--- a/packages/serverpod_database/test/embedded_postgres_integration_test.dart
+++ b/packages/serverpod_database/test/embedded_postgres_integration_test.dart
@@ -1,0 +1,118 @@
+@Tags(['integration'])
+library;
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:postgres/postgres.dart' as pg;
+import 'package:serverpod_database/serverpod_database.dart';
+import 'package:serverpod_embedded_postgres/serverpod_embedded_postgres.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(
+    'Given a server config with a password from passwords.yaml and an embedded PostgreSQL cluster created by the database pool manager,',
+    () {
+      const databasePassword = 'passwords-yaml-database-password';
+      late Directory serverDir;
+      late PostgresDatabaseConfig databaseConfig;
+      DatabasePoolManager? poolManager;
+      EmbeddedPostgres? embeddedPostgres;
+      pg.Connection? connection;
+
+      setUp(() async {
+        serverDir = Directory.systemTemp.createTempSync(
+          'serverpod_database_embedded_postgres_',
+        );
+        var configDir = Directory(p.join(serverDir.path, 'config'))
+          ..createSync();
+        File(p.join(configDir.path, 'development.yaml')).writeAsStringSync('''
+database:
+  host: localhost
+  port: 5432
+  name: serverpod_test
+  user: postgres
+  dataPath: .serverpod/pgdata
+''');
+        File(p.join(configDir.path, 'passwords.yaml')).writeAsStringSync('''
+development:
+  database: $databasePassword
+''');
+
+        var passwords = PasswordManager(
+          runMode: 'development',
+        ).loadPasswords(serverDir: serverDir.path);
+        var config = ServerpodConfig.load(
+          'development',
+          null,
+          passwords,
+          serverDir: serverDir.path,
+        );
+        databaseConfig = config.database! as PostgresDatabaseConfig;
+        poolManager =
+            DatabaseProvider.forDialect(
+              databaseConfig.dialect,
+            ).createPoolManager(
+              _TestSerializationManager(),
+              null,
+              databaseConfig,
+              serverDirectory: serverDir,
+            );
+
+        await poolManager!.started;
+        await poolManager!.stop();
+        poolManager = null;
+      });
+
+      tearDown(() async {
+        await connection?.close();
+        await embeddedPostgres?.stop();
+        await poolManager?.stop();
+        if (serverDir.existsSync()) {
+          serverDir.deleteSync(recursive: true);
+        }
+      });
+
+      test(
+        'when the cluster is reopened over TCP, '
+        'then the configured password authenticates.',
+        () async {
+          embeddedPostgres = await EmbeddedPostgres.start(
+            EmbeddedPostgresOptions(
+              dataDir: Directory(
+                p.join(serverDir.path, databaseConfig.dataPath!),
+              ),
+              databaseName: databaseConfig.name,
+              username: databaseConfig.user,
+              transport: const TcpTransport(),
+              detach: true,
+            ),
+          );
+          expect(embeddedPostgres!.endpoint.password, databasePassword);
+
+          connection = await pg.Connection.open(
+            embeddedPostgres!.endpoint,
+            settings: const pg.ConnectionSettings(
+              sslMode: pg.SslMode.disable,
+            ),
+          );
+          var result = await connection!.execute('SELECT 1');
+          expect(result.first.first, 1);
+        },
+        timeout: const Timeout(Duration(seconds: 180)),
+      );
+    },
+  );
+}
+
+class _TestSerializationManager extends DatabaseSerializationManager {
+  @override
+  String getModuleName() => 'test';
+
+  @override
+  Table? getTableForType(Type t) => null;
+
+  @override
+  List<TableDefinition> getTargetTableDefinitions() => const [];
+}

--- a/packages/serverpod_embedded_postgres/README.md
+++ b/packages/serverpod_embedded_postgres/README.md
@@ -49,10 +49,11 @@ directory already gates filesystem access to the socket. PG `chdir`s to
 cap regardless of how deep your project lives.
 
 **TCP loopback (`TcpTransport`).** scram-sha-256 against `127.0.0.1`,
-random 32-char password persisted to `<.serverpod>/postgres.password`
-for warm-restart consistency. `TcpTransport(port: 0)` (the default) gets
-an ephemeral port; explicit ports are honored. Port-race collision is
-retried up to 3 times before bubbling up.
+password via [TcpTransport.password] (Serverpod passes `config/passwords.yaml`
+`database` here) or a random dev credential when omitted. Persisted to
+`<.serverpod>/postgres.password` for warm-restart consistency. The default
+`TcpTransport(port: 0)` gets an ephemeral port; explicit ports are honored.
+Port-race collision is retried up to 3 times before bubbling up.
 
 ```dart
 // TCP variant:
@@ -139,7 +140,10 @@ The `Transport` sealed class has two variants:
 
 ```dart
 sealed class Transport { const Transport(); }
-final class UnixTransport extends Transport { const UnixTransport(); }
+final class UnixTransport extends Transport {
+  final String? password;
+  const UnixTransport({this.password});
+}
 final class TcpTransport extends Transport {
   final int port;          // 0 = ephemeral
   final String? password;  // null = generate random

--- a/packages/serverpod_embedded_postgres/README.md
+++ b/packages/serverpod_embedded_postgres/README.md
@@ -69,6 +69,22 @@ print(pg.endpoint.port);     // some ephemeral port like 49152
 print(pg.endpoint.password); // random 32-char string
 ```
 
+## Connect with external tools
+
+From a Serverpod project configured with `database.dataPath`, run:
+
+```sh
+serverpod database start
+```
+
+The command reads `config/development.yaml` and `config/passwords.yaml`, starts
+the embedded database on the configured TCP port, and prints a connection URI
+for tools such as `psql`, DBeaver, and DataGrip. It keeps the database running
+until interrupted. Start it to connect manually to the database. If this command
+is run before the Serverpod server, it will attach to the database. Use `--mode`
+to select a different configuration or `--server-dir` to select a server
+project explicitly.
+
 ## Detach + attach for cross-VM dev DBs
 
 Set `detach: true` to keep the postmaster alive after your Dart VM
@@ -141,8 +157,8 @@ The `Transport` sealed class has two variants:
 ```dart
 sealed class Transport { const Transport(); }
 final class UnixTransport extends Transport {
-  final String? password;
-  const UnixTransport({this.password});
+  final String? initialPassword;
+  const UnixTransport({this.initialPassword});
 }
 final class TcpTransport extends Transport {
   final int port;          // 0 = ephemeral

--- a/packages/serverpod_embedded_postgres/lib/src/cluster/cluster_store.dart
+++ b/packages/serverpod_embedded_postgres/lib/src/cluster/cluster_store.dart
@@ -61,10 +61,10 @@ class ClusterStore {
   /// machines, no Zonky-locale availability surprises) and seeds the
   /// auth methods so we never need to rewrite `pg_hba.conf`.
   ///
-  /// [password] is required for TCP transport (scram-sha-256 over the
-  /// host loopback): without a stored password the role can't be
-  /// authenticated via scram. Passed via `initdb --pwfile`. For UDS
-  /// (trust auth) [password] should be null.
+  /// [password] should be set for fresh clusters so the superuser can
+  /// authenticate over TCP later. Passed via `initdb --pwfile`. UDS
+  /// connections use trust auth and ignore the stored password. Omit only
+  /// when reusing a legacy cluster that was initialized without one.
   Future<void> ensureInitialized({
     required String username,
     String? password,

--- a/packages/serverpod_embedded_postgres/lib/src/embedded_postgres_impl.dart
+++ b/packages/serverpod_embedded_postgres/lib/src/embedded_postgres_impl.dart
@@ -328,9 +328,9 @@ class EmbeddedPostgresImpl extends EmbeddedPostgres {
 /// Resolves the user-supplied [transport] into a concrete one ready to
 /// pass to ClusterStore + Supervisor:
 ///
-///   - For fresh clusters, always generates and persists a superuser
-///     password (written to [pwFile]) so a later switch to [TcpTransport]
-///     works without re-init. Unix connections still use trust auth.
+///   - For fresh clusters, always seeds a superuser password (written to
+///     [pwFile]) so a later switch to [TcpTransport] works without re-init.
+///     Unix connections still use trust auth.
 ///   - For [TcpTransport] with `port == 0`, allocates an ephemeral port
 ///     by binding `127.0.0.1:0` and reading the kernel-assigned port.
 ///   - For warm TCP restarts, reads the persisted password sidecar so
@@ -342,10 +342,12 @@ Future<(Transport, String?)> _resolveTransport(
 }) async {
   String? initPassword;
   if (!hadCluster) {
-    initPassword = switch (requested) {
-      TcpTransport(:final password) => password ?? _generatePassword(),
-      UnixTransport() => _generatePassword(),
-    };
+    initPassword =
+        switch (requested) {
+          TcpTransport(:final password) => password,
+          UnixTransport(:final initialPassword) => initialPassword,
+        } ??
+        _generatePassword();
     pwFile.parent.createSync(recursive: true);
     pwFile.writeAsStringSync(initPassword);
   }

--- a/packages/serverpod_embedded_postgres/lib/src/embedded_postgres_impl.dart
+++ b/packages/serverpod_embedded_postgres/lib/src/embedded_postgres_impl.dart
@@ -340,45 +340,33 @@ Future<(Transport, String?)> _resolveTransport(
   required File pwFile,
   required bool hadCluster,
 }) async {
-  String? initPassword;
-  if (!hadCluster) {
-    initPassword =
+  String? resolvedPassword;
+  if (!hadCluster || requested is TcpTransport) {
+    resolvedPassword =
         switch (requested) {
           TcpTransport(:final password) => password,
           UnixTransport(:final initialPassword) => initialPassword,
         } ??
-        _generatePassword();
-    pwFile.parent.createSync(recursive: true);
-    pwFile.writeAsStringSync(initPassword);
+        (hadCluster && pwFile.existsSync()
+            ? pwFile.readAsStringSync()
+            : _generatePassword());
+
+    if (!hadCluster || !pwFile.existsSync()) {
+      pwFile.parent.createSync(recursive: true);
+      pwFile.writeAsStringSync(resolvedPassword);
+    }
   }
 
   switch (requested) {
     case UnixTransport():
       // Password is passed to initdb on fresh clusters only; trust auth
       // does not use it for Unix connections.
-      return (requested, initPassword);
-    case TcpTransport(:final port, :final password):
-      final String resolvedPw;
-      if (hadCluster && pwFile.existsSync()) {
-        // Warm restart: the cluster's stored hash matches whatever was
-        // initdb'd. Trust the persisted password unless the caller
-        // explicitly provides one (in which case we assume they know
-        // they aligned both sides).
-        resolvedPw = password ?? pwFile.readAsStringSync();
-      } else if (hadCluster) {
-        // Legacy cluster without a password sidecar. Out of scope to
-        // backfill the role; generate a file for the endpoint only.
-        resolvedPw = password ?? _generatePassword();
-        pwFile.parent.createSync(recursive: true);
-        pwFile.writeAsStringSync(resolvedPw);
-      } else {
-        resolvedPw = initPassword!;
-      }
-
+      return (requested, resolvedPassword);
+    case TcpTransport(:final port):
       var resolvedPort = port == 0 ? await _allocateEphemeralPort() : port;
       return (
-        TcpTransport(port: resolvedPort, password: resolvedPw),
-        resolvedPw,
+        TcpTransport(port: resolvedPort, password: resolvedPassword),
+        resolvedPassword,
       );
   }
 }

--- a/packages/serverpod_embedded_postgres/lib/src/embedded_postgres_impl.dart
+++ b/packages/serverpod_embedded_postgres/lib/src/embedded_postgres_impl.dart
@@ -328,31 +328,49 @@ class EmbeddedPostgresImpl extends EmbeddedPostgres {
 /// Resolves the user-supplied [transport] into a concrete one ready to
 /// pass to ClusterStore + Supervisor:
 ///
+///   - For fresh clusters, always generates and persists a superuser
+///     password (written to [pwFile]) so a later switch to [TcpTransport]
+///     works without re-init. Unix connections still use trust auth.
 ///   - For [TcpTransport] with `port == 0`, allocates an ephemeral port
 ///     by binding `127.0.0.1:0` and reading the kernel-assigned port.
-///   - For TCP overall, persists / reads the password sidecar so warm
-///     restarts use the same credential the cluster was init'd with.
-///   - For [UnixTransport], no resolution is needed (returns identity).
+///   - For warm TCP restarts, reads the persisted password sidecar so
+///     the endpoint matches whatever `initdb --pwfile` seeded.
 Future<(Transport, String?)> _resolveTransport(
   Transport requested, {
   required File pwFile,
   required bool hadCluster,
 }) async {
+  String? initPassword;
+  if (!hadCluster) {
+    initPassword = switch (requested) {
+      TcpTransport(:final password) => password ?? _generatePassword(),
+      UnixTransport() => _generatePassword(),
+    };
+    pwFile.parent.createSync(recursive: true);
+    pwFile.writeAsStringSync(initPassword);
+  }
+
   switch (requested) {
     case UnixTransport():
-      return (requested, null);
+      // Password is passed to initdb on fresh clusters only; trust auth
+      // does not use it for Unix connections.
+      return (requested, initPassword);
     case TcpTransport(:final port, :final password):
-      String resolvedPw;
+      final String resolvedPw;
       if (hadCluster && pwFile.existsSync()) {
         // Warm restart: the cluster's stored hash matches whatever was
         // initdb'd. Trust the persisted password unless the caller
         // explicitly provides one (in which case we assume they know
         // they aligned both sides).
         resolvedPw = password ?? pwFile.readAsStringSync();
-      } else {
+      } else if (hadCluster) {
+        // Legacy cluster without a password sidecar. Out of scope to
+        // backfill the role; generate a file for the endpoint only.
         resolvedPw = password ?? _generatePassword();
         pwFile.parent.createSync(recursive: true);
         pwFile.writeAsStringSync(resolvedPw);
+      } else {
+        resolvedPw = initPassword!;
       }
 
       var resolvedPort = port == 0 ? await _allocateEphemeralPort() : port;

--- a/packages/serverpod_embedded_postgres/lib/src/transport.dart
+++ b/packages/serverpod_embedded_postgres/lib/src/transport.dart
@@ -14,9 +14,15 @@ sealed class Transport {
 /// `../run` (after its `chdir(PGDATA)`) and keep `sun_path` ~20 bytes
 /// regardless of how deep the project lives on disk.
 final class UnixTransport extends Transport {
-  /// Creates a UDS transport. There is nothing to configure - the socket
-  /// directory is derived from [EmbeddedPostgresOptions.dataDir].
-  const UnixTransport();
+  /// Superuser password seeded at `initdb` time. Unix connections use trust
+  /// auth and ignore this; it is persisted to `postgres.password` in the data
+  /// directory parent so a later switch to [TcpTransport] works without
+  /// re-init. If null, a random password is generated on first init.
+  final String? initialPassword;
+
+  /// Creates a UDS transport. The socket directory is derived from the
+  /// [EmbeddedPostgresOptions.dataDir] option.
+  const UnixTransport({this.initialPassword});
 }
 
 /// Connection over loopback TCP. Authentication is `scram-sha-256`.
@@ -27,9 +33,10 @@ final class TcpTransport extends Transport {
   /// cover the close-then-rebind race.
   final int port;
 
-  /// Password for the configured username. If null, a cryptographically
-  /// random password is generated at start time and surfaced via
-  /// [EmbeddedPostgres.connectionString] / [EmbeddedPostgres.endpoint].
+  /// Superuser password for `scram-sha-256` over loopback. Seeded at `initdb`
+  /// on fresh clusters and persisted to `<dataDir parent>/postgres.password`.
+  /// If null, a cryptographically random password is generated. Serverpod
+  /// passes `config/passwords.yaml` `database` here.
   final String? password;
 
   /// Creates a TCP transport bound to `127.0.0.1`. Pass [port] to pin a

--- a/packages/serverpod_embedded_postgres/test/embedded_postgres_integration_test.dart
+++ b/packages/serverpod_embedded_postgres/test/embedded_postgres_integration_test.dart
@@ -68,8 +68,60 @@ void main() {
           isFalse,
           reason: 'pidfile should be removed after stop()',
         );
+
+        expect(
+          File(
+            p.join(tmpRoot.path, '.serverpod', 'postgres.password'),
+          ).existsSync(),
+          isTrue,
+          reason: 'fresh Unix clusters seed a password for a later TCP switch',
+        );
       },
       timeout: const Timeout(Duration(seconds: 120)),
+    );
+
+    test(
+      'when a cluster is started with TcpTransport '
+      'then TCP auth succeeds using the persisted postgres.password.',
+      () async {
+        var pgDataDir = Directory(p.join(tmpRoot.path, '.serverpod', 'pgdata'));
+        var pwFile = File(
+          p.join(tmpRoot.path, '.serverpod', 'postgres.password'),
+        );
+
+        var unix = await EmbeddedPostgres.start(
+          EmbeddedPostgresOptions(
+            dataDir: pgDataDir,
+            databaseName: 'projectname',
+            detach: true,
+          ),
+        );
+        expect(pwFile.existsSync(), isTrue);
+        var persistedPw = pwFile.readAsStringSync();
+        expect(persistedPw.length, greaterThan(8));
+        await unix.stop();
+
+        var tcp = await EmbeddedPostgres.start(
+          EmbeddedPostgresOptions(
+            dataDir: pgDataDir,
+            databaseName: 'projectname',
+            transport: const TcpTransport(),
+            detach: true,
+          ),
+        );
+        expect(tcp.endpoint.password, persistedPw);
+
+        var conn = await pg.Connection.open(
+          tcp.endpoint,
+          settings: const pg.ConnectionSettings(sslMode: pg.SslMode.disable),
+        );
+        var rs = await conn.execute('SELECT 1');
+        expect(rs.first.first, 1);
+        await conn.close();
+
+        await tcp.stop();
+      },
+      timeout: const Timeout(Duration(seconds: 180)),
     );
 
     test(

--- a/packages/serverpod_embedded_postgres/test/embedded_postgres_integration_test.dart
+++ b/packages/serverpod_embedded_postgres/test/embedded_postgres_integration_test.dart
@@ -82,34 +82,37 @@ void main() {
 
     test(
       'when a cluster is started with TcpTransport '
-      'then TCP auth succeeds using the persisted postgres.password.',
+      'then TCP auth succeeds using the passwords.yaml-aligned credential.',
       () async {
         var pgDataDir = Directory(p.join(tmpRoot.path, '.serverpod', 'pgdata'));
         var pwFile = File(
           p.join(tmpRoot.path, '.serverpod', 'postgres.password'),
         );
+        const passwordsYamlDatabase = 'dev-db-password';
 
         var unix = await EmbeddedPostgres.start(
           EmbeddedPostgresOptions(
             dataDir: pgDataDir,
             databaseName: 'projectname',
+            transport: const UnixTransport(
+              initialPassword: passwordsYamlDatabase,
+            ),
             detach: true,
           ),
         );
         expect(pwFile.existsSync(), isTrue);
-        var persistedPw = pwFile.readAsStringSync();
-        expect(persistedPw.length, greaterThan(8));
+        expect(pwFile.readAsStringSync(), passwordsYamlDatabase);
         await unix.stop();
 
         var tcp = await EmbeddedPostgres.start(
           EmbeddedPostgresOptions(
             dataDir: pgDataDir,
             databaseName: 'projectname',
-            transport: const TcpTransport(),
+            transport: const TcpTransport(password: passwordsYamlDatabase),
             detach: true,
           ),
         );
-        expect(tcp.endpoint.password, persistedPw);
+        expect(tcp.endpoint.password, passwordsYamlDatabase);
 
         var conn = await pg.Connection.open(
           tcp.endpoint,

--- a/packages/serverpod_embedded_postgres/test/embedded_postgres_integration_test.dart
+++ b/packages/serverpod_embedded_postgres/test/embedded_postgres_integration_test.dart
@@ -81,38 +81,73 @@ void main() {
     );
 
     test(
-      'when a cluster is started with TcpTransport '
-      'then TCP auth succeeds using the passwords.yaml-aligned credential.',
+      'when a default cluster is restarted with TcpTransport '
+      'then TCP auth succeeds using its generated password.',
       () async {
         var pgDataDir = Directory(p.join(tmpRoot.path, '.serverpod', 'pgdata'));
-        var pwFile = File(
-          p.join(tmpRoot.path, '.serverpod', 'postgres.password'),
-        );
-        const passwordsYamlDatabase = 'dev-db-password';
 
         var unix = await EmbeddedPostgres.start(
           EmbeddedPostgresOptions(
             dataDir: pgDataDir,
             databaseName: 'projectname',
-            transport: const UnixTransport(
-              initialPassword: passwordsYamlDatabase,
-            ),
             detach: true,
           ),
         );
-        expect(pwFile.existsSync(), isTrue);
-        expect(pwFile.readAsStringSync(), passwordsYamlDatabase);
         await unix.stop();
 
         var tcp = await EmbeddedPostgres.start(
           EmbeddedPostgresOptions(
             dataDir: pgDataDir,
             databaseName: 'projectname',
-            transport: const TcpTransport(password: passwordsYamlDatabase),
+            transport: const TcpTransport(),
             detach: true,
           ),
         );
-        expect(tcp.endpoint.password, passwordsYamlDatabase);
+        var conn = await pg.Connection.open(
+          tcp.endpoint,
+          settings: const pg.ConnectionSettings(sslMode: pg.SslMode.disable),
+        );
+        var rs = await conn.execute('SELECT 1');
+        expect(rs.first.first, 1);
+        await conn.close();
+        await tcp.stop();
+      },
+      timeout: const Timeout(Duration(seconds: 180)),
+    );
+
+    test(
+      'when a cluster created with a configured password is restarted with TcpTransport '
+      'then TCP auth succeeds using the configured password.',
+      () async {
+        var pgDataDir = Directory(p.join(tmpRoot.path, '.serverpod', 'pgdata'));
+        var pwFile = File(
+          p.join(tmpRoot.path, '.serverpod', 'postgres.password'),
+        );
+        const configuredPassword = 'dev-db-password';
+
+        var unix = await EmbeddedPostgres.start(
+          EmbeddedPostgresOptions(
+            dataDir: pgDataDir,
+            databaseName: 'projectname',
+            transport: const UnixTransport(
+              initialPassword: configuredPassword,
+            ),
+            detach: true,
+          ),
+        );
+        expect(pwFile.existsSync(), isTrue);
+        expect(pwFile.readAsStringSync(), configuredPassword);
+        await unix.stop();
+
+        var tcp = await EmbeddedPostgres.start(
+          EmbeddedPostgresOptions(
+            dataDir: pgDataDir,
+            databaseName: 'projectname',
+            transport: const TcpTransport(password: configuredPassword),
+            detach: true,
+          ),
+        );
+        expect(tcp.endpoint.password, configuredPassword);
 
         var conn = await pg.Connection.open(
           tcp.endpoint,

--- a/templates/pubspecs/tests/serverpod_test_shared/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_shared/pubspec.yaml
@@ -25,5 +25,9 @@ dev_dependencies:
 dependency_overrides:
   serverpod_database:
     path: ../../packages/serverpod_database
+  serverpod_embedded_postgres:
+    path: ../../packages/serverpod_embedded_postgres
   serverpod_serialization:
     path: ../../packages/serverpod_serialization
+  serverpod_shared:
+    path: ../../packages/serverpod_shared

--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   pubspec_parse: ^1.5.0
   recase: ^4.1.0
   serverpod_database: SERVERPOD_VERSION
+  serverpod_embedded_postgres: SERVERPOD_VERSION
   serverpod_logging_cli: ^0.1.0
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_service_client: SERVERPOD_VERSION

--- a/tests/serverpod_test_shared/pubspec.yaml
+++ b/tests/serverpod_test_shared/pubspec.yaml
@@ -26,5 +26,9 @@ dev_dependencies:
 dependency_overrides:
   serverpod_database:
     path: ../../packages/serverpod_database
+  serverpod_embedded_postgres:
+    path: ../../packages/serverpod_embedded_postgres
   serverpod_serialization:
     path: ../../packages/serverpod_serialization
+  serverpod_shared:
+    path: ../../packages/serverpod_shared

--- a/tools/serverpod_cli/bin/serverpod_cli.dart
+++ b/tools/serverpod_cli/bin/serverpod_cli.dart
@@ -9,6 +9,7 @@ import 'package:serverpod_cli/src/commands/cloud.dart';
 import 'package:serverpod_cli/src/commands/create.dart';
 import 'package:serverpod_cli/src/commands/create_migration.dart';
 import 'package:serverpod_cli/src/commands/create_repair_migration.dart';
+import 'package:serverpod_cli/src/commands/database.dart';
 import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/generate_pubspecs.dart';
 import 'package:serverpod_cli/src/commands/language_server.dart';
@@ -116,6 +117,7 @@ ServerpodCommandRunner buildCommandRunner() {
     AnalyzePubspecsCommand(),
     CloudCommand(),
     CreateCommand(),
+    DatabaseCommand(),
     QuickstartCommand(),
     GenerateCommand(),
     GeneratePubspecsCommand(),

--- a/tools/serverpod_cli/lib/src/commands/database.dart
+++ b/tools/serverpod_cli/lib/src/commands/database.dart
@@ -1,0 +1,175 @@
+import 'dart:io';
+
+import 'package:ci/ci.dart' as ci;
+import 'package:cli_tools/cli_tools.dart';
+import 'package:config/config.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/runner/serverpod_command.dart';
+import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
+import 'package:serverpod_cli/src/util/server_directory_finder.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:serverpod_embedded_postgres/serverpod_embedded_postgres.dart';
+import 'package:serverpod_shared/serverpod_shared.dart'
+    show PasswordManager, PostgresDatabaseConfig, ServerpodConfig;
+
+/// Database-related development commands.
+class DatabaseCommand extends ServerpodCommand<OptionDefinition> {
+  DatabaseCommand() : super(options: const []) {
+    addSubcommand(DatabaseStartCommand());
+  }
+
+  @override
+  final name = 'database';
+
+  @override
+  final description =
+      'Manage the embedded PostgreSQL database used by a Serverpod project.';
+
+  @override
+  void runWithConfig(Configuration<OptionDefinition> commandConfig) {}
+}
+
+/// Options for `serverpod database start`.
+enum DatabaseStartOption<V> implements OptionDefinition<V> {
+  serverDir(
+    StringOption(
+      argName: 'server-dir',
+      argAbbrev: 's',
+      helpText: 'Server project directory. Defaults to auto-detection.',
+      valueHelp: 'path',
+    ),
+  ),
+  mode(
+    StringOption(
+      argName: 'mode',
+      argAbbrev: 'm',
+      defaultsTo: 'development',
+      helpText: 'Serverpod run mode whose database config should be used.',
+    ),
+  ),
+  port(
+    IntOption(
+      argName: 'port',
+      argAbbrev: 'p',
+      min: 1,
+      max: 65535,
+      helpText: 'TCP port override. Defaults to the configured database port.',
+    ),
+  ),
+  ;
+
+  const DatabaseStartOption(this.option);
+
+  @override
+  final ConfigOptionBase<V> option;
+}
+
+/// Starts the configured embedded PostgreSQL database over loopback TCP.
+class DatabaseStartCommand extends ServerpodCommand<DatabaseStartOption> {
+  DatabaseStartCommand() : super(options: DatabaseStartOption.values);
+
+  @override
+  final name = 'start';
+
+  @override
+  final description =
+      'Start the configured embedded PostgreSQL database over TCP.';
+
+  @override
+  Future<void> runWithConfig(
+    Configuration<DatabaseStartOption> commandConfig,
+  ) async {
+    var interactive =
+        serverpodRunner.globalConfiguration.optionalValue(
+          GlobalOption.interactive,
+        ) ??
+        !ci.isCI;
+
+    final Directory serverDirectory;
+    try {
+      var serverDir = commandConfig.optionalValue(
+        DatabaseStartOption.serverDir,
+      );
+      serverDirectory = await ServerDirectoryFinder.findOrPrompt(
+        startDir: serverDir == null ? null : Directory(serverDir),
+        interactive: interactive,
+      );
+    } catch (e) {
+      log.error('$e');
+      throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
+    }
+
+    try {
+      var postgres = await _startFromServerpodConfig(
+        serverDirectory: serverDirectory,
+        runMode: commandConfig.value(DatabaseStartOption.mode),
+        port: commandConfig.optionalValue(DatabaseStartOption.port),
+      );
+
+      log
+        ..info('Embedded PostgreSQL is ready.')
+        ..info('Connection URI: ${postgres.connectionString}')
+        ..info(
+          Platform.isMacOS ? 'Press ⌃C to stop.' : 'Press Ctrl+C to stop.',
+        );
+
+      while (postgres.isRunning) {
+        await Future<void>.delayed(const Duration(seconds: 1));
+      }
+      await postgres.stop();
+    } catch (e, stackTrace) {
+      log.error(
+        'Failed to start embedded PostgreSQL: $e',
+        stackTrace: stackTrace,
+      );
+      throw ExitException.error();
+    }
+  }
+}
+
+Future<EmbeddedPostgres> _startFromServerpodConfig({
+  required Directory serverDirectory,
+  required String runMode,
+  int? port,
+}) async {
+  var serverDir = p.normalize(serverDirectory.absolute.path);
+  var passwords = PasswordManager(runMode: runMode).loadPasswords(
+    serverDir: serverDir,
+  );
+  var serverConfig = ServerpodConfig.load(
+    runMode,
+    null,
+    passwords,
+    serverDir: serverDir,
+  );
+  var databaseConfig = serverConfig.database;
+  if (databaseConfig is! PostgresDatabaseConfig) {
+    throw StateError(
+      'Run mode "$runMode" does not configure a PostgreSQL database.',
+    );
+  }
+
+  var dataPath = databaseConfig.dataPath;
+  if (dataPath == null) {
+    throw StateError(
+      'Run mode "$runMode" does not configure database.dataPath.',
+    );
+  }
+
+  return EmbeddedPostgres.start(
+    EmbeddedPostgresOptions(
+      dataDir: Directory(
+        p.isAbsolute(dataPath)
+            ? dataPath
+            : p.normalize(p.join(serverDir, dataPath)),
+      ),
+      databaseName: databaseConfig.name,
+      username: databaseConfig.user,
+      transport: TcpTransport(
+        port: port ?? databaseConfig.port,
+        password: databaseConfig.password,
+      ),
+      repairStaleLocks: true,
+    ),
+  );
+}

--- a/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
+++ b/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
@@ -55,6 +55,15 @@ commands:
       flag:
         template: ["mini", "fullstack", "server", "module"]
 
+  - name: database
+
+    commands:
+      - name: start
+        flags:
+          -s, --server-dir=: "Server project directory. Defaults to auto-detection."
+          -m, --mode=: "Serverpod run mode whose database config should be used."
+          -p, --port=: "TCP port override. Defaults to the configured database port."
+
   - name: quickstart
     flags:
       -f, --force: "Create the project even if there are issues that prevent it from running out of the box."

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   pubspec_parse: ^1.5.0
   recase: ^4.1.0
   serverpod_database: 4.0.0-beta.0
+  serverpod_embedded_postgres: 4.0.0-beta.0
   serverpod_logging_cli: ^0.1.0
   serverpod_serialization: 4.0.0-beta.0
   serverpod_service_client: 4.0.0-beta.0

--- a/tools/serverpod_cli/scripts/generate_command_usages.dart
+++ b/tools/serverpod_cli/scripts/generate_command_usages.dart
@@ -9,6 +9,7 @@ import 'package:serverpod_cli/src/commands/cloud.dart';
 import 'package:serverpod_cli/src/commands/create.dart';
 import 'package:serverpod_cli/src/commands/create_migration.dart';
 import 'package:serverpod_cli/src/commands/create_repair_migration.dart';
+import 'package:serverpod_cli/src/commands/database.dart';
 import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/commands/generate_pubspecs.dart';
 import 'package:serverpod_cli/src/commands/language_server.dart';
@@ -56,6 +57,7 @@ void main(final List<String> args) {
         AnalyzePubspecsCommand(),
         CloudCommand(),
         CreateCommand(),
+        DatabaseCommand(),
         QuickstartCommand(),
         GenerateCommand(),
         GeneratePubspecsCommand(),

--- a/tools/serverpod_cli/test/commands/database_command_integration_test.dart
+++ b/tools/serverpod_cli/test/commands/database_command_integration_test.dart
@@ -1,0 +1,157 @@
+@Tags(['integration'])
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:postgres/postgres.dart' as pg;
+import 'package:test/test.dart';
+
+void main() {
+  group(
+    'Given a Serverpod project configured with an embedded PostgreSQL password in passwords.yaml,',
+    () {
+      const databasePassword = 'passwords-yaml-database-password';
+      late Directory serverDirectory;
+      late int databasePort;
+      Process? cliProcess;
+      pg.Connection? connection;
+      StreamSubscription<String>? stdoutSubscription;
+      StreamSubscription<String>? stderrSubscription;
+
+      setUp(() async {
+        serverDirectory = Directory.systemTemp.createTempSync(
+          'serverpod_cli_database_start_',
+        );
+        var portReservation = await ServerSocket.bind(
+          InternetAddress.loopbackIPv4,
+          0,
+        );
+        databasePort = portReservation.port;
+        await portReservation.close();
+
+        File(p.join(serverDirectory.path, 'pubspec.yaml')).writeAsStringSync('''
+name: database_start_test_server
+environment:
+  sdk: ^3.8.0
+dependencies:
+  serverpod: any
+''');
+        var configDirectory = Directory(
+          p.join(serverDirectory.path, 'config'),
+        )..createSync();
+        File(
+          p.join(configDirectory.path, 'development.yaml'),
+        ).writeAsStringSync('''
+database:
+  host: localhost
+  port: $databasePort
+  name: serverpod_test
+  user: postgres
+  dataPath: .serverpod/pgdata
+''');
+        File(p.join(configDirectory.path, 'passwords.yaml')).writeAsStringSync(
+          '''
+development:
+  database: $databasePassword
+''',
+        );
+      });
+
+      tearDown(() async {
+        await connection?.close();
+        if (cliProcess case var process?) {
+          process.kill(
+            Platform.isWindows ? ProcessSignal.sigterm : ProcessSignal.sigint,
+          );
+          try {
+            await process.exitCode.timeout(const Duration(seconds: 15));
+          } on TimeoutException {
+            process.kill(ProcessSignal.sigkill);
+            await process.exitCode;
+          }
+        }
+        await stdoutSubscription?.cancel();
+        await stderrSubscription?.cancel();
+        if (serverDirectory.existsSync()) {
+          serverDirectory.deleteSync(recursive: true);
+        }
+      });
+
+      test(
+        'when serverpod database start runs without mode or port overrides, '
+        'then the database accepts the password from passwords.yaml.',
+        () async {
+          var output = StringBuffer();
+          var ready = Completer<void>();
+          cliProcess = await Process.start(
+            Platform.resolvedExecutable,
+            [
+              'run',
+              p.join(Directory.current.path, 'bin', 'serverpod_cli.dart'),
+              '--no-analytics',
+              '--no-interactive',
+              'database',
+              'start',
+              '--server-dir',
+              serverDirectory.path,
+            ],
+            workingDirectory: Directory.current.path,
+          );
+          stdoutSubscription = cliProcess!.stdout
+              .transform(utf8.decoder)
+              .transform(const LineSplitter())
+              .listen((line) {
+                output.writeln(line);
+                if (line.contains('Embedded PostgreSQL is ready.') &&
+                    !ready.isCompleted) {
+                  ready.complete();
+                }
+              });
+          stderrSubscription = cliProcess!.stderr
+              .transform(utf8.decoder)
+              .transform(const LineSplitter())
+              .listen(output.writeln);
+          unawaited(
+            cliProcess!.exitCode.then((exitCode) {
+              if (!ready.isCompleted) {
+                ready.completeError(
+                  TestFailure(
+                    'The command exited with code $exitCode before the '
+                    'database became ready.\n$output',
+                  ),
+                );
+              }
+            }),
+          );
+
+          await ready.future.timeout(
+            const Duration(seconds: 180),
+            onTimeout: () => throw TestFailure(
+              'The database did not become ready.\n$output',
+            ),
+          );
+
+          connection = await pg.Connection.open(
+            pg.Endpoint(
+              host: 'localhost',
+              port: databasePort,
+              database: 'serverpod_test',
+              username: 'postgres',
+              password: databasePassword,
+            ),
+            settings: const pg.ConnectionSettings(
+              sslMode: pg.SslMode.disable,
+            ),
+          );
+          var result = await connection!.execute('SELECT 1');
+
+          expect(result.first.first, 1);
+        },
+        timeout: const Timeout(Duration(minutes: 4)),
+      );
+    },
+  );
+}

--- a/tools/serverpod_cli/test/commands/database_command_test.dart
+++ b/tools/serverpod_cli/test/commands/database_command_test.dart
@@ -1,0 +1,78 @@
+import 'package:serverpod_cli/src/commands/database.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a DatabaseCommand,', () {
+    late DatabaseCommand command;
+    late DatabaseStartCommand startCommand;
+
+    setUp(() {
+      command = DatabaseCommand();
+      startCommand = command.subcommands['start']! as DatabaseStartCommand;
+    });
+
+    test(
+      'when reading its subcommands, '
+      'then the start command is available.',
+      () {
+        expect(command.subcommands, contains('start'));
+      },
+    );
+
+    test(
+      'when parsing the start command without options, '
+      'then development mode is selected and discovery overrides are unset.',
+      () {
+        var argResults = startCommand.argParser.parse([]);
+        var config = startCommand.resolveConfiguration(argResults);
+
+        expect(config.errors, isEmpty);
+        expect(config.optionalValue(DatabaseStartOption.serverDir), isNull);
+        expect(config.value(DatabaseStartOption.mode), 'development');
+        expect(config.optionalValue(DatabaseStartOption.port), isNull);
+      },
+    );
+
+    test(
+      'when parsing start command overrides, '
+      'then the selected directory, mode, and port are used.',
+      () {
+        var argResults = startCommand.argParser.parse([
+          '--server-dir',
+          'example_server',
+          '--mode',
+          'test',
+          '--port',
+          '55432',
+        ]);
+        var config = startCommand.resolveConfiguration(argResults);
+
+        expect(config.errors, isEmpty);
+        expect(
+          config.optionalValue(DatabaseStartOption.serverDir),
+          'example_server',
+        );
+        expect(config.value(DatabaseStartOption.mode), 'test');
+        expect(config.optionalValue(DatabaseStartOption.port), 55432);
+      },
+    );
+
+    test(
+      'when parsing the -s shorthand, '
+      'then the server directory is selected.',
+      () {
+        var argResults = startCommand.argParser.parse([
+          '-s',
+          'example_server',
+        ]);
+        var config = startCommand.resolveConfiguration(argResults);
+
+        expect(config.errors, isEmpty);
+        expect(
+          config.optionalValue(DatabaseStartOption.serverDir),
+          'example_server',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes: #5469

After this PR, users will be able to do: 

```console
12:21 $ serverpod database start
Embedded PostgreSQL is ready.
Connection URI: postgres://postgres:d1rxfknXbFWEWjru3H13vB7j7UJu7Q7Q@127.0.0.1:8090/demo_offline
Press Ctrl+C to stop.
```

In the future, we can also introduce more commands under `serverpod database` to manage the embedded PostgreSQL, such as a `--detach` option on `start`, a `status` and `stop` commands.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None, but this feature will only work with databases created after this PR.