### PR TITLE
feat: Unify create and apply migrations

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -1384,7 +1384,13 @@ Future<void> _runTuiBackend({
           runTrackedAction(
             holder,
             force ? 'Force-creating migration' : 'Creating migration',
-            () => _runCreateMigrationForTui(config, force: force),
+            () async {
+              await _runCreateMigrationForTui(
+                config,
+                force: force,
+              );
+              await ctx.session.applyMigration();
+            },
           );
         };
         holder.onCreateRepairMigration = ({bool force = false}) {
@@ -1393,21 +1399,16 @@ Future<void> _runTuiBackend({
             force
                 ? 'Force-creating repair migration'
                 : 'Creating repair migration',
-            () => _runCreateRepairMigrationForTui(
-              config,
-              runMode: runModeFromServerArgs(serverArgs),
-              force: force,
-            ),
+            () async {
+              await _runCreateRepairMigrationForTui(
+                config,
+                runMode: runModeFromServerArgs(serverArgs),
+                force: force,
+              );
+              await ctx.session.applyMigration();
+            },
           );
         };
-        holder.onApplyMigration = () {
-          runTrackedAction(
-            holder,
-            'Applying migrations',
-            ctx.session.applyMigration,
-          );
-        };
-
         holder.state.serverReady = ctx.session.isRunning;
         // Degraded start (no server yet): expose the manual "Start server"
         // recovery action. The watcher also auto-recovers in watch mode.

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -1389,7 +1389,7 @@ Future<void> _runTuiBackend({
                 config,
                 force: force,
               );
-              await ctx.session.applyMigration();
+              await _tryApplyMigrationForTui(ctx.session.applyMigration);
             },
           );
         };
@@ -1405,8 +1405,15 @@ Future<void> _runTuiBackend({
                 runMode: runModeFromServerArgs(serverArgs),
                 force: force,
               );
-              await ctx.session.applyMigration();
+              await _tryApplyMigrationForTui(ctx.session.applyMigration);
             },
+          );
+        };
+        holder.onApplyMigration = () {
+          runTrackedAction(
+            holder,
+            'Applying migrations',
+            ctx.session.applyMigration,
           );
         };
         holder.state.serverReady = ctx.session.isRunning;
@@ -1502,6 +1509,22 @@ Future<void> _runCreateMigrationForTui(
   );
   if (result.isError) throw Exception(result.message);
   log.info(result.message);
+}
+
+/// Applies a newly created migration without changing the tracked status of
+/// the successful create operation if applying it fails.
+Future<void> _tryApplyMigrationForTui(
+  Future<void> Function() applyMigration,
+) async {
+  try {
+    await applyMigration();
+  } catch (error, stackTrace) {
+    log.error(
+      'Failed to apply migration: $error.',
+      stackTrace: stackTrace,
+    );
+    log.info('Press A to retry apply migration');
+  }
 }
 
 /// Runs `create-migration` for the MCP `create_migration` tool. Returns a

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -24,6 +24,7 @@ class StartAppStateHolder extends TuiAppStateHolder<ServerWatchState> {
   void Function(int index)? _onStopApp;
   void Function({bool force})? _onCreateMigration;
   void Function({bool force})? _onCreateRepairMigration;
+  VoidCallback? _onApplyMigration;
   VoidCallback? _onQuit;
 
   @override
@@ -42,6 +43,7 @@ class StartAppStateHolder extends TuiAppStateHolder<ServerWatchState> {
     widgetState.onStopApp = _onStopApp;
     widgetState.onCreateMigration = _onCreateMigration;
     widgetState.onCreateRepairMigration = _onCreateRepairMigration;
+    widgetState.onApplyMigration = _onApplyMigration;
     widgetState.onQuit = _onQuit;
   }
 
@@ -85,6 +87,11 @@ class StartAppStateHolder extends TuiAppStateHolder<ServerWatchState> {
     _widgetState?.onCreateRepairMigration = cb;
   }
 
+  set onApplyMigration(VoidCallback? cb) {
+    _onApplyMigration = cb;
+    _widgetState?.onApplyMigration = cb;
+  }
+
   set onQuit(VoidCallback? cb) {
     _onQuit = cb;
     _widgetState?.onQuit = cb;
@@ -118,6 +125,7 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
   void Function(int index)? onStopApp;
   void Function({bool force})? onCreateMigration;
   void Function({bool force})? onCreateRepairMigration;
+  VoidCallback? onApplyMigration;
   VoidCallback? onQuit;
 
   bool _minSplashElapsed = false;
@@ -511,6 +519,16 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
         state.serverReady &&
         !state.actionBusy) {
       onCreateRepairMigration?.call(force: event.isShiftPressed);
+      return true;
+    }
+
+    // Applying migrations remains available as a recovery action when the
+    // automatic apply following migration creation fails. Also documented
+    // on the help screen.
+    if (event.logicalKey == LogicalKey.keyA &&
+        state.serverReady &&
+        !state.actionBusy) {
+      onApplyMigration?.call();
       return true;
     }
 

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -24,7 +24,6 @@ class StartAppStateHolder extends TuiAppStateHolder<ServerWatchState> {
   void Function(int index)? _onStopApp;
   void Function({bool force})? _onCreateMigration;
   void Function({bool force})? _onCreateRepairMigration;
-  VoidCallback? _onApplyMigration;
   VoidCallback? _onQuit;
 
   @override
@@ -43,7 +42,6 @@ class StartAppStateHolder extends TuiAppStateHolder<ServerWatchState> {
     widgetState.onStopApp = _onStopApp;
     widgetState.onCreateMigration = _onCreateMigration;
     widgetState.onCreateRepairMigration = _onCreateRepairMigration;
-    widgetState.onApplyMigration = _onApplyMigration;
     widgetState.onQuit = _onQuit;
   }
 
@@ -87,11 +85,6 @@ class StartAppStateHolder extends TuiAppStateHolder<ServerWatchState> {
     _widgetState?.onCreateRepairMigration = cb;
   }
 
-  set onApplyMigration(VoidCallback? cb) {
-    _onApplyMigration = cb;
-    _widgetState?.onApplyMigration = cb;
-  }
-
   set onQuit(VoidCallback? cb) {
     _onQuit = cb;
     _widgetState?.onQuit = cb;
@@ -125,7 +118,6 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
   void Function(int index)? onStopApp;
   void Function({bool force})? onCreateMigration;
   void Function({bool force})? onCreateRepairMigration;
-  VoidCallback? onApplyMigration;
   VoidCallback? onQuit;
 
   bool _minSplashElapsed = false;
@@ -340,7 +332,6 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
           onHotReload: onHotReload,
           onHotRestart: onHotRestart,
           onCreateMigration: onCreateMigration,
-          onApplyMigration: onApplyMigration,
           onClearLogs: () {
             state.clearLogs();
             _rebuild();

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -23,7 +23,6 @@ class MainScreen extends StatelessComponent {
     this.onHotReload,
     this.onHotRestart,
     this.onCreateMigration,
-    this.onApplyMigration,
     this.onClearLogs,
     this.onLaunchApp,
     this.onTabSelected,
@@ -43,7 +42,6 @@ class MainScreen extends StatelessComponent {
   final VoidCallback? onHotReload;
   final VoidCallback? onHotRestart;
   final void Function({bool force})? onCreateMigration;
-  final VoidCallback? onApplyMigration;
   final VoidCallback? onClearLogs;
   final ValueChanged<int>? onLaunchApp;
 
@@ -788,13 +786,6 @@ class MainScreen extends StatelessComponent {
           onActivate: (_) => onCreateMigration?.call(),
           onShiftActivate: (_) => onCreateMigration?.call(force: true),
           enabled: actionsEnabled && onCreateMigration != null,
-        ),
-        Button(
-          name: 'Apply migrations',
-          activationChar: 'A',
-          activationKeys: const [LogicalKey.keyA],
-          onActivate: (_) => onApplyMigration?.call(),
-          enabled: actionsEnabled && onApplyMigration != null,
         ),
         Button(
           name: 'Clear logs',

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -781,7 +781,7 @@ class MainScreen extends StatelessComponent {
             enabled: actionsEnabled && onHotReload != null,
           ),
         Button(
-          name: 'Create migration',
+          name: 'Migrate',
           activationChar: 'M',
           activationKeys: const [LogicalKey.keyM],
           onActivate: (_) => onCreateMigration?.call(),

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -80,6 +80,7 @@ class MainScreen extends StatelessComponent {
             state.launchableApps.length == 1 ? 'Launch app' : 'Launch apps',
           ),
         ('Shift+M', 'Force Create migration'),
+        ('A', 'Apply migration'),
         ('P', 'Repair migration'),
         ('Shift+P', 'Force Repair migration'),
         ('E', 'Expand / collapse stack traces'),

--- a/tools/serverpod_cli/test/commands/start/tui/app_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/app_test.dart
@@ -548,6 +548,15 @@ void main() {
       expect(repairCalls, 1);
       expect(forced, isFalse);
     });
+
+    test('when A is pressed then apply migration is invoked', () async {
+      var applyCalls = 0;
+      holder.onApplyMigration = () => applyCalls++;
+
+      await _sendKey(tester, LogicalKey.keyA);
+
+      expect(applyCalls, 1);
+    });
   });
 
   group('Given a running TUI start app with exactly one launchable app', () {


### PR DESCRIPTION
Apply migrations button has been removed from the TUI. Migrations are now applied once they are created from the TUI button/keyboard shortcut. This also applies to repair migrations.

Closes #5458 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None