### PR TITLE
fix: Invalidate corrupt cached server.dill after an interrupted compile

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/messages.dart
+++ b/tools/serverpod_cli/lib/src/commands/messages.dart
@@ -35,6 +35,17 @@ const startBlockedByErrorsManual =
     'Waiting for the project to build. Once the errors above are resolved, '
     'press "R" to rebuild and start the server.';
 
+/// Shown when a previous session died mid-compile, leaving the cached build
+/// suspect.
+const previousCompileInterrupted =
+    'A previous compilation was interrupted; discarding the cached build and '
+    'recompiling from scratch.';
+
+/// Shown when the server crashed booting from the cached kernel.
+const cachedBuildCrashedOnBoot =
+    'The server failed to start from the cached build (it may be corrupt); '
+    'discarding it and recompiling from scratch.';
+
 // Watch command messages
 const serverStarted = '✓ Server started.';
 const serverReloaded = '✓ Server reloaded.';

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -709,14 +709,23 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   // now. The watch session brings it up once the project is fixed.
   ServerProcess? initialServerProcess;
   if (buildOk) {
-    await log.progress('Starting server', () async {
-      final initialDill = watch
-          ? p.join(serverpodToolDir, 'server.dill')
-          : null;
-      initialServerProcess = await serverProcessFactory(initialDill);
-      return true;
-    });
-  } else {
+    initialServerProcess = await bootInitialServer(
+      initialDill: watch ? p.join(serverpodToolDir, 'server.dill') : null,
+      startServer: serverProcessFactory,
+      compiler: compiler,
+    );
+    if (initialServerProcess == null) {
+      log.error('Initial compilation failed.');
+      buildOk = false;
+      if (!keepOpenOnFailure) {
+        await compiler?.dispose();
+        await flutterManager.dispose();
+        await rollbackStartup();
+        return const WatchLoopAborted(1);
+      }
+    }
+  }
+  if (!buildOk) {
     log.warning(watch ? startBlockedByErrorsWatch : startBlockedByErrorsManual);
   }
 
@@ -857,6 +866,48 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       vmServiceInfoFile: vmServiceInfoFile,
     ),
   );
+}
+
+/// Boots the initial server process, recovering once from a corrupt cached
+/// dill (a pod that dies before publishing its VM service URI never got past
+/// kernel loading). Returns `null` if the recovery recompile fails.
+@visibleForTesting
+Future<ServerProcess?> bootInitialServer({
+  required String? initialDill,
+  required Future<ServerProcess> Function(String? dillPath) startServer,
+  required KernelCompiler? compiler,
+}) async {
+  Future<ServerProcess> boot() async {
+    late ServerProcess server;
+    await log.progress('Starting server', () async {
+      server = await startServer(initialDill);
+      return true;
+    });
+    return server;
+  }
+
+  final server = await boot();
+  if (compiler == null) return server;
+
+  // exitCode is already completed whenever isRunning is false.
+  final crashedLoadingKernel =
+      server.vmServiceUri == null &&
+      !server.isRunning &&
+      await server.exitCode != 0;
+  if (!crashedLoadingKernel) return server;
+
+  log.warning(cachedBuildCrashedOnBoot);
+  await compiler.invalidateCachedDill();
+  // Ensure a complete kernel, not an incremental delta.
+  await compiler.reset();
+  final result = await compileWithProgress(
+    'Compiling server',
+    compiler,
+    rejectOnFailure: true,
+  );
+  if (result == null) return null;
+  await compiler.accept();
+  return boot();
 }
 
 /// The paths the watch-mode [FileWatcher] observes: server/shared/client

--- a/tools/serverpod_cli/lib/src/commands/start/kernel_compiler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/kernel_compiler.dart
@@ -1,9 +1,11 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vendored/frontend_server_client.dart';
 import 'package:serverpod_shared/process_io.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
 
 export 'package:serverpod_cli/src/vendored/frontend_server_client.dart'
     show CompileResult;
@@ -50,6 +52,10 @@ class KernelCompiler {
   /// Whether [start] has run.
   bool get isStarted => _started;
 
+  /// Exists while the Frontend Server may be writing [outputDill]; left
+  /// behind if the session dies mid-compile.
+  String get _compileMarkerPath => '$outputDill.compiling';
+
   /// Start the Frontend Server process.
   ///
   /// This starts the server in resident mode, ready to receive compile
@@ -71,9 +77,11 @@ class KernelCompiler {
   }
 
   /// Returns `true` if [outputDill] exists, is newer than every file under
-  /// [watchDirs], and is compatible with the current Dart SDK's kernel binary
-  /// format.
+  /// [watchDirs], is compatible with the current Dart SDK's kernel binary
+  /// format, and the last compile that wrote it completed.
   Future<bool> isDillUpToDate(Set<String> watchDirs) async {
+    if (File(_compileMarkerPath).existsSync()) return false;
+
     final dillFile = File(outputDill);
     if (!await dillFile.exists()) return false;
 
@@ -100,7 +108,12 @@ class KernelCompiler {
   /// Returns `true` on success (including when no compilation was needed).
   /// Returns `false` if compilation failed.
   Future<bool> compileIfNeeded(Set<String> watchDirs) async {
-    if (await isDillUpToDate(watchDirs)) {
+    if (File(_compileMarkerPath).existsSync()) {
+      log.warning(previousCompileInterrupted);
+      await invalidateCachedDill();
+      // Ensure a complete kernel, not an incremental delta.
+      await reset();
+    } else if (await isDillUpToDate(watchDirs)) {
       log.debug('Cached server.dill is up to date, skipping initial compile.');
       return true;
     }
@@ -109,6 +122,14 @@ class KernelCompiler {
     if (result == null) return false;
     await accept();
     return true;
+  }
+
+  /// Deletes the cached kernel outputs and the compile marker so the next
+  /// compile starts fresh. Used when the cached build cannot be trusted.
+  Future<void> invalidateCachedDill() async {
+    await File(outputDill).deleteIfExists();
+    await File('$outputDill.incremental.dill').deleteIfExists();
+    await File(_compileMarkerPath).deleteIfExists();
   }
 
   /// Compile the project.
@@ -126,30 +147,41 @@ class KernelCompiler {
     bool invalidatePackageConfig = false,
   }) async {
     final client = await _client;
+    final marker = File(_compileMarkerPath)..createSync(recursive: true);
 
+    final CompileResult result;
     if (_needsFullCompile) {
       log.debug('compile: full');
-      final result = await client.compile();
+      result = await client.compile();
       _needsFullCompile = false;
-      return result;
+    } else {
+      // Invalidate the exact URI the FES was started with (see
+      // [FrontendServerClient.packageConfigUri]) so the resident compiler
+      // reloads its package map in place instead of the reload silently
+      // no-op'ing on a mismatched URI.
+      final packageConfigUri = invalidatePackageConfig
+          ? client.packageConfigUri
+          : null;
+      log.debug(
+        'compile: $changedPaths'
+        '${packageConfigUri != null ? ' (+package_config.json)' : ''}',
+      );
+      final invalidatedUris = [
+        ...changedPaths.map(Uri.file),
+        ?packageConfigUri,
+      ];
+      result = await client.compile(invalidatedUris);
     }
 
-    // Invalidate the exact URI the FES was started with (see
-    // [FrontendServerClient.packageConfigUri]) so the resident compiler
-    // reloads its package map in place instead of the reload silently no-op'ing
-    // on a mismatched URI.
-    final packageConfigUri = invalidatePackageConfig
-        ? client.packageConfigUri
-        : null;
-    log.debug(
-      'compile: $changedPaths'
-      '${packageConfigUri != null ? ' (+package_config.json)' : ''}',
-    );
-    final invalidatedUris = [
-      ...changedPaths.map(Uri.file),
-      ?packageConfigUri,
-    ];
-    return client.compile(invalidatedUris);
+    // A null dillOutput means the FES died mid-write; keep the marker.
+    if (result.dillOutput != null) {
+      try {
+        marker.deleteSync();
+      } on FileSystemException {
+        // A stray marker only costs an extra full compile.
+      }
+    }
+    return result;
   }
 
   /// Accept the last compile result.

--- a/tools/serverpod_cli/test/commands/start/boot_recovery_test.dart
+++ b/tools/serverpod_cli/test/commands/start/boot_recovery_test.dart
@@ -106,38 +106,38 @@ void main() {
     serverQueue = [];
   });
 
-  group('Given a healthy initial boot', () {
-    test(
-      'when bootInitialServer runs, '
-      'then it returns the server without touching the compiler',
-      () async {
-        serverQueue = [_FakeServer.running()];
+  test(
+    'Given a healthy initial boot, '
+    'when bootInitialServer runs, '
+    'then it returns the server without touching the compiler',
+    () async {
+      serverQueue = [_FakeServer.running()];
 
-        final server = await bootInitialServer(
-          initialDill: '/tmp/server.dill',
-          startServer: startServer,
-          compiler: compiler,
-        );
+      final server = await bootInitialServer(
+        initialDill: '/tmp/server.dill',
+        startServer: startServer,
+        compiler: compiler,
+      );
 
-        expect(server, same(bootedServers.single));
-        expect(compiler.calls, isEmpty);
-      },
-    );
-  });
+      expect(server, same(bootedServers.single));
+      expect(compiler.calls, isEmpty);
+    },
+  );
 
   group('Given a server that dies before publishing its VM service URI', () {
     // 0xC0000409: a Windows-style abort code; the predicate must not
     // enumerate exit codes.
     const abortCode = 3221226505;
 
+    setUp(() {
+      serverQueue = [_FakeServer.crashed(abortCode)];
+    });
+
     test(
       'when bootInitialServer runs, '
       'then it invalidates the cache, recompiles, and boots again',
       () async {
-        serverQueue = [
-          _FakeServer.crashed(abortCode),
-          _FakeServer.running(),
-        ];
+        serverQueue.add(_FakeServer.running());
 
         final server = await bootInitialServer(
           initialDill: '/tmp/server.dill',
@@ -155,7 +155,6 @@ void main() {
       'when the recovery recompile fails, '
       'then it returns null and rejects the compile',
       () async {
-        serverQueue = [_FakeServer.crashed(abortCode)];
         compiler.nextCompileResult = _failResult();
 
         final server = await bootInitialServer(
@@ -174,10 +173,7 @@ void main() {
       'when the retry boot also crashes, '
       'then the dead server is returned without a second retry',
       () async {
-        serverQueue = [
-          _FakeServer.crashed(abortCode),
-          _FakeServer.crashed(abortCode),
-        ];
+        serverQueue.add(_FakeServer.crashed(abortCode));
 
         final server = await bootInitialServer(
           initialDill: '/tmp/server.dill',
@@ -194,8 +190,6 @@ void main() {
       'when no compiler is available (non-watch mode), '
       'then the dead server is returned without a retry',
       () async {
-        serverQueue = [_FakeServer.crashed(abortCode)];
-
         final server = await bootInitialServer(
           initialDill: null,
           startServer: startServer,
@@ -207,22 +201,21 @@ void main() {
     );
   });
 
-  group('Given a server that crashes after the VM service came up', () {
-    test(
-      'when bootInitialServer runs, '
-      'then the crash is not treated as a corrupt cache',
-      () async {
-        serverQueue = [_FakeServer.crashedAfterVmService(1)];
+  test(
+    'Given a server that crashes after the VM service came up, '
+    'when bootInitialServer runs, '
+    'then the crash is not treated as a corrupt cache',
+    () async {
+      serverQueue = [_FakeServer.crashedAfterVmService(1)];
 
-        final server = await bootInitialServer(
-          initialDill: '/tmp/server.dill',
-          startServer: startServer,
-          compiler: compiler,
-        );
+      final server = await bootInitialServer(
+        initialDill: '/tmp/server.dill',
+        startServer: startServer,
+        compiler: compiler,
+      );
 
-        expect(server, same(bootedServers.single));
-        expect(compiler.calls, isEmpty);
-      },
-    );
-  });
+      expect(server, same(bootedServers.single));
+      expect(compiler.calls, isEmpty);
+    },
+  );
 }

--- a/tools/serverpod_cli/test/commands/start/boot_recovery_test.dart
+++ b/tools/serverpod_cli/test/commands/start/boot_recovery_test.dart
@@ -1,0 +1,228 @@
+import 'dart:async';
+
+import 'package:cli_tools/cli_tools.dart';
+import 'package:serverpod_cli/src/commands/start.dart';
+import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
+import 'package:serverpod_cli/src/commands/start/server_process.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:serverpod_cli/src/vendored/frontend_server_client.dart';
+import 'package:test/fake.dart';
+import 'package:test/test.dart';
+
+CompileResult _successResult() {
+  return CompileResultInternal.create(
+    dillOutput: '/out.dill',
+    compilerOutputLines: [],
+    errorCount: 0,
+    newSources: [],
+  );
+}
+
+CompileResult _failResult() {
+  return CompileResultInternal.create(
+    dillOutput: null,
+    compilerOutputLines: ['error: something failed'],
+    errorCount: 1,
+    newSources: [],
+  );
+}
+
+class _FakeCompiler extends Fake implements KernelCompiler {
+  final List<String> calls = [];
+  CompileResult nextCompileResult = _successResult();
+
+  @override
+  Future<CompileResult> compile({
+    Set<String> changedPaths = const {},
+    bool invalidatePackageConfig = false,
+  }) async {
+    calls.add('compile');
+    return nextCompileResult;
+  }
+
+  @override
+  Future<void> accept() async => calls.add('accept');
+
+  @override
+  Future<void> reject() async => calls.add('reject');
+
+  @override
+  Future<void> reset() async => calls.add('reset');
+
+  @override
+  Future<void> invalidateCachedDill() async => calls.add('invalidate');
+}
+
+class _FakeServer extends Fake implements ServerProcess {
+  _FakeServer.running()
+    : isRunning = true,
+      vmServiceUri = 'http://127.0.0.1:1/';
+
+  _FakeServer.crashed(int code) : isRunning = false, vmServiceUri = null {
+    _exitCode.complete(code);
+  }
+
+  /// Exited non-zero, but after the VM service came up (an app-level crash).
+  _FakeServer.crashedAfterVmService(int code)
+    : isRunning = false,
+      vmServiceUri = 'http://127.0.0.1:1/' {
+    _exitCode.complete(code);
+  }
+
+  @override
+  final bool isRunning;
+
+  @override
+  final String? vmServiceUri;
+
+  final _exitCode = Completer<int>();
+
+  @override
+  Future<int> get exitCode => _exitCode.future;
+}
+
+void main() {
+  setUpAll(() {
+    initializeLoggerWith(VoidLogger());
+  });
+
+  tearDownAll(() async {
+    await closeLogger();
+  });
+
+  late _FakeCompiler compiler;
+  late List<_FakeServer> bootedServers;
+  late List<_FakeServer> serverQueue;
+
+  Future<ServerProcess> startServer(String? dillPath) async {
+    final server = serverQueue.removeAt(0);
+    bootedServers.add(server);
+    return server;
+  }
+
+  setUp(() {
+    compiler = _FakeCompiler();
+    bootedServers = [];
+    serverQueue = [];
+  });
+
+  group('Given a healthy initial boot', () {
+    test(
+      'when bootInitialServer runs, '
+      'then it returns the server without touching the compiler',
+      () async {
+        serverQueue = [_FakeServer.running()];
+
+        final server = await bootInitialServer(
+          initialDill: '/tmp/server.dill',
+          startServer: startServer,
+          compiler: compiler,
+        );
+
+        expect(server, same(bootedServers.single));
+        expect(compiler.calls, isEmpty);
+      },
+    );
+  });
+
+  group('Given a server that dies before publishing its VM service URI', () {
+    // 0xC0000409: a Windows-style abort code; the predicate must not
+    // enumerate exit codes.
+    const abortCode = 3221226505;
+
+    test(
+      'when bootInitialServer runs, '
+      'then it invalidates the cache, recompiles, and boots again',
+      () async {
+        serverQueue = [
+          _FakeServer.crashed(abortCode),
+          _FakeServer.running(),
+        ];
+
+        final server = await bootInitialServer(
+          initialDill: '/tmp/server.dill',
+          startServer: startServer,
+          compiler: compiler,
+        );
+
+        expect(compiler.calls, ['invalidate', 'reset', 'compile', 'accept']);
+        expect(bootedServers, hasLength(2));
+        expect(server, same(bootedServers[1]));
+      },
+    );
+
+    test(
+      'when the recovery recompile fails, '
+      'then it returns null and rejects the compile',
+      () async {
+        serverQueue = [_FakeServer.crashed(abortCode)];
+        compiler.nextCompileResult = _failResult();
+
+        final server = await bootInitialServer(
+          initialDill: '/tmp/server.dill',
+          startServer: startServer,
+          compiler: compiler,
+        );
+
+        expect(server, isNull);
+        expect(bootedServers, hasLength(1));
+        expect(compiler.calls, ['invalidate', 'reset', 'compile', 'reject']);
+      },
+    );
+
+    test(
+      'when the retry boot also crashes, '
+      'then the dead server is returned without a second retry',
+      () async {
+        serverQueue = [
+          _FakeServer.crashed(abortCode),
+          _FakeServer.crashed(abortCode),
+        ];
+
+        final server = await bootInitialServer(
+          initialDill: '/tmp/server.dill',
+          startServer: startServer,
+          compiler: compiler,
+        );
+
+        expect(bootedServers, hasLength(2));
+        expect(server, same(bootedServers[1]));
+      },
+    );
+
+    test(
+      'when no compiler is available (non-watch mode), '
+      'then the dead server is returned without a retry',
+      () async {
+        serverQueue = [_FakeServer.crashed(abortCode)];
+
+        final server = await bootInitialServer(
+          initialDill: null,
+          startServer: startServer,
+          compiler: null,
+        );
+
+        expect(server, same(bootedServers.single));
+      },
+    );
+  });
+
+  group('Given a server that crashes after the VM service came up', () {
+    test(
+      'when bootInitialServer runs, '
+      'then the crash is not treated as a corrupt cache',
+      () async {
+        serverQueue = [_FakeServer.crashedAfterVmService(1)];
+
+        final server = await bootInitialServer(
+          initialDill: '/tmp/server.dill',
+          startServer: startServer,
+          compiler: compiler,
+        );
+
+        expect(server, same(bootedServers.single));
+        expect(compiler.calls, isEmpty);
+      },
+    );
+  });
+}

--- a/tools/serverpod_cli/test/commands/start/kernel_compiler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/kernel_compiler_test.dart
@@ -1,10 +1,20 @@
 import 'dart:io';
 
+import 'package:cli_tools/cli_tools.dart';
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/kernel_compiler.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:test/test.dart';
 
 void main() {
+  setUpAll(() {
+    initializeLoggerWith(VoidLogger());
+  });
+
+  tearDownAll(() async {
+    await closeLogger();
+  });
+
   group('Given a KernelCompiler with a valid Dart project', () {
     late Directory tempDir;
     late KernelCompiler compiler;
@@ -52,6 +62,84 @@ void main() {
         expect(result.errorCount, 0);
         expect(result.dillOutput, isNotEmpty);
         expect(File(outputDill).existsSync(), isTrue);
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+
+    test(
+      'when compile completes, '
+      'then no compile marker remains',
+      () async {
+        final marker = p.join(
+          tempDir.path,
+          '.dart_tool',
+          'serverpod',
+          'server.dill.compiling',
+        );
+
+        await compiler.start();
+        await compiler.compile();
+
+        expect(File(marker).existsSync(), isFalse);
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+
+    test(
+      'when isDillUpToDate is called with a leftover compile marker, '
+      'then it returns false',
+      () async {
+        await compiler.start();
+        await compiler.compile();
+        await compiler.accept();
+        expect(await compiler.isDillUpToDate({}), isTrue);
+
+        File('${compiler.outputDill}.compiling').createSync();
+
+        expect(await compiler.isDillUpToDate({}), isFalse);
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+
+    test(
+      'when compileIfNeeded runs with a leftover compile marker, '
+      'then it discards the cached dill and recompiles',
+      () async {
+        final watchDirs = {p.join(tempDir.path, 'bin')};
+
+        await compiler.start();
+        expect(await compiler.compileIfNeeded(watchDirs), isTrue);
+
+        // Simulate a previous session killed mid-compile.
+        File('${compiler.outputDill}.compiling').createSync();
+
+        expect(await compiler.compileIfNeeded(watchDirs), isTrue);
+        expect(File('${compiler.outputDill}.compiling').existsSync(), isFalse);
+        expect(File(compiler.outputDill).existsSync(), isTrue);
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+
+    test(
+      'when invalidateCachedDill is called, '
+      'then the dill, incremental dill, and marker are deleted',
+      () async {
+        await compiler.start();
+        await compiler.compile();
+        File('${compiler.outputDill}.incremental.dill').createSync();
+        File('${compiler.outputDill}.compiling').createSync();
+
+        await compiler.invalidateCachedDill();
+
+        expect(File(compiler.outputDill).existsSync(), isFalse);
+        expect(
+          File('${compiler.outputDill}.incremental.dill').existsSync(),
+          isFalse,
+        );
+        expect(File('${compiler.outputDill}.compiling').existsSync(), isFalse);
+
+        // Absent files do not throw.
+        await compiler.invalidateCachedDill();
       },
       timeout: const Timeout(Duration(seconds: 60)),
     );
@@ -125,6 +213,23 @@ void main() {
         final result = await compiler.compile();
 
         expect(result.errorCount, greaterThan(0));
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+
+    test(
+      'when compile finishes with errors, '
+      'then the compile marker is still cleared',
+      () async {
+        await compiler.start();
+        final result = await compiler.compile();
+
+        expect(result.errorCount, greaterThan(0));
+        // The FES finished writing, so the dill state is consistent.
+        expect(
+          File('${compiler.outputDill}.compiling').existsSync(),
+          isFalse,
+        );
       },
       timeout: const Timeout(Duration(seconds: 60)),
     );

--- a/tools/serverpod_cli/test/commands/start/kernel_compiler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/kernel_compiler_test.dart
@@ -47,7 +47,7 @@ void main() {
 
     test(
       'when compile is called, '
-      'then it produces a .dill file with no errors',
+      'then it produces a .dill file with no errors and no compile marker',
       () async {
         final outputDill = p.join(
           tempDir.path,
@@ -62,25 +62,7 @@ void main() {
         expect(result.errorCount, 0);
         expect(result.dillOutput, isNotEmpty);
         expect(File(outputDill).existsSync(), isTrue);
-      },
-      timeout: const Timeout(Duration(seconds: 60)),
-    );
-
-    test(
-      'when compile completes, '
-      'then no compile marker remains',
-      () async {
-        final marker = p.join(
-          tempDir.path,
-          '.dart_tool',
-          'serverpod',
-          'server.dill.compiling',
-        );
-
-        await compiler.start();
-        await compiler.compile();
-
-        expect(File(marker).existsSync(), isFalse);
+        expect(File('$outputDill.compiling').existsSync(), isFalse);
       },
       timeout: const Timeout(Duration(seconds: 60)),
     );
@@ -207,19 +189,7 @@ void main() {
 
     test(
       'when compile is called, '
-      'then it reports a non-zero error count',
-      () async {
-        await compiler.start();
-        final result = await compiler.compile();
-
-        expect(result.errorCount, greaterThan(0));
-      },
-      timeout: const Timeout(Duration(seconds: 60)),
-    );
-
-    test(
-      'when compile finishes with errors, '
-      'then the compile marker is still cleared',
+      'then it reports a non-zero error count and still clears the marker',
       () async {
         await compiler.start();
         final result = await compiler.compile();


### PR DESCRIPTION
Killing `serverpod start` while the Frontend Server is writing `.dart_tool/serverpod/server.dill` leaves a truncated file behind. The next `serverpod start` reuses the file and `dart server.dill` hard-crashes the VM.

Nothing invalidated the cache on crash, so every subsequent start failed until the user manually deleted the dill files.

This PR fixes that with two changes:
**Compile-in-progress marker** `KernelCompiler.compile()` creates `server.dill.compiling` before handing the compile to the FES and deletes it once the FES reports the write finished. A leftover marker on the next start means the previous session died mid-write. `compileIfNeeded` logs a warning, deletes `server.dill`, `server.dill.incremental.dill`, and the marker, and runs a full compile.
**Crash-at-boot recovery** The initial boot now detects a pod that exits non-zero *before publishing its VM service URI* It invalidates the cached dills, resets the compiler, recompiles, and retries the boot once; a crash from a freshly compiled kernel is reported through the existing exit path.

Fixes #5468 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None