### PR TITLE
feat: Make stack trace logs clickable to expand in serverpod start

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -291,6 +291,10 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
           onCopyAlert: copyAlert,
           onDismissAlert: dismissAlert,
           onStopOrCloseAppTab: _stopOrCloseAppTab,
+          onToggleStackTrace: (entry) {
+            state.toggleStackTrace(entry);
+            _rebuild();
+          },
         ),
       ),
     );
@@ -435,7 +439,7 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
     final focusedTab = state.tabs.focusedTab;
     if (event.logicalKey == LogicalKey.keyE &&
         (focusedTab is ServerLogTab || focusedTab is AppLogTab)) {
-      state.expandStackTraces = !state.expandStackTraces;
+      state.toggleAllStackTraces();
       _rebuild();
       return true;
     }

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -31,6 +31,7 @@ class MainScreen extends StatelessComponent {
     required this.onCopyAlert,
     required this.onDismissAlert,
     required this.onStopOrCloseAppTab,
+    required this.onToggleStackTrace,
   });
 
   final ServerWatchState state;
@@ -59,6 +60,10 @@ class MainScreen extends StatelessComponent {
   /// Stops the app or closes the tab for the given app tab (also bound to `X`).
   final void Function(AppLogTab tab) onStopOrCloseAppTab;
 
+  /// Flips the stack-trace visibility of one log entry, invoked by clicking
+  /// its expand/collapse affordance (`E` toggles all entries at once).
+  final void Function(LogEntry entry) onToggleStackTrace;
+
   List<(String, List<(String, String)>)> get _helpBindings => [
     (
       'Navigation',
@@ -79,7 +84,7 @@ class MainScreen extends StatelessComponent {
         ('Shift+M', 'Force Create migration'),
         ('P', 'Repair migration'),
         ('Shift+P', 'Force Repair migration'),
-        ('E', 'Expand / collapse stack traces'),
+        ('E', 'Expand / collapse all stack traces (click one to toggle it)'),
         ('S', 'Show raw server logs'),
       ],
     ),
@@ -651,6 +656,9 @@ class MainScreen extends StatelessComponent {
 
   /// Renders a single [LogEntry], appending its stack trace - or a collapsed
   /// affordance hinting that one exists - when the entry carries one.
+  ///
+  /// The affordance line is clickable and toggles just this entry's trace;
+  /// the `E` key still expands or collapses all traces at once.
   Component _buildLogEntry(BuildContext context, LogEntry entry, int index) {
     final message = LogMessageWidget(key: ValueKey(index), entry: entry);
     final stackTrace = entry.stackTrace?.toString().trimRight();
@@ -658,13 +666,35 @@ class MainScreen extends StatelessComponent {
 
     final st = ServerpodTheme.of(context);
     final dim = TextStyle(color: st.debugLevel, fontWeight: FontWeight.dim);
+    final expanded = state.isStackTraceExpanded(entry);
 
-    final trailing = state.expandStackTraces
-        ? Text(stackTrace, style: dim)
-        : Text(
-            '▸ ${stackTrace.split('\n').length}-line stack trace (press e)',
-            style: dim,
-          );
+    final lineCount = stackTrace.split('\n').length;
+    final affordance = GestureDetector(
+      onTap: () => onToggleStackTrace(entry),
+      child: RichText(
+        text: TextSpan(
+          children: [
+            TextSpan(
+              text: expanded
+                  ? '▾ $lineCount-line stack trace '
+                  : '▸ $lineCount-line stack trace ',
+              style: dim,
+            ),
+            TextSpan(
+              text: 'E',
+              style: TextStyle(
+                color: st.activationKey,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            TextSpan(
+              text: expanded ? ' Collapse' : ' Expand',
+              style: TextStyle(color: st.brightText),
+            ),
+          ],
+        ),
+      ),
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -672,8 +702,13 @@ class MainScreen extends StatelessComponent {
         message,
         Padding(
           padding: const EdgeInsets.only(left: 6),
-          child: trailing,
+          child: affordance,
         ),
+        if (expanded)
+          Padding(
+            padding: const EdgeInsets.only(left: 6),
+            child: Text(stackTrace, style: dim),
+          ),
       ],
     );
   }

--- a/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/state.dart
@@ -1,4 +1,5 @@
 import 'package:serverpod_cli/src/config/flutter_app_config.dart';
+import 'package:serverpod_shared/log.dart';
 import 'package:serverpod_tui/serverpod_tui.dart';
 
 import 'tab_model.dart';
@@ -100,7 +101,31 @@ class ServerWatchState extends TuiState {
   ///
   /// When false, an error entry that carries a trace shows a compact
   /// affordance instead; toggled with `e` on the structured log tab.
+  /// Individual entries can deviate from this via [toggleStackTrace].
   bool expandStackTraces = false;
+
+  /// Entries whose stack-trace visibility is inverted relative to
+  /// [expandStackTraces], toggled by clicking an entry's affordance.
+  ///
+  /// Identity-keyed: [LogEntry] has no value equality and the same object
+  /// stays in [logHistory] for its lifetime.
+  final _toggledStackTraces = Set<LogEntry>.identity();
+
+  /// Whether [entry]'s stack trace is currently shown inline.
+  bool isStackTraceExpanded(LogEntry entry) =>
+      expandStackTraces != _toggledStackTraces.contains(entry);
+
+  /// Flips the stack-trace visibility of [entry] only.
+  void toggleStackTrace(LogEntry entry) {
+    if (!_toggledStackTraces.remove(entry)) _toggledStackTraces.add(entry);
+  }
+
+  /// Flips [expandStackTraces] for every entry, dropping per-entry
+  /// [toggleStackTrace] deviations so the result is uniform.
+  void toggleAllStackTraces() {
+    expandStackTraces = !expandStackTraces;
+    _toggledStackTraces.clear();
+  }
 
   /// Whether the raw server logs overlay (the "dev console") is visible.
   ///
@@ -176,6 +201,7 @@ class ServerWatchState extends TuiState {
   void clearLogs() {
     logHistory.clear();
     rawLines.clear();
+    _toggledStackTraces.clear();
     for (final tab in appsTabArea?.tabs ?? []) {
       if (tab is AppLogTab) {
         tab.lines.clear();

--- a/tools/serverpod_cli/test/commands/start/tui/app_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/app_test.dart
@@ -100,18 +100,6 @@ void main() {
     });
 
     test(
-      'when e is pressed on an app log tab then traces do not toggle',
-      () async {
-        state.getOrCreateAppLogTab(appId: 'app', label: 'App');
-        state.tabs.focusedAreaIndex = 1;
-
-        await _sendKey(tester, LogicalKey.keyE);
-
-        expect(state.expandStackTraces, isFalse);
-      },
-    );
-
-    test(
       'when e is pressed after a per-entry toggle then all traces align to '
       'the global state',
       () async {

--- a/tools/serverpod_cli/test/commands/start/tui/app_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/app_test.dart
@@ -99,6 +99,38 @@ void main() {
       expect(state.expandStackTraces, isFalse);
     });
 
+    test(
+      'when e is pressed on an app log tab then traces do not toggle',
+      () async {
+        state.getOrCreateAppLogTab(appId: 'app', label: 'App');
+        state.tabs.focusedAreaIndex = 1;
+
+        await _sendKey(tester, LogicalKey.keyE);
+
+        expect(state.expandStackTraces, isFalse);
+      },
+    );
+
+    test(
+      'when e is pressed after a per-entry toggle then all traces align to '
+      'the global state',
+      () async {
+        final entry = state.logHistory.whereType<LogEntry>().first;
+        state.toggleStackTrace(entry);
+        expect(state.isStackTraceExpanded(entry), isTrue);
+
+        // E flips the global flag and drops per-entry deviations, so the
+        // already-expanded entry stays expanded (not double-flipped shut).
+        await _sendKey(tester, LogicalKey.keyE);
+        expect(state.expandStackTraces, isTrue);
+        expect(state.isStackTraceExpanded(entry), isTrue);
+
+        await _sendKey(tester, LogicalKey.keyE);
+        expect(state.expandStackTraces, isFalse);
+        expect(state.isStackTraceExpanded(entry), isFalse);
+      },
+    );
+
     test('when backtick is pressed then the raw server logs open', () async {
       expect(state.showRawServerLogs, isFalse);
 

--- a/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
@@ -291,4 +291,120 @@ void main() {
       },
     );
   });
+
+  group('Given a structured log with stack-traced error entries', () {
+    late ServerWatchState state;
+    late NoctermTester tester;
+
+    LogEntry stackTracedEntry(String message, String trace) => LogEntry(
+      time: DateTime(2026),
+      level: LogLevel.error,
+      message: message,
+      scope: LogScope.root('server'),
+      error: 'Exception: $message',
+      stackTrace: StackTrace.fromString(trace),
+    );
+
+    setUp(() async {
+      state = ServerWatchState();
+      state.showSplash = false;
+      state.serverReady = true;
+      state.logHistory.add(stackTracedEntry('boom', '#0 boom-trace'));
+      tester = await _pump(state, const Size(100, 24));
+    });
+
+    test('then a collapsed entry shows a styled clickable affordance', () {
+      final ts = tester.terminalState;
+
+      expect(ts.containsText('▸ 1-line stack trace E Expand'), isTrue);
+      expect(ts.containsText('#0 boom-trace'), isFalse);
+
+      // The `E` key hint follows the action-button convention: the
+      // activation key is highlighted apart from the label.
+      final key = ts.getStyledText().firstWhere(
+        (s) =>
+            s.text.trim() == 'E' &&
+            s.style.color == ServerpodThemeData.dark.activationKey,
+        orElse: () => throw StateError('No styled activation-key E found'),
+      );
+      expect(key.style.color, ServerpodThemeData.dark.activationKey);
+    });
+
+    test(
+      'when the affordance is clicked then only that entry toggles',
+      () async {
+        final affordance = tester.terminalState.findText('E Expand').first;
+        await tester.tap(affordance.x, affordance.y);
+        await tester.pump();
+
+        expect(tester.terminalState.containsText('#0 boom-trace'), isTrue);
+        expect(tester.terminalState.containsText('E Collapse'), isTrue);
+        expect(
+          state.expandStackTraces,
+          isFalse,
+          reason: 'clicking one entry must not flip the global toggle',
+        );
+
+        final collapse = tester.terminalState.findText('E Collapse').first;
+        await tester.tap(collapse.x, collapse.y);
+        await tester.pump();
+
+        expect(tester.terminalState.containsText('#0 boom-trace'), isFalse);
+        expect(tester.terminalState.containsText('E Expand'), isTrue);
+      },
+    );
+  });
+
+  group('Given a structured log with two stack-traced error entries', () {
+    late NoctermTester tester;
+
+    setUp(() async {
+      final state = ServerWatchState();
+      state.showSplash = false;
+      state.serverReady = true;
+      for (final (message, trace) in [
+        ('boom', '#0 boom-trace'),
+        ('kaboom', '#0 other-trace'),
+      ]) {
+        state.logHistory.add(
+          LogEntry(
+            time: DateTime(2026),
+            level: LogLevel.error,
+            message: message,
+            scope: LogScope.root('server'),
+            error: 'Exception: $message',
+            stackTrace: StackTrace.fromString(trace),
+          ),
+        );
+      }
+      tester = await _pump(state, const Size(100, 24));
+    });
+
+    test(
+      'when one entry is clicked then the other stays collapsed',
+      () async {
+        expect(tester.terminalState.findText('E Expand'), hasLength(2));
+
+        final affordance = tester.terminalState.findText('E Expand').first;
+        await tester.tap(affordance.x, affordance.y);
+        await tester.pump();
+
+        final ts = tester.terminalState;
+        final expandedBoth =
+            ts.containsText('#0 boom-trace') &&
+            ts.containsText('#0 other-trace');
+        expect(expandedBoth, isFalse, reason: 'only one entry may expand');
+        expect(
+          ts.containsText('#0 boom-trace') || ts.containsText('#0 other-trace'),
+          isTrue,
+          reason: 'the clicked entry must expand',
+        );
+        expect(
+          ts.findText('E Expand'),
+          hasLength(1),
+          reason: 'the other entry must keep its collapsed affordance',
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
Stack traces in the start TUI's structured log could only be expanded all at once with the E key. Each entry's affordance line is now clickable to expand or collapse just that trace, and the old '(press e)' hint is restyled to the 'E Expand' / 'E Collapse' action-button convention.

Per-entry toggles are stored as deviations from the global expandStackTraces flag; pressing E still flips every trace at once and resets the deviations so the result is uniform.

Closes #5460 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._