### PR TITLE
chore: Remove deprecated orderDescending

### DIFF
--- a/examples/legacy/chat/chat_server/lib/src/generated/channel.dart
+++ b/examples/legacy/chat/chat_server/lib/src/generated/channel.dart
@@ -88,8 +88,6 @@ abstract class Channel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChannelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChannelTable>? orderByList,
     ChannelInclude? include,
   }) {
@@ -98,8 +96,6 @@ abstract class Channel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Channel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Channel.t),
       include: include,
     );
@@ -200,8 +196,6 @@ class ChannelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -246,8 +240,6 @@ class ChannelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChannelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChannelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -257,8 +249,6 @@ class ChannelRepository {
       where: where?.call(Channel.t),
       orderBy: orderBy?.call(Channel.t),
       orderByList: orderByList?.call(Channel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -289,8 +279,6 @@ class ChannelRepository {
     _i1.WhereExpressionBuilder<ChannelTable>? where,
     int? offset,
     _i1.OrderByBuilder<ChannelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChannelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -300,8 +288,6 @@ class ChannelRepository {
       where: where?.call(Channel.t),
       orderBy: orderBy?.call(Channel.t),
       orderByList: orderByList?.call(Channel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -506,8 +492,6 @@ class ChannelRepository {
     int? offset,
     _i1.OrderByBuilder<ChannelTable>? orderBy,
     _i1.OrderByListBuilder<ChannelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -518,8 +502,6 @@ class ChannelRepository {
       offset: offset,
       orderBy: orderBy?.call(Channel.t),
       orderByList: orderByList?.call(Channel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -540,8 +522,6 @@ class ChannelRepository {
     _i1.DatabaseSession session,
     List<Channel> rows, {
     _i1.OrderByBuilder<ChannelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChannelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -550,8 +530,6 @@ class ChannelRepository {
       rows,
       orderBy: orderBy?.call(Channel.t),
       orderByList: orderByList?.call(Channel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -581,8 +559,6 @@ class ChannelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChannelTable> where,
     _i1.OrderByBuilder<ChannelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChannelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -591,8 +567,6 @@ class ChannelRepository {
       where: where(Channel.t),
       orderBy: orderBy?.call(Channel.t),
       orderByList: orderByList?.call(Channel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/auth_key.dart
@@ -119,8 +119,6 @@ abstract class AuthKey
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AuthKeyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AuthKeyTable>? orderByList,
     AuthKeyInclude? include,
   }) {
@@ -129,8 +127,6 @@ abstract class AuthKey
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(AuthKey.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(AuthKey.t),
       include: include,
     );
@@ -271,8 +267,6 @@ class AuthKeyIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -317,8 +311,6 @@ class AuthKeyRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AuthKeyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AuthKeyTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -328,8 +320,6 @@ class AuthKeyRepository {
       where: where?.call(AuthKey.t),
       orderBy: orderBy?.call(AuthKey.t),
       orderByList: orderByList?.call(AuthKey.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -360,8 +350,6 @@ class AuthKeyRepository {
     _i1.WhereExpressionBuilder<AuthKeyTable>? where,
     int? offset,
     _i1.OrderByBuilder<AuthKeyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AuthKeyTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -371,8 +359,6 @@ class AuthKeyRepository {
       where: where?.call(AuthKey.t),
       orderBy: orderBy?.call(AuthKey.t),
       orderByList: orderByList?.call(AuthKey.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -577,8 +563,6 @@ class AuthKeyRepository {
     int? offset,
     _i1.OrderByBuilder<AuthKeyTable>? orderBy,
     _i1.OrderByListBuilder<AuthKeyTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -589,8 +573,6 @@ class AuthKeyRepository {
       offset: offset,
       orderBy: orderBy?.call(AuthKey.t),
       orderByList: orderByList?.call(AuthKey.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -611,8 +593,6 @@ class AuthKeyRepository {
     _i1.DatabaseSession session,
     List<AuthKey> rows, {
     _i1.OrderByBuilder<AuthKeyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AuthKeyTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -621,8 +601,6 @@ class AuthKeyRepository {
       rows,
       orderBy: orderBy?.call(AuthKey.t),
       orderByList: orderByList?.call(AuthKey.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -652,8 +630,6 @@ class AuthKeyRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AuthKeyTable> where,
     _i1.OrderByBuilder<AuthKeyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AuthKeyTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -662,8 +638,6 @@ class AuthKeyRepository {
       where: where(AuthKey.t),
       orderBy: orderBy?.call(AuthKey.t),
       orderByList: orderByList?.call(AuthKey.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_auth.dart
@@ -97,8 +97,6 @@ abstract class EmailAuth
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailAuthTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAuthTable>? orderByList,
     EmailAuthInclude? include,
   }) {
@@ -107,8 +105,6 @@ abstract class EmailAuth
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EmailAuth.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EmailAuth.t),
       include: include,
     );
@@ -227,8 +223,6 @@ class EmailAuthIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -273,8 +267,6 @@ class EmailAuthRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailAuthTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAuthTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -284,8 +276,6 @@ class EmailAuthRepository {
       where: where?.call(EmailAuth.t),
       orderBy: orderBy?.call(EmailAuth.t),
       orderByList: orderByList?.call(EmailAuth.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -316,8 +306,6 @@ class EmailAuthRepository {
     _i1.WhereExpressionBuilder<EmailAuthTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmailAuthTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAuthTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -327,8 +315,6 @@ class EmailAuthRepository {
       where: where?.call(EmailAuth.t),
       orderBy: orderBy?.call(EmailAuth.t),
       orderByList: orderByList?.call(EmailAuth.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -533,8 +519,6 @@ class EmailAuthRepository {
     int? offset,
     _i1.OrderByBuilder<EmailAuthTable>? orderBy,
     _i1.OrderByListBuilder<EmailAuthTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -545,8 +529,6 @@ class EmailAuthRepository {
       offset: offset,
       orderBy: orderBy?.call(EmailAuth.t),
       orderByList: orderByList?.call(EmailAuth.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -567,8 +549,6 @@ class EmailAuthRepository {
     _i1.DatabaseSession session,
     List<EmailAuth> rows, {
     _i1.OrderByBuilder<EmailAuthTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAuthTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -577,8 +557,6 @@ class EmailAuthRepository {
       rows,
       orderBy: orderBy?.call(EmailAuth.t),
       orderByList: orderByList?.call(EmailAuth.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -608,8 +586,6 @@ class EmailAuthRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmailAuthTable> where,
     _i1.OrderByBuilder<EmailAuthTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAuthTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -618,8 +594,6 @@ class EmailAuthRepository {
       where: where(EmailAuth.t),
       orderBy: orderBy?.call(EmailAuth.t),
       orderByList: orderByList?.call(EmailAuth.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_create_account_request.dart
@@ -109,8 +109,6 @@ abstract class EmailCreateAccountRequest
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailCreateAccountRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailCreateAccountRequestTable>? orderByList,
     EmailCreateAccountRequestInclude? include,
   }) {
@@ -119,8 +117,6 @@ abstract class EmailCreateAccountRequest
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EmailCreateAccountRequest.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EmailCreateAccountRequest.t),
       include: include,
     );
@@ -258,8 +254,6 @@ class EmailCreateAccountRequestIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -304,8 +298,6 @@ class EmailCreateAccountRequestRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailCreateAccountRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailCreateAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -315,8 +307,6 @@ class EmailCreateAccountRequestRepository {
       where: where?.call(EmailCreateAccountRequest.t),
       orderBy: orderBy?.call(EmailCreateAccountRequest.t),
       orderByList: orderByList?.call(EmailCreateAccountRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -347,8 +337,6 @@ class EmailCreateAccountRequestRepository {
     _i1.WhereExpressionBuilder<EmailCreateAccountRequestTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmailCreateAccountRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailCreateAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -358,8 +346,6 @@ class EmailCreateAccountRequestRepository {
       where: where?.call(EmailCreateAccountRequest.t),
       orderBy: orderBy?.call(EmailCreateAccountRequest.t),
       orderByList: orderByList?.call(EmailCreateAccountRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -568,8 +554,6 @@ class EmailCreateAccountRequestRepository {
     int? offset,
     _i1.OrderByBuilder<EmailCreateAccountRequestTable>? orderBy,
     _i1.OrderByListBuilder<EmailCreateAccountRequestTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -580,8 +564,6 @@ class EmailCreateAccountRequestRepository {
       offset: offset,
       orderBy: orderBy?.call(EmailCreateAccountRequest.t),
       orderByList: orderByList?.call(EmailCreateAccountRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -602,8 +584,6 @@ class EmailCreateAccountRequestRepository {
     _i1.DatabaseSession session,
     List<EmailCreateAccountRequest> rows, {
     _i1.OrderByBuilder<EmailCreateAccountRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailCreateAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -612,8 +592,6 @@ class EmailCreateAccountRequestRepository {
       rows,
       orderBy: orderBy?.call(EmailCreateAccountRequest.t),
       orderByList: orderByList?.call(EmailCreateAccountRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -643,8 +621,6 @@ class EmailCreateAccountRequestRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmailCreateAccountRequestTable> where,
     _i1.OrderByBuilder<EmailCreateAccountRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailCreateAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -653,8 +629,6 @@ class EmailCreateAccountRequestRepository {
       where: where(EmailCreateAccountRequest.t),
       orderBy: orderBy?.call(EmailCreateAccountRequest.t),
       orderByList: orderByList?.call(EmailCreateAccountRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_failed_sign_in.dart
@@ -98,8 +98,6 @@ abstract class EmailFailedSignIn
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailFailedSignInTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailFailedSignInTable>? orderByList,
     EmailFailedSignInInclude? include,
   }) {
@@ -108,8 +106,6 @@ abstract class EmailFailedSignIn
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EmailFailedSignIn.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EmailFailedSignIn.t),
       include: include,
     );
@@ -229,8 +225,6 @@ class EmailFailedSignInIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -275,8 +269,6 @@ class EmailFailedSignInRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailFailedSignInTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailFailedSignInTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -286,8 +278,6 @@ class EmailFailedSignInRepository {
       where: where?.call(EmailFailedSignIn.t),
       orderBy: orderBy?.call(EmailFailedSignIn.t),
       orderByList: orderByList?.call(EmailFailedSignIn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -318,8 +308,6 @@ class EmailFailedSignInRepository {
     _i1.WhereExpressionBuilder<EmailFailedSignInTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmailFailedSignInTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailFailedSignInTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -329,8 +317,6 @@ class EmailFailedSignInRepository {
       where: where?.call(EmailFailedSignIn.t),
       orderBy: orderBy?.call(EmailFailedSignIn.t),
       orderByList: orderByList?.call(EmailFailedSignIn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -537,8 +523,6 @@ class EmailFailedSignInRepository {
     int? offset,
     _i1.OrderByBuilder<EmailFailedSignInTable>? orderBy,
     _i1.OrderByListBuilder<EmailFailedSignInTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -549,8 +533,6 @@ class EmailFailedSignInRepository {
       offset: offset,
       orderBy: orderBy?.call(EmailFailedSignIn.t),
       orderByList: orderByList?.call(EmailFailedSignIn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -571,8 +553,6 @@ class EmailFailedSignInRepository {
     _i1.DatabaseSession session,
     List<EmailFailedSignIn> rows, {
     _i1.OrderByBuilder<EmailFailedSignInTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailFailedSignInTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -581,8 +561,6 @@ class EmailFailedSignInRepository {
       rows,
       orderBy: orderBy?.call(EmailFailedSignIn.t),
       orderByList: orderByList?.call(EmailFailedSignIn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -612,8 +590,6 @@ class EmailFailedSignInRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmailFailedSignInTable> where,
     _i1.OrderByBuilder<EmailFailedSignInTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailFailedSignInTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -622,8 +598,6 @@ class EmailFailedSignInRepository {
       where: where(EmailFailedSignIn.t),
       orderBy: orderBy?.call(EmailFailedSignIn.t),
       orderByList: orderByList?.call(EmailFailedSignIn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/email_reset.dart
@@ -99,8 +99,6 @@ abstract class EmailReset
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailResetTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailResetTable>? orderByList,
     EmailResetInclude? include,
   }) {
@@ -109,8 +107,6 @@ abstract class EmailReset
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EmailReset.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EmailReset.t),
       include: include,
     );
@@ -231,8 +227,6 @@ class EmailResetIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -277,8 +271,6 @@ class EmailResetRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailResetTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailResetTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -288,8 +280,6 @@ class EmailResetRepository {
       where: where?.call(EmailReset.t),
       orderBy: orderBy?.call(EmailReset.t),
       orderByList: orderByList?.call(EmailReset.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -320,8 +310,6 @@ class EmailResetRepository {
     _i1.WhereExpressionBuilder<EmailResetTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmailResetTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailResetTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -331,8 +319,6 @@ class EmailResetRepository {
       where: where?.call(EmailReset.t),
       orderBy: orderBy?.call(EmailReset.t),
       orderByList: orderByList?.call(EmailReset.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -537,8 +523,6 @@ class EmailResetRepository {
     int? offset,
     _i1.OrderByBuilder<EmailResetTable>? orderBy,
     _i1.OrderByListBuilder<EmailResetTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -549,8 +533,6 @@ class EmailResetRepository {
       offset: offset,
       orderBy: orderBy?.call(EmailReset.t),
       orderByList: orderByList?.call(EmailReset.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -571,8 +553,6 @@ class EmailResetRepository {
     _i1.DatabaseSession session,
     List<EmailReset> rows, {
     _i1.OrderByBuilder<EmailResetTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailResetTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -581,8 +561,6 @@ class EmailResetRepository {
       rows,
       orderBy: orderBy?.call(EmailReset.t),
       orderByList: orderByList?.call(EmailReset.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -612,8 +590,6 @@ class EmailResetRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmailResetTable> where,
     _i1.OrderByBuilder<EmailResetTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailResetTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -622,8 +598,6 @@ class EmailResetRepository {
       where: where(EmailReset.t),
       orderBy: orderBy?.call(EmailReset.t),
       orderByList: orderByList?.call(EmailReset.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/google_refresh_token.dart
@@ -88,8 +88,6 @@ abstract class GoogleRefreshToken
     int? limit,
     int? offset,
     _i1.OrderByBuilder<GoogleRefreshTokenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleRefreshTokenTable>? orderByList,
     GoogleRefreshTokenInclude? include,
   }) {
@@ -98,8 +96,6 @@ abstract class GoogleRefreshToken
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(GoogleRefreshToken.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(GoogleRefreshToken.t),
       include: include,
     );
@@ -202,8 +198,6 @@ class GoogleRefreshTokenIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -248,8 +242,6 @@ class GoogleRefreshTokenRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<GoogleRefreshTokenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleRefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -259,8 +251,6 @@ class GoogleRefreshTokenRepository {
       where: where?.call(GoogleRefreshToken.t),
       orderBy: orderBy?.call(GoogleRefreshToken.t),
       orderByList: orderByList?.call(GoogleRefreshToken.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -291,8 +281,6 @@ class GoogleRefreshTokenRepository {
     _i1.WhereExpressionBuilder<GoogleRefreshTokenTable>? where,
     int? offset,
     _i1.OrderByBuilder<GoogleRefreshTokenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleRefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -302,8 +290,6 @@ class GoogleRefreshTokenRepository {
       where: where?.call(GoogleRefreshToken.t),
       orderBy: orderBy?.call(GoogleRefreshToken.t),
       orderByList: orderByList?.call(GoogleRefreshToken.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -510,8 +496,6 @@ class GoogleRefreshTokenRepository {
     int? offset,
     _i1.OrderByBuilder<GoogleRefreshTokenTable>? orderBy,
     _i1.OrderByListBuilder<GoogleRefreshTokenTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -522,8 +506,6 @@ class GoogleRefreshTokenRepository {
       offset: offset,
       orderBy: orderBy?.call(GoogleRefreshToken.t),
       orderByList: orderByList?.call(GoogleRefreshToken.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -544,8 +526,6 @@ class GoogleRefreshTokenRepository {
     _i1.DatabaseSession session,
     List<GoogleRefreshToken> rows, {
     _i1.OrderByBuilder<GoogleRefreshTokenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleRefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -554,8 +534,6 @@ class GoogleRefreshTokenRepository {
       rows,
       orderBy: orderBy?.call(GoogleRefreshToken.t),
       orderByList: orderByList?.call(GoogleRefreshToken.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -585,8 +563,6 @@ class GoogleRefreshTokenRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<GoogleRefreshTokenTable> where,
     _i1.OrderByBuilder<GoogleRefreshTokenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleRefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -595,8 +571,6 @@ class GoogleRefreshTokenRepository {
       where: where(GoogleRefreshToken.t),
       orderBy: orderBy?.call(GoogleRefreshToken.t),
       orderByList: orderByList?.call(GoogleRefreshToken.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/user_image.dart
@@ -97,8 +97,6 @@ abstract class UserImage
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserImageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserImageTable>? orderByList,
     UserImageInclude? include,
   }) {
@@ -107,8 +105,6 @@ abstract class UserImage
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UserImage.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UserImage.t),
       include: include,
     );
@@ -227,8 +223,6 @@ class UserImageIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -273,8 +267,6 @@ class UserImageRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserImageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserImageTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -284,8 +276,6 @@ class UserImageRepository {
       where: where?.call(UserImage.t),
       orderBy: orderBy?.call(UserImage.t),
       orderByList: orderByList?.call(UserImage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -316,8 +306,6 @@ class UserImageRepository {
     _i1.WhereExpressionBuilder<UserImageTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserImageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserImageTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -327,8 +315,6 @@ class UserImageRepository {
       where: where?.call(UserImage.t),
       orderBy: orderBy?.call(UserImage.t),
       orderByList: orderByList?.call(UserImage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -533,8 +519,6 @@ class UserImageRepository {
     int? offset,
     _i1.OrderByBuilder<UserImageTable>? orderBy,
     _i1.OrderByListBuilder<UserImageTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -545,8 +529,6 @@ class UserImageRepository {
       offset: offset,
       orderBy: orderBy?.call(UserImage.t),
       orderByList: orderByList?.call(UserImage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -567,8 +549,6 @@ class UserImageRepository {
     _i1.DatabaseSession session,
     List<UserImage> rows, {
     _i1.OrderByBuilder<UserImageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserImageTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -577,8 +557,6 @@ class UserImageRepository {
       rows,
       orderBy: orderBy?.call(UserImage.t),
       orderByList: orderByList?.call(UserImage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -608,8 +586,6 @@ class UserImageRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserImageTable> where,
     _i1.OrderByBuilder<UserImageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserImageTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -618,8 +594,6 @@ class UserImageRepository {
       where: where(UserImage.t),
       orderBy: orderBy?.call(UserImage.t),
       orderByList: orderByList?.call(UserImage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/lib/src/generated/user_info.dart
@@ -150,8 +150,6 @@ abstract class UserInfo
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserInfoTable>? orderByList,
     UserInfoInclude? include,
   }) {
@@ -160,8 +158,6 @@ abstract class UserInfo
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UserInfo.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UserInfo.t),
       include: include,
     );
@@ -369,8 +365,6 @@ class UserInfoIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -415,8 +409,6 @@ class UserInfoRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserInfoTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -426,8 +418,6 @@ class UserInfoRepository {
       where: where?.call(UserInfo.t),
       orderBy: orderBy?.call(UserInfo.t),
       orderByList: orderByList?.call(UserInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -458,8 +448,6 @@ class UserInfoRepository {
     _i1.WhereExpressionBuilder<UserInfoTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserInfoTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -469,8 +457,6 @@ class UserInfoRepository {
       where: where?.call(UserInfo.t),
       orderBy: orderBy?.call(UserInfo.t),
       orderByList: orderByList?.call(UserInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -675,8 +661,6 @@ class UserInfoRepository {
     int? offset,
     _i1.OrderByBuilder<UserInfoTable>? orderBy,
     _i1.OrderByListBuilder<UserInfoTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -687,8 +671,6 @@ class UserInfoRepository {
       offset: offset,
       orderBy: orderBy?.call(UserInfo.t),
       orderByList: orderByList?.call(UserInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -709,8 +691,6 @@ class UserInfoRepository {
     _i1.DatabaseSession session,
     List<UserInfo> rows, {
     _i1.OrderByBuilder<UserInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserInfoTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -719,8 +699,6 @@ class UserInfoRepository {
       rows,
       orderBy: orderBy?.call(UserInfo.t),
       orderByList: orderByList?.call(UserInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -750,8 +728,6 @@ class UserInfoRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserInfoTable> where,
     _i1.OrderByBuilder<UserInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserInfoTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -760,8 +736,6 @@ class UserInfoRepository {
       where: where(UserInfo.t),
       orderBy: orderBy?.call(UserInfo.t),
       orderByList: orderByList?.call(UserInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
+++ b/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_message.dart
@@ -168,8 +168,6 @@ abstract class ChatMessage
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChatMessageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChatMessageTable>? orderByList,
     ChatMessageInclude? include,
   }) {
@@ -178,8 +176,6 @@ abstract class ChatMessage
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ChatMessage.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ChatMessage.t),
       include: include,
     );
@@ -372,8 +368,6 @@ class ChatMessageIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -418,8 +412,6 @@ class ChatMessageRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChatMessageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChatMessageTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -429,8 +421,6 @@ class ChatMessageRepository {
       where: where?.call(ChatMessage.t),
       orderBy: orderBy?.call(ChatMessage.t),
       orderByList: orderByList?.call(ChatMessage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -461,8 +451,6 @@ class ChatMessageRepository {
     _i1.WhereExpressionBuilder<ChatMessageTable>? where,
     int? offset,
     _i1.OrderByBuilder<ChatMessageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChatMessageTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -472,8 +460,6 @@ class ChatMessageRepository {
       where: where?.call(ChatMessage.t),
       orderBy: orderBy?.call(ChatMessage.t),
       orderByList: orderByList?.call(ChatMessage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -678,8 +664,6 @@ class ChatMessageRepository {
     int? offset,
     _i1.OrderByBuilder<ChatMessageTable>? orderBy,
     _i1.OrderByListBuilder<ChatMessageTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -690,8 +674,6 @@ class ChatMessageRepository {
       offset: offset,
       orderBy: orderBy?.call(ChatMessage.t),
       orderByList: orderByList?.call(ChatMessage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -712,8 +694,6 @@ class ChatMessageRepository {
     _i1.DatabaseSession session,
     List<ChatMessage> rows, {
     _i1.OrderByBuilder<ChatMessageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChatMessageTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -722,8 +702,6 @@ class ChatMessageRepository {
       rows,
       orderBy: orderBy?.call(ChatMessage.t),
       orderByList: orderByList?.call(ChatMessage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -753,8 +731,6 @@ class ChatMessageRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChatMessageTable> where,
     _i1.OrderByBuilder<ChatMessageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChatMessageTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -763,8 +739,6 @@ class ChatMessageRepository {
       where: where(ChatMessage.t),
       orderBy: orderBy?.call(ChatMessage.t),
       orderByList: orderByList?.call(ChatMessage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
+++ b/modules/legacy/serverpod_chat/serverpod_chat_server/lib/src/generated/chat_read_message.dart
@@ -97,8 +97,6 @@ abstract class ChatReadMessage
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChatReadMessageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChatReadMessageTable>? orderByList,
     ChatReadMessageInclude? include,
   }) {
@@ -107,8 +105,6 @@ abstract class ChatReadMessage
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ChatReadMessage.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ChatReadMessage.t),
       include: include,
     );
@@ -227,8 +223,6 @@ class ChatReadMessageIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -273,8 +267,6 @@ class ChatReadMessageRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChatReadMessageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChatReadMessageTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -284,8 +276,6 @@ class ChatReadMessageRepository {
       where: where?.call(ChatReadMessage.t),
       orderBy: orderBy?.call(ChatReadMessage.t),
       orderByList: orderByList?.call(ChatReadMessage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -316,8 +306,6 @@ class ChatReadMessageRepository {
     _i1.WhereExpressionBuilder<ChatReadMessageTable>? where,
     int? offset,
     _i1.OrderByBuilder<ChatReadMessageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChatReadMessageTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -327,8 +315,6 @@ class ChatReadMessageRepository {
       where: where?.call(ChatReadMessage.t),
       orderBy: orderBy?.call(ChatReadMessage.t),
       orderByList: orderByList?.call(ChatReadMessage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -535,8 +521,6 @@ class ChatReadMessageRepository {
     int? offset,
     _i1.OrderByBuilder<ChatReadMessageTable>? orderBy,
     _i1.OrderByListBuilder<ChatReadMessageTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -547,8 +531,6 @@ class ChatReadMessageRepository {
       offset: offset,
       orderBy: orderBy?.call(ChatReadMessage.t),
       orderByList: orderByList?.call(ChatReadMessage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -569,8 +551,6 @@ class ChatReadMessageRepository {
     _i1.DatabaseSession session,
     List<ChatReadMessage> rows, {
     _i1.OrderByBuilder<ChatReadMessageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChatReadMessageTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -579,8 +559,6 @@ class ChatReadMessageRepository {
       rows,
       orderBy: orderBy?.call(ChatReadMessage.t),
       orderByList: orderByList?.call(ChatReadMessage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -610,8 +588,6 @@ class ChatReadMessageRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChatReadMessageTable> where,
     _i1.OrderByBuilder<ChatReadMessageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChatReadMessageTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -620,8 +596,6 @@ class ChatReadMessageRepository {
       where: where(ChatReadMessage.t),
       orderBy: orderBy?.call(ChatReadMessage.t),
       orderByList: orderByList?.call(ChatReadMessage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_email_password.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_email_password.dart
@@ -106,8 +106,6 @@ abstract class LegacyEmailPassword
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LegacyEmailPasswordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyEmailPasswordTable>? orderByList,
     LegacyEmailPasswordInclude? include,
   }) {
@@ -116,8 +114,6 @@ abstract class LegacyEmailPassword
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(LegacyEmailPassword.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(LegacyEmailPassword.t),
       include: include,
     );
@@ -257,8 +253,6 @@ class LegacyEmailPasswordIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -305,8 +299,6 @@ class LegacyEmailPasswordRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LegacyEmailPasswordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyEmailPasswordTable>? orderByList,
     _i1.Transaction? transaction,
     LegacyEmailPasswordInclude? include,
@@ -317,8 +309,6 @@ class LegacyEmailPasswordRepository {
       where: where?.call(LegacyEmailPassword.t),
       orderBy: orderBy?.call(LegacyEmailPassword.t),
       orderByList: orderByList?.call(LegacyEmailPassword.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -350,8 +340,6 @@ class LegacyEmailPasswordRepository {
     _i1.WhereExpressionBuilder<LegacyEmailPasswordTable>? where,
     int? offset,
     _i1.OrderByBuilder<LegacyEmailPasswordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyEmailPasswordTable>? orderByList,
     _i1.Transaction? transaction,
     LegacyEmailPasswordInclude? include,
@@ -362,8 +350,6 @@ class LegacyEmailPasswordRepository {
       where: where?.call(LegacyEmailPassword.t),
       orderBy: orderBy?.call(LegacyEmailPassword.t),
       orderByList: orderByList?.call(LegacyEmailPassword.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -573,8 +559,6 @@ class LegacyEmailPasswordRepository {
     int? offset,
     _i1.OrderByBuilder<LegacyEmailPasswordTable>? orderBy,
     _i1.OrderByListBuilder<LegacyEmailPasswordTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -585,8 +569,6 @@ class LegacyEmailPasswordRepository {
       offset: offset,
       orderBy: orderBy?.call(LegacyEmailPassword.t),
       orderByList: orderByList?.call(LegacyEmailPassword.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -607,8 +589,6 @@ class LegacyEmailPasswordRepository {
     _i1.DatabaseSession session,
     List<LegacyEmailPassword> rows, {
     _i1.OrderByBuilder<LegacyEmailPasswordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyEmailPasswordTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -617,8 +597,6 @@ class LegacyEmailPasswordRepository {
       rows,
       orderBy: orderBy?.call(LegacyEmailPassword.t),
       orderByList: orderByList?.call(LegacyEmailPassword.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -648,8 +626,6 @@ class LegacyEmailPasswordRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<LegacyEmailPasswordTable> where,
     _i1.OrderByBuilder<LegacyEmailPasswordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyEmailPasswordTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -658,8 +634,6 @@ class LegacyEmailPasswordRepository {
       where: where(LegacyEmailPassword.t),
       orderBy: orderBy?.call(LegacyEmailPassword.t),
       orderByList: orderByList?.call(LegacyEmailPassword.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_external_user_identifier.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_external_user_identifier.dart
@@ -109,8 +109,6 @@ abstract class LegacyExternalUserIdentifier
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LegacyExternalUserIdentifierTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyExternalUserIdentifierTable>? orderByList,
     LegacyExternalUserIdentifierInclude? include,
   }) {
@@ -119,8 +117,6 @@ abstract class LegacyExternalUserIdentifier
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(LegacyExternalUserIdentifier.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(LegacyExternalUserIdentifier.t),
       include: include,
     );
@@ -262,8 +258,6 @@ class LegacyExternalUserIdentifierIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -310,8 +304,6 @@ class LegacyExternalUserIdentifierRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LegacyExternalUserIdentifierTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyExternalUserIdentifierTable>? orderByList,
     _i1.Transaction? transaction,
     LegacyExternalUserIdentifierInclude? include,
@@ -322,8 +314,6 @@ class LegacyExternalUserIdentifierRepository {
       where: where?.call(LegacyExternalUserIdentifier.t),
       orderBy: orderBy?.call(LegacyExternalUserIdentifier.t),
       orderByList: orderByList?.call(LegacyExternalUserIdentifier.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -355,8 +345,6 @@ class LegacyExternalUserIdentifierRepository {
     _i1.WhereExpressionBuilder<LegacyExternalUserIdentifierTable>? where,
     int? offset,
     _i1.OrderByBuilder<LegacyExternalUserIdentifierTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyExternalUserIdentifierTable>? orderByList,
     _i1.Transaction? transaction,
     LegacyExternalUserIdentifierInclude? include,
@@ -367,8 +355,6 @@ class LegacyExternalUserIdentifierRepository {
       where: where?.call(LegacyExternalUserIdentifier.t),
       orderBy: orderBy?.call(LegacyExternalUserIdentifier.t),
       orderByList: orderByList?.call(LegacyExternalUserIdentifier.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -581,8 +567,6 @@ class LegacyExternalUserIdentifierRepository {
     int? offset,
     _i1.OrderByBuilder<LegacyExternalUserIdentifierTable>? orderBy,
     _i1.OrderByListBuilder<LegacyExternalUserIdentifierTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -593,8 +577,6 @@ class LegacyExternalUserIdentifierRepository {
       offset: offset,
       orderBy: orderBy?.call(LegacyExternalUserIdentifier.t),
       orderByList: orderByList?.call(LegacyExternalUserIdentifier.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -615,8 +597,6 @@ class LegacyExternalUserIdentifierRepository {
     _i1.DatabaseSession session,
     List<LegacyExternalUserIdentifier> rows, {
     _i1.OrderByBuilder<LegacyExternalUserIdentifierTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyExternalUserIdentifierTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -625,8 +605,6 @@ class LegacyExternalUserIdentifierRepository {
       rows,
       orderBy: orderBy?.call(LegacyExternalUserIdentifier.t),
       orderByList: orderByList?.call(LegacyExternalUserIdentifier.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -657,8 +635,6 @@ class LegacyExternalUserIdentifierRepository {
     required _i1.WhereExpressionBuilder<LegacyExternalUserIdentifierTable>
     where,
     _i1.OrderByBuilder<LegacyExternalUserIdentifierTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacyExternalUserIdentifierTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -667,8 +643,6 @@ class LegacyExternalUserIdentifierRepository {
       where: where(LegacyExternalUserIdentifier.t),
       orderBy: orderBy?.call(LegacyExternalUserIdentifier.t),
       orderByList: orderByList?.call(LegacyExternalUserIdentifier.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_session.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/generated/legacy_session.dart
@@ -120,8 +120,6 @@ abstract class LegacySession
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LegacySessionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacySessionTable>? orderByList,
     LegacySessionInclude? include,
   }) {
@@ -130,8 +128,6 @@ abstract class LegacySession
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(LegacySession.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(LegacySession.t),
       include: include,
     );
@@ -305,8 +301,6 @@ class LegacySessionIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -353,8 +347,6 @@ class LegacySessionRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LegacySessionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacySessionTable>? orderByList,
     _i1.Transaction? transaction,
     LegacySessionInclude? include,
@@ -365,8 +357,6 @@ class LegacySessionRepository {
       where: where?.call(LegacySession.t),
       orderBy: orderBy?.call(LegacySession.t),
       orderByList: orderByList?.call(LegacySession.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -398,8 +388,6 @@ class LegacySessionRepository {
     _i1.WhereExpressionBuilder<LegacySessionTable>? where,
     int? offset,
     _i1.OrderByBuilder<LegacySessionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacySessionTable>? orderByList,
     _i1.Transaction? transaction,
     LegacySessionInclude? include,
@@ -410,8 +398,6 @@ class LegacySessionRepository {
       where: where?.call(LegacySession.t),
       orderBy: orderBy?.call(LegacySession.t),
       orderByList: orderByList?.call(LegacySession.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -619,8 +605,6 @@ class LegacySessionRepository {
     int? offset,
     _i1.OrderByBuilder<LegacySessionTable>? orderBy,
     _i1.OrderByListBuilder<LegacySessionTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -631,8 +615,6 @@ class LegacySessionRepository {
       offset: offset,
       orderBy: orderBy?.call(LegacySession.t),
       orderByList: orderByList?.call(LegacySession.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -653,8 +635,6 @@ class LegacySessionRepository {
     _i1.DatabaseSession session,
     List<LegacySession> rows, {
     _i1.OrderByBuilder<LegacySessionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacySessionTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -663,8 +643,6 @@ class LegacySessionRepository {
       rows,
       orderBy: orderBy?.call(LegacySession.t),
       orderByList: orderByList?.call(LegacySession.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -694,8 +672,6 @@ class LegacySessionRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<LegacySessionTable> where,
     _i1.OrderByBuilder<LegacySessionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LegacySessionTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -704,8 +680,6 @@ class LegacySessionRepository {
       where: where(LegacySession.t),
       orderBy: orderBy?.call(LegacySession.t),
       orderByList: orderByList?.call(LegacySession.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/auth_user/models/auth_user.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/auth_user/models/auth_user.dart
@@ -110,8 +110,6 @@ abstract class AuthUser
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AuthUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AuthUserTable>? orderByList,
     AuthUserInclude? include,
   }) {
@@ -120,8 +118,6 @@ abstract class AuthUser
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(AuthUser.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(AuthUser.t),
       include: include,
     );
@@ -242,8 +238,6 @@ class AuthUserIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -288,8 +282,6 @@ class AuthUserRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AuthUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AuthUserTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -299,8 +291,6 @@ class AuthUserRepository {
       where: where?.call(AuthUser.t),
       orderBy: orderBy?.call(AuthUser.t),
       orderByList: orderByList?.call(AuthUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -331,8 +321,6 @@ class AuthUserRepository {
     _i1.WhereExpressionBuilder<AuthUserTable>? where,
     int? offset,
     _i1.OrderByBuilder<AuthUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AuthUserTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -342,8 +330,6 @@ class AuthUserRepository {
       where: where?.call(AuthUser.t),
       orderBy: orderBy?.call(AuthUser.t),
       orderByList: orderByList?.call(AuthUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -548,8 +534,6 @@ class AuthUserRepository {
     int? offset,
     _i1.OrderByBuilder<AuthUserTable>? orderBy,
     _i1.OrderByListBuilder<AuthUserTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -560,8 +544,6 @@ class AuthUserRepository {
       offset: offset,
       orderBy: orderBy?.call(AuthUser.t),
       orderByList: orderByList?.call(AuthUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -582,8 +564,6 @@ class AuthUserRepository {
     _i1.DatabaseSession session,
     List<AuthUser> rows, {
     _i1.OrderByBuilder<AuthUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AuthUserTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -592,8 +572,6 @@ class AuthUserRepository {
       rows,
       orderBy: orderBy?.call(AuthUser.t),
       orderByList: orderByList?.call(AuthUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -623,8 +601,6 @@ class AuthUserRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AuthUserTable> where,
     _i1.OrderByBuilder<AuthUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AuthUserTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -633,8 +609,6 @@ class AuthUserRepository {
       where: where(AuthUser.t),
       orderBy: orderBy?.call(AuthUser.t),
       orderByList: orderByList?.call(AuthUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/jwt/models/refresh_token.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/jwt/models/refresh_token.dart
@@ -187,8 +187,6 @@ abstract class RefreshToken
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RefreshTokenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RefreshTokenTable>? orderByList,
     RefreshTokenInclude? include,
   }) {
@@ -197,8 +195,6 @@ abstract class RefreshToken
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(RefreshToken.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(RefreshToken.t),
       include: include,
     );
@@ -470,8 +466,6 @@ class RefreshTokenIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -518,8 +512,6 @@ class RefreshTokenRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RefreshTokenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
     RefreshTokenInclude? include,
@@ -530,8 +522,6 @@ class RefreshTokenRepository {
       where: where?.call(RefreshToken.t),
       orderBy: orderBy?.call(RefreshToken.t),
       orderByList: orderByList?.call(RefreshToken.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -563,8 +553,6 @@ class RefreshTokenRepository {
     _i1.WhereExpressionBuilder<RefreshTokenTable>? where,
     int? offset,
     _i1.OrderByBuilder<RefreshTokenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
     RefreshTokenInclude? include,
@@ -575,8 +563,6 @@ class RefreshTokenRepository {
       where: where?.call(RefreshToken.t),
       orderBy: orderBy?.call(RefreshToken.t),
       orderByList: orderByList?.call(RefreshToken.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -784,8 +770,6 @@ class RefreshTokenRepository {
     int? offset,
     _i1.OrderByBuilder<RefreshTokenTable>? orderBy,
     _i1.OrderByListBuilder<RefreshTokenTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -796,8 +780,6 @@ class RefreshTokenRepository {
       offset: offset,
       orderBy: orderBy?.call(RefreshToken.t),
       orderByList: orderByList?.call(RefreshToken.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -818,8 +800,6 @@ class RefreshTokenRepository {
     _i1.DatabaseSession session,
     List<RefreshToken> rows, {
     _i1.OrderByBuilder<RefreshTokenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -828,8 +808,6 @@ class RefreshTokenRepository {
       rows,
       orderBy: orderBy?.call(RefreshToken.t),
       orderByList: orderByList?.call(RefreshToken.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -859,8 +837,6 @@ class RefreshTokenRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RefreshTokenTable> where,
     _i1.OrderByBuilder<RefreshTokenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RefreshTokenTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -869,8 +845,6 @@ class RefreshTokenRepository {
       where: where(RefreshToken.t),
       orderBy: orderBy?.call(RefreshToken.t),
       orderByList: orderByList?.call(RefreshToken.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/profile/models/user_profile.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/profile/models/user_profile.dart
@@ -174,8 +174,6 @@ abstract class UserProfile
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserProfileTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileTable>? orderByList,
     UserProfileInclude? include,
   }) {
@@ -184,8 +182,6 @@ abstract class UserProfile
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UserProfile.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UserProfile.t),
       include: include,
     );
@@ -429,8 +425,6 @@ class UserProfileIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -479,8 +473,6 @@ class UserProfileRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserProfileTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileTable>? orderByList,
     _i1.Transaction? transaction,
     UserProfileInclude? include,
@@ -491,8 +483,6 @@ class UserProfileRepository {
       where: where?.call(UserProfile.t),
       orderBy: orderBy?.call(UserProfile.t),
       orderByList: orderByList?.call(UserProfile.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -524,8 +514,6 @@ class UserProfileRepository {
     _i1.WhereExpressionBuilder<UserProfileTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserProfileTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileTable>? orderByList,
     _i1.Transaction? transaction,
     UserProfileInclude? include,
@@ -536,8 +524,6 @@ class UserProfileRepository {
       where: where?.call(UserProfile.t),
       orderBy: orderBy?.call(UserProfile.t),
       orderByList: orderByList?.call(UserProfile.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -745,8 +731,6 @@ class UserProfileRepository {
     int? offset,
     _i1.OrderByBuilder<UserProfileTable>? orderBy,
     _i1.OrderByListBuilder<UserProfileTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -757,8 +741,6 @@ class UserProfileRepository {
       offset: offset,
       orderBy: orderBy?.call(UserProfile.t),
       orderByList: orderByList?.call(UserProfile.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -779,8 +761,6 @@ class UserProfileRepository {
     _i1.DatabaseSession session,
     List<UserProfile> rows, {
     _i1.OrderByBuilder<UserProfileTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -789,8 +769,6 @@ class UserProfileRepository {
       rows,
       orderBy: orderBy?.call(UserProfile.t),
       orderByList: orderByList?.call(UserProfile.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -820,8 +798,6 @@ class UserProfileRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserProfileTable> where,
     _i1.OrderByBuilder<UserProfileTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -830,8 +806,6 @@ class UserProfileRepository {
       where: where(UserProfile.t),
       orderBy: orderBy?.call(UserProfile.t),
       orderByList: orderByList?.call(UserProfile.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/profile/models/user_profile_image.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/profile/models/user_profile_image.dart
@@ -138,8 +138,6 @@ abstract class UserProfileImage
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserProfileImageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileImageTable>? orderByList,
     UserProfileImageInclude? include,
   }) {
@@ -148,8 +146,6 @@ abstract class UserProfileImage
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UserProfileImage.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UserProfileImage.t),
       include: include,
     );
@@ -340,8 +336,6 @@ class UserProfileImageIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -388,8 +382,6 @@ class UserProfileImageRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserProfileImageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileImageTable>? orderByList,
     _i1.Transaction? transaction,
     UserProfileImageInclude? include,
@@ -400,8 +392,6 @@ class UserProfileImageRepository {
       where: where?.call(UserProfileImage.t),
       orderBy: orderBy?.call(UserProfileImage.t),
       orderByList: orderByList?.call(UserProfileImage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -433,8 +423,6 @@ class UserProfileImageRepository {
     _i1.WhereExpressionBuilder<UserProfileImageTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserProfileImageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileImageTable>? orderByList,
     _i1.Transaction? transaction,
     UserProfileImageInclude? include,
@@ -445,8 +433,6 @@ class UserProfileImageRepository {
       where: where?.call(UserProfileImage.t),
       orderBy: orderBy?.call(UserProfileImage.t),
       orderByList: orderByList?.call(UserProfileImage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -656,8 +642,6 @@ class UserProfileImageRepository {
     int? offset,
     _i1.OrderByBuilder<UserProfileImageTable>? orderBy,
     _i1.OrderByListBuilder<UserProfileImageTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -668,8 +652,6 @@ class UserProfileImageRepository {
       offset: offset,
       orderBy: orderBy?.call(UserProfileImage.t),
       orderByList: orderByList?.call(UserProfileImage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -690,8 +672,6 @@ class UserProfileImageRepository {
     _i1.DatabaseSession session,
     List<UserProfileImage> rows, {
     _i1.OrderByBuilder<UserProfileImageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileImageTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -700,8 +680,6 @@ class UserProfileImageRepository {
       rows,
       orderBy: orderBy?.call(UserProfileImage.t),
       orderByList: orderByList?.call(UserProfileImage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -731,8 +709,6 @@ class UserProfileImageRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserProfileImageTable> where,
     _i1.OrderByBuilder<UserProfileImageTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserProfileImageTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -741,8 +717,6 @@ class UserProfileImageRepository {
       where: where(UserProfileImage.t),
       orderBy: orderBy?.call(UserProfileImage.t),
       orderByList: orderByList?.call(UserProfileImage.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/session/models/server_side_session.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/generated/session/models/server_side_session.dart
@@ -190,8 +190,6 @@ abstract class ServerSideSession
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServerSideSessionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerSideSessionTable>? orderByList,
     ServerSideSessionInclude? include,
   }) {
@@ -200,8 +198,6 @@ abstract class ServerSideSession
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ServerSideSession.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ServerSideSession.t),
       include: include,
     );
@@ -485,8 +481,6 @@ class ServerSideSessionIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -533,8 +527,6 @@ class ServerSideSessionRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServerSideSessionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerSideSessionTable>? orderByList,
     _i1.Transaction? transaction,
     ServerSideSessionInclude? include,
@@ -545,8 +537,6 @@ class ServerSideSessionRepository {
       where: where?.call(ServerSideSession.t),
       orderBy: orderBy?.call(ServerSideSession.t),
       orderByList: orderByList?.call(ServerSideSession.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -578,8 +568,6 @@ class ServerSideSessionRepository {
     _i1.WhereExpressionBuilder<ServerSideSessionTable>? where,
     int? offset,
     _i1.OrderByBuilder<ServerSideSessionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerSideSessionTable>? orderByList,
     _i1.Transaction? transaction,
     ServerSideSessionInclude? include,
@@ -590,8 +578,6 @@ class ServerSideSessionRepository {
       where: where?.call(ServerSideSession.t),
       orderBy: orderBy?.call(ServerSideSession.t),
       orderByList: orderByList?.call(ServerSideSession.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -801,8 +787,6 @@ class ServerSideSessionRepository {
     int? offset,
     _i1.OrderByBuilder<ServerSideSessionTable>? orderBy,
     _i1.OrderByListBuilder<ServerSideSessionTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -813,8 +797,6 @@ class ServerSideSessionRepository {
       offset: offset,
       orderBy: orderBy?.call(ServerSideSession.t),
       orderByList: orderByList?.call(ServerSideSession.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -835,8 +817,6 @@ class ServerSideSessionRepository {
     _i1.DatabaseSession session,
     List<ServerSideSession> rows, {
     _i1.OrderByBuilder<ServerSideSessionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerSideSessionTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -845,8 +825,6 @@ class ServerSideSessionRepository {
       rows,
       orderBy: orderBy?.call(ServerSideSession.t),
       orderByList: orderByList?.call(ServerSideSession.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -876,8 +854,6 @@ class ServerSideSessionRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ServerSideSessionTable> where,
     _i1.OrderByBuilder<ServerSideSessionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerSideSessionTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -886,8 +862,6 @@ class ServerSideSessionRepository {
       where: where(ServerSideSession.t),
       orderBy: orderBy?.call(ServerSideSession.t),
       orderByList: orderByList?.call(ServerSideSession.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/common/rate_limited_request_attempt/models/rate_limited_request_attempt.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/common/rate_limited_request_attempt/models/rate_limited_request_attempt.dart
@@ -133,8 +133,6 @@ abstract class RateLimitedRequestAttempt
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RateLimitedRequestAttemptTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RateLimitedRequestAttemptTable>? orderByList,
     RateLimitedRequestAttemptInclude? include,
   }) {
@@ -143,8 +141,6 @@ abstract class RateLimitedRequestAttempt
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(RateLimitedRequestAttempt.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(RateLimitedRequestAttempt.t),
       include: include,
     );
@@ -332,8 +328,6 @@ class RateLimitedRequestAttemptIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -378,8 +372,6 @@ class RateLimitedRequestAttemptRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RateLimitedRequestAttemptTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RateLimitedRequestAttemptTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -389,8 +381,6 @@ class RateLimitedRequestAttemptRepository {
       where: where?.call(RateLimitedRequestAttempt.t),
       orderBy: orderBy?.call(RateLimitedRequestAttempt.t),
       orderByList: orderByList?.call(RateLimitedRequestAttempt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -421,8 +411,6 @@ class RateLimitedRequestAttemptRepository {
     _i1.WhereExpressionBuilder<RateLimitedRequestAttemptTable>? where,
     int? offset,
     _i1.OrderByBuilder<RateLimitedRequestAttemptTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RateLimitedRequestAttemptTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -432,8 +420,6 @@ class RateLimitedRequestAttemptRepository {
       where: where?.call(RateLimitedRequestAttempt.t),
       orderBy: orderBy?.call(RateLimitedRequestAttempt.t),
       orderByList: orderByList?.call(RateLimitedRequestAttempt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -642,8 +628,6 @@ class RateLimitedRequestAttemptRepository {
     int? offset,
     _i1.OrderByBuilder<RateLimitedRequestAttemptTable>? orderBy,
     _i1.OrderByListBuilder<RateLimitedRequestAttemptTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -654,8 +638,6 @@ class RateLimitedRequestAttemptRepository {
       offset: offset,
       orderBy: orderBy?.call(RateLimitedRequestAttempt.t),
       orderByList: orderByList?.call(RateLimitedRequestAttempt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -676,8 +658,6 @@ class RateLimitedRequestAttemptRepository {
     _i1.DatabaseSession session,
     List<RateLimitedRequestAttempt> rows, {
     _i1.OrderByBuilder<RateLimitedRequestAttemptTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RateLimitedRequestAttemptTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -686,8 +666,6 @@ class RateLimitedRequestAttemptRepository {
       rows,
       orderBy: orderBy?.call(RateLimitedRequestAttempt.t),
       orderByList: orderByList?.call(RateLimitedRequestAttempt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -717,8 +695,6 @@ class RateLimitedRequestAttemptRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RateLimitedRequestAttemptTable> where,
     _i1.OrderByBuilder<RateLimitedRequestAttemptTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RateLimitedRequestAttemptTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -727,8 +703,6 @@ class RateLimitedRequestAttemptRepository {
       where: where(RateLimitedRequestAttempt.t),
       orderBy: orderBy?.call(RateLimitedRequestAttempt.t),
       orderByList: orderByList?.call(RateLimitedRequestAttempt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/common/secret_challenge/models/secret_challenge.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/common/secret_challenge/models/secret_challenge.dart
@@ -80,8 +80,6 @@ abstract class SecretChallenge
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SecretChallengeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SecretChallengeTable>? orderByList,
     SecretChallengeInclude? include,
   }) {
@@ -90,8 +88,6 @@ abstract class SecretChallenge
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(SecretChallenge.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(SecretChallenge.t),
       include: include,
     );
@@ -179,8 +175,6 @@ class SecretChallengeIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -225,8 +219,6 @@ class SecretChallengeRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SecretChallengeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SecretChallengeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -236,8 +228,6 @@ class SecretChallengeRepository {
       where: where?.call(SecretChallenge.t),
       orderBy: orderBy?.call(SecretChallenge.t),
       orderByList: orderByList?.call(SecretChallenge.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -268,8 +258,6 @@ class SecretChallengeRepository {
     _i1.WhereExpressionBuilder<SecretChallengeTable>? where,
     int? offset,
     _i1.OrderByBuilder<SecretChallengeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SecretChallengeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -279,8 +267,6 @@ class SecretChallengeRepository {
       where: where?.call(SecretChallenge.t),
       orderBy: orderBy?.call(SecretChallenge.t),
       orderByList: orderByList?.call(SecretChallenge.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -487,8 +473,6 @@ class SecretChallengeRepository {
     int? offset,
     _i1.OrderByBuilder<SecretChallengeTable>? orderBy,
     _i1.OrderByListBuilder<SecretChallengeTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -499,8 +483,6 @@ class SecretChallengeRepository {
       offset: offset,
       orderBy: orderBy?.call(SecretChallenge.t),
       orderByList: orderByList?.call(SecretChallenge.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -521,8 +503,6 @@ class SecretChallengeRepository {
     _i1.DatabaseSession session,
     List<SecretChallenge> rows, {
     _i1.OrderByBuilder<SecretChallengeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SecretChallengeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -531,8 +511,6 @@ class SecretChallengeRepository {
       rows,
       orderBy: orderBy?.call(SecretChallenge.t),
       orderByList: orderByList?.call(SecretChallenge.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -562,8 +540,6 @@ class SecretChallengeRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SecretChallengeTable> where,
     _i1.OrderByBuilder<SecretChallengeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SecretChallengeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -572,8 +548,6 @@ class SecretChallengeRepository {
       where: where(SecretChallenge.t),
       orderBy: orderBy?.call(SecretChallenge.t),
       orderByList: orderByList?.call(SecretChallenge.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/anonymous/models/anonymous_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/anonymous/models/anonymous_account.dart
@@ -106,8 +106,6 @@ abstract class AnonymousAccount
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AnonymousAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AnonymousAccountTable>? orderByList,
     AnonymousAccountInclude? include,
   }) {
@@ -116,8 +114,6 @@ abstract class AnonymousAccount
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(AnonymousAccount.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(AnonymousAccount.t),
       include: include,
     );
@@ -256,8 +252,6 @@ class AnonymousAccountIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -304,8 +298,6 @@ class AnonymousAccountRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AnonymousAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AnonymousAccountTable>? orderByList,
     _i1.Transaction? transaction,
     AnonymousAccountInclude? include,
@@ -316,8 +308,6 @@ class AnonymousAccountRepository {
       where: where?.call(AnonymousAccount.t),
       orderBy: orderBy?.call(AnonymousAccount.t),
       orderByList: orderByList?.call(AnonymousAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -349,8 +339,6 @@ class AnonymousAccountRepository {
     _i1.WhereExpressionBuilder<AnonymousAccountTable>? where,
     int? offset,
     _i1.OrderByBuilder<AnonymousAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AnonymousAccountTable>? orderByList,
     _i1.Transaction? transaction,
     AnonymousAccountInclude? include,
@@ -361,8 +349,6 @@ class AnonymousAccountRepository {
       where: where?.call(AnonymousAccount.t),
       orderBy: orderBy?.call(AnonymousAccount.t),
       orderByList: orderByList?.call(AnonymousAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -572,8 +558,6 @@ class AnonymousAccountRepository {
     int? offset,
     _i1.OrderByBuilder<AnonymousAccountTable>? orderBy,
     _i1.OrderByListBuilder<AnonymousAccountTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -584,8 +568,6 @@ class AnonymousAccountRepository {
       offset: offset,
       orderBy: orderBy?.call(AnonymousAccount.t),
       orderByList: orderByList?.call(AnonymousAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -606,8 +588,6 @@ class AnonymousAccountRepository {
     _i1.DatabaseSession session,
     List<AnonymousAccount> rows, {
     _i1.OrderByBuilder<AnonymousAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AnonymousAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -616,8 +596,6 @@ class AnonymousAccountRepository {
       rows,
       orderBy: orderBy?.call(AnonymousAccount.t),
       orderByList: orderByList?.call(AnonymousAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -647,8 +625,6 @@ class AnonymousAccountRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AnonymousAccountTable> where,
     _i1.OrderByBuilder<AnonymousAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AnonymousAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -657,8 +633,6 @@ class AnonymousAccountRepository {
       where: where(AnonymousAccount.t),
       orderBy: orderBy?.call(AnonymousAccount.t),
       orderByList: orderByList?.call(AnonymousAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/apple/models/apple_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/apple/models/apple_account.dart
@@ -207,8 +207,6 @@ abstract class AppleAccount
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AppleAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AppleAccountTable>? orderByList,
     AppleAccountInclude? include,
   }) {
@@ -217,8 +215,6 @@ abstract class AppleAccount
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(AppleAccount.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(AppleAccount.t),
       include: include,
     );
@@ -538,8 +534,6 @@ class AppleAccountIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -586,8 +580,6 @@ class AppleAccountRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AppleAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AppleAccountTable>? orderByList,
     _i1.Transaction? transaction,
     AppleAccountInclude? include,
@@ -598,8 +590,6 @@ class AppleAccountRepository {
       where: where?.call(AppleAccount.t),
       orderBy: orderBy?.call(AppleAccount.t),
       orderByList: orderByList?.call(AppleAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -631,8 +621,6 @@ class AppleAccountRepository {
     _i1.WhereExpressionBuilder<AppleAccountTable>? where,
     int? offset,
     _i1.OrderByBuilder<AppleAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AppleAccountTable>? orderByList,
     _i1.Transaction? transaction,
     AppleAccountInclude? include,
@@ -643,8 +631,6 @@ class AppleAccountRepository {
       where: where?.call(AppleAccount.t),
       orderBy: orderBy?.call(AppleAccount.t),
       orderByList: orderByList?.call(AppleAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -852,8 +838,6 @@ class AppleAccountRepository {
     int? offset,
     _i1.OrderByBuilder<AppleAccountTable>? orderBy,
     _i1.OrderByListBuilder<AppleAccountTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -864,8 +848,6 @@ class AppleAccountRepository {
       offset: offset,
       orderBy: orderBy?.call(AppleAccount.t),
       orderByList: orderByList?.call(AppleAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -886,8 +868,6 @@ class AppleAccountRepository {
     _i1.DatabaseSession session,
     List<AppleAccount> rows, {
     _i1.OrderByBuilder<AppleAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AppleAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -896,8 +876,6 @@ class AppleAccountRepository {
       rows,
       orderBy: orderBy?.call(AppleAccount.t),
       orderByList: orderByList?.call(AppleAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -927,8 +905,6 @@ class AppleAccountRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AppleAccountTable> where,
     _i1.OrderByBuilder<AppleAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AppleAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -937,8 +913,6 @@ class AppleAccountRepository {
       where: where(AppleAccount.t),
       orderBy: orderBy?.call(AppleAccount.t),
       orderByList: orderByList?.call(AppleAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account.dart
@@ -124,8 +124,6 @@ abstract class EmailAccount
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountTable>? orderByList,
     EmailAccountInclude? include,
   }) {
@@ -134,8 +132,6 @@ abstract class EmailAccount
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EmailAccount.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EmailAccount.t),
       include: include,
     );
@@ -311,8 +307,6 @@ class EmailAccountIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -359,8 +353,6 @@ class EmailAccountRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountTable>? orderByList,
     _i1.Transaction? transaction,
     EmailAccountInclude? include,
@@ -371,8 +363,6 @@ class EmailAccountRepository {
       where: where?.call(EmailAccount.t),
       orderBy: orderBy?.call(EmailAccount.t),
       orderByList: orderByList?.call(EmailAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -404,8 +394,6 @@ class EmailAccountRepository {
     _i1.WhereExpressionBuilder<EmailAccountTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmailAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountTable>? orderByList,
     _i1.Transaction? transaction,
     EmailAccountInclude? include,
@@ -416,8 +404,6 @@ class EmailAccountRepository {
       where: where?.call(EmailAccount.t),
       orderBy: orderBy?.call(EmailAccount.t),
       orderByList: orderByList?.call(EmailAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -625,8 +611,6 @@ class EmailAccountRepository {
     int? offset,
     _i1.OrderByBuilder<EmailAccountTable>? orderBy,
     _i1.OrderByListBuilder<EmailAccountTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -637,8 +621,6 @@ class EmailAccountRepository {
       offset: offset,
       orderBy: orderBy?.call(EmailAccount.t),
       orderByList: orderByList?.call(EmailAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -659,8 +641,6 @@ class EmailAccountRepository {
     _i1.DatabaseSession session,
     List<EmailAccount> rows, {
     _i1.OrderByBuilder<EmailAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -669,8 +649,6 @@ class EmailAccountRepository {
       rows,
       orderBy: orderBy?.call(EmailAccount.t),
       orderByList: orderByList?.call(EmailAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -700,8 +678,6 @@ class EmailAccountRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmailAccountTable> where,
     _i1.OrderByBuilder<EmailAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -710,8 +686,6 @@ class EmailAccountRepository {
       where: where(EmailAccount.t),
       orderBy: orderBy?.call(EmailAccount.t),
       orderByList: orderByList?.call(EmailAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account_password_reset_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account_password_reset_request.dart
@@ -162,8 +162,6 @@ abstract class EmailAccountPasswordResetRequest
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailAccountPasswordResetRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountPasswordResetRequestTable>? orderByList,
     EmailAccountPasswordResetRequestInclude? include,
   }) {
@@ -172,8 +170,6 @@ abstract class EmailAccountPasswordResetRequest
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EmailAccountPasswordResetRequest.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EmailAccountPasswordResetRequest.t),
       include: include,
     );
@@ -419,8 +415,6 @@ class EmailAccountPasswordResetRequestIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -471,8 +465,6 @@ class EmailAccountPasswordResetRequestRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailAccountPasswordResetRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountPasswordResetRequestTable>? orderByList,
     _i1.Transaction? transaction,
     EmailAccountPasswordResetRequestInclude? include,
@@ -483,8 +475,6 @@ class EmailAccountPasswordResetRequestRepository {
       where: where?.call(EmailAccountPasswordResetRequest.t),
       orderBy: orderBy?.call(EmailAccountPasswordResetRequest.t),
       orderByList: orderByList?.call(EmailAccountPasswordResetRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -516,8 +506,6 @@ class EmailAccountPasswordResetRequestRepository {
     _i1.WhereExpressionBuilder<EmailAccountPasswordResetRequestTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmailAccountPasswordResetRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountPasswordResetRequestTable>? orderByList,
     _i1.Transaction? transaction,
     EmailAccountPasswordResetRequestInclude? include,
@@ -528,8 +516,6 @@ class EmailAccountPasswordResetRequestRepository {
       where: where?.call(EmailAccountPasswordResetRequest.t),
       orderBy: orderBy?.call(EmailAccountPasswordResetRequest.t),
       orderByList: orderByList?.call(EmailAccountPasswordResetRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -750,8 +736,6 @@ class EmailAccountPasswordResetRequestRepository {
     int? offset,
     _i1.OrderByBuilder<EmailAccountPasswordResetRequestTable>? orderBy,
     _i1.OrderByListBuilder<EmailAccountPasswordResetRequestTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -764,8 +748,6 @@ class EmailAccountPasswordResetRequestRepository {
       offset: offset,
       orderBy: orderBy?.call(EmailAccountPasswordResetRequest.t),
       orderByList: orderByList?.call(EmailAccountPasswordResetRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -786,8 +768,6 @@ class EmailAccountPasswordResetRequestRepository {
     _i1.DatabaseSession session,
     List<EmailAccountPasswordResetRequest> rows, {
     _i1.OrderByBuilder<EmailAccountPasswordResetRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountPasswordResetRequestTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -796,8 +776,6 @@ class EmailAccountPasswordResetRequestRepository {
       rows,
       orderBy: orderBy?.call(EmailAccountPasswordResetRequest.t),
       orderByList: orderByList?.call(EmailAccountPasswordResetRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -828,8 +806,6 @@ class EmailAccountPasswordResetRequestRepository {
     required _i1.WhereExpressionBuilder<EmailAccountPasswordResetRequestTable>
     where,
     _i1.OrderByBuilder<EmailAccountPasswordResetRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountPasswordResetRequestTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -838,8 +814,6 @@ class EmailAccountPasswordResetRequestRepository {
       where: where(EmailAccountPasswordResetRequest.t),
       orderBy: orderBy?.call(EmailAccountPasswordResetRequest.t),
       orderByList: orderByList?.call(EmailAccountPasswordResetRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account_request.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/email/models/email_account_request.dart
@@ -147,8 +147,6 @@ abstract class EmailAccountRequest
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailAccountRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountRequestTable>? orderByList,
     EmailAccountRequestInclude? include,
   }) {
@@ -157,8 +155,6 @@ abstract class EmailAccountRequest
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EmailAccountRequest.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EmailAccountRequest.t),
       include: include,
     );
@@ -372,8 +368,6 @@ class EmailAccountRequestIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -422,8 +416,6 @@ class EmailAccountRequestRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmailAccountRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
     EmailAccountRequestInclude? include,
@@ -434,8 +426,6 @@ class EmailAccountRequestRepository {
       where: where?.call(EmailAccountRequest.t),
       orderBy: orderBy?.call(EmailAccountRequest.t),
       orderByList: orderByList?.call(EmailAccountRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -467,8 +457,6 @@ class EmailAccountRequestRepository {
     _i1.WhereExpressionBuilder<EmailAccountRequestTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmailAccountRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
     EmailAccountRequestInclude? include,
@@ -479,8 +467,6 @@ class EmailAccountRequestRepository {
       where: where?.call(EmailAccountRequest.t),
       orderBy: orderBy?.call(EmailAccountRequest.t),
       orderByList: orderByList?.call(EmailAccountRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -690,8 +676,6 @@ class EmailAccountRequestRepository {
     int? offset,
     _i1.OrderByBuilder<EmailAccountRequestTable>? orderBy,
     _i1.OrderByListBuilder<EmailAccountRequestTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -702,8 +686,6 @@ class EmailAccountRequestRepository {
       offset: offset,
       orderBy: orderBy?.call(EmailAccountRequest.t),
       orderByList: orderByList?.call(EmailAccountRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -724,8 +706,6 @@ class EmailAccountRequestRepository {
     _i1.DatabaseSession session,
     List<EmailAccountRequest> rows, {
     _i1.OrderByBuilder<EmailAccountRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -734,8 +714,6 @@ class EmailAccountRequestRepository {
       rows,
       orderBy: orderBy?.call(EmailAccountRequest.t),
       orderByList: orderByList?.call(EmailAccountRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -765,8 +743,6 @@ class EmailAccountRequestRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmailAccountRequestTable> where,
     _i1.OrderByBuilder<EmailAccountRequestTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmailAccountRequestTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -775,8 +751,6 @@ class EmailAccountRequestRepository {
       where: where(EmailAccountRequest.t),
       orderBy: orderBy?.call(EmailAccountRequest.t),
       orderByList: orderByList?.call(EmailAccountRequest.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/facebook/models/facebook_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/facebook/models/facebook_account.dart
@@ -153,8 +153,6 @@ abstract class FacebookAccount
     int? limit,
     int? offset,
     _i1.OrderByBuilder<FacebookAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FacebookAccountTable>? orderByList,
     FacebookAccountInclude? include,
   }) {
@@ -163,8 +161,6 @@ abstract class FacebookAccount
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(FacebookAccount.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(FacebookAccount.t),
       include: include,
     );
@@ -397,8 +393,6 @@ class FacebookAccountIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -445,8 +439,6 @@ class FacebookAccountRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<FacebookAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FacebookAccountTable>? orderByList,
     _i1.Transaction? transaction,
     FacebookAccountInclude? include,
@@ -457,8 +449,6 @@ class FacebookAccountRepository {
       where: where?.call(FacebookAccount.t),
       orderBy: orderBy?.call(FacebookAccount.t),
       orderByList: orderByList?.call(FacebookAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -490,8 +480,6 @@ class FacebookAccountRepository {
     _i1.WhereExpressionBuilder<FacebookAccountTable>? where,
     int? offset,
     _i1.OrderByBuilder<FacebookAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FacebookAccountTable>? orderByList,
     _i1.Transaction? transaction,
     FacebookAccountInclude? include,
@@ -502,8 +490,6 @@ class FacebookAccountRepository {
       where: where?.call(FacebookAccount.t),
       orderBy: orderBy?.call(FacebookAccount.t),
       orderByList: orderByList?.call(FacebookAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -713,8 +699,6 @@ class FacebookAccountRepository {
     int? offset,
     _i1.OrderByBuilder<FacebookAccountTable>? orderBy,
     _i1.OrderByListBuilder<FacebookAccountTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -725,8 +709,6 @@ class FacebookAccountRepository {
       offset: offset,
       orderBy: orderBy?.call(FacebookAccount.t),
       orderByList: orderByList?.call(FacebookAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -747,8 +729,6 @@ class FacebookAccountRepository {
     _i1.DatabaseSession session,
     List<FacebookAccount> rows, {
     _i1.OrderByBuilder<FacebookAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FacebookAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -757,8 +737,6 @@ class FacebookAccountRepository {
       rows,
       orderBy: orderBy?.call(FacebookAccount.t),
       orderByList: orderByList?.call(FacebookAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -788,8 +766,6 @@ class FacebookAccountRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<FacebookAccountTable> where,
     _i1.OrderByBuilder<FacebookAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FacebookAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -798,8 +774,6 @@ class FacebookAccountRepository {
       where: where(FacebookAccount.t),
       orderBy: orderBy?.call(FacebookAccount.t),
       orderByList: orderByList?.call(FacebookAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/firebase/models/firebase_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/firebase/models/firebase_account.dart
@@ -135,8 +135,6 @@ abstract class FirebaseAccount
     int? limit,
     int? offset,
     _i1.OrderByBuilder<FirebaseAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FirebaseAccountTable>? orderByList,
     FirebaseAccountInclude? include,
   }) {
@@ -145,8 +143,6 @@ abstract class FirebaseAccount
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(FirebaseAccount.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(FirebaseAccount.t),
       include: include,
     );
@@ -343,8 +339,6 @@ class FirebaseAccountIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -391,8 +385,6 @@ class FirebaseAccountRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<FirebaseAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FirebaseAccountTable>? orderByList,
     _i1.Transaction? transaction,
     FirebaseAccountInclude? include,
@@ -403,8 +395,6 @@ class FirebaseAccountRepository {
       where: where?.call(FirebaseAccount.t),
       orderBy: orderBy?.call(FirebaseAccount.t),
       orderByList: orderByList?.call(FirebaseAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -436,8 +426,6 @@ class FirebaseAccountRepository {
     _i1.WhereExpressionBuilder<FirebaseAccountTable>? where,
     int? offset,
     _i1.OrderByBuilder<FirebaseAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FirebaseAccountTable>? orderByList,
     _i1.Transaction? transaction,
     FirebaseAccountInclude? include,
@@ -448,8 +436,6 @@ class FirebaseAccountRepository {
       where: where?.call(FirebaseAccount.t),
       orderBy: orderBy?.call(FirebaseAccount.t),
       orderByList: orderByList?.call(FirebaseAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -659,8 +645,6 @@ class FirebaseAccountRepository {
     int? offset,
     _i1.OrderByBuilder<FirebaseAccountTable>? orderBy,
     _i1.OrderByListBuilder<FirebaseAccountTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -671,8 +655,6 @@ class FirebaseAccountRepository {
       offset: offset,
       orderBy: orderBy?.call(FirebaseAccount.t),
       orderByList: orderByList?.call(FirebaseAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -693,8 +675,6 @@ class FirebaseAccountRepository {
     _i1.DatabaseSession session,
     List<FirebaseAccount> rows, {
     _i1.OrderByBuilder<FirebaseAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FirebaseAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -703,8 +683,6 @@ class FirebaseAccountRepository {
       rows,
       orderBy: orderBy?.call(FirebaseAccount.t),
       orderByList: orderByList?.call(FirebaseAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -734,8 +712,6 @@ class FirebaseAccountRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<FirebaseAccountTable> where,
     _i1.OrderByBuilder<FirebaseAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FirebaseAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -744,8 +720,6 @@ class FirebaseAccountRepository {
       where: where(FirebaseAccount.t),
       orderBy: orderBy?.call(FirebaseAccount.t),
       orderByList: orderByList?.call(FirebaseAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/github/models/github_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/github/models/github_account.dart
@@ -127,8 +127,6 @@ abstract class GitHubAccount
     int? limit,
     int? offset,
     _i1.OrderByBuilder<GitHubAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GitHubAccountTable>? orderByList,
     GitHubAccountInclude? include,
   }) {
@@ -137,8 +135,6 @@ abstract class GitHubAccount
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(GitHubAccount.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(GitHubAccount.t),
       include: include,
     );
@@ -318,8 +314,6 @@ class GitHubAccountIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -366,8 +360,6 @@ class GitHubAccountRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<GitHubAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GitHubAccountTable>? orderByList,
     _i1.Transaction? transaction,
     GitHubAccountInclude? include,
@@ -378,8 +370,6 @@ class GitHubAccountRepository {
       where: where?.call(GitHubAccount.t),
       orderBy: orderBy?.call(GitHubAccount.t),
       orderByList: orderByList?.call(GitHubAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -411,8 +401,6 @@ class GitHubAccountRepository {
     _i1.WhereExpressionBuilder<GitHubAccountTable>? where,
     int? offset,
     _i1.OrderByBuilder<GitHubAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GitHubAccountTable>? orderByList,
     _i1.Transaction? transaction,
     GitHubAccountInclude? include,
@@ -423,8 +411,6 @@ class GitHubAccountRepository {
       where: where?.call(GitHubAccount.t),
       orderBy: orderBy?.call(GitHubAccount.t),
       orderByList: orderByList?.call(GitHubAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -632,8 +618,6 @@ class GitHubAccountRepository {
     int? offset,
     _i1.OrderByBuilder<GitHubAccountTable>? orderBy,
     _i1.OrderByListBuilder<GitHubAccountTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -644,8 +628,6 @@ class GitHubAccountRepository {
       offset: offset,
       orderBy: orderBy?.call(GitHubAccount.t),
       orderByList: orderByList?.call(GitHubAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -666,8 +648,6 @@ class GitHubAccountRepository {
     _i1.DatabaseSession session,
     List<GitHubAccount> rows, {
     _i1.OrderByBuilder<GitHubAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GitHubAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -676,8 +656,6 @@ class GitHubAccountRepository {
       rows,
       orderBy: orderBy?.call(GitHubAccount.t),
       orderByList: orderByList?.call(GitHubAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -707,8 +685,6 @@ class GitHubAccountRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<GitHubAccountTable> where,
     _i1.OrderByBuilder<GitHubAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GitHubAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -717,8 +693,6 @@ class GitHubAccountRepository {
       where: where(GitHubAccount.t),
       orderBy: orderBy?.call(GitHubAccount.t),
       orderByList: orderByList?.call(GitHubAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/google/models/google_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/google/models/google_account.dart
@@ -125,8 +125,6 @@ abstract class GoogleAccount
     int? limit,
     int? offset,
     _i1.OrderByBuilder<GoogleAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleAccountTable>? orderByList,
     GoogleAccountInclude? include,
   }) {
@@ -135,8 +133,6 @@ abstract class GoogleAccount
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(GoogleAccount.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(GoogleAccount.t),
       include: include,
     );
@@ -314,8 +310,6 @@ class GoogleAccountIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -362,8 +356,6 @@ class GoogleAccountRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<GoogleAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleAccountTable>? orderByList,
     _i1.Transaction? transaction,
     GoogleAccountInclude? include,
@@ -374,8 +366,6 @@ class GoogleAccountRepository {
       where: where?.call(GoogleAccount.t),
       orderBy: orderBy?.call(GoogleAccount.t),
       orderByList: orderByList?.call(GoogleAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -407,8 +397,6 @@ class GoogleAccountRepository {
     _i1.WhereExpressionBuilder<GoogleAccountTable>? where,
     int? offset,
     _i1.OrderByBuilder<GoogleAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleAccountTable>? orderByList,
     _i1.Transaction? transaction,
     GoogleAccountInclude? include,
@@ -419,8 +407,6 @@ class GoogleAccountRepository {
       where: where?.call(GoogleAccount.t),
       orderBy: orderBy?.call(GoogleAccount.t),
       orderByList: orderByList?.call(GoogleAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -628,8 +614,6 @@ class GoogleAccountRepository {
     int? offset,
     _i1.OrderByBuilder<GoogleAccountTable>? orderBy,
     _i1.OrderByListBuilder<GoogleAccountTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -640,8 +624,6 @@ class GoogleAccountRepository {
       offset: offset,
       orderBy: orderBy?.call(GoogleAccount.t),
       orderByList: orderByList?.call(GoogleAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -662,8 +644,6 @@ class GoogleAccountRepository {
     _i1.DatabaseSession session,
     List<GoogleAccount> rows, {
     _i1.OrderByBuilder<GoogleAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -672,8 +652,6 @@ class GoogleAccountRepository {
       rows,
       orderBy: orderBy?.call(GoogleAccount.t),
       orderByList: orderByList?.call(GoogleAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -703,8 +681,6 @@ class GoogleAccountRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<GoogleAccountTable> where,
     _i1.OrderByBuilder<GoogleAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GoogleAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -713,8 +689,6 @@ class GoogleAccountRepository {
       where: where(GoogleAccount.t),
       orderBy: orderBy?.call(GoogleAccount.t),
       orderByList: orderByList?.call(GoogleAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/microsoft/models/microsoft_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/microsoft/models/microsoft_account.dart
@@ -127,8 +127,6 @@ abstract class MicrosoftAccount
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MicrosoftAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MicrosoftAccountTable>? orderByList,
     MicrosoftAccountInclude? include,
   }) {
@@ -137,8 +135,6 @@ abstract class MicrosoftAccount
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(MicrosoftAccount.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(MicrosoftAccount.t),
       include: include,
     );
@@ -319,8 +315,6 @@ class MicrosoftAccountIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -367,8 +361,6 @@ class MicrosoftAccountRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MicrosoftAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MicrosoftAccountTable>? orderByList,
     _i1.Transaction? transaction,
     MicrosoftAccountInclude? include,
@@ -379,8 +371,6 @@ class MicrosoftAccountRepository {
       where: where?.call(MicrosoftAccount.t),
       orderBy: orderBy?.call(MicrosoftAccount.t),
       orderByList: orderByList?.call(MicrosoftAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -412,8 +402,6 @@ class MicrosoftAccountRepository {
     _i1.WhereExpressionBuilder<MicrosoftAccountTable>? where,
     int? offset,
     _i1.OrderByBuilder<MicrosoftAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MicrosoftAccountTable>? orderByList,
     _i1.Transaction? transaction,
     MicrosoftAccountInclude? include,
@@ -424,8 +412,6 @@ class MicrosoftAccountRepository {
       where: where?.call(MicrosoftAccount.t),
       orderBy: orderBy?.call(MicrosoftAccount.t),
       orderByList: orderByList?.call(MicrosoftAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -635,8 +621,6 @@ class MicrosoftAccountRepository {
     int? offset,
     _i1.OrderByBuilder<MicrosoftAccountTable>? orderBy,
     _i1.OrderByListBuilder<MicrosoftAccountTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -647,8 +631,6 @@ class MicrosoftAccountRepository {
       offset: offset,
       orderBy: orderBy?.call(MicrosoftAccount.t),
       orderByList: orderByList?.call(MicrosoftAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -669,8 +651,6 @@ class MicrosoftAccountRepository {
     _i1.DatabaseSession session,
     List<MicrosoftAccount> rows, {
     _i1.OrderByBuilder<MicrosoftAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MicrosoftAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -679,8 +659,6 @@ class MicrosoftAccountRepository {
       rows,
       orderBy: orderBy?.call(MicrosoftAccount.t),
       orderByList: orderByList?.call(MicrosoftAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -710,8 +688,6 @@ class MicrosoftAccountRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MicrosoftAccountTable> where,
     _i1.OrderByBuilder<MicrosoftAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MicrosoftAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -720,8 +696,6 @@ class MicrosoftAccountRepository {
       where: where(MicrosoftAccount.t),
       orderBy: orderBy?.call(MicrosoftAccount.t),
       orderByList: orderByList?.call(MicrosoftAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/passkey/models/passkey_account.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/passkey/models/passkey_account.dart
@@ -151,8 +151,6 @@ abstract class PasskeyAccount
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PasskeyAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyAccountTable>? orderByList,
     PasskeyAccountInclude? include,
   }) {
@@ -161,8 +159,6 @@ abstract class PasskeyAccount
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(PasskeyAccount.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(PasskeyAccount.t),
       include: include,
     );
@@ -392,8 +388,6 @@ class PasskeyAccountIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -440,8 +434,6 @@ class PasskeyAccountRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PasskeyAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyAccountTable>? orderByList,
     _i1.Transaction? transaction,
     PasskeyAccountInclude? include,
@@ -452,8 +444,6 @@ class PasskeyAccountRepository {
       where: where?.call(PasskeyAccount.t),
       orderBy: orderBy?.call(PasskeyAccount.t),
       orderByList: orderByList?.call(PasskeyAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -485,8 +475,6 @@ class PasskeyAccountRepository {
     _i1.WhereExpressionBuilder<PasskeyAccountTable>? where,
     int? offset,
     _i1.OrderByBuilder<PasskeyAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyAccountTable>? orderByList,
     _i1.Transaction? transaction,
     PasskeyAccountInclude? include,
@@ -497,8 +485,6 @@ class PasskeyAccountRepository {
       where: where?.call(PasskeyAccount.t),
       orderBy: orderBy?.call(PasskeyAccount.t),
       orderByList: orderByList?.call(PasskeyAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -706,8 +692,6 @@ class PasskeyAccountRepository {
     int? offset,
     _i1.OrderByBuilder<PasskeyAccountTable>? orderBy,
     _i1.OrderByListBuilder<PasskeyAccountTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -718,8 +702,6 @@ class PasskeyAccountRepository {
       offset: offset,
       orderBy: orderBy?.call(PasskeyAccount.t),
       orderByList: orderByList?.call(PasskeyAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -740,8 +722,6 @@ class PasskeyAccountRepository {
     _i1.DatabaseSession session,
     List<PasskeyAccount> rows, {
     _i1.OrderByBuilder<PasskeyAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -750,8 +730,6 @@ class PasskeyAccountRepository {
       rows,
       orderBy: orderBy?.call(PasskeyAccount.t),
       orderByList: orderByList?.call(PasskeyAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -781,8 +759,6 @@ class PasskeyAccountRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PasskeyAccountTable> where,
     _i1.OrderByBuilder<PasskeyAccountTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyAccountTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -791,8 +767,6 @@ class PasskeyAccountRepository {
       where: where(PasskeyAccount.t),
       orderBy: orderBy?.call(PasskeyAccount.t),
       orderByList: orderByList?.call(PasskeyAccount.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/passkey/models/passkey_challenge.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/generated/providers/passkey/models/passkey_challenge.dart
@@ -90,8 +90,6 @@ abstract class PasskeyChallenge
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PasskeyChallengeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyChallengeTable>? orderByList,
     PasskeyChallengeInclude? include,
   }) {
@@ -100,8 +98,6 @@ abstract class PasskeyChallenge
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(PasskeyChallenge.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(PasskeyChallenge.t),
       include: include,
     );
@@ -206,8 +202,6 @@ class PasskeyChallengeIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -252,8 +246,6 @@ class PasskeyChallengeRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PasskeyChallengeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyChallengeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -263,8 +255,6 @@ class PasskeyChallengeRepository {
       where: where?.call(PasskeyChallenge.t),
       orderBy: orderBy?.call(PasskeyChallenge.t),
       orderByList: orderByList?.call(PasskeyChallenge.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -295,8 +285,6 @@ class PasskeyChallengeRepository {
     _i1.WhereExpressionBuilder<PasskeyChallengeTable>? where,
     int? offset,
     _i1.OrderByBuilder<PasskeyChallengeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyChallengeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -306,8 +294,6 @@ class PasskeyChallengeRepository {
       where: where?.call(PasskeyChallenge.t),
       orderBy: orderBy?.call(PasskeyChallenge.t),
       orderByList: orderByList?.call(PasskeyChallenge.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -514,8 +500,6 @@ class PasskeyChallengeRepository {
     int? offset,
     _i1.OrderByBuilder<PasskeyChallengeTable>? orderBy,
     _i1.OrderByListBuilder<PasskeyChallengeTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -526,8 +510,6 @@ class PasskeyChallengeRepository {
       offset: offset,
       orderBy: orderBy?.call(PasskeyChallenge.t),
       orderByList: orderByList?.call(PasskeyChallenge.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -548,8 +530,6 @@ class PasskeyChallengeRepository {
     _i1.DatabaseSession session,
     List<PasskeyChallenge> rows, {
     _i1.OrderByBuilder<PasskeyChallengeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyChallengeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -558,8 +538,6 @@ class PasskeyChallengeRepository {
       rows,
       orderBy: orderBy?.call(PasskeyChallenge.t),
       orderByList: orderByList?.call(PasskeyChallenge.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -589,8 +567,6 @@ class PasskeyChallengeRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PasskeyChallengeTable> where,
     _i1.OrderByBuilder<PasskeyChallengeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PasskeyChallengeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -599,8 +575,6 @@ class PasskeyChallengeRepository {
       where: where(PasskeyChallenge.t),
       orderBy: orderBy?.call(PasskeyChallenge.t),
       orderByList: orderByList?.call(PasskeyChallenge.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/migrated_user.dart
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/lib/src/generated/migrated_user.dart
@@ -118,8 +118,6 @@ abstract class MigratedUser
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MigratedUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MigratedUserTable>? orderByList,
     MigratedUserInclude? include,
   }) {
@@ -128,8 +126,6 @@ abstract class MigratedUser
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(MigratedUser.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(MigratedUser.t),
       include: include,
     );
@@ -297,8 +293,6 @@ class MigratedUserIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -345,8 +339,6 @@ class MigratedUserRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MigratedUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MigratedUserTable>? orderByList,
     _i1.Transaction? transaction,
     MigratedUserInclude? include,
@@ -357,8 +349,6 @@ class MigratedUserRepository {
       where: where?.call(MigratedUser.t),
       orderBy: orderBy?.call(MigratedUser.t),
       orderByList: orderByList?.call(MigratedUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -390,8 +380,6 @@ class MigratedUserRepository {
     _i1.WhereExpressionBuilder<MigratedUserTable>? where,
     int? offset,
     _i1.OrderByBuilder<MigratedUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MigratedUserTable>? orderByList,
     _i1.Transaction? transaction,
     MigratedUserInclude? include,
@@ -402,8 +390,6 @@ class MigratedUserRepository {
       where: where?.call(MigratedUser.t),
       orderBy: orderBy?.call(MigratedUser.t),
       orderByList: orderByList?.call(MigratedUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -611,8 +597,6 @@ class MigratedUserRepository {
     int? offset,
     _i1.OrderByBuilder<MigratedUserTable>? orderBy,
     _i1.OrderByListBuilder<MigratedUserTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -623,8 +607,6 @@ class MigratedUserRepository {
       offset: offset,
       orderBy: orderBy?.call(MigratedUser.t),
       orderByList: orderByList?.call(MigratedUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -645,8 +627,6 @@ class MigratedUserRepository {
     _i1.DatabaseSession session,
     List<MigratedUser> rows, {
     _i1.OrderByBuilder<MigratedUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MigratedUserTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -655,8 +635,6 @@ class MigratedUserRepository {
       rows,
       orderBy: orderBy?.call(MigratedUser.t),
       orderByList: orderByList?.call(MigratedUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -686,8 +664,6 @@ class MigratedUserRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MigratedUserTable> where,
     _i1.OrderByBuilder<MigratedUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MigratedUserTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -696,8 +672,6 @@ class MigratedUserRepository {
       where: where(MigratedUser.t),
       orderBy: orderBy?.call(MigratedUser.t),
       orderByList: orderByList?.call(MigratedUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/cloud_storage.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage.dart
@@ -131,8 +131,6 @@ abstract class CloudStorageEntry
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CloudStorageEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageEntryTable>? orderByList,
     CloudStorageEntryInclude? include,
   }) {
@@ -141,8 +139,6 @@ abstract class CloudStorageEntry
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CloudStorageEntry.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CloudStorageEntry.t),
       include: include,
     );
@@ -316,8 +312,6 @@ class CloudStorageEntryIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -362,8 +356,6 @@ class CloudStorageEntryRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CloudStorageEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -373,8 +365,6 @@ class CloudStorageEntryRepository {
       where: where?.call(CloudStorageEntry.t),
       orderBy: orderBy?.call(CloudStorageEntry.t),
       orderByList: orderByList?.call(CloudStorageEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -405,8 +395,6 @@ class CloudStorageEntryRepository {
     _i1.WhereExpressionBuilder<CloudStorageEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<CloudStorageEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -416,8 +404,6 @@ class CloudStorageEntryRepository {
       where: where?.call(CloudStorageEntry.t),
       orderBy: orderBy?.call(CloudStorageEntry.t),
       orderByList: orderByList?.call(CloudStorageEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -624,8 +610,6 @@ class CloudStorageEntryRepository {
     int? offset,
     _i1.OrderByBuilder<CloudStorageEntryTable>? orderBy,
     _i1.OrderByListBuilder<CloudStorageEntryTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -636,8 +620,6 @@ class CloudStorageEntryRepository {
       offset: offset,
       orderBy: orderBy?.call(CloudStorageEntry.t),
       orderByList: orderByList?.call(CloudStorageEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -658,8 +640,6 @@ class CloudStorageEntryRepository {
     _i1.DatabaseSession session,
     List<CloudStorageEntry> rows, {
     _i1.OrderByBuilder<CloudStorageEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -668,8 +648,6 @@ class CloudStorageEntryRepository {
       rows,
       orderBy: orderBy?.call(CloudStorageEntry.t),
       orderByList: orderByList?.call(CloudStorageEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -699,8 +677,6 @@ class CloudStorageEntryRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CloudStorageEntryTable> where,
     _i1.OrderByBuilder<CloudStorageEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -709,8 +685,6 @@ class CloudStorageEntryRepository {
       where: where(CloudStorageEntry.t),
       orderBy: orderBy?.call(CloudStorageEntry.t),
       orderByList: orderByList?.call(CloudStorageEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
+++ b/packages/serverpod/lib/src/generated/cloud_storage_direct_upload.dart
@@ -110,8 +110,6 @@ abstract class CloudStorageDirectUploadEntry
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CloudStorageDirectUploadEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageDirectUploadEntryTable>? orderByList,
     CloudStorageDirectUploadEntryInclude? include,
   }) {
@@ -120,8 +118,6 @@ abstract class CloudStorageDirectUploadEntry
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CloudStorageDirectUploadEntry.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CloudStorageDirectUploadEntry.t),
       include: include,
     );
@@ -259,8 +255,6 @@ class CloudStorageDirectUploadEntryIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -305,8 +299,6 @@ class CloudStorageDirectUploadEntryRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CloudStorageDirectUploadEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageDirectUploadEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -316,8 +308,6 @@ class CloudStorageDirectUploadEntryRepository {
       where: where?.call(CloudStorageDirectUploadEntry.t),
       orderBy: orderBy?.call(CloudStorageDirectUploadEntry.t),
       orderByList: orderByList?.call(CloudStorageDirectUploadEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -348,8 +338,6 @@ class CloudStorageDirectUploadEntryRepository {
     _i1.WhereExpressionBuilder<CloudStorageDirectUploadEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<CloudStorageDirectUploadEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageDirectUploadEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -359,8 +347,6 @@ class CloudStorageDirectUploadEntryRepository {
       where: where?.call(CloudStorageDirectUploadEntry.t),
       orderBy: orderBy?.call(CloudStorageDirectUploadEntry.t),
       orderByList: orderByList?.call(CloudStorageDirectUploadEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -574,8 +560,6 @@ class CloudStorageDirectUploadEntryRepository {
     int? offset,
     _i1.OrderByBuilder<CloudStorageDirectUploadEntryTable>? orderBy,
     _i1.OrderByListBuilder<CloudStorageDirectUploadEntryTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -586,8 +570,6 @@ class CloudStorageDirectUploadEntryRepository {
       offset: offset,
       orderBy: orderBy?.call(CloudStorageDirectUploadEntry.t),
       orderByList: orderByList?.call(CloudStorageDirectUploadEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -608,8 +590,6 @@ class CloudStorageDirectUploadEntryRepository {
     _i1.DatabaseSession session,
     List<CloudStorageDirectUploadEntry> rows, {
     _i1.OrderByBuilder<CloudStorageDirectUploadEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageDirectUploadEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -618,8 +598,6 @@ class CloudStorageDirectUploadEntryRepository {
       rows,
       orderBy: orderBy?.call(CloudStorageDirectUploadEntry.t),
       orderByList: orderByList?.call(CloudStorageDirectUploadEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -650,8 +628,6 @@ class CloudStorageDirectUploadEntryRepository {
     required _i1.WhereExpressionBuilder<CloudStorageDirectUploadEntryTable>
     where,
     _i1.OrderByBuilder<CloudStorageDirectUploadEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CloudStorageDirectUploadEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -660,8 +636,6 @@ class CloudStorageDirectUploadEntryRepository {
       where: where(CloudStorageDirectUploadEntry.t),
       orderBy: orderBy?.call(CloudStorageDirectUploadEntry.t),
       orderByList: orderByList?.call(CloudStorageDirectUploadEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/database_migration_version.dart
+++ b/packages/serverpod/lib/src/generated/database_migration_version.dart
@@ -95,8 +95,6 @@ abstract class DatabaseMigrationVersion
     int? limit,
     int? offset,
     _i2.OrderByBuilder<DatabaseMigrationVersionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<DatabaseMigrationVersionTable>? orderByList,
     DatabaseMigrationVersionInclude? include,
   }) {
@@ -105,8 +103,6 @@ abstract class DatabaseMigrationVersion
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DatabaseMigrationVersion.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DatabaseMigrationVersion.t),
       include: include,
     );
@@ -227,8 +223,6 @@ class DatabaseMigrationVersionIncludeList extends _i2.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -273,8 +267,6 @@ class DatabaseMigrationVersionRepository {
     int? limit,
     int? offset,
     _i2.OrderByBuilder<DatabaseMigrationVersionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<DatabaseMigrationVersionTable>? orderByList,
     _i2.Transaction? transaction,
     _i2.LockMode? lockMode,
@@ -284,8 +276,6 @@ class DatabaseMigrationVersionRepository {
       where: where?.call(DatabaseMigrationVersion.t),
       orderBy: orderBy?.call(DatabaseMigrationVersion.t),
       orderByList: orderByList?.call(DatabaseMigrationVersion.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -316,8 +306,6 @@ class DatabaseMigrationVersionRepository {
     _i2.WhereExpressionBuilder<DatabaseMigrationVersionTable>? where,
     int? offset,
     _i2.OrderByBuilder<DatabaseMigrationVersionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<DatabaseMigrationVersionTable>? orderByList,
     _i2.Transaction? transaction,
     _i2.LockMode? lockMode,
@@ -327,8 +315,6 @@ class DatabaseMigrationVersionRepository {
       where: where?.call(DatabaseMigrationVersion.t),
       orderBy: orderBy?.call(DatabaseMigrationVersion.t),
       orderByList: orderByList?.call(DatabaseMigrationVersion.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -537,8 +523,6 @@ class DatabaseMigrationVersionRepository {
     int? offset,
     _i2.OrderByBuilder<DatabaseMigrationVersionTable>? orderBy,
     _i2.OrderByListBuilder<DatabaseMigrationVersionTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -549,8 +533,6 @@ class DatabaseMigrationVersionRepository {
       offset: offset,
       orderBy: orderBy?.call(DatabaseMigrationVersion.t),
       orderByList: orderByList?.call(DatabaseMigrationVersion.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -571,8 +553,6 @@ class DatabaseMigrationVersionRepository {
     _i2.DatabaseSession session,
     List<DatabaseMigrationVersion> rows, {
     _i2.OrderByBuilder<DatabaseMigrationVersionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<DatabaseMigrationVersionTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -581,8 +561,6 @@ class DatabaseMigrationVersionRepository {
       rows,
       orderBy: orderBy?.call(DatabaseMigrationVersion.t),
       orderByList: orderByList?.call(DatabaseMigrationVersion.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -612,8 +590,6 @@ class DatabaseMigrationVersionRepository {
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<DatabaseMigrationVersionTable> where,
     _i2.OrderByBuilder<DatabaseMigrationVersionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<DatabaseMigrationVersionTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -622,8 +598,6 @@ class DatabaseMigrationVersionRepository {
       where: where(DatabaseMigrationVersion.t),
       orderBy: orderBy?.call(DatabaseMigrationVersion.t),
       orderByList: orderByList?.call(DatabaseMigrationVersion.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/future_call_claim_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_claim_entry.dart
@@ -93,8 +93,6 @@ abstract class FutureCallClaimEntry
     int? limit,
     int? offset,
     _i1.OrderByBuilder<FutureCallClaimEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallClaimEntryTable>? orderByList,
     FutureCallClaimEntryInclude? include,
   }) {
@@ -103,8 +101,6 @@ abstract class FutureCallClaimEntry
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(FutureCallClaimEntry.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(FutureCallClaimEntry.t),
       include: include,
     );
@@ -209,8 +205,6 @@ class FutureCallClaimEntryIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -255,8 +249,6 @@ class FutureCallClaimEntryRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<FutureCallClaimEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallClaimEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -266,8 +258,6 @@ class FutureCallClaimEntryRepository {
       where: where?.call(FutureCallClaimEntry.t),
       orderBy: orderBy?.call(FutureCallClaimEntry.t),
       orderByList: orderByList?.call(FutureCallClaimEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -298,8 +288,6 @@ class FutureCallClaimEntryRepository {
     _i1.WhereExpressionBuilder<FutureCallClaimEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<FutureCallClaimEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallClaimEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -309,8 +297,6 @@ class FutureCallClaimEntryRepository {
       where: where?.call(FutureCallClaimEntry.t),
       orderBy: orderBy?.call(FutureCallClaimEntry.t),
       orderByList: orderByList?.call(FutureCallClaimEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -517,8 +503,6 @@ class FutureCallClaimEntryRepository {
     int? offset,
     _i1.OrderByBuilder<FutureCallClaimEntryTable>? orderBy,
     _i1.OrderByListBuilder<FutureCallClaimEntryTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -529,8 +513,6 @@ class FutureCallClaimEntryRepository {
       offset: offset,
       orderBy: orderBy?.call(FutureCallClaimEntry.t),
       orderByList: orderByList?.call(FutureCallClaimEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -551,8 +533,6 @@ class FutureCallClaimEntryRepository {
     _i1.DatabaseSession session,
     List<FutureCallClaimEntry> rows, {
     _i1.OrderByBuilder<FutureCallClaimEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallClaimEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -561,8 +541,6 @@ class FutureCallClaimEntryRepository {
       rows,
       orderBy: orderBy?.call(FutureCallClaimEntry.t),
       orderByList: orderByList?.call(FutureCallClaimEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -592,8 +570,6 @@ class FutureCallClaimEntryRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<FutureCallClaimEntryTable> where,
     _i1.OrderByBuilder<FutureCallClaimEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallClaimEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -602,8 +578,6 @@ class FutureCallClaimEntryRepository {
       where: where(FutureCallClaimEntry.t),
       orderBy: orderBy?.call(FutureCallClaimEntry.t),
       orderByList: orderByList?.call(FutureCallClaimEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/future_call_entry.dart
+++ b/packages/serverpod/lib/src/generated/future_call_entry.dart
@@ -131,8 +131,6 @@ abstract class FutureCallEntry
     int? limit,
     int? offset,
     _i1.OrderByBuilder<FutureCallEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallEntryTable>? orderByList,
     FutureCallEntryInclude? include,
   }) {
@@ -141,8 +139,6 @@ abstract class FutureCallEntry
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(FutureCallEntry.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(FutureCallEntry.t),
       include: include,
     );
@@ -319,8 +315,6 @@ class FutureCallEntryIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -365,8 +359,6 @@ class FutureCallEntryRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<FutureCallEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -376,8 +368,6 @@ class FutureCallEntryRepository {
       where: where?.call(FutureCallEntry.t),
       orderBy: orderBy?.call(FutureCallEntry.t),
       orderByList: orderByList?.call(FutureCallEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -408,8 +398,6 @@ class FutureCallEntryRepository {
     _i1.WhereExpressionBuilder<FutureCallEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<FutureCallEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -419,8 +407,6 @@ class FutureCallEntryRepository {
       where: where?.call(FutureCallEntry.t),
       orderBy: orderBy?.call(FutureCallEntry.t),
       orderByList: orderByList?.call(FutureCallEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -627,8 +613,6 @@ class FutureCallEntryRepository {
     int? offset,
     _i1.OrderByBuilder<FutureCallEntryTable>? orderBy,
     _i1.OrderByListBuilder<FutureCallEntryTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -639,8 +623,6 @@ class FutureCallEntryRepository {
       offset: offset,
       orderBy: orderBy?.call(FutureCallEntry.t),
       orderByList: orderByList?.call(FutureCallEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -661,8 +643,6 @@ class FutureCallEntryRepository {
     _i1.DatabaseSession session,
     List<FutureCallEntry> rows, {
     _i1.OrderByBuilder<FutureCallEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -671,8 +651,6 @@ class FutureCallEntryRepository {
       rows,
       orderBy: orderBy?.call(FutureCallEntry.t),
       orderByList: orderByList?.call(FutureCallEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -702,8 +680,6 @@ class FutureCallEntryRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<FutureCallEntryTable> where,
     _i1.OrderByBuilder<FutureCallEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<FutureCallEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -712,8 +688,6 @@ class FutureCallEntryRepository {
       where: where(FutureCallEntry.t),
       orderBy: orderBy?.call(FutureCallEntry.t),
       orderByList: orderByList?.call(FutureCallEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/log_entry.dart
+++ b/packages/serverpod/lib/src/generated/log_entry.dart
@@ -161,8 +161,6 @@ abstract class LogEntry
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LogEntryTable>? orderByList,
     LogEntryInclude? include,
   }) {
@@ -171,8 +169,6 @@ abstract class LogEntry
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(LogEntry.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(LogEntry.t),
       include: include,
     );
@@ -411,8 +407,6 @@ class LogEntryIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -457,8 +451,6 @@ class LogEntryRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -468,8 +460,6 @@ class LogEntryRepository {
       where: where?.call(LogEntry.t),
       orderBy: orderBy?.call(LogEntry.t),
       orderByList: orderByList?.call(LogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -500,8 +490,6 @@ class LogEntryRepository {
     _i1.WhereExpressionBuilder<LogEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<LogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -511,8 +499,6 @@ class LogEntryRepository {
       where: where?.call(LogEntry.t),
       orderBy: orderBy?.call(LogEntry.t),
       orderByList: orderByList?.call(LogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -717,8 +703,6 @@ class LogEntryRepository {
     int? offset,
     _i1.OrderByBuilder<LogEntryTable>? orderBy,
     _i1.OrderByListBuilder<LogEntryTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -729,8 +713,6 @@ class LogEntryRepository {
       offset: offset,
       orderBy: orderBy?.call(LogEntry.t),
       orderByList: orderByList?.call(LogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -751,8 +733,6 @@ class LogEntryRepository {
     _i1.DatabaseSession session,
     List<LogEntry> rows, {
     _i1.OrderByBuilder<LogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -761,8 +741,6 @@ class LogEntryRepository {
       rows,
       orderBy: orderBy?.call(LogEntry.t),
       orderByList: orderByList?.call(LogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -792,8 +770,6 @@ class LogEntryRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<LogEntryTable> where,
     _i1.OrderByBuilder<LogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -802,8 +778,6 @@ class LogEntryRepository {
       where: where(LogEntry.t),
       orderBy: orderBy?.call(LogEntry.t),
       orderByList: orderByList?.call(LogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/message_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/message_log_entry.dart
@@ -162,8 +162,6 @@ abstract class MessageLogEntry
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MessageLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MessageLogEntryTable>? orderByList,
     MessageLogEntryInclude? include,
   }) {
@@ -172,8 +170,6 @@ abstract class MessageLogEntry
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(MessageLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(MessageLogEntry.t),
       include: include,
     );
@@ -413,8 +409,6 @@ class MessageLogEntryIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -459,8 +453,6 @@ class MessageLogEntryRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MessageLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MessageLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -470,8 +462,6 @@ class MessageLogEntryRepository {
       where: where?.call(MessageLogEntry.t),
       orderBy: orderBy?.call(MessageLogEntry.t),
       orderByList: orderByList?.call(MessageLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -502,8 +492,6 @@ class MessageLogEntryRepository {
     _i1.WhereExpressionBuilder<MessageLogEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<MessageLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MessageLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -513,8 +501,6 @@ class MessageLogEntryRepository {
       where: where?.call(MessageLogEntry.t),
       orderBy: orderBy?.call(MessageLogEntry.t),
       orderByList: orderByList?.call(MessageLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -721,8 +707,6 @@ class MessageLogEntryRepository {
     int? offset,
     _i1.OrderByBuilder<MessageLogEntryTable>? orderBy,
     _i1.OrderByListBuilder<MessageLogEntryTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -733,8 +717,6 @@ class MessageLogEntryRepository {
       offset: offset,
       orderBy: orderBy?.call(MessageLogEntry.t),
       orderByList: orderByList?.call(MessageLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -755,8 +737,6 @@ class MessageLogEntryRepository {
     _i1.DatabaseSession session,
     List<MessageLogEntry> rows, {
     _i1.OrderByBuilder<MessageLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MessageLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -765,8 +745,6 @@ class MessageLogEntryRepository {
       rows,
       orderBy: orderBy?.call(MessageLogEntry.t),
       orderByList: orderByList?.call(MessageLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -796,8 +774,6 @@ class MessageLogEntryRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MessageLogEntryTable> where,
     _i1.OrderByBuilder<MessageLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MessageLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -806,8 +782,6 @@ class MessageLogEntryRepository {
       where: where(MessageLogEntry.t),
       orderBy: orderBy?.call(MessageLogEntry.t),
       orderByList: orderByList?.call(MessageLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/method_info.dart
+++ b/packages/serverpod/lib/src/generated/method_info.dart
@@ -88,8 +88,6 @@ abstract class MethodInfo
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MethodInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MethodInfoTable>? orderByList,
     MethodInfoInclude? include,
   }) {
@@ -98,8 +96,6 @@ abstract class MethodInfo
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(MethodInfo.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(MethodInfo.t),
       include: include,
     );
@@ -201,8 +197,6 @@ class MethodInfoIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -247,8 +241,6 @@ class MethodInfoRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MethodInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MethodInfoTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -258,8 +250,6 @@ class MethodInfoRepository {
       where: where?.call(MethodInfo.t),
       orderBy: orderBy?.call(MethodInfo.t),
       orderByList: orderByList?.call(MethodInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -290,8 +280,6 @@ class MethodInfoRepository {
     _i1.WhereExpressionBuilder<MethodInfoTable>? where,
     int? offset,
     _i1.OrderByBuilder<MethodInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MethodInfoTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -301,8 +289,6 @@ class MethodInfoRepository {
       where: where?.call(MethodInfo.t),
       orderBy: orderBy?.call(MethodInfo.t),
       orderByList: orderByList?.call(MethodInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -507,8 +493,6 @@ class MethodInfoRepository {
     int? offset,
     _i1.OrderByBuilder<MethodInfoTable>? orderBy,
     _i1.OrderByListBuilder<MethodInfoTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -519,8 +503,6 @@ class MethodInfoRepository {
       offset: offset,
       orderBy: orderBy?.call(MethodInfo.t),
       orderByList: orderByList?.call(MethodInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -541,8 +523,6 @@ class MethodInfoRepository {
     _i1.DatabaseSession session,
     List<MethodInfo> rows, {
     _i1.OrderByBuilder<MethodInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MethodInfoTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -551,8 +531,6 @@ class MethodInfoRepository {
       rows,
       orderBy: orderBy?.call(MethodInfo.t),
       orderByList: orderByList?.call(MethodInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -582,8 +560,6 @@ class MethodInfoRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MethodInfoTable> where,
     _i1.OrderByBuilder<MethodInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MethodInfoTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -592,8 +568,6 @@ class MethodInfoRepository {
       where: where(MethodInfo.t),
       orderBy: orderBy?.call(MethodInfo.t),
       orderByList: orderByList?.call(MethodInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/query_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/query_log_entry.dart
@@ -162,8 +162,6 @@ abstract class QueryLogEntry
     int? limit,
     int? offset,
     _i1.OrderByBuilder<QueryLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<QueryLogEntryTable>? orderByList,
     QueryLogEntryInclude? include,
   }) {
@@ -172,8 +170,6 @@ abstract class QueryLogEntry
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(QueryLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(QueryLogEntry.t),
       include: include,
     );
@@ -413,8 +409,6 @@ class QueryLogEntryIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -459,8 +453,6 @@ class QueryLogEntryRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<QueryLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<QueryLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -470,8 +462,6 @@ class QueryLogEntryRepository {
       where: where?.call(QueryLogEntry.t),
       orderBy: orderBy?.call(QueryLogEntry.t),
       orderByList: orderByList?.call(QueryLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -502,8 +492,6 @@ class QueryLogEntryRepository {
     _i1.WhereExpressionBuilder<QueryLogEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<QueryLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<QueryLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -513,8 +501,6 @@ class QueryLogEntryRepository {
       where: where?.call(QueryLogEntry.t),
       orderBy: orderBy?.call(QueryLogEntry.t),
       orderByList: orderByList?.call(QueryLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -719,8 +705,6 @@ class QueryLogEntryRepository {
     int? offset,
     _i1.OrderByBuilder<QueryLogEntryTable>? orderBy,
     _i1.OrderByListBuilder<QueryLogEntryTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -731,8 +715,6 @@ class QueryLogEntryRepository {
       offset: offset,
       orderBy: orderBy?.call(QueryLogEntry.t),
       orderByList: orderByList?.call(QueryLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -753,8 +735,6 @@ class QueryLogEntryRepository {
     _i1.DatabaseSession session,
     List<QueryLogEntry> rows, {
     _i1.OrderByBuilder<QueryLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<QueryLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -763,8 +743,6 @@ class QueryLogEntryRepository {
       rows,
       orderBy: orderBy?.call(QueryLogEntry.t),
       orderByList: orderByList?.call(QueryLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -794,8 +772,6 @@ class QueryLogEntryRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<QueryLogEntryTable> where,
     _i1.OrderByBuilder<QueryLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<QueryLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -804,8 +780,6 @@ class QueryLogEntryRepository {
       where: where(QueryLogEntry.t),
       orderBy: orderBy?.call(QueryLogEntry.t),
       orderByList: orderByList?.call(QueryLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/readwrite_test.dart
+++ b/packages/serverpod/lib/src/generated/readwrite_test.dart
@@ -80,8 +80,6 @@ abstract class ReadWriteTestEntry
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ReadWriteTestEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ReadWriteTestEntryTable>? orderByList,
     ReadWriteTestEntryInclude? include,
   }) {
@@ -90,8 +88,6 @@ abstract class ReadWriteTestEntry
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ReadWriteTestEntry.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ReadWriteTestEntry.t),
       include: include,
     );
@@ -177,8 +173,6 @@ class ReadWriteTestEntryIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -223,8 +217,6 @@ class ReadWriteTestEntryRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ReadWriteTestEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ReadWriteTestEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -234,8 +226,6 @@ class ReadWriteTestEntryRepository {
       where: where?.call(ReadWriteTestEntry.t),
       orderBy: orderBy?.call(ReadWriteTestEntry.t),
       orderByList: orderByList?.call(ReadWriteTestEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -266,8 +256,6 @@ class ReadWriteTestEntryRepository {
     _i1.WhereExpressionBuilder<ReadWriteTestEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<ReadWriteTestEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ReadWriteTestEntryTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -277,8 +265,6 @@ class ReadWriteTestEntryRepository {
       where: where?.call(ReadWriteTestEntry.t),
       orderBy: orderBy?.call(ReadWriteTestEntry.t),
       orderByList: orderByList?.call(ReadWriteTestEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -485,8 +471,6 @@ class ReadWriteTestEntryRepository {
     int? offset,
     _i1.OrderByBuilder<ReadWriteTestEntryTable>? orderBy,
     _i1.OrderByListBuilder<ReadWriteTestEntryTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -497,8 +481,6 @@ class ReadWriteTestEntryRepository {
       offset: offset,
       orderBy: orderBy?.call(ReadWriteTestEntry.t),
       orderByList: orderByList?.call(ReadWriteTestEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -519,8 +501,6 @@ class ReadWriteTestEntryRepository {
     _i1.DatabaseSession session,
     List<ReadWriteTestEntry> rows, {
     _i1.OrderByBuilder<ReadWriteTestEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ReadWriteTestEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -529,8 +509,6 @@ class ReadWriteTestEntryRepository {
       rows,
       orderBy: orderBy?.call(ReadWriteTestEntry.t),
       orderByList: orderByList?.call(ReadWriteTestEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -560,8 +538,6 @@ class ReadWriteTestEntryRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ReadWriteTestEntryTable> where,
     _i1.OrderByBuilder<ReadWriteTestEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ReadWriteTestEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -570,8 +546,6 @@ class ReadWriteTestEntryRepository {
       where: where(ReadWriteTestEntry.t),
       orderBy: orderBy?.call(ReadWriteTestEntry.t),
       orderByList: orderByList?.call(ReadWriteTestEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/runtime_settings.dart
+++ b/packages/serverpod/lib/src/generated/runtime_settings.dart
@@ -122,8 +122,6 @@ abstract class RuntimeSettings
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RuntimeSettingsTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RuntimeSettingsTable>? orderByList,
     RuntimeSettingsInclude? include,
   }) {
@@ -132,8 +130,6 @@ abstract class RuntimeSettings
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(RuntimeSettings.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(RuntimeSettings.t),
       include: include,
     );
@@ -276,8 +272,6 @@ class RuntimeSettingsIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -322,8 +316,6 @@ class RuntimeSettingsRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RuntimeSettingsTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RuntimeSettingsTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -333,8 +325,6 @@ class RuntimeSettingsRepository {
       where: where?.call(RuntimeSettings.t),
       orderBy: orderBy?.call(RuntimeSettings.t),
       orderByList: orderByList?.call(RuntimeSettings.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -365,8 +355,6 @@ class RuntimeSettingsRepository {
     _i1.WhereExpressionBuilder<RuntimeSettingsTable>? where,
     int? offset,
     _i1.OrderByBuilder<RuntimeSettingsTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RuntimeSettingsTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -376,8 +364,6 @@ class RuntimeSettingsRepository {
       where: where?.call(RuntimeSettings.t),
       orderBy: orderBy?.call(RuntimeSettings.t),
       orderByList: orderByList?.call(RuntimeSettings.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -584,8 +570,6 @@ class RuntimeSettingsRepository {
     int? offset,
     _i1.OrderByBuilder<RuntimeSettingsTable>? orderBy,
     _i1.OrderByListBuilder<RuntimeSettingsTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -596,8 +580,6 @@ class RuntimeSettingsRepository {
       offset: offset,
       orderBy: orderBy?.call(RuntimeSettings.t),
       orderByList: orderByList?.call(RuntimeSettings.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -618,8 +600,6 @@ class RuntimeSettingsRepository {
     _i1.DatabaseSession session,
     List<RuntimeSettings> rows, {
     _i1.OrderByBuilder<RuntimeSettingsTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RuntimeSettingsTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -628,8 +608,6 @@ class RuntimeSettingsRepository {
       rows,
       orderBy: orderBy?.call(RuntimeSettings.t),
       orderByList: orderByList?.call(RuntimeSettings.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -659,8 +637,6 @@ class RuntimeSettingsRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RuntimeSettingsTable> where,
     _i1.OrderByBuilder<RuntimeSettingsTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RuntimeSettingsTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -669,8 +645,6 @@ class RuntimeSettingsRepository {
       where: where(RuntimeSettings.t),
       orderBy: orderBy?.call(RuntimeSettings.t),
       orderByList: orderByList?.call(RuntimeSettings.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/server_health_connection_info.dart
+++ b/packages/serverpod/lib/src/generated/server_health_connection_info.dart
@@ -131,8 +131,6 @@ abstract class ServerHealthConnectionInfo
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServerHealthConnectionInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthConnectionInfoTable>? orderByList,
     ServerHealthConnectionInfoInclude? include,
   }) {
@@ -141,8 +139,6 @@ abstract class ServerHealthConnectionInfo
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ServerHealthConnectionInfo.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ServerHealthConnectionInfo.t),
       include: include,
     );
@@ -315,8 +311,6 @@ class ServerHealthConnectionInfoIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -361,8 +355,6 @@ class ServerHealthConnectionInfoRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServerHealthConnectionInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthConnectionInfoTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -372,8 +364,6 @@ class ServerHealthConnectionInfoRepository {
       where: where?.call(ServerHealthConnectionInfo.t),
       orderBy: orderBy?.call(ServerHealthConnectionInfo.t),
       orderByList: orderByList?.call(ServerHealthConnectionInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -404,8 +394,6 @@ class ServerHealthConnectionInfoRepository {
     _i1.WhereExpressionBuilder<ServerHealthConnectionInfoTable>? where,
     int? offset,
     _i1.OrderByBuilder<ServerHealthConnectionInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthConnectionInfoTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -415,8 +403,6 @@ class ServerHealthConnectionInfoRepository {
       where: where?.call(ServerHealthConnectionInfo.t),
       orderBy: orderBy?.call(ServerHealthConnectionInfo.t),
       orderByList: orderByList?.call(ServerHealthConnectionInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -625,8 +611,6 @@ class ServerHealthConnectionInfoRepository {
     int? offset,
     _i1.OrderByBuilder<ServerHealthConnectionInfoTable>? orderBy,
     _i1.OrderByListBuilder<ServerHealthConnectionInfoTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -637,8 +621,6 @@ class ServerHealthConnectionInfoRepository {
       offset: offset,
       orderBy: orderBy?.call(ServerHealthConnectionInfo.t),
       orderByList: orderByList?.call(ServerHealthConnectionInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -659,8 +641,6 @@ class ServerHealthConnectionInfoRepository {
     _i1.DatabaseSession session,
     List<ServerHealthConnectionInfo> rows, {
     _i1.OrderByBuilder<ServerHealthConnectionInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthConnectionInfoTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -669,8 +649,6 @@ class ServerHealthConnectionInfoRepository {
       rows,
       orderBy: orderBy?.call(ServerHealthConnectionInfo.t),
       orderByList: orderByList?.call(ServerHealthConnectionInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -700,8 +678,6 @@ class ServerHealthConnectionInfoRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ServerHealthConnectionInfoTable> where,
     _i1.OrderByBuilder<ServerHealthConnectionInfoTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthConnectionInfoTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -710,8 +686,6 @@ class ServerHealthConnectionInfoRepository {
       where: where(ServerHealthConnectionInfo.t),
       orderBy: orderBy?.call(ServerHealthConnectionInfo.t),
       orderByList: orderByList?.call(ServerHealthConnectionInfo.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/server_health_metric.dart
+++ b/packages/serverpod/lib/src/generated/server_health_metric.dart
@@ -129,8 +129,6 @@ abstract class ServerHealthMetric
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServerHealthMetricTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthMetricTable>? orderByList,
     ServerHealthMetricInclude? include,
   }) {
@@ -139,8 +137,6 @@ abstract class ServerHealthMetric
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ServerHealthMetric.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ServerHealthMetric.t),
       include: include,
     );
@@ -313,8 +309,6 @@ class ServerHealthMetricIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -359,8 +353,6 @@ class ServerHealthMetricRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServerHealthMetricTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthMetricTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -370,8 +362,6 @@ class ServerHealthMetricRepository {
       where: where?.call(ServerHealthMetric.t),
       orderBy: orderBy?.call(ServerHealthMetric.t),
       orderByList: orderByList?.call(ServerHealthMetric.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -402,8 +392,6 @@ class ServerHealthMetricRepository {
     _i1.WhereExpressionBuilder<ServerHealthMetricTable>? where,
     int? offset,
     _i1.OrderByBuilder<ServerHealthMetricTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthMetricTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -413,8 +401,6 @@ class ServerHealthMetricRepository {
       where: where?.call(ServerHealthMetric.t),
       orderBy: orderBy?.call(ServerHealthMetric.t),
       orderByList: orderByList?.call(ServerHealthMetric.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -621,8 +607,6 @@ class ServerHealthMetricRepository {
     int? offset,
     _i1.OrderByBuilder<ServerHealthMetricTable>? orderBy,
     _i1.OrderByListBuilder<ServerHealthMetricTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -633,8 +617,6 @@ class ServerHealthMetricRepository {
       offset: offset,
       orderBy: orderBy?.call(ServerHealthMetric.t),
       orderByList: orderByList?.call(ServerHealthMetric.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -655,8 +637,6 @@ class ServerHealthMetricRepository {
     _i1.DatabaseSession session,
     List<ServerHealthMetric> rows, {
     _i1.OrderByBuilder<ServerHealthMetricTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthMetricTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -665,8 +645,6 @@ class ServerHealthMetricRepository {
       rows,
       orderBy: orderBy?.call(ServerHealthMetric.t),
       orderByList: orderByList?.call(ServerHealthMetric.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -696,8 +674,6 @@ class ServerHealthMetricRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ServerHealthMetricTable> where,
     _i1.OrderByBuilder<ServerHealthMetricTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerHealthMetricTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -706,8 +682,6 @@ class ServerHealthMetricRepository {
       where: where(ServerHealthMetric.t),
       orderBy: orderBy?.call(ServerHealthMetric.t),
       orderByList: orderByList?.call(ServerHealthMetric.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod/lib/src/generated/session_log_entry.dart
+++ b/packages/serverpod/lib/src/generated/session_log_entry.dart
@@ -261,8 +261,6 @@ abstract class SessionLogEntry
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SessionLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SessionLogEntryTable>? orderByList,
     SessionLogEntryInclude? include,
   }) {
@@ -271,8 +269,6 @@ abstract class SessionLogEntry
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(SessionLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(SessionLogEntry.t),
       include: include,
     );
@@ -749,8 +745,6 @@ class SessionLogEntryIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -799,8 +793,6 @@ class SessionLogEntryRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SessionLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SessionLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     SessionLogEntryInclude? include,
@@ -811,8 +803,6 @@ class SessionLogEntryRepository {
       where: where?.call(SessionLogEntry.t),
       orderBy: orderBy?.call(SessionLogEntry.t),
       orderByList: orderByList?.call(SessionLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -844,8 +834,6 @@ class SessionLogEntryRepository {
     _i1.WhereExpressionBuilder<SessionLogEntryTable>? where,
     int? offset,
     _i1.OrderByBuilder<SessionLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SessionLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     SessionLogEntryInclude? include,
@@ -856,8 +844,6 @@ class SessionLogEntryRepository {
       where: where?.call(SessionLogEntry.t),
       orderBy: orderBy?.call(SessionLogEntry.t),
       orderByList: orderByList?.call(SessionLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -1067,8 +1053,6 @@ class SessionLogEntryRepository {
     int? offset,
     _i1.OrderByBuilder<SessionLogEntryTable>? orderBy,
     _i1.OrderByListBuilder<SessionLogEntryTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -1079,8 +1063,6 @@ class SessionLogEntryRepository {
       offset: offset,
       orderBy: orderBy?.call(SessionLogEntry.t),
       orderByList: orderByList?.call(SessionLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -1101,8 +1083,6 @@ class SessionLogEntryRepository {
     _i1.DatabaseSession session,
     List<SessionLogEntry> rows, {
     _i1.OrderByBuilder<SessionLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SessionLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -1111,8 +1091,6 @@ class SessionLogEntryRepository {
       rows,
       orderBy: orderBy?.call(SessionLogEntry.t),
       orderByList: orderByList?.call(SessionLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -1142,8 +1120,6 @@ class SessionLogEntryRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SessionLogEntryTable> where,
     _i1.OrderByBuilder<SessionLogEntryTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SessionLogEntryTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -1152,8 +1128,6 @@ class SessionLogEntryRepository {
       where: where(SessionLogEntry.t),
       orderBy: orderBy?.call(SessionLogEntry.t),
       orderByList: orderByList?.call(SessionLogEntry.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/packages/serverpod_database/lib/src/adapters/postgres/database_connection.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/database_connection.dart
@@ -41,15 +41,13 @@ class PostgresDatabaseConnection
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Include? include,
     Transaction? transaction,
     LockMode? lockMode,
     LockBehavior? lockBehavior,
   }) async {
     var table = _getTableOrAssert<T>(session, operation: 'find');
-    var orderByCols = _resolveOrderBy(orderByList, orderBy, orderDescending);
+    var orderByCols = _resolveOrderBy(orderByList, orderBy);
 
     var query = SelectQueryBuilder(table: table)
         .withSelectFields(table.columns)
@@ -78,8 +76,6 @@ class PostgresDatabaseConnection
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     Include? include,
     LockMode? lockMode,
@@ -92,8 +88,6 @@ class PostgresDatabaseConnection
       offset: offset,
       orderBy: orderBy,
       orderByList: orderByList,
-      // ignore: deprecated_member_use_from_same_package
-      orderDescending: orderDescending,
       limit: 1,
       transaction: transaction,
       include: include,
@@ -436,8 +430,6 @@ class PostgresDatabaseConnection
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -463,7 +455,7 @@ class PostgresDatabaseConnection
         orderByList != null;
 
     if (requiresFilteredSubquery) {
-      var orders = _resolveOrderBy(orderByList, orderBy, orderDescending);
+      var orders = _resolveOrderBy(orderByList, orderBy);
       var subquery = SelectQueryBuilder(table: table)
           .withSelectFields([table.id])
           .withWhere(where)
@@ -518,8 +510,6 @@ class PostgresDatabaseConnection
     List<T> rows, {
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -535,8 +525,6 @@ class PostgresDatabaseConnection
       table.id.inSet(rows.map((row) => row.id!).castToIdType().toSet()),
       orderBy: orderBy,
       orderByList: orderByList,
-      // ignore: deprecated_member_use_from_same_package
-      orderDescending: orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -569,17 +557,13 @@ class PostgresDatabaseConnection
     Expression where, {
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   }) async {
     var table = _getTableOrAssert<T>(session, operation: 'deleteWhere');
     // Ordering applies to the returned deleted rows, not to which rows are
     // deleted, so it is irrelevant when nothing is returned.
-    var orderByCols = noReturn
-        ? null
-        : _resolveOrderBy(orderByList, orderBy, orderDescending);
+    var orderByCols = noReturn ? null : _resolveOrderBy(orderByList, orderBy);
 
     var query = DeleteQueryBuilder(table: table)
         .withReturn(noReturn ? Returning.none : Returning.all)
@@ -931,8 +915,6 @@ class PostgresDatabaseConnection
         var orderBy = _resolveOrderBy(
           nestedInclude.orderByList,
           nestedInclude.orderBy,
-          // ignore: deprecated_member_use_from_same_package
-          nestedInclude.orderDescending,
         );
 
         var query = SelectQueryBuilder(table: relationTable)
@@ -1014,12 +996,11 @@ class PostgresDatabaseConnection
   List<Order>? _resolveOrderBy(
     List<Column>? orderByList,
     Column<dynamic>? orderBy,
-    bool orderDescending,
   ) {
     assert(orderByList == null || orderBy == null);
     if (orderBy != null) {
       if (orderBy is Order) return [orderBy];
-      return [orderDescending ? orderBy.desc() : orderBy.asc()];
+      return [orderBy.asc()];
     }
     if (orderByList == null || orderByList.isEmpty) return null;
     return orderByList.asOrderBy();

--- a/packages/serverpod_database/lib/src/adapters/postgres/database_connection.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/database_connection.dart
@@ -999,8 +999,7 @@ class PostgresDatabaseConnection
   ) {
     assert(orderByList == null || orderBy == null);
     if (orderBy != null) {
-      if (orderBy is Order) return [orderBy];
-      return [orderBy.asc()];
+      return [orderBy is Order ? orderBy : orderBy.asc()];
     }
     if (orderByList == null || orderByList.isEmpty) return null;
     return orderByList.asOrderBy();

--- a/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
@@ -1363,8 +1363,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
   ) {
     assert(orderByList == null || orderBy == null);
     if (orderBy != null) {
-      if (orderBy is Order) return [orderBy];
-      return [orderBy.asc()];
+      return [orderBy is Order ? orderBy : orderBy.asc()];
     }
     if (orderByList == null || orderByList.isEmpty) return null;
     return orderByList.asOrderBy();

--- a/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
@@ -56,15 +56,13 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Include? include,
     Transaction? transaction,
     LockMode? lockMode,
     LockBehavior? lockBehavior,
   }) async {
     var table = _getTableOrAssert<T>(session, operation: 'find');
-    var orderByCols = _resolveOrderBy(orderByList, orderBy, orderDescending);
+    var orderByCols = _resolveOrderBy(orderByList, orderBy);
 
     await _warnIfSqliteIgnoresLockBehavior(
       session,
@@ -98,8 +96,6 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     Include? include,
     LockMode? lockMode,
@@ -112,8 +108,6 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
       offset: offset,
       orderBy: orderBy,
       orderByList: orderByList,
-      // ignore: deprecated_member_use_from_same_package
-      orderDescending: orderDescending,
       limit: 1,
       transaction: transaction,
       include: include,
@@ -554,8 +548,6 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -573,7 +565,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
 
     String selectQuery;
     if (requiresFilteredSubquery) {
-      var orders = _resolveOrderBy(orderByList, orderBy, orderDescending);
+      var orders = _resolveOrderBy(orderByList, orderBy);
       // SQLite requires LIMIT if using OFFSET. In this case, use a large limit.
       var effectiveLimit = limit ?? (offset != null ? 0x7fffffff : null);
       selectQuery = SelectQueryBuilder(table: table)
@@ -638,8 +630,6 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     List<T> rows, {
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -654,8 +644,6 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
       table.id.inSet(rows.map((row) => row.id!).castToIdType().toSet()),
       orderBy: orderBy,
       orderByList: orderByList,
-      // ignore: deprecated_member_use_from_same_package
-      orderDescending: orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -684,17 +672,13 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     Expression where, {
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   }) async {
     var table = _getTableOrAssert<T>(session, operation: 'deleteWhere');
     // Ordering applies to the returned deleted rows, so it is irrelevant when
     // nothing is returned.
-    var orderByCols = noReturn
-        ? null
-        : _resolveOrderBy(orderByList, orderBy, orderDescending);
+    var orderByCols = noReturn ? null : _resolveOrderBy(orderByList, orderBy);
 
     // SQLite does not support DELETE ... USING. Use subquery to get ids first.
     var selectIdsQuery = SelectQueryBuilder(table: table)
@@ -1293,8 +1277,6 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
         var orderBy = _resolveOrderBy(
           nestedInclude.orderByList,
           nestedInclude.orderBy,
-          // ignore: deprecated_member_use_from_same_package
-          nestedInclude.orderDescending,
         );
 
         var query = SelectQueryBuilder(table: relationTable)
@@ -1378,12 +1360,11 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
   List<Order>? _resolveOrderBy(
     List<Column>? orderByList,
     Column<dynamic>? orderBy,
-    bool orderDescending,
   ) {
     assert(orderByList == null || orderBy == null);
     if (orderBy != null) {
       if (orderBy is Order) return [orderBy];
-      return [orderDescending ? orderBy.desc() : orderBy.asc()];
+      return [orderBy.asc()];
     }
     if (orderByList == null || orderByList.isEmpty) return null;
     return orderByList.asOrderBy();

--- a/packages/serverpod_database/lib/src/concepts/includes.dart
+++ b/packages/serverpod_database/lib/src/concepts/includes.dart
@@ -21,7 +21,6 @@ abstract class IncludeList extends Include {
     this.limit,
     this.offset,
     this.orderBy,
-    this.orderDescending = false,
     this.orderByList,
     this.include,
   });
@@ -37,10 +36,6 @@ abstract class IncludeList extends Include {
 
   /// The column to order by.
   Column? orderBy;
-
-  /// Whether the column should be ordered descending or ascending.
-  @Deprecated('Use desc() on the orderBy column instead.')
-  bool orderDescending = false;
 
   /// The columns to order by.
   List<Column>? orderByList;

--- a/packages/serverpod_database/lib/src/concepts/order.dart
+++ b/packages/serverpod_database/lib/src/concepts/order.dart
@@ -38,11 +38,6 @@ class Order implements Column {
 
   Order._({required this.column, this.orderDescending = false});
 
-  /// Creates a new [Order] definition for a specific [column] and whether it
-  /// should be ordered descending or ascending.
-  @Deprecated('Use the helpers asc() and desc() on the column instead.')
-  factory Order({required Column column, bool orderDescending}) = Order._;
-
   @override
   String toString() {
     var str = '$column';

--- a/packages/serverpod_database/lib/src/database.dart
+++ b/packages/serverpod_database/lib/src/database.dart
@@ -75,8 +75,6 @@ class Database {
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     Include? include,
     LockMode? lockMode,
@@ -98,8 +96,6 @@ class Database {
       offset: offset,
       orderBy: orderBy,
       orderByList: orderByList,
-      // ignore: deprecated_member_use_from_same_package
-      orderDescending: orderDescending,
       transaction: resolvedTransaction,
       include: include,
       lockMode: lockMode,
@@ -127,8 +123,6 @@ class Database {
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     Include? include,
     LockMode? lockMode,
@@ -149,8 +143,6 @@ class Database {
       offset: offset,
       orderBy: orderBy,
       orderByList: orderByList,
-      // ignore: deprecated_member_use_from_same_package
-      orderDescending: orderDescending,
       transaction: resolvedTransaction,
       include: include,
       lockMode: lockMode,
@@ -295,8 +287,6 @@ class Database {
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -308,8 +298,6 @@ class Database {
       offset: offset,
       orderBy: orderBy,
       orderByList: orderByList,
-      // ignore: deprecated_member_use_from_same_package
-      orderDescending: orderDescending,
       // ignore: invalid_use_of_visible_for_testing_member
       transaction: transaction ?? _session.transaction,
       noReturn: noReturn,
@@ -434,8 +422,6 @@ class Database {
     List<T> rows, {
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -444,8 +430,6 @@ class Database {
       rows,
       orderBy: orderBy,
       orderByList: orderByList,
-      // ignore: deprecated_member_use_from_same_package
-      orderDescending: orderDescending,
       // ignore: invalid_use_of_visible_for_testing_member
       transaction: transaction ?? _session.transaction,
       noReturn: noReturn,
@@ -479,8 +463,6 @@ class Database {
     required Expression where,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -489,8 +471,6 @@ class Database {
       where,
       orderBy: orderBy,
       orderByList: orderByList,
-      // ignore: deprecated_member_use_from_same_package
-      orderDescending: orderDescending,
       // ignore: invalid_use_of_visible_for_testing_member
       transaction: transaction ?? _session.transaction,
       noReturn: noReturn,

--- a/packages/serverpod_database/lib/src/interface/database_connection.dart
+++ b/packages/serverpod_database/lib/src/interface/database_connection.dart
@@ -35,8 +35,6 @@ abstract class DatabaseConnection<D extends DatabasePoolManager> {
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Include? include,
     Transaction? transaction,
     LockMode? lockMode,
@@ -50,8 +48,6 @@ abstract class DatabaseConnection<D extends DatabasePoolManager> {
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     Include? include,
     LockMode? lockMode,
@@ -149,7 +145,7 @@ abstract class DatabaseConnection<D extends DatabasePoolManager> {
   /// Returns a list of all updated rows. Returns an empty list if no rows match.
   /// Throws [ArgumentError] if [columnValues] is empty.
   ///
-  /// When [limit], [offset], [orderBy], [orderByList], or [orderDescending] are provided,
+  /// When [limit], [offset], [orderBy], or [orderByList] are provided,
   /// only the rows selected by these parameters will be updated.
   ///
   /// For most cases use the corresponding method in [Database] instead.
@@ -161,8 +157,6 @@ abstract class DatabaseConnection<D extends DatabasePoolManager> {
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   });
@@ -173,8 +167,6 @@ abstract class DatabaseConnection<D extends DatabasePoolManager> {
     List<T> rows, {
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   });
@@ -192,8 +184,6 @@ abstract class DatabaseConnection<D extends DatabasePoolManager> {
     Expression where, {
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   });

--- a/packages/serverpod_test/lib/src/test_database_proxy.dart
+++ b/packages/serverpod_test/lib/src/test_database_proxy.dart
@@ -55,8 +55,6 @@ class TestDatabaseProxy implements Database {
     List<T> rows, {
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   }) {
@@ -65,8 +63,6 @@ class TestDatabaseProxy implements Database {
         rows,
         orderBy: orderBy,
         orderByList: orderByList,
-        // ignore: deprecated_member_use
-        orderDescending: orderDescending,
         transaction: transaction,
         noReturn: noReturn,
       ),
@@ -93,8 +89,6 @@ class TestDatabaseProxy implements Database {
     required Expression where,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   }) {
@@ -103,8 +97,6 @@ class TestDatabaseProxy implements Database {
         where: where,
         orderBy: orderBy,
         orderByList: orderByList,
-        // ignore: deprecated_member_use
-        orderDescending: orderDescending,
         transaction: transaction,
         noReturn: noReturn,
       ),
@@ -119,8 +111,6 @@ class TestDatabaseProxy implements Database {
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     Include? include,
     LockMode? lockMode,
@@ -133,8 +123,6 @@ class TestDatabaseProxy implements Database {
         offset: offset,
         orderBy: orderBy,
         orderByList: orderByList,
-        // ignore: deprecated_member_use
-        orderDescending: orderDescending,
         transaction: transaction,
         include: include,
         lockMode: lockMode,
@@ -170,8 +158,6 @@ class TestDatabaseProxy implements Database {
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     Include? include,
     LockMode? lockMode,
@@ -183,8 +169,6 @@ class TestDatabaseProxy implements Database {
         offset: offset,
         orderBy: orderBy,
         orderByList: orderByList,
-        // ignore: deprecated_member_use
-        orderDescending: orderDescending,
         transaction: transaction,
         include: include,
         lockMode: lockMode,
@@ -470,8 +454,6 @@ class TestDatabaseProxy implements Database {
     int? offset,
     Column? orderBy,
     List<Column>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     Transaction? transaction,
     bool noReturn = false,
   }) {
@@ -483,8 +465,6 @@ class TestDatabaseProxy implements Database {
         offset: offset,
         orderBy: orderBy,
         orderByList: orderByList,
-        // ignore: deprecated_member_use
-        orderDescending: orderDescending,
         transaction: transaction,
         noReturn: noReturn,
       ),

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/challenge_tracker.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/challenge_tracker.dart
@@ -111,8 +111,6 @@ abstract class ChallengeTracker
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChallengeTrackerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChallengeTrackerTable>? orderByList,
     ChallengeTrackerInclude? include,
   }) {
@@ -121,8 +119,6 @@ abstract class ChallengeTracker
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ChallengeTracker.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ChallengeTracker.t),
       include: include,
     );
@@ -280,8 +276,6 @@ class ChallengeTrackerIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -328,8 +322,6 @@ class ChallengeTrackerRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChallengeTrackerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChallengeTrackerTable>? orderByList,
     _i1.Transaction? transaction,
     ChallengeTrackerInclude? include,
@@ -340,8 +332,6 @@ class ChallengeTrackerRepository {
       where: where?.call(ChallengeTracker.t),
       orderBy: orderBy?.call(ChallengeTracker.t),
       orderByList: orderByList?.call(ChallengeTracker.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -373,8 +363,6 @@ class ChallengeTrackerRepository {
     _i1.WhereExpressionBuilder<ChallengeTrackerTable>? where,
     int? offset,
     _i1.OrderByBuilder<ChallengeTrackerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChallengeTrackerTable>? orderByList,
     _i1.Transaction? transaction,
     ChallengeTrackerInclude? include,
@@ -385,8 +373,6 @@ class ChallengeTrackerRepository {
       where: where?.call(ChallengeTracker.t),
       orderBy: orderBy?.call(ChallengeTracker.t),
       orderByList: orderByList?.call(ChallengeTracker.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -596,8 +582,6 @@ class ChallengeTrackerRepository {
     int? offset,
     _i1.OrderByBuilder<ChallengeTrackerTable>? orderBy,
     _i1.OrderByListBuilder<ChallengeTrackerTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -608,8 +592,6 @@ class ChallengeTrackerRepository {
       offset: offset,
       orderBy: orderBy?.call(ChallengeTracker.t),
       orderByList: orderByList?.call(ChallengeTracker.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -630,8 +612,6 @@ class ChallengeTrackerRepository {
     _i1.DatabaseSession session,
     List<ChallengeTracker> rows, {
     _i1.OrderByBuilder<ChallengeTrackerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChallengeTrackerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -640,8 +620,6 @@ class ChallengeTrackerRepository {
       rows,
       orderBy: orderBy?.call(ChallengeTracker.t),
       orderByList: orderByList?.call(ChallengeTracker.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -671,8 +649,6 @@ class ChallengeTrackerRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChallengeTrackerTable> where,
     _i1.OrderByBuilder<ChallengeTrackerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChallengeTrackerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -681,8 +657,6 @@ class ChallengeTrackerRepository {
       where: where(ChallengeTracker.t),
       orderBy: orderBy?.call(ChallengeTracker.t),
       orderByList: orderByList?.call(ChallengeTracker.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/session_metadata.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/session_metadata.dart
@@ -126,8 +126,6 @@ abstract class SessionMetadata
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SessionMetadataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SessionMetadataTable>? orderByList,
     SessionMetadataInclude? include,
   }) {
@@ -136,8 +134,6 @@ abstract class SessionMetadata
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(SessionMetadata.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(SessionMetadata.t),
       include: include,
     );
@@ -327,8 +323,6 @@ class SessionMetadataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -375,8 +369,6 @@ class SessionMetadataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SessionMetadataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SessionMetadataTable>? orderByList,
     _i1.Transaction? transaction,
     SessionMetadataInclude? include,
@@ -387,8 +379,6 @@ class SessionMetadataRepository {
       where: where?.call(SessionMetadata.t),
       orderBy: orderBy?.call(SessionMetadata.t),
       orderByList: orderByList?.call(SessionMetadata.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -420,8 +410,6 @@ class SessionMetadataRepository {
     _i1.WhereExpressionBuilder<SessionMetadataTable>? where,
     int? offset,
     _i1.OrderByBuilder<SessionMetadataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SessionMetadataTable>? orderByList,
     _i1.Transaction? transaction,
     SessionMetadataInclude? include,
@@ -432,8 +420,6 @@ class SessionMetadataRepository {
       where: where?.call(SessionMetadata.t),
       orderBy: orderBy?.call(SessionMetadata.t),
       orderByList: orderByList?.call(SessionMetadata.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -643,8 +629,6 @@ class SessionMetadataRepository {
     int? offset,
     _i1.OrderByBuilder<SessionMetadataTable>? orderBy,
     _i1.OrderByListBuilder<SessionMetadataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -655,8 +639,6 @@ class SessionMetadataRepository {
       offset: offset,
       orderBy: orderBy?.call(SessionMetadata.t),
       orderByList: orderByList?.call(SessionMetadata.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -677,8 +659,6 @@ class SessionMetadataRepository {
     _i1.DatabaseSession session,
     List<SessionMetadata> rows, {
     _i1.OrderByBuilder<SessionMetadataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SessionMetadataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -687,8 +667,6 @@ class SessionMetadataRepository {
       rows,
       orderBy: orderBy?.call(SessionMetadata.t),
       orderByList: orderByList?.call(SessionMetadata.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -718,8 +696,6 @@ class SessionMetadataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SessionMetadataTable> where,
     _i1.OrderByBuilder<SessionMetadataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SessionMetadataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -728,8 +704,6 @@ class SessionMetadataRepository {
       where: where(SessionMetadata.t),
       orderBy: orderBy?.call(SessionMetadata.t),
       orderByList: orderByList?.call(SessionMetadata.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/token_metadata.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/token_metadata.dart
@@ -123,8 +123,6 @@ abstract class TokenMetadata
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TokenMetadataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TokenMetadataTable>? orderByList,
     TokenMetadataInclude? include,
   }) {
@@ -133,8 +131,6 @@ abstract class TokenMetadata
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(TokenMetadata.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(TokenMetadata.t),
       include: include,
     );
@@ -322,8 +318,6 @@ class TokenMetadataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -370,8 +364,6 @@ class TokenMetadataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TokenMetadataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TokenMetadataTable>? orderByList,
     _i1.Transaction? transaction,
     TokenMetadataInclude? include,
@@ -382,8 +374,6 @@ class TokenMetadataRepository {
       where: where?.call(TokenMetadata.t),
       orderBy: orderBy?.call(TokenMetadata.t),
       orderByList: orderByList?.call(TokenMetadata.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -415,8 +405,6 @@ class TokenMetadataRepository {
     _i1.WhereExpressionBuilder<TokenMetadataTable>? where,
     int? offset,
     _i1.OrderByBuilder<TokenMetadataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TokenMetadataTable>? orderByList,
     _i1.Transaction? transaction,
     TokenMetadataInclude? include,
@@ -427,8 +415,6 @@ class TokenMetadataRepository {
       where: where?.call(TokenMetadata.t),
       orderBy: orderBy?.call(TokenMetadata.t),
       orderByList: orderByList?.call(TokenMetadata.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -636,8 +622,6 @@ class TokenMetadataRepository {
     int? offset,
     _i1.OrderByBuilder<TokenMetadataTable>? orderBy,
     _i1.OrderByListBuilder<TokenMetadataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -648,8 +632,6 @@ class TokenMetadataRepository {
       offset: offset,
       orderBy: orderBy?.call(TokenMetadata.t),
       orderByList: orderByList?.call(TokenMetadata.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -670,8 +652,6 @@ class TokenMetadataRepository {
     _i1.DatabaseSession session,
     List<TokenMetadata> rows, {
     _i1.OrderByBuilder<TokenMetadataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TokenMetadataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -680,8 +660,6 @@ class TokenMetadataRepository {
       rows,
       orderBy: orderBy?.call(TokenMetadata.t),
       orderByList: orderByList?.call(TokenMetadata.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -711,8 +689,6 @@ class TokenMetadataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TokenMetadataTable> where,
     _i1.OrderByBuilder<TokenMetadataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TokenMetadataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -721,8 +697,6 @@ class TokenMetadataRepository {
       where: where(TokenMetadata.t),
       orderBy: orderBy?.call(TokenMetadata.t),
       orderByList: orderByList?.call(TokenMetadata.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/user_data.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/user_data.dart
@@ -114,8 +114,6 @@ abstract class UserData
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserDataTable>? orderByList,
     UserDataInclude? include,
   }) {
@@ -124,8 +122,6 @@ abstract class UserData
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UserData.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UserData.t),
       include: include,
     );
@@ -278,8 +274,6 @@ class UserDataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -326,8 +320,6 @@ class UserDataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserDataTable>? orderByList,
     _i1.Transaction? transaction,
     UserDataInclude? include,
@@ -338,8 +330,6 @@ class UserDataRepository {
       where: where?.call(UserData.t),
       orderBy: orderBy?.call(UserData.t),
       orderByList: orderByList?.call(UserData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -371,8 +361,6 @@ class UserDataRepository {
     _i1.WhereExpressionBuilder<UserDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserDataTable>? orderByList,
     _i1.Transaction? transaction,
     UserDataInclude? include,
@@ -383,8 +371,6 @@ class UserDataRepository {
       where: where?.call(UserData.t),
       orderBy: orderBy?.call(UserData.t),
       orderByList: orderByList?.call(UserData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -592,8 +578,6 @@ class UserDataRepository {
     int? offset,
     _i1.OrderByBuilder<UserDataTable>? orderBy,
     _i1.OrderByListBuilder<UserDataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -604,8 +588,6 @@ class UserDataRepository {
       offset: offset,
       orderBy: orderBy?.call(UserData.t),
       orderByList: orderByList?.call(UserData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -626,8 +608,6 @@ class UserDataRepository {
     _i1.DatabaseSession session,
     List<UserData> rows, {
     _i1.OrderByBuilder<UserDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -636,8 +616,6 @@ class UserDataRepository {
       rows,
       orderBy: orderBy?.call(UserData.t),
       orderByList: orderByList?.call(UserData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -667,8 +645,6 @@ class UserDataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserDataTable> where,
     _i1.OrderByBuilder<UserDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -677,8 +653,6 @@ class UserDataRepository {
       where: where(UserData.t),
       orderBy: orderBy?.call(UserData.t),
       orderByList: orderByList?.call(UserData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/generated/greeting.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/generated/greeting.dart
@@ -99,8 +99,6 @@ abstract class Greeting
     int? limit,
     int? offset,
     _i1.OrderByBuilder<GreetingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GreetingTable>? orderByList,
     GreetingInclude? include,
   }) {
@@ -109,8 +107,6 @@ abstract class Greeting
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Greeting.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Greeting.t),
       include: include,
     );
@@ -229,8 +225,6 @@ class GreetingIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -275,8 +269,6 @@ class GreetingRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<GreetingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GreetingTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -286,8 +278,6 @@ class GreetingRepository {
       where: where?.call(Greeting.t),
       orderBy: orderBy?.call(Greeting.t),
       orderByList: orderByList?.call(Greeting.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -318,8 +308,6 @@ class GreetingRepository {
     _i1.WhereExpressionBuilder<GreetingTable>? where,
     int? offset,
     _i1.OrderByBuilder<GreetingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GreetingTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -329,8 +317,6 @@ class GreetingRepository {
       where: where?.call(Greeting.t),
       orderBy: orderBy?.call(Greeting.t),
       orderByList: orderByList?.call(Greeting.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -535,8 +521,6 @@ class GreetingRepository {
     int? offset,
     _i1.OrderByBuilder<GreetingTable>? orderBy,
     _i1.OrderByListBuilder<GreetingTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -547,8 +531,6 @@ class GreetingRepository {
       offset: offset,
       orderBy: orderBy?.call(Greeting.t),
       orderByList: orderByList?.call(Greeting.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -569,8 +551,6 @@ class GreetingRepository {
     _i1.DatabaseSession session,
     List<Greeting> rows, {
     _i1.OrderByBuilder<GreetingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GreetingTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -579,8 +559,6 @@ class GreetingRepository {
       rows,
       orderBy: orderBy?.call(Greeting.t),
       orderByList: orderByList?.call(Greeting.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -610,8 +588,6 @@ class GreetingRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<GreetingTable> where,
     _i1.OrderByBuilder<GreetingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<GreetingTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -620,8 +596,6 @@ class GreetingRepository {
       where: where(Greeting.t),
       orderBy: orderBy?.call(Greeting.t),
       orderByList: orderByList?.call(Greeting.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/course.dart
@@ -100,8 +100,6 @@ abstract class CourseUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CourseUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     CourseUuidInclude? include,
   }) {
@@ -110,8 +108,6 @@ abstract class CourseUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CourseUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CourseUuid.t),
       include: include,
     );
@@ -248,8 +244,6 @@ class CourseUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -302,8 +296,6 @@ class CourseUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CourseUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     _i1.Transaction? transaction,
     CourseUuidInclude? include,
@@ -314,8 +306,6 @@ class CourseUuidRepository {
       where: where?.call(CourseUuid.t),
       orderBy: orderBy?.call(CourseUuid.t),
       orderByList: orderByList?.call(CourseUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -347,8 +337,6 @@ class CourseUuidRepository {
     _i1.WhereExpressionBuilder<CourseUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<CourseUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     _i1.Transaction? transaction,
     CourseUuidInclude? include,
@@ -359,8 +347,6 @@ class CourseUuidRepository {
       where: where?.call(CourseUuid.t),
       orderBy: orderBy?.call(CourseUuid.t),
       orderByList: orderByList?.call(CourseUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -568,8 +554,6 @@ class CourseUuidRepository {
     int? offset,
     _i1.OrderByBuilder<CourseUuidTable>? orderBy,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -580,8 +564,6 @@ class CourseUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(CourseUuid.t),
       orderByList: orderByList?.call(CourseUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -602,8 +584,6 @@ class CourseUuidRepository {
     _i1.DatabaseSession session,
     List<CourseUuid> rows, {
     _i1.OrderByBuilder<CourseUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -612,8 +592,6 @@ class CourseUuidRepository {
       rows,
       orderBy: orderBy?.call(CourseUuid.t),
       orderByList: orderByList?.call(CourseUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -643,8 +621,6 @@ class CourseUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CourseUuidTable> where,
     _i1.OrderByBuilder<CourseUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -653,8 +629,6 @@ class CourseUuidRepository {
       where: where(CourseUuid.t),
       orderBy: orderBy?.call(CourseUuid.t),
       orderByList: orderByList?.call(CourseUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/enrollment.dart
@@ -123,8 +123,6 @@ abstract class EnrollmentInt
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnrollmentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     EnrollmentIntInclude? include,
   }) {
@@ -133,8 +131,6 @@ abstract class EnrollmentInt
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EnrollmentInt.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EnrollmentInt.t),
       include: include,
     );
@@ -299,8 +295,6 @@ class EnrollmentIntIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -347,8 +341,6 @@ class EnrollmentIntRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnrollmentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     _i1.Transaction? transaction,
     EnrollmentIntInclude? include,
@@ -359,8 +351,6 @@ class EnrollmentIntRepository {
       where: where?.call(EnrollmentInt.t),
       orderBy: orderBy?.call(EnrollmentInt.t),
       orderByList: orderByList?.call(EnrollmentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -392,8 +382,6 @@ class EnrollmentIntRepository {
     _i1.WhereExpressionBuilder<EnrollmentIntTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnrollmentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     _i1.Transaction? transaction,
     EnrollmentIntInclude? include,
@@ -404,8 +392,6 @@ class EnrollmentIntRepository {
       where: where?.call(EnrollmentInt.t),
       orderBy: orderBy?.call(EnrollmentInt.t),
       orderByList: orderByList?.call(EnrollmentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -613,8 +599,6 @@ class EnrollmentIntRepository {
     int? offset,
     _i1.OrderByBuilder<EnrollmentIntTable>? orderBy,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -625,8 +609,6 @@ class EnrollmentIntRepository {
       offset: offset,
       orderBy: orderBy?.call(EnrollmentInt.t),
       orderByList: orderByList?.call(EnrollmentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -647,8 +629,6 @@ class EnrollmentIntRepository {
     _i1.DatabaseSession session,
     List<EnrollmentInt> rows, {
     _i1.OrderByBuilder<EnrollmentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -657,8 +637,6 @@ class EnrollmentIntRepository {
       rows,
       orderBy: orderBy?.call(EnrollmentInt.t),
       orderByList: orderByList?.call(EnrollmentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -688,8 +666,6 @@ class EnrollmentIntRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnrollmentIntTable> where,
     _i1.OrderByBuilder<EnrollmentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -698,8 +674,6 @@ class EnrollmentIntRepository {
       where: where(EnrollmentInt.t),
       orderBy: orderBy?.call(EnrollmentInt.t),
       orderByList: orderByList?.call(EnrollmentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/student.dart
@@ -100,8 +100,6 @@ abstract class StudentUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StudentUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     StudentUuidInclude? include,
   }) {
@@ -110,8 +108,6 @@ abstract class StudentUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(StudentUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(StudentUuid.t),
       include: include,
     );
@@ -248,8 +244,6 @@ class StudentUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -298,8 +292,6 @@ class StudentUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StudentUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     _i1.Transaction? transaction,
     StudentUuidInclude? include,
@@ -310,8 +302,6 @@ class StudentUuidRepository {
       where: where?.call(StudentUuid.t),
       orderBy: orderBy?.call(StudentUuid.t),
       orderByList: orderByList?.call(StudentUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -343,8 +333,6 @@ class StudentUuidRepository {
     _i1.WhereExpressionBuilder<StudentUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<StudentUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     _i1.Transaction? transaction,
     StudentUuidInclude? include,
@@ -355,8 +343,6 @@ class StudentUuidRepository {
       where: where?.call(StudentUuid.t),
       orderBy: orderBy?.call(StudentUuid.t),
       orderByList: orderByList?.call(StudentUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -564,8 +550,6 @@ class StudentUuidRepository {
     int? offset,
     _i1.OrderByBuilder<StudentUuidTable>? orderBy,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -576,8 +560,6 @@ class StudentUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(StudentUuid.t),
       orderByList: orderByList?.call(StudentUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -598,8 +580,6 @@ class StudentUuidRepository {
     _i1.DatabaseSession session,
     List<StudentUuid> rows, {
     _i1.OrderByBuilder<StudentUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -608,8 +588,6 @@ class StudentUuidRepository {
       rows,
       orderBy: orderBy?.call(StudentUuid.t),
       orderByList: orderByList?.call(StudentUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -639,8 +617,6 @@ class StudentUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StudentUuidTable> where,
     _i1.OrderByBuilder<StudentUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -649,8 +625,6 @@ class StudentUuidRepository {
       where: where(StudentUuid.t),
       orderBy: orderBy?.call(StudentUuid.t),
       orderByList: orderByList?.call(StudentUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/arena.dart
@@ -92,8 +92,6 @@ abstract class ArenaUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ArenaUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     ArenaUuidInclude? include,
   }) {
@@ -102,8 +100,6 @@ abstract class ArenaUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ArenaUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ArenaUuid.t),
       include: include,
     );
@@ -217,8 +213,6 @@ class ArenaUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -267,8 +261,6 @@ class ArenaUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ArenaUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     _i1.Transaction? transaction,
     ArenaUuidInclude? include,
@@ -279,8 +271,6 @@ class ArenaUuidRepository {
       where: where?.call(ArenaUuid.t),
       orderBy: orderBy?.call(ArenaUuid.t),
       orderByList: orderByList?.call(ArenaUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -312,8 +302,6 @@ class ArenaUuidRepository {
     _i1.WhereExpressionBuilder<ArenaUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<ArenaUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     _i1.Transaction? transaction,
     ArenaUuidInclude? include,
@@ -324,8 +312,6 @@ class ArenaUuidRepository {
       where: where?.call(ArenaUuid.t),
       orderBy: orderBy?.call(ArenaUuid.t),
       orderByList: orderByList?.call(ArenaUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -533,8 +519,6 @@ class ArenaUuidRepository {
     int? offset,
     _i1.OrderByBuilder<ArenaUuidTable>? orderBy,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -545,8 +529,6 @@ class ArenaUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(ArenaUuid.t),
       orderByList: orderByList?.call(ArenaUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -567,8 +549,6 @@ class ArenaUuidRepository {
     _i1.DatabaseSession session,
     List<ArenaUuid> rows, {
     _i1.OrderByBuilder<ArenaUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -577,8 +557,6 @@ class ArenaUuidRepository {
       rows,
       orderBy: orderBy?.call(ArenaUuid.t),
       orderByList: orderByList?.call(ArenaUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -608,8 +586,6 @@ class ArenaUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ArenaUuidTable> where,
     _i1.OrderByBuilder<ArenaUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -618,8 +594,6 @@ class ArenaUuidRepository {
       where: where(ArenaUuid.t),
       orderBy: orderBy?.call(ArenaUuid.t),
       orderByList: orderByList?.call(ArenaUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
@@ -100,8 +100,6 @@ abstract class PlayerUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PlayerUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     PlayerUuidInclude? include,
   }) {
@@ -110,8 +108,6 @@ abstract class PlayerUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(PlayerUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(PlayerUuid.t),
       include: include,
     );
@@ -241,8 +237,6 @@ class PlayerUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -291,8 +285,6 @@ class PlayerUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PlayerUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     _i1.Transaction? transaction,
     PlayerUuidInclude? include,
@@ -303,8 +295,6 @@ class PlayerUuidRepository {
       where: where?.call(PlayerUuid.t),
       orderBy: orderBy?.call(PlayerUuid.t),
       orderByList: orderByList?.call(PlayerUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -336,8 +326,6 @@ class PlayerUuidRepository {
     _i1.WhereExpressionBuilder<PlayerUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<PlayerUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     _i1.Transaction? transaction,
     PlayerUuidInclude? include,
@@ -348,8 +336,6 @@ class PlayerUuidRepository {
       where: where?.call(PlayerUuid.t),
       orderBy: orderBy?.call(PlayerUuid.t),
       orderByList: orderByList?.call(PlayerUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -557,8 +543,6 @@ class PlayerUuidRepository {
     int? offset,
     _i1.OrderByBuilder<PlayerUuidTable>? orderBy,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -569,8 +553,6 @@ class PlayerUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(PlayerUuid.t),
       orderByList: orderByList?.call(PlayerUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -591,8 +573,6 @@ class PlayerUuidRepository {
     _i1.DatabaseSession session,
     List<PlayerUuid> rows, {
     _i1.OrderByBuilder<PlayerUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -601,8 +581,6 @@ class PlayerUuidRepository {
       rows,
       orderBy: orderBy?.call(PlayerUuid.t),
       orderByList: orderByList?.call(PlayerUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -632,8 +610,6 @@ class PlayerUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PlayerUuidTable> where,
     _i1.OrderByBuilder<PlayerUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -642,8 +618,6 @@ class PlayerUuidRepository {
       where: where(PlayerUuid.t),
       orderBy: orderBy?.call(PlayerUuid.t),
       orderByList: orderByList?.call(PlayerUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/nested_one_to_many/team.dart
@@ -123,8 +123,6 @@ abstract class TeamInt
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TeamIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     TeamIntInclude? include,
   }) {
@@ -133,8 +131,6 @@ abstract class TeamInt
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(TeamInt.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(TeamInt.t),
       include: include,
     );
@@ -319,8 +315,6 @@ class TeamIntIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -373,8 +367,6 @@ class TeamIntRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TeamIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     _i1.Transaction? transaction,
     TeamIntInclude? include,
@@ -385,8 +377,6 @@ class TeamIntRepository {
       where: where?.call(TeamInt.t),
       orderBy: orderBy?.call(TeamInt.t),
       orderByList: orderByList?.call(TeamInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -418,8 +408,6 @@ class TeamIntRepository {
     _i1.WhereExpressionBuilder<TeamIntTable>? where,
     int? offset,
     _i1.OrderByBuilder<TeamIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     _i1.Transaction? transaction,
     TeamIntInclude? include,
@@ -430,8 +418,6 @@ class TeamIntRepository {
       where: where?.call(TeamInt.t),
       orderBy: orderBy?.call(TeamInt.t),
       orderByList: orderByList?.call(TeamInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -639,8 +625,6 @@ class TeamIntRepository {
     int? offset,
     _i1.OrderByBuilder<TeamIntTable>? orderBy,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -651,8 +635,6 @@ class TeamIntRepository {
       offset: offset,
       orderBy: orderBy?.call(TeamInt.t),
       orderByList: orderByList?.call(TeamInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -673,8 +655,6 @@ class TeamIntRepository {
     _i1.DatabaseSession session,
     List<TeamInt> rows, {
     _i1.OrderByBuilder<TeamIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -683,8 +663,6 @@ class TeamIntRepository {
       rows,
       orderBy: orderBy?.call(TeamInt.t),
       orderByList: orderByList?.call(TeamInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -714,8 +692,6 @@ class TeamIntRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TeamIntTable> where,
     _i1.OrderByBuilder<TeamIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -724,8 +700,6 @@ class TeamIntRepository {
       where: where(TeamInt.t),
       orderBy: orderBy?.call(TeamInt.t),
       orderByList: orderByList?.call(TeamInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/comment.dart
@@ -102,8 +102,6 @@ abstract class CommentInt
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CommentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     CommentIntInclude? include,
   }) {
@@ -112,8 +110,6 @@ abstract class CommentInt
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CommentInt.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CommentInt.t),
       include: include,
     );
@@ -244,8 +240,6 @@ class CommentIntIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -292,8 +286,6 @@ class CommentIntRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CommentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     _i1.Transaction? transaction,
     CommentIntInclude? include,
@@ -304,8 +296,6 @@ class CommentIntRepository {
       where: where?.call(CommentInt.t),
       orderBy: orderBy?.call(CommentInt.t),
       orderByList: orderByList?.call(CommentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -337,8 +327,6 @@ class CommentIntRepository {
     _i1.WhereExpressionBuilder<CommentIntTable>? where,
     int? offset,
     _i1.OrderByBuilder<CommentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     _i1.Transaction? transaction,
     CommentIntInclude? include,
@@ -349,8 +337,6 @@ class CommentIntRepository {
       where: where?.call(CommentInt.t),
       orderBy: orderBy?.call(CommentInt.t),
       orderByList: orderByList?.call(CommentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -558,8 +544,6 @@ class CommentIntRepository {
     int? offset,
     _i1.OrderByBuilder<CommentIntTable>? orderBy,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -570,8 +554,6 @@ class CommentIntRepository {
       offset: offset,
       orderBy: orderBy?.call(CommentInt.t),
       orderByList: orderByList?.call(CommentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -592,8 +574,6 @@ class CommentIntRepository {
     _i1.DatabaseSession session,
     List<CommentInt> rows, {
     _i1.OrderByBuilder<CommentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -602,8 +582,6 @@ class CommentIntRepository {
       rows,
       orderBy: orderBy?.call(CommentInt.t),
       orderByList: orderByList?.call(CommentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -633,8 +611,6 @@ class CommentIntRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CommentIntTable> where,
     _i1.OrderByBuilder<CommentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -643,8 +619,6 @@ class CommentIntRepository {
       where: where(CommentInt.t),
       orderBy: orderBy?.call(CommentInt.t),
       orderByList: orderByList?.call(CommentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
@@ -94,8 +94,6 @@ abstract class CustomerInt
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CustomerIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     CustomerIntInclude? include,
   }) {
@@ -104,8 +102,6 @@ abstract class CustomerInt
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CustomerInt.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CustomerInt.t),
       include: include,
     );
@@ -242,8 +238,6 @@ class CustomerIntIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -296,8 +290,6 @@ class CustomerIntRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CustomerIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     _i1.Transaction? transaction,
     CustomerIntInclude? include,
@@ -308,8 +300,6 @@ class CustomerIntRepository {
       where: where?.call(CustomerInt.t),
       orderBy: orderBy?.call(CustomerInt.t),
       orderByList: orderByList?.call(CustomerInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -341,8 +331,6 @@ class CustomerIntRepository {
     _i1.WhereExpressionBuilder<CustomerIntTable>? where,
     int? offset,
     _i1.OrderByBuilder<CustomerIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     _i1.Transaction? transaction,
     CustomerIntInclude? include,
@@ -353,8 +341,6 @@ class CustomerIntRepository {
       where: where?.call(CustomerInt.t),
       orderBy: orderBy?.call(CustomerInt.t),
       orderByList: orderByList?.call(CustomerInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -562,8 +548,6 @@ class CustomerIntRepository {
     int? offset,
     _i1.OrderByBuilder<CustomerIntTable>? orderBy,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -574,8 +558,6 @@ class CustomerIntRepository {
       offset: offset,
       orderBy: orderBy?.call(CustomerInt.t),
       orderByList: orderByList?.call(CustomerInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -596,8 +578,6 @@ class CustomerIntRepository {
     _i1.DatabaseSession session,
     List<CustomerInt> rows, {
     _i1.OrderByBuilder<CustomerIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -606,8 +586,6 @@ class CustomerIntRepository {
       rows,
       orderBy: orderBy?.call(CustomerInt.t),
       orderByList: orderByList?.call(CustomerInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -637,8 +615,6 @@ class CustomerIntRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CustomerIntTable> where,
     _i1.OrderByBuilder<CustomerIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -647,8 +623,6 @@ class CustomerIntRepository {
       where: where(CustomerInt.t),
       orderBy: orderBy?.call(CustomerInt.t),
       orderByList: orderByList?.call(CustomerInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/order.dart
@@ -123,8 +123,6 @@ abstract class OrderUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrderUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     OrderUuidInclude? include,
   }) {
@@ -133,8 +131,6 @@ abstract class OrderUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(OrderUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(OrderUuid.t),
       include: include,
     );
@@ -320,8 +316,6 @@ class OrderUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -370,8 +364,6 @@ class OrderUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrderUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     _i1.Transaction? transaction,
     OrderUuidInclude? include,
@@ -382,8 +374,6 @@ class OrderUuidRepository {
       where: where?.call(OrderUuid.t),
       orderBy: orderBy?.call(OrderUuid.t),
       orderByList: orderByList?.call(OrderUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -415,8 +405,6 @@ class OrderUuidRepository {
     _i1.WhereExpressionBuilder<OrderUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<OrderUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     _i1.Transaction? transaction,
     OrderUuidInclude? include,
@@ -427,8 +415,6 @@ class OrderUuidRepository {
       where: where?.call(OrderUuid.t),
       orderBy: orderBy?.call(OrderUuid.t),
       orderByList: orderByList?.call(OrderUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -636,8 +622,6 @@ class OrderUuidRepository {
     int? offset,
     _i1.OrderByBuilder<OrderUuidTable>? orderBy,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -648,8 +632,6 @@ class OrderUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(OrderUuid.t),
       orderByList: orderByList?.call(OrderUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -670,8 +652,6 @@ class OrderUuidRepository {
     _i1.DatabaseSession session,
     List<OrderUuid> rows, {
     _i1.OrderByBuilder<OrderUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -680,8 +660,6 @@ class OrderUuidRepository {
       rows,
       orderBy: orderBy?.call(OrderUuid.t),
       orderByList: orderByList?.call(OrderUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -711,8 +689,6 @@ class OrderUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrderUuidTable> where,
     _i1.OrderByBuilder<OrderUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -721,8 +697,6 @@ class OrderUuidRepository {
       where: where(OrderUuid.t),
       orderBy: orderBy?.call(OrderUuid.t),
       orderByList: orderByList?.call(OrderUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/address.dart
@@ -102,8 +102,6 @@ abstract class AddressUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AddressUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     AddressUuidInclude? include,
   }) {
@@ -112,8 +110,6 @@ abstract class AddressUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(AddressUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(AddressUuid.t),
       include: include,
     );
@@ -245,8 +241,6 @@ class AddressUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -295,8 +289,6 @@ class AddressUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AddressUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     _i1.Transaction? transaction,
     AddressUuidInclude? include,
@@ -307,8 +299,6 @@ class AddressUuidRepository {
       where: where?.call(AddressUuid.t),
       orderBy: orderBy?.call(AddressUuid.t),
       orderByList: orderByList?.call(AddressUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -340,8 +330,6 @@ class AddressUuidRepository {
     _i1.WhereExpressionBuilder<AddressUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<AddressUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     _i1.Transaction? transaction,
     AddressUuidInclude? include,
@@ -352,8 +340,6 @@ class AddressUuidRepository {
       where: where?.call(AddressUuid.t),
       orderBy: orderBy?.call(AddressUuid.t),
       orderByList: orderByList?.call(AddressUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -561,8 +547,6 @@ class AddressUuidRepository {
     int? offset,
     _i1.OrderByBuilder<AddressUuidTable>? orderBy,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -573,8 +557,6 @@ class AddressUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(AddressUuid.t),
       orderByList: orderByList?.call(AddressUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -595,8 +577,6 @@ class AddressUuidRepository {
     _i1.DatabaseSession session,
     List<AddressUuid> rows, {
     _i1.OrderByBuilder<AddressUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -605,8 +585,6 @@ class AddressUuidRepository {
       rows,
       orderBy: orderBy?.call(AddressUuid.t),
       orderByList: orderByList?.call(AddressUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -636,8 +614,6 @@ class AddressUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AddressUuidTable> where,
     _i1.OrderByBuilder<AddressUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -646,8 +622,6 @@ class AddressUuidRepository {
       where: where(AddressUuid.t),
       orderBy: orderBy?.call(AddressUuid.t),
       orderByList: orderByList?.call(AddressUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/citizen.dart
@@ -147,8 +147,6 @@ abstract class CitizenInt
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CitizenIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     CitizenIntInclude? include,
   }) {
@@ -157,8 +155,6 @@ abstract class CitizenInt
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CitizenInt.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CitizenInt.t),
       include: include,
     );
@@ -370,8 +366,6 @@ class CitizenIntIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -420,8 +414,6 @@ class CitizenIntRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CitizenIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     _i1.Transaction? transaction,
     CitizenIntInclude? include,
@@ -432,8 +424,6 @@ class CitizenIntRepository {
       where: where?.call(CitizenInt.t),
       orderBy: orderBy?.call(CitizenInt.t),
       orderByList: orderByList?.call(CitizenInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -465,8 +455,6 @@ class CitizenIntRepository {
     _i1.WhereExpressionBuilder<CitizenIntTable>? where,
     int? offset,
     _i1.OrderByBuilder<CitizenIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     _i1.Transaction? transaction,
     CitizenIntInclude? include,
@@ -477,8 +465,6 @@ class CitizenIntRepository {
       where: where?.call(CitizenInt.t),
       orderBy: orderBy?.call(CitizenInt.t),
       orderByList: orderByList?.call(CitizenInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -686,8 +672,6 @@ class CitizenIntRepository {
     int? offset,
     _i1.OrderByBuilder<CitizenIntTable>? orderBy,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -698,8 +682,6 @@ class CitizenIntRepository {
       offset: offset,
       orderBy: orderBy?.call(CitizenInt.t),
       orderByList: orderByList?.call(CitizenInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -720,8 +702,6 @@ class CitizenIntRepository {
     _i1.DatabaseSession session,
     List<CitizenInt> rows, {
     _i1.OrderByBuilder<CitizenIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -730,8 +710,6 @@ class CitizenIntRepository {
       rows,
       orderBy: orderBy?.call(CitizenInt.t),
       orderByList: orderByList?.call(CitizenInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -761,8 +739,6 @@ class CitizenIntRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CitizenIntTable> where,
     _i1.OrderByBuilder<CitizenIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -771,8 +747,6 @@ class CitizenIntRepository {
       where: where(CitizenInt.t),
       orderBy: orderBy?.call(CitizenInt.t),
       orderByList: orderByList?.call(CitizenInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/company.dart
@@ -100,8 +100,6 @@ abstract class CompanyUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CompanyUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     CompanyUuidInclude? include,
   }) {
@@ -110,8 +108,6 @@ abstract class CompanyUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CompanyUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CompanyUuid.t),
       include: include,
     );
@@ -241,8 +237,6 @@ class CompanyUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -289,8 +283,6 @@ class CompanyUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CompanyUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     _i1.Transaction? transaction,
     CompanyUuidInclude? include,
@@ -301,8 +293,6 @@ class CompanyUuidRepository {
       where: where?.call(CompanyUuid.t),
       orderBy: orderBy?.call(CompanyUuid.t),
       orderByList: orderByList?.call(CompanyUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -334,8 +324,6 @@ class CompanyUuidRepository {
     _i1.WhereExpressionBuilder<CompanyUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<CompanyUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     _i1.Transaction? transaction,
     CompanyUuidInclude? include,
@@ -346,8 +334,6 @@ class CompanyUuidRepository {
       where: where?.call(CompanyUuid.t),
       orderBy: orderBy?.call(CompanyUuid.t),
       orderByList: orderByList?.call(CompanyUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -555,8 +541,6 @@ class CompanyUuidRepository {
     int? offset,
     _i1.OrderByBuilder<CompanyUuidTable>? orderBy,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -567,8 +551,6 @@ class CompanyUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(CompanyUuid.t),
       orderByList: orderByList?.call(CompanyUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -589,8 +571,6 @@ class CompanyUuidRepository {
     _i1.DatabaseSession session,
     List<CompanyUuid> rows, {
     _i1.OrderByBuilder<CompanyUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -599,8 +579,6 @@ class CompanyUuidRepository {
       rows,
       orderBy: orderBy?.call(CompanyUuid.t),
       orderByList: orderByList?.call(CompanyUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -630,8 +608,6 @@ class CompanyUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CompanyUuidTable> where,
     _i1.OrderByBuilder<CompanyUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -640,8 +616,6 @@ class CompanyUuidRepository {
       where: where(CompanyUuid.t),
       orderBy: orderBy?.call(CompanyUuid.t),
       orderByList: orderByList?.call(CompanyUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_one/town.dart
@@ -100,8 +100,6 @@ abstract class TownInt
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TownIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     TownIntInclude? include,
   }) {
@@ -110,8 +108,6 @@ abstract class TownInt
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(TownInt.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(TownInt.t),
       include: include,
     );
@@ -241,8 +237,6 @@ class TownIntIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -291,8 +285,6 @@ class TownIntRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TownIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     _i1.Transaction? transaction,
     TownIntInclude? include,
@@ -303,8 +295,6 @@ class TownIntRepository {
       where: where?.call(TownInt.t),
       orderBy: orderBy?.call(TownInt.t),
       orderByList: orderByList?.call(TownInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -336,8 +326,6 @@ class TownIntRepository {
     _i1.WhereExpressionBuilder<TownIntTable>? where,
     int? offset,
     _i1.OrderByBuilder<TownIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     _i1.Transaction? transaction,
     TownIntInclude? include,
@@ -348,8 +336,6 @@ class TownIntRepository {
       where: where?.call(TownInt.t),
       orderBy: orderBy?.call(TownInt.t),
       orderByList: orderByList?.call(TownInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -557,8 +543,6 @@ class TownIntRepository {
     int? offset,
     _i1.OrderByBuilder<TownIntTable>? orderBy,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -569,8 +553,6 @@ class TownIntRepository {
       offset: offset,
       orderBy: orderBy?.call(TownInt.t),
       orderByList: orderByList?.call(TownInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -591,8 +573,6 @@ class TownIntRepository {
     _i1.DatabaseSession session,
     List<TownInt> rows, {
     _i1.OrderByBuilder<TownIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -601,8 +581,6 @@ class TownIntRepository {
       rows,
       orderBy: orderBy?.call(TownInt.t),
       orderByList: orderByList?.call(TownInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -632,8 +610,6 @@ class TownIntRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TownIntTable> where,
     _i1.OrderByBuilder<TownIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -642,8 +618,6 @@ class TownIntRepository {
       where: where(TownInt.t),
       orderBy: orderBy?.call(TownInt.t),
       orderByList: orderByList?.call(TownInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/self.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/self.dart
@@ -162,8 +162,6 @@ abstract class ChangedIdTypeSelf
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChangedIdTypeSelfTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     ChangedIdTypeSelfInclude? include,
   }) {
@@ -172,8 +170,6 @@ abstract class ChangedIdTypeSelf
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ChangedIdTypeSelf.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ChangedIdTypeSelf.t),
       include: include,
     );
@@ -436,8 +432,6 @@ class ChangedIdTypeSelfIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -490,8 +484,6 @@ class ChangedIdTypeSelfRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChangedIdTypeSelfTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     _i1.Transaction? transaction,
     ChangedIdTypeSelfInclude? include,
@@ -502,8 +494,6 @@ class ChangedIdTypeSelfRepository {
       where: where?.call(ChangedIdTypeSelf.t),
       orderBy: orderBy?.call(ChangedIdTypeSelf.t),
       orderByList: orderByList?.call(ChangedIdTypeSelf.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -535,8 +525,6 @@ class ChangedIdTypeSelfRepository {
     _i1.WhereExpressionBuilder<ChangedIdTypeSelfTable>? where,
     int? offset,
     _i1.OrderByBuilder<ChangedIdTypeSelfTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     _i1.Transaction? transaction,
     ChangedIdTypeSelfInclude? include,
@@ -547,8 +535,6 @@ class ChangedIdTypeSelfRepository {
       where: where?.call(ChangedIdTypeSelf.t),
       orderBy: orderBy?.call(ChangedIdTypeSelf.t),
       orderByList: orderByList?.call(ChangedIdTypeSelf.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -758,8 +744,6 @@ class ChangedIdTypeSelfRepository {
     int? offset,
     _i1.OrderByBuilder<ChangedIdTypeSelfTable>? orderBy,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -770,8 +754,6 @@ class ChangedIdTypeSelfRepository {
       offset: offset,
       orderBy: orderBy?.call(ChangedIdTypeSelf.t),
       orderByList: orderByList?.call(ChangedIdTypeSelf.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -792,8 +774,6 @@ class ChangedIdTypeSelfRepository {
     _i1.DatabaseSession session,
     List<ChangedIdTypeSelf> rows, {
     _i1.OrderByBuilder<ChangedIdTypeSelfTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -802,8 +782,6 @@ class ChangedIdTypeSelfRepository {
       rows,
       orderBy: orderBy?.call(ChangedIdTypeSelf.t),
       orderByList: orderByList?.call(ChangedIdTypeSelf.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -833,8 +811,6 @@ class ChangedIdTypeSelfRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChangedIdTypeSelfTable> where,
     _i1.OrderByBuilder<ChangedIdTypeSelfTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -843,8 +819,6 @@ class ChangedIdTypeSelfRepository {
       where: where(ChangedIdTypeSelf.t),
       orderBy: orderBy?.call(ChangedIdTypeSelf.t),
       orderByList: orderByList?.call(ChangedIdTypeSelf.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/server_only.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/server_only.dart
@@ -65,8 +65,6 @@ abstract class ServerOnlyChangedIdFieldClass
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServerOnlyChangedIdFieldClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     ServerOnlyChangedIdFieldClassInclude? include,
   }) {
@@ -75,8 +73,6 @@ abstract class ServerOnlyChangedIdFieldClass
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ServerOnlyChangedIdFieldClass.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ServerOnlyChangedIdFieldClass.t),
       include: include,
     );
@@ -137,8 +133,6 @@ class ServerOnlyChangedIdFieldClassIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -183,8 +177,6 @@ class ServerOnlyChangedIdFieldClassRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServerOnlyChangedIdFieldClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -194,8 +186,6 @@ class ServerOnlyChangedIdFieldClassRepository {
       where: where?.call(ServerOnlyChangedIdFieldClass.t),
       orderBy: orderBy?.call(ServerOnlyChangedIdFieldClass.t),
       orderByList: orderByList?.call(ServerOnlyChangedIdFieldClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -226,8 +216,6 @@ class ServerOnlyChangedIdFieldClassRepository {
     _i1.WhereExpressionBuilder<ServerOnlyChangedIdFieldClassTable>? where,
     int? offset,
     _i1.OrderByBuilder<ServerOnlyChangedIdFieldClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -237,8 +225,6 @@ class ServerOnlyChangedIdFieldClassRepository {
       where: where?.call(ServerOnlyChangedIdFieldClass.t),
       orderBy: orderBy?.call(ServerOnlyChangedIdFieldClass.t),
       orderByList: orderByList?.call(ServerOnlyChangedIdFieldClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -452,8 +438,6 @@ class ServerOnlyChangedIdFieldClassRepository {
     int? offset,
     _i1.OrderByBuilder<ServerOnlyChangedIdFieldClassTable>? orderBy,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -464,8 +448,6 @@ class ServerOnlyChangedIdFieldClassRepository {
       offset: offset,
       orderBy: orderBy?.call(ServerOnlyChangedIdFieldClass.t),
       orderByList: orderByList?.call(ServerOnlyChangedIdFieldClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -486,8 +468,6 @@ class ServerOnlyChangedIdFieldClassRepository {
     _i1.DatabaseSession session,
     List<ServerOnlyChangedIdFieldClass> rows, {
     _i1.OrderByBuilder<ServerOnlyChangedIdFieldClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -496,8 +476,6 @@ class ServerOnlyChangedIdFieldClassRepository {
       rows,
       orderBy: orderBy?.call(ServerOnlyChangedIdFieldClass.t),
       orderByList: orderByList?.call(ServerOnlyChangedIdFieldClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -528,8 +506,6 @@ class ServerOnlyChangedIdFieldClassRepository {
     required _i1.WhereExpressionBuilder<ServerOnlyChangedIdFieldClassTable>
     where,
     _i1.OrderByBuilder<ServerOnlyChangedIdFieldClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -538,8 +514,6 @@ class ServerOnlyChangedIdFieldClassRepository {
       where: where(ServerOnlyChangedIdFieldClass.t),
       orderBy: orderBy?.call(ServerOnlyChangedIdFieldClass.t),
       orderByList: orderByList?.call(ServerOnlyChangedIdFieldClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default.dart
@@ -98,8 +98,6 @@ abstract class BigIntDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     BigIntDefaultInclude? include,
   }) {
@@ -108,8 +106,6 @@ abstract class BigIntDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BigIntDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BigIntDefault.t),
       include: include,
     );
@@ -215,8 +211,6 @@ class BigIntDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -261,8 +255,6 @@ class BigIntDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -272,8 +264,6 @@ class BigIntDefaultRepository {
       where: where?.call(BigIntDefault.t),
       orderBy: orderBy?.call(BigIntDefault.t),
       orderByList: orderByList?.call(BigIntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -304,8 +294,6 @@ class BigIntDefaultRepository {
     _i1.WhereExpressionBuilder<BigIntDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -315,8 +303,6 @@ class BigIntDefaultRepository {
       where: where?.call(BigIntDefault.t),
       orderBy: orderBy?.call(BigIntDefault.t),
       orderByList: orderByList?.call(BigIntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -521,8 +507,6 @@ class BigIntDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultTable>? orderBy,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -533,8 +517,6 @@ class BigIntDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(BigIntDefault.t),
       orderByList: orderByList?.call(BigIntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -555,8 +537,6 @@ class BigIntDefaultRepository {
     _i1.DatabaseSession session,
     List<BigIntDefault> rows, {
     _i1.OrderByBuilder<BigIntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -565,8 +545,6 @@ class BigIntDefaultRepository {
       rows,
       orderBy: orderBy?.call(BigIntDefault.t),
       orderByList: orderByList?.call(BigIntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -596,8 +574,6 @@ class BigIntDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultTable> where,
     _i1.OrderByBuilder<BigIntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -606,8 +582,6 @@ class BigIntDefaultRepository {
       where: where(BigIntDefault.t),
       orderBy: orderBy?.call(BigIntDefault.t),
       orderByList: orderByList?.call(BigIntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default_mix.dart
@@ -117,8 +117,6 @@ abstract class BigIntDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     BigIntDefaultMixInclude? include,
   }) {
@@ -127,8 +125,6 @@ abstract class BigIntDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BigIntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BigIntDefaultMix.t),
       include: include,
     );
@@ -258,8 +254,6 @@ class BigIntDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -304,8 +298,6 @@ class BigIntDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -315,8 +307,6 @@ class BigIntDefaultMixRepository {
       where: where?.call(BigIntDefaultMix.t),
       orderBy: orderBy?.call(BigIntDefaultMix.t),
       orderByList: orderByList?.call(BigIntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -347,8 +337,6 @@ class BigIntDefaultMixRepository {
     _i1.WhereExpressionBuilder<BigIntDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -358,8 +346,6 @@ class BigIntDefaultMixRepository {
       where: where?.call(BigIntDefaultMix.t),
       orderBy: orderBy?.call(BigIntDefaultMix.t),
       orderByList: orderByList?.call(BigIntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -566,8 +552,6 @@ class BigIntDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -578,8 +562,6 @@ class BigIntDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(BigIntDefaultMix.t),
       orderByList: orderByList?.call(BigIntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -600,8 +582,6 @@ class BigIntDefaultMixRepository {
     _i1.DatabaseSession session,
     List<BigIntDefaultMix> rows, {
     _i1.OrderByBuilder<BigIntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -610,8 +590,6 @@ class BigIntDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(BigIntDefaultMix.t),
       orderByList: orderByList?.call(BigIntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -641,8 +619,6 @@ class BigIntDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultMixTable> where,
     _i1.OrderByBuilder<BigIntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -651,8 +627,6 @@ class BigIntDefaultMixRepository {
       where: where(BigIntDefaultMix.t),
       orderBy: orderBy?.call(BigIntDefaultMix.t),
       orderByList: orderByList?.call(BigIntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default_model.dart
@@ -101,8 +101,6 @@ abstract class BigIntDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     BigIntDefaultModelInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class BigIntDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BigIntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BigIntDefaultModel.t),
       include: include,
     );
@@ -218,8 +214,6 @@ class BigIntDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -264,8 +258,6 @@ class BigIntDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -275,8 +267,6 @@ class BigIntDefaultModelRepository {
       where: where?.call(BigIntDefaultModel.t),
       orderBy: orderBy?.call(BigIntDefaultModel.t),
       orderByList: orderByList?.call(BigIntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -307,8 +297,6 @@ class BigIntDefaultModelRepository {
     _i1.WhereExpressionBuilder<BigIntDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -318,8 +306,6 @@ class BigIntDefaultModelRepository {
       where: where?.call(BigIntDefaultModel.t),
       orderBy: orderBy?.call(BigIntDefaultModel.t),
       orderByList: orderByList?.call(BigIntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -526,8 +512,6 @@ class BigIntDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -538,8 +522,6 @@ class BigIntDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(BigIntDefaultModel.t),
       orderByList: orderByList?.call(BigIntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -560,8 +542,6 @@ class BigIntDefaultModelRepository {
     _i1.DatabaseSession session,
     List<BigIntDefaultModel> rows, {
     _i1.OrderByBuilder<BigIntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -570,8 +550,6 @@ class BigIntDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(BigIntDefaultModel.t),
       orderByList: orderByList?.call(BigIntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -601,8 +579,6 @@ class BigIntDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultModelTable> where,
     _i1.OrderByBuilder<BigIntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -611,8 +587,6 @@ class BigIntDefaultModelRepository {
       where: where(BigIntDefaultModel.t),
       orderBy: orderBy?.call(BigIntDefaultModel.t),
       orderByList: orderByList?.call(BigIntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/bigint/bigint_default_persist.dart
@@ -86,8 +86,6 @@ abstract class BigIntDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     BigIntDefaultPersistInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class BigIntDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BigIntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BigIntDefaultPersist.t),
       include: include,
     );
@@ -186,8 +182,6 @@ class BigIntDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -232,8 +226,6 @@ class BigIntDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -243,8 +235,6 @@ class BigIntDefaultPersistRepository {
       where: where?.call(BigIntDefaultPersist.t),
       orderBy: orderBy?.call(BigIntDefaultPersist.t),
       orderByList: orderByList?.call(BigIntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -275,8 +265,6 @@ class BigIntDefaultPersistRepository {
     _i1.WhereExpressionBuilder<BigIntDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -286,8 +274,6 @@ class BigIntDefaultPersistRepository {
       where: where?.call(BigIntDefaultPersist.t),
       orderBy: orderBy?.call(BigIntDefaultPersist.t),
       orderByList: orderByList?.call(BigIntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -494,8 +480,6 @@ class BigIntDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -506,8 +490,6 @@ class BigIntDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(BigIntDefaultPersist.t),
       orderByList: orderByList?.call(BigIntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -528,8 +510,6 @@ class BigIntDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<BigIntDefaultPersist> rows, {
     _i1.OrderByBuilder<BigIntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -538,8 +518,6 @@ class BigIntDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(BigIntDefaultPersist.t),
       orderByList: orderByList?.call(BigIntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -569,8 +547,6 @@ class BigIntDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultPersistTable> where,
     _i1.OrderByBuilder<BigIntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -579,8 +555,6 @@ class BigIntDefaultPersistRepository {
       where: where(BigIntDefaultPersist.t),
       orderBy: orderBy?.call(BigIntDefaultPersist.t),
       orderByList: orderByList?.call(BigIntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default.dart
@@ -109,8 +109,6 @@ abstract class BoolDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     BoolDefaultInclude? include,
   }) {
@@ -119,8 +117,6 @@ abstract class BoolDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BoolDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BoolDefault.t),
       include: include,
     );
@@ -241,8 +237,6 @@ class BoolDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -287,8 +281,6 @@ class BoolDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -298,8 +290,6 @@ class BoolDefaultRepository {
       where: where?.call(BoolDefault.t),
       orderBy: orderBy?.call(BoolDefault.t),
       orderByList: orderByList?.call(BoolDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -330,8 +320,6 @@ class BoolDefaultRepository {
     _i1.WhereExpressionBuilder<BoolDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -341,8 +329,6 @@ class BoolDefaultRepository {
       where: where?.call(BoolDefault.t),
       orderBy: orderBy?.call(BoolDefault.t),
       orderByList: orderByList?.call(BoolDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -547,8 +533,6 @@ class BoolDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<BoolDefaultTable>? orderBy,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -559,8 +543,6 @@ class BoolDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(BoolDefault.t),
       orderByList: orderByList?.call(BoolDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -581,8 +563,6 @@ class BoolDefaultRepository {
     _i1.DatabaseSession session,
     List<BoolDefault> rows, {
     _i1.OrderByBuilder<BoolDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -591,8 +571,6 @@ class BoolDefaultRepository {
       rows,
       orderBy: orderBy?.call(BoolDefault.t),
       orderByList: orderByList?.call(BoolDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -622,8 +600,6 @@ class BoolDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultTable> where,
     _i1.OrderByBuilder<BoolDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -632,8 +608,6 @@ class BoolDefaultRepository {
       where: where(BoolDefault.t),
       orderBy: orderBy?.call(BoolDefault.t),
       orderByList: orderByList?.call(BoolDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
@@ -111,8 +111,6 @@ abstract class BoolDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     BoolDefaultMixInclude? include,
   }) {
@@ -121,8 +119,6 @@ abstract class BoolDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BoolDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BoolDefaultMix.t),
       include: include,
     );
@@ -248,8 +244,6 @@ class BoolDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -294,8 +288,6 @@ class BoolDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -305,8 +297,6 @@ class BoolDefaultMixRepository {
       where: where?.call(BoolDefaultMix.t),
       orderBy: orderBy?.call(BoolDefaultMix.t),
       orderByList: orderByList?.call(BoolDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -337,8 +327,6 @@ class BoolDefaultMixRepository {
     _i1.WhereExpressionBuilder<BoolDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -348,8 +336,6 @@ class BoolDefaultMixRepository {
       where: where?.call(BoolDefaultMix.t),
       orderBy: orderBy?.call(BoolDefaultMix.t),
       orderByList: orderByList?.call(BoolDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -554,8 +540,6 @@ class BoolDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<BoolDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -566,8 +550,6 @@ class BoolDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(BoolDefaultMix.t),
       orderByList: orderByList?.call(BoolDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -588,8 +570,6 @@ class BoolDefaultMixRepository {
     _i1.DatabaseSession session,
     List<BoolDefaultMix> rows, {
     _i1.OrderByBuilder<BoolDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -598,8 +578,6 @@ class BoolDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(BoolDefaultMix.t),
       orderByList: orderByList?.call(BoolDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -629,8 +607,6 @@ class BoolDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultMixTable> where,
     _i1.OrderByBuilder<BoolDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -639,8 +615,6 @@ class BoolDefaultMixRepository {
       where: where(BoolDefaultMix.t),
       orderBy: orderBy?.call(BoolDefaultMix.t),
       orderByList: orderByList?.call(BoolDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_model.dart
@@ -108,8 +108,6 @@ abstract class BoolDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     BoolDefaultModelInclude? include,
   }) {
@@ -118,8 +116,6 @@ abstract class BoolDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BoolDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BoolDefaultModel.t),
       include: include,
     );
@@ -241,8 +237,6 @@ class BoolDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -287,8 +281,6 @@ class BoolDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -298,8 +290,6 @@ class BoolDefaultModelRepository {
       where: where?.call(BoolDefaultModel.t),
       orderBy: orderBy?.call(BoolDefaultModel.t),
       orderByList: orderByList?.call(BoolDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -330,8 +320,6 @@ class BoolDefaultModelRepository {
     _i1.WhereExpressionBuilder<BoolDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -341,8 +329,6 @@ class BoolDefaultModelRepository {
       where: where?.call(BoolDefaultModel.t),
       orderBy: orderBy?.call(BoolDefaultModel.t),
       orderByList: orderByList?.call(BoolDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -549,8 +535,6 @@ class BoolDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<BoolDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -561,8 +545,6 @@ class BoolDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(BoolDefaultModel.t),
       orderByList: orderByList?.call(BoolDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -583,8 +565,6 @@ class BoolDefaultModelRepository {
     _i1.DatabaseSession session,
     List<BoolDefaultModel> rows, {
     _i1.OrderByBuilder<BoolDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -593,8 +573,6 @@ class BoolDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(BoolDefaultModel.t),
       orderByList: orderByList?.call(BoolDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -624,8 +602,6 @@ class BoolDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultModelTable> where,
     _i1.OrderByBuilder<BoolDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -634,8 +610,6 @@ class BoolDefaultModelRepository {
       where: where(BoolDefaultModel.t),
       orderBy: orderBy?.call(BoolDefaultModel.t),
       orderByList: orderByList?.call(BoolDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
@@ -99,8 +99,6 @@ abstract class BoolDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     BoolDefaultPersistInclude? include,
   }) {
@@ -109,8 +107,6 @@ abstract class BoolDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BoolDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BoolDefaultPersist.t),
       include: include,
     );
@@ -219,8 +215,6 @@ class BoolDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -265,8 +259,6 @@ class BoolDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -276,8 +268,6 @@ class BoolDefaultPersistRepository {
       where: where?.call(BoolDefaultPersist.t),
       orderBy: orderBy?.call(BoolDefaultPersist.t),
       orderByList: orderByList?.call(BoolDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -308,8 +298,6 @@ class BoolDefaultPersistRepository {
     _i1.WhereExpressionBuilder<BoolDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -319,8 +307,6 @@ class BoolDefaultPersistRepository {
       where: where?.call(BoolDefaultPersist.t),
       orderBy: orderBy?.call(BoolDefaultPersist.t),
       orderByList: orderByList?.call(BoolDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -527,8 +513,6 @@ class BoolDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<BoolDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -539,8 +523,6 @@ class BoolDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(BoolDefaultPersist.t),
       orderByList: orderByList?.call(BoolDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -561,8 +543,6 @@ class BoolDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<BoolDefaultPersist> rows, {
     _i1.OrderByBuilder<BoolDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -571,8 +551,6 @@ class BoolDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(BoolDefaultPersist.t),
       orderByList: orderByList?.call(BoolDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -602,8 +580,6 @@ class BoolDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultPersistTable> where,
     _i1.OrderByBuilder<BoolDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -612,8 +588,6 @@ class BoolDefaultPersistRepository {
       where: where(BoolDefaultPersist.t),
       orderBy: orderBy?.call(BoolDefaultPersist.t),
       orderByList: orderByList?.call(BoolDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default.dart
@@ -112,8 +112,6 @@ abstract class DateTimeDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     DateTimeDefaultInclude? include,
   }) {
@@ -122,8 +120,6 @@ abstract class DateTimeDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DateTimeDefault.t),
       include: include,
     );
@@ -247,8 +243,6 @@ class DateTimeDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -293,8 +287,6 @@ class DateTimeDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -304,8 +296,6 @@ class DateTimeDefaultRepository {
       where: where?.call(DateTimeDefault.t),
       orderBy: orderBy?.call(DateTimeDefault.t),
       orderByList: orderByList?.call(DateTimeDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -336,8 +326,6 @@ class DateTimeDefaultRepository {
     _i1.WhereExpressionBuilder<DateTimeDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -347,8 +335,6 @@ class DateTimeDefaultRepository {
       where: where?.call(DateTimeDefault.t),
       orderBy: orderBy?.call(DateTimeDefault.t),
       orderByList: orderByList?.call(DateTimeDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -555,8 +541,6 @@ class DateTimeDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultTable>? orderBy,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -567,8 +551,6 @@ class DateTimeDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefault.t),
       orderByList: orderByList?.call(DateTimeDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -589,8 +571,6 @@ class DateTimeDefaultRepository {
     _i1.DatabaseSession session,
     List<DateTimeDefault> rows, {
     _i1.OrderByBuilder<DateTimeDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -599,8 +579,6 @@ class DateTimeDefaultRepository {
       rows,
       orderBy: orderBy?.call(DateTimeDefault.t),
       orderByList: orderByList?.call(DateTimeDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -630,8 +608,6 @@ class DateTimeDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultTable> where,
     _i1.OrderByBuilder<DateTimeDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -640,8 +616,6 @@ class DateTimeDefaultRepository {
       where: where(DateTimeDefault.t),
       orderBy: orderBy?.call(DateTimeDefault.t),
       orderByList: orderByList?.call(DateTimeDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
@@ -120,8 +120,6 @@ abstract class DateTimeDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     DateTimeDefaultMixInclude? include,
   }) {
@@ -130,8 +128,6 @@ abstract class DateTimeDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DateTimeDefaultMix.t),
       include: include,
     );
@@ -263,8 +259,6 @@ class DateTimeDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -309,8 +303,6 @@ class DateTimeDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -320,8 +312,6 @@ class DateTimeDefaultMixRepository {
       where: where?.call(DateTimeDefaultMix.t),
       orderBy: orderBy?.call(DateTimeDefaultMix.t),
       orderByList: orderByList?.call(DateTimeDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -352,8 +342,6 @@ class DateTimeDefaultMixRepository {
     _i1.WhereExpressionBuilder<DateTimeDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -363,8 +351,6 @@ class DateTimeDefaultMixRepository {
       where: where?.call(DateTimeDefaultMix.t),
       orderBy: orderBy?.call(DateTimeDefaultMix.t),
       orderByList: orderByList?.call(DateTimeDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -571,8 +557,6 @@ class DateTimeDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -583,8 +567,6 @@ class DateTimeDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefaultMix.t),
       orderByList: orderByList?.call(DateTimeDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -605,8 +587,6 @@ class DateTimeDefaultMixRepository {
     _i1.DatabaseSession session,
     List<DateTimeDefaultMix> rows, {
     _i1.OrderByBuilder<DateTimeDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -615,8 +595,6 @@ class DateTimeDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(DateTimeDefaultMix.t),
       orderByList: orderByList?.call(DateTimeDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -646,8 +624,6 @@ class DateTimeDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultMixTable> where,
     _i1.OrderByBuilder<DateTimeDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -656,8 +632,6 @@ class DateTimeDefaultMixRepository {
       where: where(DateTimeDefaultMix.t),
       orderBy: orderBy?.call(DateTimeDefaultMix.t),
       orderByList: orderByList?.call(DateTimeDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
@@ -118,8 +118,6 @@ abstract class DateTimeDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     DateTimeDefaultModelInclude? include,
   }) {
@@ -128,8 +126,6 @@ abstract class DateTimeDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DateTimeDefaultModel.t),
       include: include,
     );
@@ -254,8 +250,6 @@ class DateTimeDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -300,8 +294,6 @@ class DateTimeDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -311,8 +303,6 @@ class DateTimeDefaultModelRepository {
       where: where?.call(DateTimeDefaultModel.t),
       orderBy: orderBy?.call(DateTimeDefaultModel.t),
       orderByList: orderByList?.call(DateTimeDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -343,8 +333,6 @@ class DateTimeDefaultModelRepository {
     _i1.WhereExpressionBuilder<DateTimeDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -354,8 +342,6 @@ class DateTimeDefaultModelRepository {
       where: where?.call(DateTimeDefaultModel.t),
       orderBy: orderBy?.call(DateTimeDefaultModel.t),
       orderByList: orderByList?.call(DateTimeDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -562,8 +548,6 @@ class DateTimeDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -574,8 +558,6 @@ class DateTimeDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefaultModel.t),
       orderByList: orderByList?.call(DateTimeDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -596,8 +578,6 @@ class DateTimeDefaultModelRepository {
     _i1.DatabaseSession session,
     List<DateTimeDefaultModel> rows, {
     _i1.OrderByBuilder<DateTimeDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -606,8 +586,6 @@ class DateTimeDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(DateTimeDefaultModel.t),
       orderByList: orderByList?.call(DateTimeDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -637,8 +615,6 @@ class DateTimeDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultModelTable> where,
     _i1.OrderByBuilder<DateTimeDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -647,8 +623,6 @@ class DateTimeDefaultModelRepository {
       where: where(DateTimeDefaultModel.t),
       orderBy: orderBy?.call(DateTimeDefaultModel.t),
       orderByList: orderByList?.call(DateTimeDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
@@ -101,8 +101,6 @@ abstract class DateTimeDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     DateTimeDefaultPersistInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class DateTimeDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DateTimeDefaultPersist.t),
       include: include,
     );
@@ -223,8 +219,6 @@ class DateTimeDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -269,8 +263,6 @@ class DateTimeDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -280,8 +272,6 @@ class DateTimeDefaultPersistRepository {
       where: where?.call(DateTimeDefaultPersist.t),
       orderBy: orderBy?.call(DateTimeDefaultPersist.t),
       orderByList: orderByList?.call(DateTimeDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -312,8 +302,6 @@ class DateTimeDefaultPersistRepository {
     _i1.WhereExpressionBuilder<DateTimeDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -323,8 +311,6 @@ class DateTimeDefaultPersistRepository {
       where: where?.call(DateTimeDefaultPersist.t),
       orderBy: orderBy?.call(DateTimeDefaultPersist.t),
       orderByList: orderByList?.call(DateTimeDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -531,8 +517,6 @@ class DateTimeDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -543,8 +527,6 @@ class DateTimeDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefaultPersist.t),
       orderByList: orderByList?.call(DateTimeDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -565,8 +547,6 @@ class DateTimeDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<DateTimeDefaultPersist> rows, {
     _i1.OrderByBuilder<DateTimeDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -575,8 +555,6 @@ class DateTimeDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(DateTimeDefaultPersist.t),
       orderByList: orderByList?.call(DateTimeDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -606,8 +584,6 @@ class DateTimeDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultPersistTable> where,
     _i1.OrderByBuilder<DateTimeDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -616,8 +592,6 @@ class DateTimeDefaultPersistRepository {
       where: where(DateTimeDefaultPersist.t),
       orderBy: orderBy?.call(DateTimeDefaultPersist.t),
       orderByList: orderByList?.call(DateTimeDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default.dart
@@ -87,8 +87,6 @@ abstract class DoubleDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     DoubleDefaultInclude? include,
   }) {
@@ -97,8 +95,6 @@ abstract class DoubleDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DoubleDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DoubleDefault.t),
       include: include,
     );
@@ -204,8 +200,6 @@ class DoubleDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -250,8 +244,6 @@ class DoubleDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -261,8 +253,6 @@ class DoubleDefaultRepository {
       where: where?.call(DoubleDefault.t),
       orderBy: orderBy?.call(DoubleDefault.t),
       orderByList: orderByList?.call(DoubleDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -293,8 +283,6 @@ class DoubleDefaultRepository {
     _i1.WhereExpressionBuilder<DoubleDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -304,8 +292,6 @@ class DoubleDefaultRepository {
       where: where?.call(DoubleDefault.t),
       orderBy: orderBy?.call(DoubleDefault.t),
       orderByList: orderByList?.call(DoubleDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -510,8 +496,6 @@ class DoubleDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultTable>? orderBy,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -522,8 +506,6 @@ class DoubleDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(DoubleDefault.t),
       orderByList: orderByList?.call(DoubleDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -544,8 +526,6 @@ class DoubleDefaultRepository {
     _i1.DatabaseSession session,
     List<DoubleDefault> rows, {
     _i1.OrderByBuilder<DoubleDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -554,8 +534,6 @@ class DoubleDefaultRepository {
       rows,
       orderBy: orderBy?.call(DoubleDefault.t),
       orderByList: orderByList?.call(DoubleDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -585,8 +563,6 @@ class DoubleDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultTable> where,
     _i1.OrderByBuilder<DoubleDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -595,8 +571,6 @@ class DoubleDefaultRepository {
       where: where(DoubleDefault.t),
       orderBy: orderBy?.call(DoubleDefault.t),
       orderByList: orderByList?.call(DoubleDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_mix.dart
@@ -104,8 +104,6 @@ abstract class DoubleDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     DoubleDefaultMixInclude? include,
   }) {
@@ -114,8 +112,6 @@ abstract class DoubleDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DoubleDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DoubleDefaultMix.t),
       include: include,
     );
@@ -245,8 +241,6 @@ class DoubleDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -291,8 +285,6 @@ class DoubleDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -302,8 +294,6 @@ class DoubleDefaultMixRepository {
       where: where?.call(DoubleDefaultMix.t),
       orderBy: orderBy?.call(DoubleDefaultMix.t),
       orderByList: orderByList?.call(DoubleDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -334,8 +324,6 @@ class DoubleDefaultMixRepository {
     _i1.WhereExpressionBuilder<DoubleDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -345,8 +333,6 @@ class DoubleDefaultMixRepository {
       where: where?.call(DoubleDefaultMix.t),
       orderBy: orderBy?.call(DoubleDefaultMix.t),
       orderByList: orderByList?.call(DoubleDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -553,8 +539,6 @@ class DoubleDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -565,8 +549,6 @@ class DoubleDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(DoubleDefaultMix.t),
       orderByList: orderByList?.call(DoubleDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -587,8 +569,6 @@ class DoubleDefaultMixRepository {
     _i1.DatabaseSession session,
     List<DoubleDefaultMix> rows, {
     _i1.OrderByBuilder<DoubleDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -597,8 +577,6 @@ class DoubleDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(DoubleDefaultMix.t),
       orderByList: orderByList?.call(DoubleDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -628,8 +606,6 @@ class DoubleDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultMixTable> where,
     _i1.OrderByBuilder<DoubleDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -638,8 +614,6 @@ class DoubleDefaultMixRepository {
       where: where(DoubleDefaultMix.t),
       orderBy: orderBy?.call(DoubleDefaultMix.t),
       orderByList: orderByList?.call(DoubleDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_model.dart
@@ -88,8 +88,6 @@ abstract class DoubleDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     DoubleDefaultModelInclude? include,
   }) {
@@ -98,8 +96,6 @@ abstract class DoubleDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DoubleDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DoubleDefaultModel.t),
       include: include,
     );
@@ -203,8 +199,6 @@ class DoubleDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -249,8 +243,6 @@ class DoubleDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -260,8 +252,6 @@ class DoubleDefaultModelRepository {
       where: where?.call(DoubleDefaultModel.t),
       orderBy: orderBy?.call(DoubleDefaultModel.t),
       orderByList: orderByList?.call(DoubleDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -292,8 +282,6 @@ class DoubleDefaultModelRepository {
     _i1.WhereExpressionBuilder<DoubleDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -303,8 +291,6 @@ class DoubleDefaultModelRepository {
       where: where?.call(DoubleDefaultModel.t),
       orderBy: orderBy?.call(DoubleDefaultModel.t),
       orderByList: orderByList?.call(DoubleDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -511,8 +497,6 @@ class DoubleDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -523,8 +507,6 @@ class DoubleDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(DoubleDefaultModel.t),
       orderByList: orderByList?.call(DoubleDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -545,8 +527,6 @@ class DoubleDefaultModelRepository {
     _i1.DatabaseSession session,
     List<DoubleDefaultModel> rows, {
     _i1.OrderByBuilder<DoubleDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -555,8 +535,6 @@ class DoubleDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(DoubleDefaultModel.t),
       orderByList: orderByList?.call(DoubleDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -586,8 +564,6 @@ class DoubleDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultModelTable> where,
     _i1.OrderByBuilder<DoubleDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -596,8 +572,6 @@ class DoubleDefaultModelRepository {
       where: where(DoubleDefaultModel.t),
       orderBy: orderBy?.call(DoubleDefaultModel.t),
       orderByList: orderByList?.call(DoubleDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/double/double_default_persist.dart
@@ -82,8 +82,6 @@ abstract class DoubleDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     DoubleDefaultPersistInclude? include,
   }) {
@@ -92,8 +90,6 @@ abstract class DoubleDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DoubleDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DoubleDefaultPersist.t),
       include: include,
     );
@@ -182,8 +178,6 @@ class DoubleDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -228,8 +222,6 @@ class DoubleDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -239,8 +231,6 @@ class DoubleDefaultPersistRepository {
       where: where?.call(DoubleDefaultPersist.t),
       orderBy: orderBy?.call(DoubleDefaultPersist.t),
       orderByList: orderByList?.call(DoubleDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -271,8 +261,6 @@ class DoubleDefaultPersistRepository {
     _i1.WhereExpressionBuilder<DoubleDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -282,8 +270,6 @@ class DoubleDefaultPersistRepository {
       where: where?.call(DoubleDefaultPersist.t),
       orderBy: orderBy?.call(DoubleDefaultPersist.t),
       orderByList: orderByList?.call(DoubleDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -490,8 +476,6 @@ class DoubleDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -502,8 +486,6 @@ class DoubleDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(DoubleDefaultPersist.t),
       orderByList: orderByList?.call(DoubleDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -524,8 +506,6 @@ class DoubleDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<DoubleDefaultPersist> rows, {
     _i1.OrderByBuilder<DoubleDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -534,8 +514,6 @@ class DoubleDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(DoubleDefaultPersist.t),
       orderByList: orderByList?.call(DoubleDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -565,8 +543,6 @@ class DoubleDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultPersistTable> where,
     _i1.OrderByBuilder<DoubleDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -575,8 +551,6 @@ class DoubleDefaultPersistRepository {
       where: where(DoubleDefaultPersist.t),
       orderBy: orderBy?.call(DoubleDefaultPersist.t),
       orderByList: orderByList?.call(DoubleDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default.dart
@@ -112,8 +112,6 @@ abstract class DurationDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     DurationDefaultInclude? include,
   }) {
@@ -122,8 +120,6 @@ abstract class DurationDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DurationDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DurationDefault.t),
       include: include,
     );
@@ -229,8 +225,6 @@ class DurationDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -275,8 +269,6 @@ class DurationDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -286,8 +278,6 @@ class DurationDefaultRepository {
       where: where?.call(DurationDefault.t),
       orderBy: orderBy?.call(DurationDefault.t),
       orderByList: orderByList?.call(DurationDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -318,8 +308,6 @@ class DurationDefaultRepository {
     _i1.WhereExpressionBuilder<DurationDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -329,8 +317,6 @@ class DurationDefaultRepository {
       where: where?.call(DurationDefault.t),
       orderBy: orderBy?.call(DurationDefault.t),
       orderByList: orderByList?.call(DurationDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -537,8 +523,6 @@ class DurationDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<DurationDefaultTable>? orderBy,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -549,8 +533,6 @@ class DurationDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(DurationDefault.t),
       orderByList: orderByList?.call(DurationDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -571,8 +553,6 @@ class DurationDefaultRepository {
     _i1.DatabaseSession session,
     List<DurationDefault> rows, {
     _i1.OrderByBuilder<DurationDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -581,8 +561,6 @@ class DurationDefaultRepository {
       rows,
       orderBy: orderBy?.call(DurationDefault.t),
       orderByList: orderByList?.call(DurationDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -612,8 +590,6 @@ class DurationDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultTable> where,
     _i1.OrderByBuilder<DurationDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -622,8 +598,6 @@ class DurationDefaultRepository {
       where: where(DurationDefault.t),
       orderBy: orderBy?.call(DurationDefault.t),
       orderByList: orderByList?.call(DurationDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_mix.dart
@@ -138,8 +138,6 @@ abstract class DurationDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     DurationDefaultMixInclude? include,
   }) {
@@ -148,8 +146,6 @@ abstract class DurationDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DurationDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DurationDefaultMix.t),
       include: include,
     );
@@ -281,8 +277,6 @@ class DurationDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -327,8 +321,6 @@ class DurationDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -338,8 +330,6 @@ class DurationDefaultMixRepository {
       where: where?.call(DurationDefaultMix.t),
       orderBy: orderBy?.call(DurationDefaultMix.t),
       orderByList: orderByList?.call(DurationDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -370,8 +360,6 @@ class DurationDefaultMixRepository {
     _i1.WhereExpressionBuilder<DurationDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -381,8 +369,6 @@ class DurationDefaultMixRepository {
       where: where?.call(DurationDefaultMix.t),
       orderBy: orderBy?.call(DurationDefaultMix.t),
       orderByList: orderByList?.call(DurationDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -589,8 +575,6 @@ class DurationDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<DurationDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -601,8 +585,6 @@ class DurationDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(DurationDefaultMix.t),
       orderByList: orderByList?.call(DurationDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -623,8 +605,6 @@ class DurationDefaultMixRepository {
     _i1.DatabaseSession session,
     List<DurationDefaultMix> rows, {
     _i1.OrderByBuilder<DurationDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -633,8 +613,6 @@ class DurationDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(DurationDefaultMix.t),
       orderByList: orderByList?.call(DurationDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -664,8 +642,6 @@ class DurationDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultMixTable> where,
     _i1.OrderByBuilder<DurationDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -674,8 +650,6 @@ class DurationDefaultMixRepository {
       where: where(DurationDefaultMix.t),
       orderBy: orderBy?.call(DurationDefaultMix.t),
       orderByList: orderByList?.call(DurationDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_model.dart
@@ -115,8 +115,6 @@ abstract class DurationDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     DurationDefaultModelInclude? include,
   }) {
@@ -125,8 +123,6 @@ abstract class DurationDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DurationDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DurationDefaultModel.t),
       include: include,
     );
@@ -232,8 +228,6 @@ class DurationDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -278,8 +272,6 @@ class DurationDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -289,8 +281,6 @@ class DurationDefaultModelRepository {
       where: where?.call(DurationDefaultModel.t),
       orderBy: orderBy?.call(DurationDefaultModel.t),
       orderByList: orderByList?.call(DurationDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -321,8 +311,6 @@ class DurationDefaultModelRepository {
     _i1.WhereExpressionBuilder<DurationDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -332,8 +320,6 @@ class DurationDefaultModelRepository {
       where: where?.call(DurationDefaultModel.t),
       orderBy: orderBy?.call(DurationDefaultModel.t),
       orderByList: orderByList?.call(DurationDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -540,8 +526,6 @@ class DurationDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<DurationDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -552,8 +536,6 @@ class DurationDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(DurationDefaultModel.t),
       orderByList: orderByList?.call(DurationDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -574,8 +556,6 @@ class DurationDefaultModelRepository {
     _i1.DatabaseSession session,
     List<DurationDefaultModel> rows, {
     _i1.OrderByBuilder<DurationDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -584,8 +564,6 @@ class DurationDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(DurationDefaultModel.t),
       orderByList: orderByList?.call(DurationDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -615,8 +593,6 @@ class DurationDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultModelTable> where,
     _i1.OrderByBuilder<DurationDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -625,8 +601,6 @@ class DurationDefaultModelRepository {
       where: where(DurationDefaultModel.t),
       orderBy: orderBy?.call(DurationDefaultModel.t),
       orderByList: orderByList?.call(DurationDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/duration/duration_default_persist.dart
@@ -86,8 +86,6 @@ abstract class DurationDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     DurationDefaultPersistInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class DurationDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DurationDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DurationDefaultPersist.t),
       include: include,
     );
@@ -186,8 +182,6 @@ class DurationDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -232,8 +226,6 @@ class DurationDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -243,8 +235,6 @@ class DurationDefaultPersistRepository {
       where: where?.call(DurationDefaultPersist.t),
       orderBy: orderBy?.call(DurationDefaultPersist.t),
       orderByList: orderByList?.call(DurationDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -275,8 +265,6 @@ class DurationDefaultPersistRepository {
     _i1.WhereExpressionBuilder<DurationDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -286,8 +274,6 @@ class DurationDefaultPersistRepository {
       where: where?.call(DurationDefaultPersist.t),
       orderBy: orderBy?.call(DurationDefaultPersist.t),
       orderByList: orderByList?.call(DurationDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -494,8 +480,6 @@ class DurationDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<DurationDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -506,8 +490,6 @@ class DurationDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(DurationDefaultPersist.t),
       orderByList: orderByList?.call(DurationDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -528,8 +510,6 @@ class DurationDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<DurationDefaultPersist> rows, {
     _i1.OrderByBuilder<DurationDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -538,8 +518,6 @@ class DurationDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(DurationDefaultPersist.t),
       orderByList: orderByList?.call(DurationDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -569,8 +547,6 @@ class DurationDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultPersistTable> where,
     _i1.OrderByBuilder<DurationDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -579,8 +555,6 @@ class DurationDefaultPersistRepository {
       where: where(DurationDefaultPersist.t),
       orderBy: orderBy?.call(DurationDefaultPersist.t),
       orderByList: orderByList?.call(DurationDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default.dart
@@ -128,8 +128,6 @@ abstract class EnumDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     EnumDefaultInclude? include,
   }) {
@@ -138,8 +136,6 @@ abstract class EnumDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EnumDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EnumDefault.t),
       include: include,
     );
@@ -290,8 +286,6 @@ class EnumDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -336,8 +330,6 @@ class EnumDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -347,8 +339,6 @@ class EnumDefaultRepository {
       where: where?.call(EnumDefault.t),
       orderBy: orderBy?.call(EnumDefault.t),
       orderByList: orderByList?.call(EnumDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -379,8 +369,6 @@ class EnumDefaultRepository {
     _i1.WhereExpressionBuilder<EnumDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -390,8 +378,6 @@ class EnumDefaultRepository {
       where: where?.call(EnumDefault.t),
       orderBy: orderBy?.call(EnumDefault.t),
       orderByList: orderByList?.call(EnumDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -596,8 +582,6 @@ class EnumDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<EnumDefaultTable>? orderBy,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -608,8 +592,6 @@ class EnumDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(EnumDefault.t),
       orderByList: orderByList?.call(EnumDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -630,8 +612,6 @@ class EnumDefaultRepository {
     _i1.DatabaseSession session,
     List<EnumDefault> rows, {
     _i1.OrderByBuilder<EnumDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -640,8 +620,6 @@ class EnumDefaultRepository {
       rows,
       orderBy: orderBy?.call(EnumDefault.t),
       orderByList: orderByList?.call(EnumDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -671,8 +649,6 @@ class EnumDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultTable> where,
     _i1.OrderByBuilder<EnumDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -681,8 +657,6 @@ class EnumDefaultRepository {
       where: where(EnumDefault.t),
       orderBy: orderBy?.call(EnumDefault.t),
       orderByList: orderByList?.call(EnumDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_mix.dart
@@ -122,8 +122,6 @@ abstract class EnumDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     EnumDefaultMixInclude? include,
   }) {
@@ -132,8 +130,6 @@ abstract class EnumDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EnumDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EnumDefaultMix.t),
       include: include,
     );
@@ -267,8 +263,6 @@ class EnumDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -313,8 +307,6 @@ class EnumDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -324,8 +316,6 @@ class EnumDefaultMixRepository {
       where: where?.call(EnumDefaultMix.t),
       orderBy: orderBy?.call(EnumDefaultMix.t),
       orderByList: orderByList?.call(EnumDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -356,8 +346,6 @@ class EnumDefaultMixRepository {
     _i1.WhereExpressionBuilder<EnumDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -367,8 +355,6 @@ class EnumDefaultMixRepository {
       where: where?.call(EnumDefaultMix.t),
       orderBy: orderBy?.call(EnumDefaultMix.t),
       orderByList: orderByList?.call(EnumDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -573,8 +559,6 @@ class EnumDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<EnumDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -585,8 +569,6 @@ class EnumDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(EnumDefaultMix.t),
       orderByList: orderByList?.call(EnumDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -607,8 +589,6 @@ class EnumDefaultMixRepository {
     _i1.DatabaseSession session,
     List<EnumDefaultMix> rows, {
     _i1.OrderByBuilder<EnumDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -617,8 +597,6 @@ class EnumDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(EnumDefaultMix.t),
       orderByList: orderByList?.call(EnumDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -648,8 +626,6 @@ class EnumDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultMixTable> where,
     _i1.OrderByBuilder<EnumDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -658,8 +634,6 @@ class EnumDefaultMixRepository {
       where: where(EnumDefaultMix.t),
       orderBy: orderBy?.call(EnumDefaultMix.t),
       orderByList: orderByList?.call(EnumDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_model.dart
@@ -134,8 +134,6 @@ abstract class EnumDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     EnumDefaultModelInclude? include,
   }) {
@@ -144,8 +142,6 @@ abstract class EnumDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EnumDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EnumDefaultModel.t),
       include: include,
     );
@@ -297,8 +293,6 @@ class EnumDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -343,8 +337,6 @@ class EnumDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -354,8 +346,6 @@ class EnumDefaultModelRepository {
       where: where?.call(EnumDefaultModel.t),
       orderBy: orderBy?.call(EnumDefaultModel.t),
       orderByList: orderByList?.call(EnumDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -386,8 +376,6 @@ class EnumDefaultModelRepository {
     _i1.WhereExpressionBuilder<EnumDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -397,8 +385,6 @@ class EnumDefaultModelRepository {
       where: where?.call(EnumDefaultModel.t),
       orderBy: orderBy?.call(EnumDefaultModel.t),
       orderByList: orderByList?.call(EnumDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -605,8 +591,6 @@ class EnumDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<EnumDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -617,8 +601,6 @@ class EnumDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(EnumDefaultModel.t),
       orderByList: orderByList?.call(EnumDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -639,8 +621,6 @@ class EnumDefaultModelRepository {
     _i1.DatabaseSession session,
     List<EnumDefaultModel> rows, {
     _i1.OrderByBuilder<EnumDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -649,8 +629,6 @@ class EnumDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(EnumDefaultModel.t),
       orderByList: orderByList?.call(EnumDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -680,8 +658,6 @@ class EnumDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultModelTable> where,
     _i1.OrderByBuilder<EnumDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -690,8 +666,6 @@ class EnumDefaultModelRepository {
       where: where(EnumDefaultModel.t),
       orderBy: orderBy?.call(EnumDefaultModel.t),
       orderByList: orderByList?.call(EnumDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/enum/enum_default_persist.dart
@@ -101,8 +101,6 @@ abstract class EnumDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     EnumDefaultPersistInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class EnumDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EnumDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EnumDefaultPersist.t),
       include: include,
     );
@@ -225,8 +221,6 @@ class EnumDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -271,8 +265,6 @@ class EnumDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -282,8 +274,6 @@ class EnumDefaultPersistRepository {
       where: where?.call(EnumDefaultPersist.t),
       orderBy: orderBy?.call(EnumDefaultPersist.t),
       orderByList: orderByList?.call(EnumDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -314,8 +304,6 @@ class EnumDefaultPersistRepository {
     _i1.WhereExpressionBuilder<EnumDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -325,8 +313,6 @@ class EnumDefaultPersistRepository {
       where: where?.call(EnumDefaultPersist.t),
       orderBy: orderBy?.call(EnumDefaultPersist.t),
       orderByList: orderByList?.call(EnumDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -533,8 +519,6 @@ class EnumDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<EnumDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -545,8 +529,6 @@ class EnumDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(EnumDefaultPersist.t),
       orderByList: orderByList?.call(EnumDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -567,8 +549,6 @@ class EnumDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<EnumDefaultPersist> rows, {
     _i1.OrderByBuilder<EnumDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -577,8 +557,6 @@ class EnumDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(EnumDefaultPersist.t),
       orderByList: orderByList?.call(EnumDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -608,8 +586,6 @@ class EnumDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultPersistTable> where,
     _i1.OrderByBuilder<EnumDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -618,8 +594,6 @@ class EnumDefaultPersistRepository {
       where: where(EnumDefaultPersist.t),
       orderBy: orderBy?.call(EnumDefaultPersist.t),
       orderByList: orderByList?.call(EnumDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default.dart
@@ -86,8 +86,6 @@ abstract class IntDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     IntDefaultInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class IntDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(IntDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(IntDefault.t),
       include: include,
     );
@@ -200,8 +196,6 @@ class IntDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -246,8 +240,6 @@ class IntDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -257,8 +249,6 @@ class IntDefaultRepository {
       where: where?.call(IntDefault.t),
       orderBy: orderBy?.call(IntDefault.t),
       orderByList: orderByList?.call(IntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -289,8 +279,6 @@ class IntDefaultRepository {
     _i1.WhereExpressionBuilder<IntDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<IntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -300,8 +288,6 @@ class IntDefaultRepository {
       where: where?.call(IntDefault.t),
       orderBy: orderBy?.call(IntDefault.t),
       orderByList: orderByList?.call(IntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -506,8 +492,6 @@ class IntDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<IntDefaultTable>? orderBy,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -518,8 +502,6 @@ class IntDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(IntDefault.t),
       orderByList: orderByList?.call(IntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -540,8 +522,6 @@ class IntDefaultRepository {
     _i1.DatabaseSession session,
     List<IntDefault> rows, {
     _i1.OrderByBuilder<IntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -550,8 +530,6 @@ class IntDefaultRepository {
       rows,
       orderBy: orderBy?.call(IntDefault.t),
       orderByList: orderByList?.call(IntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -581,8 +559,6 @@ class IntDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultTable> where,
     _i1.OrderByBuilder<IntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -591,8 +567,6 @@ class IntDefaultRepository {
       where: where(IntDefault.t),
       orderBy: orderBy?.call(IntDefault.t),
       orderByList: orderByList?.call(IntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_mix.dart
@@ -99,8 +99,6 @@ abstract class IntDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     IntDefaultMixInclude? include,
   }) {
@@ -109,8 +107,6 @@ abstract class IntDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(IntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(IntDefaultMix.t),
       include: include,
     );
@@ -236,8 +232,6 @@ class IntDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -282,8 +276,6 @@ class IntDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -293,8 +285,6 @@ class IntDefaultMixRepository {
       where: where?.call(IntDefaultMix.t),
       orderBy: orderBy?.call(IntDefaultMix.t),
       orderByList: orderByList?.call(IntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -325,8 +315,6 @@ class IntDefaultMixRepository {
     _i1.WhereExpressionBuilder<IntDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<IntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -336,8 +324,6 @@ class IntDefaultMixRepository {
       where: where?.call(IntDefaultMix.t),
       orderBy: orderBy?.call(IntDefaultMix.t),
       orderByList: orderByList?.call(IntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -542,8 +528,6 @@ class IntDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<IntDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -554,8 +538,6 @@ class IntDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(IntDefaultMix.t),
       orderByList: orderByList?.call(IntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -576,8 +558,6 @@ class IntDefaultMixRepository {
     _i1.DatabaseSession session,
     List<IntDefaultMix> rows, {
     _i1.OrderByBuilder<IntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -586,8 +566,6 @@ class IntDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(IntDefaultMix.t),
       orderByList: orderByList?.call(IntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -617,8 +595,6 @@ class IntDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultMixTable> where,
     _i1.OrderByBuilder<IntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -627,8 +603,6 @@ class IntDefaultMixRepository {
       where: where(IntDefaultMix.t),
       orderBy: orderBy?.call(IntDefaultMix.t),
       orderByList: orderByList?.call(IntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_model.dart
@@ -86,8 +86,6 @@ abstract class IntDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     IntDefaultModelInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class IntDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(IntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(IntDefaultModel.t),
       include: include,
     );
@@ -197,8 +193,6 @@ class IntDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -243,8 +237,6 @@ class IntDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -254,8 +246,6 @@ class IntDefaultModelRepository {
       where: where?.call(IntDefaultModel.t),
       orderBy: orderBy?.call(IntDefaultModel.t),
       orderByList: orderByList?.call(IntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -286,8 +276,6 @@ class IntDefaultModelRepository {
     _i1.WhereExpressionBuilder<IntDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<IntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -297,8 +285,6 @@ class IntDefaultModelRepository {
       where: where?.call(IntDefaultModel.t),
       orderBy: orderBy?.call(IntDefaultModel.t),
       orderByList: orderByList?.call(IntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -505,8 +491,6 @@ class IntDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<IntDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -517,8 +501,6 @@ class IntDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(IntDefaultModel.t),
       orderByList: orderByList?.call(IntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -539,8 +521,6 @@ class IntDefaultModelRepository {
     _i1.DatabaseSession session,
     List<IntDefaultModel> rows, {
     _i1.OrderByBuilder<IntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -549,8 +529,6 @@ class IntDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(IntDefaultModel.t),
       orderByList: orderByList?.call(IntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -580,8 +558,6 @@ class IntDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultModelTable> where,
     _i1.OrderByBuilder<IntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -590,8 +566,6 @@ class IntDefaultModelRepository {
       where: where(IntDefaultModel.t),
       orderBy: orderBy?.call(IntDefaultModel.t),
       orderByList: orderByList?.call(IntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/integer/int_default_persist.dart
@@ -77,8 +77,6 @@ abstract class IntDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     IntDefaultPersistInclude? include,
   }) {
@@ -87,8 +85,6 @@ abstract class IntDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(IntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(IntDefaultPersist.t),
       include: include,
     );
@@ -176,8 +172,6 @@ class IntDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -222,8 +216,6 @@ class IntDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -233,8 +225,6 @@ class IntDefaultPersistRepository {
       where: where?.call(IntDefaultPersist.t),
       orderBy: orderBy?.call(IntDefaultPersist.t),
       orderByList: orderByList?.call(IntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -265,8 +255,6 @@ class IntDefaultPersistRepository {
     _i1.WhereExpressionBuilder<IntDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<IntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -276,8 +264,6 @@ class IntDefaultPersistRepository {
       where: where?.call(IntDefaultPersist.t),
       orderBy: orderBy?.call(IntDefaultPersist.t),
       orderByList: orderByList?.call(IntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -484,8 +470,6 @@ class IntDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<IntDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -496,8 +480,6 @@ class IntDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(IntDefaultPersist.t),
       orderByList: orderByList?.call(IntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -518,8 +500,6 @@ class IntDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<IntDefaultPersist> rows, {
     _i1.OrderByBuilder<IntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -528,8 +508,6 @@ class IntDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(IntDefaultPersist.t),
       orderByList: orderByList?.call(IntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -559,8 +537,6 @@ class IntDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultPersistTable> where,
     _i1.OrderByBuilder<IntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -569,8 +545,6 @@ class IntDefaultPersistRepository {
       where: where(IntDefaultPersist.t),
       orderBy: orderBy?.call(IntDefaultPersist.t),
       orderByList: orderByList?.call(IntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default.dart
@@ -86,8 +86,6 @@ abstract class StringDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     StringDefaultInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class StringDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(StringDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(StringDefault.t),
       include: include,
     );
@@ -203,8 +199,6 @@ class StringDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -249,8 +243,6 @@ class StringDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -260,8 +252,6 @@ class StringDefaultRepository {
       where: where?.call(StringDefault.t),
       orderBy: orderBy?.call(StringDefault.t),
       orderByList: orderByList?.call(StringDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -292,8 +282,6 @@ class StringDefaultRepository {
     _i1.WhereExpressionBuilder<StringDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<StringDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -303,8 +291,6 @@ class StringDefaultRepository {
       where: where?.call(StringDefault.t),
       orderBy: orderBy?.call(StringDefault.t),
       orderByList: orderByList?.call(StringDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -509,8 +495,6 @@ class StringDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<StringDefaultTable>? orderBy,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -521,8 +505,6 @@ class StringDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(StringDefault.t),
       orderByList: orderByList?.call(StringDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -543,8 +525,6 @@ class StringDefaultRepository {
     _i1.DatabaseSession session,
     List<StringDefault> rows, {
     _i1.OrderByBuilder<StringDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -553,8 +533,6 @@ class StringDefaultRepository {
       rows,
       orderBy: orderBy?.call(StringDefault.t),
       orderByList: orderByList?.call(StringDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -584,8 +562,6 @@ class StringDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultTable> where,
     _i1.OrderByBuilder<StringDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -594,8 +570,6 @@ class StringDefaultRepository {
       where: where(StringDefault.t),
       orderBy: orderBy?.call(StringDefault.t),
       orderByList: orderByList?.call(StringDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_mix.dart
@@ -103,8 +103,6 @@ abstract class StringDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     StringDefaultMixInclude? include,
   }) {
@@ -113,8 +111,6 @@ abstract class StringDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(StringDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(StringDefaultMix.t),
       include: include,
     );
@@ -244,8 +240,6 @@ class StringDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -290,8 +284,6 @@ class StringDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -301,8 +293,6 @@ class StringDefaultMixRepository {
       where: where?.call(StringDefaultMix.t),
       orderBy: orderBy?.call(StringDefaultMix.t),
       orderByList: orderByList?.call(StringDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -333,8 +323,6 @@ class StringDefaultMixRepository {
     _i1.WhereExpressionBuilder<StringDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<StringDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -344,8 +332,6 @@ class StringDefaultMixRepository {
       where: where?.call(StringDefaultMix.t),
       orderBy: orderBy?.call(StringDefaultMix.t),
       orderByList: orderByList?.call(StringDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -552,8 +538,6 @@ class StringDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<StringDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -564,8 +548,6 @@ class StringDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(StringDefaultMix.t),
       orderByList: orderByList?.call(StringDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -586,8 +568,6 @@ class StringDefaultMixRepository {
     _i1.DatabaseSession session,
     List<StringDefaultMix> rows, {
     _i1.OrderByBuilder<StringDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -596,8 +576,6 @@ class StringDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(StringDefaultMix.t),
       orderByList: orderByList?.call(StringDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -627,8 +605,6 @@ class StringDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultMixTable> where,
     _i1.OrderByBuilder<StringDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -637,8 +613,6 @@ class StringDefaultMixRepository {
       where: where(StringDefaultMix.t),
       orderBy: orderBy?.call(StringDefaultMix.t),
       orderByList: orderByList?.call(StringDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_model.dart
@@ -89,8 +89,6 @@ abstract class StringDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     StringDefaultModelInclude? include,
   }) {
@@ -99,8 +97,6 @@ abstract class StringDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(StringDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(StringDefaultModel.t),
       include: include,
     );
@@ -204,8 +200,6 @@ class StringDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -250,8 +244,6 @@ class StringDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -261,8 +253,6 @@ class StringDefaultModelRepository {
       where: where?.call(StringDefaultModel.t),
       orderBy: orderBy?.call(StringDefaultModel.t),
       orderByList: orderByList?.call(StringDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -293,8 +283,6 @@ class StringDefaultModelRepository {
     _i1.WhereExpressionBuilder<StringDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<StringDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -304,8 +292,6 @@ class StringDefaultModelRepository {
       where: where?.call(StringDefaultModel.t),
       orderBy: orderBy?.call(StringDefaultModel.t),
       orderByList: orderByList?.call(StringDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -512,8 +498,6 @@ class StringDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<StringDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -524,8 +508,6 @@ class StringDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(StringDefaultModel.t),
       orderByList: orderByList?.call(StringDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -546,8 +528,6 @@ class StringDefaultModelRepository {
     _i1.DatabaseSession session,
     List<StringDefaultModel> rows, {
     _i1.OrderByBuilder<StringDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -556,8 +536,6 @@ class StringDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(StringDefaultModel.t),
       orderByList: orderByList?.call(StringDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -587,8 +565,6 @@ class StringDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultModelTable> where,
     _i1.OrderByBuilder<StringDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -597,8 +573,6 @@ class StringDefaultModelRepository {
       where: where(StringDefaultModel.t),
       orderBy: orderBy?.call(StringDefaultModel.t),
       orderByList: orderByList?.call(StringDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/string/string_default_persist.dart
@@ -194,8 +194,6 @@ abstract class StringDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     StringDefaultPersistInclude? include,
   }) {
@@ -204,8 +202,6 @@ abstract class StringDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(StringDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(StringDefaultPersist.t),
       include: include,
     );
@@ -486,8 +482,6 @@ class StringDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -532,8 +526,6 @@ class StringDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -543,8 +535,6 @@ class StringDefaultPersistRepository {
       where: where?.call(StringDefaultPersist.t),
       orderBy: orderBy?.call(StringDefaultPersist.t),
       orderByList: orderByList?.call(StringDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -575,8 +565,6 @@ class StringDefaultPersistRepository {
     _i1.WhereExpressionBuilder<StringDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<StringDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -586,8 +574,6 @@ class StringDefaultPersistRepository {
       where: where?.call(StringDefaultPersist.t),
       orderBy: orderBy?.call(StringDefaultPersist.t),
       orderByList: orderByList?.call(StringDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -794,8 +780,6 @@ class StringDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<StringDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -806,8 +790,6 @@ class StringDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(StringDefaultPersist.t),
       orderByList: orderByList?.call(StringDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -828,8 +810,6 @@ class StringDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<StringDefaultPersist> rows, {
     _i1.OrderByBuilder<StringDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -838,8 +818,6 @@ class StringDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(StringDefaultPersist.t),
       orderByList: orderByList?.call(StringDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -869,8 +847,6 @@ class StringDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultPersistTable> where,
     _i1.OrderByBuilder<StringDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -879,8 +855,6 @@ class StringDefaultPersistRepository {
       where: where(StringDefaultPersist.t),
       orderBy: orderBy?.call(StringDefaultPersist.t),
       orderByList: orderByList?.call(StringDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default.dart
@@ -91,8 +91,6 @@ abstract class UriDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     UriDefaultInclude? include,
   }) {
@@ -101,8 +99,6 @@ abstract class UriDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UriDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UriDefault.t),
       include: include,
     );
@@ -205,8 +201,6 @@ class UriDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -251,8 +245,6 @@ class UriDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -262,8 +254,6 @@ class UriDefaultRepository {
       where: where?.call(UriDefault.t),
       orderBy: orderBy?.call(UriDefault.t),
       orderByList: orderByList?.call(UriDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -294,8 +284,6 @@ class UriDefaultRepository {
     _i1.WhereExpressionBuilder<UriDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<UriDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -305,8 +293,6 @@ class UriDefaultRepository {
       where: where?.call(UriDefault.t),
       orderBy: orderBy?.call(UriDefault.t),
       orderByList: orderByList?.call(UriDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -511,8 +497,6 @@ class UriDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<UriDefaultTable>? orderBy,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -523,8 +507,6 @@ class UriDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(UriDefault.t),
       orderByList: orderByList?.call(UriDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -545,8 +527,6 @@ class UriDefaultRepository {
     _i1.DatabaseSession session,
     List<UriDefault> rows, {
     _i1.OrderByBuilder<UriDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -555,8 +535,6 @@ class UriDefaultRepository {
       rows,
       orderBy: orderBy?.call(UriDefault.t),
       orderByList: orderByList?.call(UriDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -586,8 +564,6 @@ class UriDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultTable> where,
     _i1.OrderByBuilder<UriDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -596,8 +572,6 @@ class UriDefaultRepository {
       where: where(UriDefault.t),
       orderBy: orderBy?.call(UriDefault.t),
       orderByList: orderByList?.call(UriDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default_mix.dart
@@ -118,8 +118,6 @@ abstract class UriDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     UriDefaultMixInclude? include,
   }) {
@@ -128,8 +126,6 @@ abstract class UriDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UriDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UriDefaultMix.t),
       include: include,
     );
@@ -255,8 +251,6 @@ class UriDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -301,8 +295,6 @@ class UriDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -312,8 +304,6 @@ class UriDefaultMixRepository {
       where: where?.call(UriDefaultMix.t),
       orderBy: orderBy?.call(UriDefaultMix.t),
       orderByList: orderByList?.call(UriDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -344,8 +334,6 @@ class UriDefaultMixRepository {
     _i1.WhereExpressionBuilder<UriDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<UriDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -355,8 +343,6 @@ class UriDefaultMixRepository {
       where: where?.call(UriDefaultMix.t),
       orderBy: orderBy?.call(UriDefaultMix.t),
       orderByList: orderByList?.call(UriDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -561,8 +547,6 @@ class UriDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<UriDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -573,8 +557,6 @@ class UriDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(UriDefaultMix.t),
       orderByList: orderByList?.call(UriDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -595,8 +577,6 @@ class UriDefaultMixRepository {
     _i1.DatabaseSession session,
     List<UriDefaultMix> rows, {
     _i1.OrderByBuilder<UriDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -605,8 +585,6 @@ class UriDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(UriDefaultMix.t),
       orderByList: orderByList?.call(UriDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -636,8 +614,6 @@ class UriDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultMixTable> where,
     _i1.OrderByBuilder<UriDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -646,8 +622,6 @@ class UriDefaultMixRepository {
       where: where(UriDefaultMix.t),
       orderBy: orderBy?.call(UriDefaultMix.t),
       orderByList: orderByList?.call(UriDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default_model.dart
@@ -97,8 +97,6 @@ abstract class UriDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     UriDefaultModelInclude? include,
   }) {
@@ -107,8 +105,6 @@ abstract class UriDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UriDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UriDefaultModel.t),
       include: include,
     );
@@ -210,8 +206,6 @@ class UriDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -256,8 +250,6 @@ class UriDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -267,8 +259,6 @@ class UriDefaultModelRepository {
       where: where?.call(UriDefaultModel.t),
       orderBy: orderBy?.call(UriDefaultModel.t),
       orderByList: orderByList?.call(UriDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -299,8 +289,6 @@ class UriDefaultModelRepository {
     _i1.WhereExpressionBuilder<UriDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<UriDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -310,8 +298,6 @@ class UriDefaultModelRepository {
       where: where?.call(UriDefaultModel.t),
       orderBy: orderBy?.call(UriDefaultModel.t),
       orderByList: orderByList?.call(UriDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -518,8 +504,6 @@ class UriDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<UriDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -530,8 +514,6 @@ class UriDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(UriDefaultModel.t),
       orderByList: orderByList?.call(UriDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -552,8 +534,6 @@ class UriDefaultModelRepository {
     _i1.DatabaseSession session,
     List<UriDefaultModel> rows, {
     _i1.OrderByBuilder<UriDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -562,8 +542,6 @@ class UriDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(UriDefaultModel.t),
       orderByList: orderByList?.call(UriDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -593,8 +571,6 @@ class UriDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultModelTable> where,
     _i1.OrderByBuilder<UriDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -603,8 +579,6 @@ class UriDefaultModelRepository {
       where: where(UriDefaultModel.t),
       orderBy: orderBy?.call(UriDefaultModel.t),
       orderByList: orderByList?.call(UriDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uri/uri_default_persist.dart
@@ -83,8 +83,6 @@ abstract class UriDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     UriDefaultPersistInclude? include,
   }) {
@@ -93,8 +91,6 @@ abstract class UriDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UriDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UriDefaultPersist.t),
       include: include,
     );
@@ -182,8 +178,6 @@ class UriDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -228,8 +222,6 @@ class UriDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -239,8 +231,6 @@ class UriDefaultPersistRepository {
       where: where?.call(UriDefaultPersist.t),
       orderBy: orderBy?.call(UriDefaultPersist.t),
       orderByList: orderByList?.call(UriDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -271,8 +261,6 @@ class UriDefaultPersistRepository {
     _i1.WhereExpressionBuilder<UriDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<UriDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -282,8 +270,6 @@ class UriDefaultPersistRepository {
       where: where?.call(UriDefaultPersist.t),
       orderBy: orderBy?.call(UriDefaultPersist.t),
       orderByList: orderByList?.call(UriDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -490,8 +476,6 @@ class UriDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<UriDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -502,8 +486,6 @@ class UriDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(UriDefaultPersist.t),
       orderByList: orderByList?.call(UriDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -524,8 +506,6 @@ class UriDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<UriDefaultPersist> rows, {
     _i1.OrderByBuilder<UriDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -534,8 +514,6 @@ class UriDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(UriDefaultPersist.t),
       orderByList: orderByList?.call(UriDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -565,8 +543,6 @@ class UriDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultPersistTable> where,
     _i1.OrderByBuilder<UriDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -575,8 +551,6 @@ class UriDefaultPersistRepository {
       where: where(UriDefaultPersist.t),
       orderBy: orderBy?.call(UriDefaultPersist.t),
       orderByList: orderByList?.call(UriDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default.dart
@@ -142,8 +142,6 @@ abstract class UuidDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     UuidDefaultInclude? include,
   }) {
@@ -152,8 +150,6 @@ abstract class UuidDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UuidDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UuidDefault.t),
       include: include,
     );
@@ -319,8 +315,6 @@ class UuidDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -365,8 +359,6 @@ class UuidDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -376,8 +368,6 @@ class UuidDefaultRepository {
       where: where?.call(UuidDefault.t),
       orderBy: orderBy?.call(UuidDefault.t),
       orderByList: orderByList?.call(UuidDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -408,8 +398,6 @@ class UuidDefaultRepository {
     _i1.WhereExpressionBuilder<UuidDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -419,8 +407,6 @@ class UuidDefaultRepository {
       where: where?.call(UuidDefault.t),
       orderBy: orderBy?.call(UuidDefault.t),
       orderByList: orderByList?.call(UuidDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -625,8 +611,6 @@ class UuidDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<UuidDefaultTable>? orderBy,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -637,8 +621,6 @@ class UuidDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(UuidDefault.t),
       orderByList: orderByList?.call(UuidDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -659,8 +641,6 @@ class UuidDefaultRepository {
     _i1.DatabaseSession session,
     List<UuidDefault> rows, {
     _i1.OrderByBuilder<UuidDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -669,8 +649,6 @@ class UuidDefaultRepository {
       rows,
       orderBy: orderBy?.call(UuidDefault.t),
       orderByList: orderByList?.call(UuidDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -700,8 +678,6 @@ class UuidDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultTable> where,
     _i1.OrderByBuilder<UuidDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -710,8 +686,6 @@ class UuidDefaultRepository {
       where: where(UuidDefault.t),
       orderBy: orderBy?.call(UuidDefault.t),
       orderByList: orderByList?.call(UuidDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
@@ -118,8 +118,6 @@ abstract class UuidDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     UuidDefaultMixInclude? include,
   }) {
@@ -128,8 +126,6 @@ abstract class UuidDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UuidDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UuidDefaultMix.t),
       include: include,
     );
@@ -257,8 +253,6 @@ class UuidDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -303,8 +297,6 @@ class UuidDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -314,8 +306,6 @@ class UuidDefaultMixRepository {
       where: where?.call(UuidDefaultMix.t),
       orderBy: orderBy?.call(UuidDefaultMix.t),
       orderByList: orderByList?.call(UuidDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -346,8 +336,6 @@ class UuidDefaultMixRepository {
     _i1.WhereExpressionBuilder<UuidDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -357,8 +345,6 @@ class UuidDefaultMixRepository {
       where: where?.call(UuidDefaultMix.t),
       orderBy: orderBy?.call(UuidDefaultMix.t),
       orderByList: orderByList?.call(UuidDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -563,8 +549,6 @@ class UuidDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<UuidDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -575,8 +559,6 @@ class UuidDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(UuidDefaultMix.t),
       orderByList: orderByList?.call(UuidDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -597,8 +579,6 @@ class UuidDefaultMixRepository {
     _i1.DatabaseSession session,
     List<UuidDefaultMix> rows, {
     _i1.OrderByBuilder<UuidDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -607,8 +587,6 @@ class UuidDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(UuidDefaultMix.t),
       orderByList: orderByList?.call(UuidDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -638,8 +616,6 @@ class UuidDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultMixTable> where,
     _i1.OrderByBuilder<UuidDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -648,8 +624,6 @@ class UuidDefaultMixRepository {
       where: where(UuidDefaultMix.t),
       orderBy: orderBy?.call(UuidDefaultMix.t),
       orderByList: orderByList?.call(UuidDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
@@ -148,8 +148,6 @@ abstract class UuidDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     UuidDefaultModelInclude? include,
   }) {
@@ -158,8 +156,6 @@ abstract class UuidDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UuidDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UuidDefaultModel.t),
       include: include,
     );
@@ -324,8 +320,6 @@ class UuidDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -370,8 +364,6 @@ class UuidDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -381,8 +373,6 @@ class UuidDefaultModelRepository {
       where: where?.call(UuidDefaultModel.t),
       orderBy: orderBy?.call(UuidDefaultModel.t),
       orderByList: orderByList?.call(UuidDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -413,8 +403,6 @@ class UuidDefaultModelRepository {
     _i1.WhereExpressionBuilder<UuidDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -424,8 +412,6 @@ class UuidDefaultModelRepository {
       where: where?.call(UuidDefaultModel.t),
       orderBy: orderBy?.call(UuidDefaultModel.t),
       orderByList: orderByList?.call(UuidDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -632,8 +618,6 @@ class UuidDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<UuidDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -644,8 +628,6 @@ class UuidDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(UuidDefaultModel.t),
       orderByList: orderByList?.call(UuidDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -666,8 +648,6 @@ class UuidDefaultModelRepository {
     _i1.DatabaseSession session,
     List<UuidDefaultModel> rows, {
     _i1.OrderByBuilder<UuidDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -676,8 +656,6 @@ class UuidDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(UuidDefaultModel.t),
       orderByList: orderByList?.call(UuidDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -707,8 +685,6 @@ class UuidDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultModelTable> where,
     _i1.OrderByBuilder<UuidDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -717,8 +693,6 @@ class UuidDefaultModelRepository {
       where: where(UuidDefaultModel.t),
       orderBy: orderBy?.call(UuidDefaultModel.t),
       orderByList: orderByList?.call(UuidDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
@@ -113,8 +113,6 @@ abstract class UuidDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     UuidDefaultPersistInclude? include,
   }) {
@@ -123,8 +121,6 @@ abstract class UuidDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UuidDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UuidDefaultPersist.t),
       include: include,
     );
@@ -256,8 +252,6 @@ class UuidDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -302,8 +296,6 @@ class UuidDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -313,8 +305,6 @@ class UuidDefaultPersistRepository {
       where: where?.call(UuidDefaultPersist.t),
       orderBy: orderBy?.call(UuidDefaultPersist.t),
       orderByList: orderByList?.call(UuidDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -345,8 +335,6 @@ class UuidDefaultPersistRepository {
     _i1.WhereExpressionBuilder<UuidDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -356,8 +344,6 @@ class UuidDefaultPersistRepository {
       where: where?.call(UuidDefaultPersist.t),
       orderBy: orderBy?.call(UuidDefaultPersist.t),
       orderByList: orderByList?.call(UuidDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -564,8 +550,6 @@ class UuidDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<UuidDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -576,8 +560,6 @@ class UuidDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(UuidDefaultPersist.t),
       orderByList: orderByList?.call(UuidDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -598,8 +580,6 @@ class UuidDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<UuidDefaultPersist> rows, {
     _i1.OrderByBuilder<UuidDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -608,8 +588,6 @@ class UuidDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(UuidDefaultPersist.t),
       orderByList: orderByList?.call(UuidDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -639,8 +617,6 @@ class UuidDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultPersistTable> where,
     _i1.OrderByBuilder<UuidDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -649,8 +625,6 @@ class UuidDefaultPersistRepository {
       where: where(UuidDefaultPersist.t),
       orderBy: orderBy?.call(UuidDefaultPersist.t),
       orderByList: orderByList?.call(UuidDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_relation_item.dart
@@ -87,8 +87,6 @@ abstract class EmptyModelRelationItem
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     EmptyModelRelationItemInclude? include,
   }) {
@@ -97,8 +95,6 @@ abstract class EmptyModelRelationItem
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
       include: include,
     );
@@ -233,8 +229,6 @@ class EmptyModelRelationItemIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -279,8 +273,6 @@ class EmptyModelRelationItemRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -290,8 +282,6 @@ class EmptyModelRelationItemRepository {
       where: where?.call(EmptyModelRelationItem.t),
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -322,8 +312,6 @@ class EmptyModelRelationItemRepository {
     _i1.WhereExpressionBuilder<EmptyModelRelationItemTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -333,8 +321,6 @@ class EmptyModelRelationItemRepository {
       where: where?.call(EmptyModelRelationItem.t),
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -541,8 +527,6 @@ class EmptyModelRelationItemRepository {
     int? offset,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -553,8 +537,6 @@ class EmptyModelRelationItemRepository {
       offset: offset,
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -575,8 +557,6 @@ class EmptyModelRelationItemRepository {
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -585,8 +565,6 @@ class EmptyModelRelationItemRepository {
       rows,
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -616,8 +594,6 @@ class EmptyModelRelationItemRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmptyModelRelationItemTable> where,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -626,8 +602,6 @@ class EmptyModelRelationItemRepository {
       where: where(EmptyModelRelationItem.t),
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/empty_model_with_table.dart
@@ -61,8 +61,6 @@ abstract class EmptyModelWithTable
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     EmptyModelWithTableInclude? include,
   }) {
@@ -71,8 +69,6 @@ abstract class EmptyModelWithTable
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EmptyModelWithTable.t),
       include: include,
     );
@@ -131,8 +127,6 @@ class EmptyModelWithTableIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -177,8 +171,6 @@ class EmptyModelWithTableRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -188,8 +180,6 @@ class EmptyModelWithTableRepository {
       where: where?.call(EmptyModelWithTable.t),
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -220,8 +210,6 @@ class EmptyModelWithTableRepository {
     _i1.WhereExpressionBuilder<EmptyModelWithTableTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -231,8 +219,6 @@ class EmptyModelWithTableRepository {
       where: where?.call(EmptyModelWithTable.t),
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -439,8 +425,6 @@ class EmptyModelWithTableRepository {
     int? offset,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -451,8 +435,6 @@ class EmptyModelWithTableRepository {
       offset: offset,
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -473,8 +455,6 @@ class EmptyModelWithTableRepository {
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -483,8 +463,6 @@ class EmptyModelWithTableRepository {
       rows,
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -514,8 +492,6 @@ class EmptyModelWithTableRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmptyModelWithTableTable> where,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -524,8 +500,6 @@ class EmptyModelWithTableRepository {
       where: where(EmptyModelWithTable.t),
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/empty_model/relation_empy_model.dart
@@ -87,8 +87,6 @@ abstract class RelationEmptyModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     RelationEmptyModelInclude? include,
   }) {
@@ -97,8 +95,6 @@ abstract class RelationEmptyModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(RelationEmptyModel.t),
       include: include,
     );
@@ -225,8 +221,6 @@ class RelationEmptyModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -279,8 +273,6 @@ class RelationEmptyModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
     RelationEmptyModelInclude? include,
@@ -291,8 +283,6 @@ class RelationEmptyModelRepository {
       where: where?.call(RelationEmptyModel.t),
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -324,8 +314,6 @@ class RelationEmptyModelRepository {
     _i1.WhereExpressionBuilder<RelationEmptyModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
     RelationEmptyModelInclude? include,
@@ -336,8 +324,6 @@ class RelationEmptyModelRepository {
       where: where?.call(RelationEmptyModel.t),
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -547,8 +533,6 @@ class RelationEmptyModelRepository {
     int? offset,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -559,8 +543,6 @@ class RelationEmptyModelRepository {
       offset: offset,
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -581,8 +563,6 @@ class RelationEmptyModelRepository {
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -591,8 +571,6 @@ class RelationEmptyModelRepository {
       rows,
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -622,8 +600,6 @@ class RelationEmptyModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelationEmptyModelTable> where,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -632,8 +608,6 @@ class RelationEmptyModelRepository {
       where: where(RelationEmptyModel.t),
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/inheritance/child_class_explicit_column.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/inheritance/child_class_explicit_column.dart
@@ -87,8 +87,6 @@ abstract class ChildClassExplicitColumn extends _i1.NonTableParentClass
     int? limit,
     int? offset,
     _i2.OrderByBuilder<ChildClassExplicitColumnTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     ChildClassExplicitColumnInclude? include,
   }) {
@@ -97,8 +95,6 @@ abstract class ChildClassExplicitColumn extends _i1.NonTableParentClass
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ChildClassExplicitColumn.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ChildClassExplicitColumn.t),
       include: include,
     );
@@ -202,8 +198,6 @@ class ChildClassExplicitColumnIncludeList extends _i2.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -248,8 +242,6 @@ class ChildClassExplicitColumnRepository {
     int? limit,
     int? offset,
     _i2.OrderByBuilder<ChildClassExplicitColumnTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     _i2.Transaction? transaction,
     _i2.LockMode? lockMode,
@@ -259,8 +251,6 @@ class ChildClassExplicitColumnRepository {
       where: where?.call(ChildClassExplicitColumn.t),
       orderBy: orderBy?.call(ChildClassExplicitColumn.t),
       orderByList: orderByList?.call(ChildClassExplicitColumn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -291,8 +281,6 @@ class ChildClassExplicitColumnRepository {
     _i2.WhereExpressionBuilder<ChildClassExplicitColumnTable>? where,
     int? offset,
     _i2.OrderByBuilder<ChildClassExplicitColumnTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     _i2.Transaction? transaction,
     _i2.LockMode? lockMode,
@@ -302,8 +290,6 @@ class ChildClassExplicitColumnRepository {
       where: where?.call(ChildClassExplicitColumn.t),
       orderBy: orderBy?.call(ChildClassExplicitColumn.t),
       orderByList: orderByList?.call(ChildClassExplicitColumn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -512,8 +498,6 @@ class ChildClassExplicitColumnRepository {
     int? offset,
     _i2.OrderByBuilder<ChildClassExplicitColumnTable>? orderBy,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -524,8 +508,6 @@ class ChildClassExplicitColumnRepository {
       offset: offset,
       orderBy: orderBy?.call(ChildClassExplicitColumn.t),
       orderByList: orderByList?.call(ChildClassExplicitColumn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -546,8 +528,6 @@ class ChildClassExplicitColumnRepository {
     _i2.DatabaseSession session,
     List<ChildClassExplicitColumn> rows, {
     _i2.OrderByBuilder<ChildClassExplicitColumnTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -556,8 +536,6 @@ class ChildClassExplicitColumnRepository {
       rows,
       orderBy: orderBy?.call(ChildClassExplicitColumn.t),
       orderByList: orderByList?.call(ChildClassExplicitColumn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -587,8 +565,6 @@ class ChildClassExplicitColumnRepository {
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<ChildClassExplicitColumnTable> where,
     _i2.OrderByBuilder<ChildClassExplicitColumnTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -597,8 +573,6 @@ class ChildClassExplicitColumnRepository {
       where: where(ChildClassExplicitColumn.t),
       orderBy: orderBy?.call(ChildClassExplicitColumn.t),
       orderByList: orderByList?.call(ChildClassExplicitColumn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/modified_column_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/modified_column_name.dart
@@ -85,8 +85,6 @@ abstract class ModifiedColumnName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ModifiedColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     ModifiedColumnNameInclude? include,
   }) {
@@ -95,8 +93,6 @@ abstract class ModifiedColumnName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ModifiedColumnName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ModifiedColumnName.t),
       include: include,
     );
@@ -200,8 +196,6 @@ class ModifiedColumnNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -246,8 +240,6 @@ class ModifiedColumnNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ModifiedColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -257,8 +249,6 @@ class ModifiedColumnNameRepository {
       where: where?.call(ModifiedColumnName.t),
       orderBy: orderBy?.call(ModifiedColumnName.t),
       orderByList: orderByList?.call(ModifiedColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -289,8 +279,6 @@ class ModifiedColumnNameRepository {
     _i1.WhereExpressionBuilder<ModifiedColumnNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<ModifiedColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -300,8 +288,6 @@ class ModifiedColumnNameRepository {
       where: where?.call(ModifiedColumnName.t),
       orderBy: orderBy?.call(ModifiedColumnName.t),
       orderByList: orderByList?.call(ModifiedColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -508,8 +494,6 @@ class ModifiedColumnNameRepository {
     int? offset,
     _i1.OrderByBuilder<ModifiedColumnNameTable>? orderBy,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -520,8 +504,6 @@ class ModifiedColumnNameRepository {
       offset: offset,
       orderBy: orderBy?.call(ModifiedColumnName.t),
       orderByList: orderByList?.call(ModifiedColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -542,8 +524,6 @@ class ModifiedColumnNameRepository {
     _i1.DatabaseSession session,
     List<ModifiedColumnName> rows, {
     _i1.OrderByBuilder<ModifiedColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -552,8 +532,6 @@ class ModifiedColumnNameRepository {
       rows,
       orderBy: orderBy?.call(ModifiedColumnName.t),
       orderByList: orderByList?.call(ModifiedColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -583,8 +561,6 @@ class ModifiedColumnNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ModifiedColumnNameTable> where,
     _i1.OrderByBuilder<ModifiedColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -593,8 +569,6 @@ class ModifiedColumnNameRepository {
       where: where(ModifiedColumnName.t),
       orderBy: orderBy?.call(ModifiedColumnName.t),
       orderByList: orderByList?.call(ModifiedColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_many/department.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_many/department.dart
@@ -97,8 +97,6 @@ abstract class Department
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DepartmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     DepartmentInclude? include,
   }) {
@@ -107,8 +105,6 @@ abstract class Department
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Department.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Department.t),
       include: include,
     );
@@ -245,8 +241,6 @@ class DepartmentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -295,8 +289,6 @@ class DepartmentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DepartmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     _i1.Transaction? transaction,
     DepartmentInclude? include,
@@ -307,8 +299,6 @@ class DepartmentRepository {
       where: where?.call(Department.t),
       orderBy: orderBy?.call(Department.t),
       orderByList: orderByList?.call(Department.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -340,8 +330,6 @@ class DepartmentRepository {
     _i1.WhereExpressionBuilder<DepartmentTable>? where,
     int? offset,
     _i1.OrderByBuilder<DepartmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     _i1.Transaction? transaction,
     DepartmentInclude? include,
@@ -352,8 +340,6 @@ class DepartmentRepository {
       where: where?.call(Department.t),
       orderBy: orderBy?.call(Department.t),
       orderByList: orderByList?.call(Department.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -561,8 +547,6 @@ class DepartmentRepository {
     int? offset,
     _i1.OrderByBuilder<DepartmentTable>? orderBy,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -573,8 +557,6 @@ class DepartmentRepository {
       offset: offset,
       orderBy: orderBy?.call(Department.t),
       orderByList: orderByList?.call(Department.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -595,8 +577,6 @@ class DepartmentRepository {
     _i1.DatabaseSession session,
     List<Department> rows, {
     _i1.OrderByBuilder<DepartmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -605,8 +585,6 @@ class DepartmentRepository {
       rows,
       orderBy: orderBy?.call(Department.t),
       orderByList: orderByList?.call(Department.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -636,8 +614,6 @@ class DepartmentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DepartmentTable> where,
     _i1.OrderByBuilder<DepartmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -646,8 +622,6 @@ class DepartmentRepository {
       where: where(Department.t),
       orderBy: orderBy?.call(Department.t),
       orderByList: orderByList?.call(Department.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_many/employee.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_many/employee.dart
@@ -85,8 +85,6 @@ abstract class Employee
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmployeeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     EmployeeInclude? include,
   }) {
@@ -95,8 +93,6 @@ abstract class Employee
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Employee.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Employee.t),
       include: include,
     );
@@ -196,8 +192,6 @@ class EmployeeIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -242,8 +236,6 @@ class EmployeeRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmployeeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -253,8 +245,6 @@ class EmployeeRepository {
       where: where?.call(Employee.t),
       orderBy: orderBy?.call(Employee.t),
       orderByList: orderByList?.call(Employee.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -285,8 +275,6 @@ class EmployeeRepository {
     _i1.WhereExpressionBuilder<EmployeeTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmployeeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -296,8 +284,6 @@ class EmployeeRepository {
       where: where?.call(Employee.t),
       orderBy: orderBy?.call(Employee.t),
       orderByList: orderByList?.call(Employee.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -502,8 +488,6 @@ class EmployeeRepository {
     int? offset,
     _i1.OrderByBuilder<EmployeeTable>? orderBy,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -514,8 +498,6 @@ class EmployeeRepository {
       offset: offset,
       orderBy: orderBy?.call(Employee.t),
       orderByList: orderByList?.call(Employee.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -536,8 +518,6 @@ class EmployeeRepository {
     _i1.DatabaseSession session,
     List<Employee> rows, {
     _i1.OrderByBuilder<EmployeeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -546,8 +526,6 @@ class EmployeeRepository {
       rows,
       orderBy: orderBy?.call(Employee.t),
       orderByList: orderByList?.call(Employee.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -577,8 +555,6 @@ class EmployeeRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmployeeTable> where,
     _i1.OrderByBuilder<EmployeeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -587,8 +563,6 @@ class EmployeeRepository {
       where: where(Employee.t),
       orderBy: orderBy?.call(Employee.t),
       orderByList: orderByList?.call(Employee.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_one/contractor.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_one/contractor.dart
@@ -100,8 +100,6 @@ abstract class Contractor
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ContractorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     ContractorInclude? include,
   }) {
@@ -110,8 +108,6 @@ abstract class Contractor
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Contractor.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Contractor.t),
       include: include,
     );
@@ -244,8 +240,6 @@ class ContractorIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -294,8 +288,6 @@ class ContractorRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ContractorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     _i1.Transaction? transaction,
     ContractorInclude? include,
@@ -306,8 +298,6 @@ class ContractorRepository {
       where: where?.call(Contractor.t),
       orderBy: orderBy?.call(Contractor.t),
       orderByList: orderByList?.call(Contractor.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -339,8 +329,6 @@ class ContractorRepository {
     _i1.WhereExpressionBuilder<ContractorTable>? where,
     int? offset,
     _i1.OrderByBuilder<ContractorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     _i1.Transaction? transaction,
     ContractorInclude? include,
@@ -351,8 +339,6 @@ class ContractorRepository {
       where: where?.call(Contractor.t),
       orderBy: orderBy?.call(Contractor.t),
       orderByList: orderByList?.call(Contractor.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -560,8 +546,6 @@ class ContractorRepository {
     int? offset,
     _i1.OrderByBuilder<ContractorTable>? orderBy,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -572,8 +556,6 @@ class ContractorRepository {
       offset: offset,
       orderBy: orderBy?.call(Contractor.t),
       orderByList: orderByList?.call(Contractor.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -594,8 +576,6 @@ class ContractorRepository {
     _i1.DatabaseSession session,
     List<Contractor> rows, {
     _i1.OrderByBuilder<ContractorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -604,8 +584,6 @@ class ContractorRepository {
       rows,
       orderBy: orderBy?.call(Contractor.t),
       orderByList: orderByList?.call(Contractor.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -635,8 +613,6 @@ class ContractorRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ContractorTable> where,
     _i1.OrderByBuilder<ContractorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -645,8 +621,6 @@ class ContractorRepository {
       where: where(Contractor.t),
       orderBy: orderBy?.call(Contractor.t),
       orderByList: orderByList?.call(Contractor.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_one/service.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/relations/one_to_one/service.dart
@@ -85,8 +85,6 @@ abstract class Service
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServiceTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     ServiceInclude? include,
   }) {
@@ -95,8 +93,6 @@ abstract class Service
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Service.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Service.t),
       include: include,
     );
@@ -195,8 +191,6 @@ class ServiceIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -241,8 +235,6 @@ class ServiceRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServiceTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -252,8 +244,6 @@ class ServiceRepository {
       where: where?.call(Service.t),
       orderBy: orderBy?.call(Service.t),
       orderByList: orderByList?.call(Service.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -284,8 +274,6 @@ class ServiceRepository {
     _i1.WhereExpressionBuilder<ServiceTable>? where,
     int? offset,
     _i1.OrderByBuilder<ServiceTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -295,8 +283,6 @@ class ServiceRepository {
       where: where?.call(Service.t),
       orderBy: orderBy?.call(Service.t),
       orderByList: orderByList?.call(Service.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -501,8 +487,6 @@ class ServiceRepository {
     int? offset,
     _i1.OrderByBuilder<ServiceTable>? orderBy,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -513,8 +497,6 @@ class ServiceRepository {
       offset: offset,
       orderBy: orderBy?.call(Service.t),
       orderByList: orderByList?.call(Service.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -535,8 +517,6 @@ class ServiceRepository {
     _i1.DatabaseSession session,
     List<Service> rows, {
     _i1.OrderByBuilder<ServiceTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -545,8 +525,6 @@ class ServiceRepository {
       rows,
       orderBy: orderBy?.call(Service.t),
       orderByList: orderByList?.call(Service.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -576,8 +554,6 @@ class ServiceRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ServiceTable> where,
     _i1.OrderByBuilder<ServiceTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -586,8 +562,6 @@ class ServiceRepository {
       where: where(Service.t),
       orderBy: orderBy?.call(Service.t),
       orderByList: orderByList?.call(Service.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/explicit_column_name/table_with_explicit_column_names.dart
+++ b/tests/serverpod_test_server/lib/src/generated/explicit_column_name/table_with_explicit_column_names.dart
@@ -87,8 +87,6 @@ abstract class TableWithExplicitColumnName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TableWithExplicitColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     TableWithExplicitColumnNameInclude? include,
   }) {
@@ -97,8 +95,6 @@ abstract class TableWithExplicitColumnName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(TableWithExplicitColumnName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(TableWithExplicitColumnName.t),
       include: include,
     );
@@ -202,8 +198,6 @@ class TableWithExplicitColumnNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -248,8 +242,6 @@ class TableWithExplicitColumnNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TableWithExplicitColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -259,8 +251,6 @@ class TableWithExplicitColumnNameRepository {
       where: where?.call(TableWithExplicitColumnName.t),
       orderBy: orderBy?.call(TableWithExplicitColumnName.t),
       orderByList: orderByList?.call(TableWithExplicitColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -291,8 +281,6 @@ class TableWithExplicitColumnNameRepository {
     _i1.WhereExpressionBuilder<TableWithExplicitColumnNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<TableWithExplicitColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -302,8 +290,6 @@ class TableWithExplicitColumnNameRepository {
       where: where?.call(TableWithExplicitColumnName.t),
       orderBy: orderBy?.call(TableWithExplicitColumnName.t),
       orderByList: orderByList?.call(TableWithExplicitColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -512,8 +498,6 @@ class TableWithExplicitColumnNameRepository {
     int? offset,
     _i1.OrderByBuilder<TableWithExplicitColumnNameTable>? orderBy,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -524,8 +508,6 @@ class TableWithExplicitColumnNameRepository {
       offset: offset,
       orderBy: orderBy?.call(TableWithExplicitColumnName.t),
       orderByList: orderByList?.call(TableWithExplicitColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -546,8 +528,6 @@ class TableWithExplicitColumnNameRepository {
     _i1.DatabaseSession session,
     List<TableWithExplicitColumnName> rows, {
     _i1.OrderByBuilder<TableWithExplicitColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -556,8 +536,6 @@ class TableWithExplicitColumnNameRepository {
       rows,
       orderBy: orderBy?.call(TableWithExplicitColumnName.t),
       orderByList: orderByList?.call(TableWithExplicitColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -587,8 +565,6 @@ class TableWithExplicitColumnNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TableWithExplicitColumnNameTable> where,
     _i1.OrderByBuilder<TableWithExplicitColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -597,8 +573,6 @@ class TableWithExplicitColumnNameRepository {
       where: where(TableWithExplicitColumnName.t),
       orderBy: orderBy?.call(TableWithExplicitColumnName.t),
       orderByList: orderByList?.call(TableWithExplicitColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/immutable/immutable_object_with_table.dart
+++ b/tests/serverpod_test_server/lib/src/generated/immutable/immutable_object_with_table.dart
@@ -109,8 +109,6 @@ abstract class ImmutableObjectWithTable
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ImmutableObjectWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ImmutableObjectWithTableTable>? orderByList,
     ImmutableObjectWithTableInclude? include,
   }) {
@@ -119,8 +117,6 @@ abstract class ImmutableObjectWithTable
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ImmutableObjectWithTable.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ImmutableObjectWithTable.t),
       include: include,
     );
@@ -205,8 +201,6 @@ class ImmutableObjectWithTableIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -251,8 +245,6 @@ class ImmutableObjectWithTableRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ImmutableObjectWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ImmutableObjectWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -262,8 +254,6 @@ class ImmutableObjectWithTableRepository {
       where: where?.call(ImmutableObjectWithTable.t),
       orderBy: orderBy?.call(ImmutableObjectWithTable.t),
       orderByList: orderByList?.call(ImmutableObjectWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -294,8 +284,6 @@ class ImmutableObjectWithTableRepository {
     _i1.WhereExpressionBuilder<ImmutableObjectWithTableTable>? where,
     int? offset,
     _i1.OrderByBuilder<ImmutableObjectWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ImmutableObjectWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -305,8 +293,6 @@ class ImmutableObjectWithTableRepository {
       where: where?.call(ImmutableObjectWithTable.t),
       orderBy: orderBy?.call(ImmutableObjectWithTable.t),
       orderByList: orderByList?.call(ImmutableObjectWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -515,8 +501,6 @@ class ImmutableObjectWithTableRepository {
     int? offset,
     _i1.OrderByBuilder<ImmutableObjectWithTableTable>? orderBy,
     _i1.OrderByListBuilder<ImmutableObjectWithTableTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -527,8 +511,6 @@ class ImmutableObjectWithTableRepository {
       offset: offset,
       orderBy: orderBy?.call(ImmutableObjectWithTable.t),
       orderByList: orderByList?.call(ImmutableObjectWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -549,8 +531,6 @@ class ImmutableObjectWithTableRepository {
     _i1.DatabaseSession session,
     List<ImmutableObjectWithTable> rows, {
     _i1.OrderByBuilder<ImmutableObjectWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ImmutableObjectWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -559,8 +539,6 @@ class ImmutableObjectWithTableRepository {
       rows,
       orderBy: orderBy?.call(ImmutableObjectWithTable.t),
       orderByList: orderByList?.call(ImmutableObjectWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -590,8 +568,6 @@ class ImmutableObjectWithTableRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ImmutableObjectWithTableTable> where,
     _i1.OrderByBuilder<ImmutableObjectWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ImmutableObjectWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -600,8 +576,6 @@ class ImmutableObjectWithTableRepository {
       where: where(ImmutableObjectWithTable.t),
       orderBy: orderBy?.call(ImmutableObjectWithTable.t),
       orderByList: orderByList?.call(ImmutableObjectWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/child_with_inherited_id.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/child_with_inherited_id.dart
@@ -118,8 +118,6 @@ abstract class ChildWithInheritedId extends _i1.ParentWithChangedId
     int? limit,
     int? offset,
     _i2.OrderByBuilder<ChildWithInheritedIdTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildWithInheritedIdTable>? orderByList,
     ChildWithInheritedIdInclude? include,
   }) {
@@ -128,8 +126,6 @@ abstract class ChildWithInheritedId extends _i1.ParentWithChangedId
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ChildWithInheritedId.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ChildWithInheritedId.t),
       include: include,
     );
@@ -299,8 +295,6 @@ class ChildWithInheritedIdIncludeList extends _i2.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -349,8 +343,6 @@ class ChildWithInheritedIdRepository {
     int? limit,
     int? offset,
     _i2.OrderByBuilder<ChildWithInheritedIdTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildWithInheritedIdTable>? orderByList,
     _i2.Transaction? transaction,
     ChildWithInheritedIdInclude? include,
@@ -361,8 +353,6 @@ class ChildWithInheritedIdRepository {
       where: where?.call(ChildWithInheritedId.t),
       orderBy: orderBy?.call(ChildWithInheritedId.t),
       orderByList: orderByList?.call(ChildWithInheritedId.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -394,8 +384,6 @@ class ChildWithInheritedIdRepository {
     _i2.WhereExpressionBuilder<ChildWithInheritedIdTable>? where,
     int? offset,
     _i2.OrderByBuilder<ChildWithInheritedIdTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildWithInheritedIdTable>? orderByList,
     _i2.Transaction? transaction,
     ChildWithInheritedIdInclude? include,
@@ -406,8 +394,6 @@ class ChildWithInheritedIdRepository {
       where: where?.call(ChildWithInheritedId.t),
       orderBy: orderBy?.call(ChildWithInheritedId.t),
       orderByList: orderByList?.call(ChildWithInheritedId.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -617,8 +603,6 @@ class ChildWithInheritedIdRepository {
     int? offset,
     _i2.OrderByBuilder<ChildWithInheritedIdTable>? orderBy,
     _i2.OrderByListBuilder<ChildWithInheritedIdTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -629,8 +613,6 @@ class ChildWithInheritedIdRepository {
       offset: offset,
       orderBy: orderBy?.call(ChildWithInheritedId.t),
       orderByList: orderByList?.call(ChildWithInheritedId.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -651,8 +633,6 @@ class ChildWithInheritedIdRepository {
     _i2.DatabaseSession session,
     List<ChildWithInheritedId> rows, {
     _i2.OrderByBuilder<ChildWithInheritedIdTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildWithInheritedIdTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -661,8 +641,6 @@ class ChildWithInheritedIdRepository {
       rows,
       orderBy: orderBy?.call(ChildWithInheritedId.t),
       orderByList: orderByList?.call(ChildWithInheritedId.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -692,8 +670,6 @@ class ChildWithInheritedIdRepository {
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<ChildWithInheritedIdTable> where,
     _i2.OrderByBuilder<ChildWithInheritedIdTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildWithInheritedIdTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -702,8 +678,6 @@ class ChildWithInheritedIdRepository {
       where: where(ChildWithInheritedId.t),
       orderBy: orderBy?.call(ChildWithInheritedId.t),
       orderByList: orderByList?.call(ChildWithInheritedId.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/child_without_id.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/child_without_id.dart
@@ -93,8 +93,6 @@ abstract class ChildClassWithoutId extends _i1.ParentClassWithoutId
     int? limit,
     int? offset,
     _i2.OrderByBuilder<ChildClassWithoutIdTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassWithoutIdTable>? orderByList,
     ChildClassWithoutIdInclude? include,
   }) {
@@ -103,8 +101,6 @@ abstract class ChildClassWithoutId extends _i1.ParentClassWithoutId
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ChildClassWithoutId.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ChildClassWithoutId.t),
       include: include,
     );
@@ -222,8 +218,6 @@ class ChildClassWithoutIdIncludeList extends _i2.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -268,8 +262,6 @@ class ChildClassWithoutIdRepository {
     int? limit,
     int? offset,
     _i2.OrderByBuilder<ChildClassWithoutIdTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassWithoutIdTable>? orderByList,
     _i2.Transaction? transaction,
     _i2.LockMode? lockMode,
@@ -279,8 +271,6 @@ class ChildClassWithoutIdRepository {
       where: where?.call(ChildClassWithoutId.t),
       orderBy: orderBy?.call(ChildClassWithoutId.t),
       orderByList: orderByList?.call(ChildClassWithoutId.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -311,8 +301,6 @@ class ChildClassWithoutIdRepository {
     _i2.WhereExpressionBuilder<ChildClassWithoutIdTable>? where,
     int? offset,
     _i2.OrderByBuilder<ChildClassWithoutIdTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassWithoutIdTable>? orderByList,
     _i2.Transaction? transaction,
     _i2.LockMode? lockMode,
@@ -322,8 +310,6 @@ class ChildClassWithoutIdRepository {
       where: where?.call(ChildClassWithoutId.t),
       orderBy: orderBy?.call(ChildClassWithoutId.t),
       orderByList: orderByList?.call(ChildClassWithoutId.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -530,8 +516,6 @@ class ChildClassWithoutIdRepository {
     int? offset,
     _i2.OrderByBuilder<ChildClassWithoutIdTable>? orderBy,
     _i2.OrderByListBuilder<ChildClassWithoutIdTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -542,8 +526,6 @@ class ChildClassWithoutIdRepository {
       offset: offset,
       orderBy: orderBy?.call(ChildClassWithoutId.t),
       orderByList: orderByList?.call(ChildClassWithoutId.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -564,8 +546,6 @@ class ChildClassWithoutIdRepository {
     _i2.DatabaseSession session,
     List<ChildClassWithoutId> rows, {
     _i2.OrderByBuilder<ChildClassWithoutIdTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassWithoutIdTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -574,8 +554,6 @@ class ChildClassWithoutIdRepository {
       rows,
       orderBy: orderBy?.call(ChildClassWithoutId.t),
       orderByList: orderByList?.call(ChildClassWithoutId.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -605,8 +583,6 @@ class ChildClassWithoutIdRepository {
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<ChildClassWithoutIdTable> where,
     _i2.OrderByBuilder<ChildClassWithoutIdTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassWithoutIdTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -615,8 +591,6 @@ class ChildClassWithoutIdRepository {
       where: where(ChildClassWithoutId.t),
       orderBy: orderBy?.call(ChildClassWithoutId.t),
       orderByList: orderByList?.call(ChildClassWithoutId.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/list_relation_of_child/child_entity.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/list_relation_of_child/child_entity.dart
@@ -92,8 +92,6 @@ abstract class ChildEntity extends _i1.BaseEntity
     int? limit,
     int? offset,
     _i2.OrderByBuilder<ChildEntityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildEntityTable>? orderByList,
     ChildEntityInclude? include,
   }) {
@@ -102,8 +100,6 @@ abstract class ChildEntity extends _i1.BaseEntity
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ChildEntity.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ChildEntity.t),
       include: include,
     );
@@ -255,8 +251,6 @@ class ChildEntityIncludeList extends _i2.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -301,8 +295,6 @@ class ChildEntityRepository {
     int? limit,
     int? offset,
     _i2.OrderByBuilder<ChildEntityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildEntityTable>? orderByList,
     _i2.Transaction? transaction,
     _i2.LockMode? lockMode,
@@ -312,8 +304,6 @@ class ChildEntityRepository {
       where: where?.call(ChildEntity.t),
       orderBy: orderBy?.call(ChildEntity.t),
       orderByList: orderByList?.call(ChildEntity.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -344,8 +334,6 @@ class ChildEntityRepository {
     _i2.WhereExpressionBuilder<ChildEntityTable>? where,
     int? offset,
     _i2.OrderByBuilder<ChildEntityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildEntityTable>? orderByList,
     _i2.Transaction? transaction,
     _i2.LockMode? lockMode,
@@ -355,8 +343,6 @@ class ChildEntityRepository {
       where: where?.call(ChildEntity.t),
       orderBy: orderBy?.call(ChildEntity.t),
       orderByList: orderByList?.call(ChildEntity.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -561,8 +547,6 @@ class ChildEntityRepository {
     int? offset,
     _i2.OrderByBuilder<ChildEntityTable>? orderBy,
     _i2.OrderByListBuilder<ChildEntityTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -573,8 +557,6 @@ class ChildEntityRepository {
       offset: offset,
       orderBy: orderBy?.call(ChildEntity.t),
       orderByList: orderByList?.call(ChildEntity.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -595,8 +577,6 @@ class ChildEntityRepository {
     _i2.DatabaseSession session,
     List<ChildEntity> rows, {
     _i2.OrderByBuilder<ChildEntityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildEntityTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -605,8 +585,6 @@ class ChildEntityRepository {
       rows,
       orderBy: orderBy?.call(ChildEntity.t),
       orderByList: orderByList?.call(ChildEntity.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -636,8 +614,6 @@ class ChildEntityRepository {
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<ChildEntityTable> where,
     _i2.OrderByBuilder<ChildEntityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildEntityTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -646,8 +622,6 @@ class ChildEntityRepository {
       where: where(ChildEntity.t),
       orderBy: orderBy?.call(ChildEntity.t),
       orderByList: orderByList?.call(ChildEntity.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/list_relation_of_child/parent_entity.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/list_relation_of_child/parent_entity.dart
@@ -86,8 +86,6 @@ abstract class ParentEntity
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ParentEntityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ParentEntityTable>? orderByList,
     ParentEntityInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class ParentEntity
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ParentEntity.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ParentEntity.t),
       include: include,
     );
@@ -216,8 +212,6 @@ class ParentEntityIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -270,8 +264,6 @@ class ParentEntityRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ParentEntityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ParentEntityTable>? orderByList,
     _i1.Transaction? transaction,
     ParentEntityInclude? include,
@@ -282,8 +274,6 @@ class ParentEntityRepository {
       where: where?.call(ParentEntity.t),
       orderBy: orderBy?.call(ParentEntity.t),
       orderByList: orderByList?.call(ParentEntity.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -315,8 +305,6 @@ class ParentEntityRepository {
     _i1.WhereExpressionBuilder<ParentEntityTable>? where,
     int? offset,
     _i1.OrderByBuilder<ParentEntityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ParentEntityTable>? orderByList,
     _i1.Transaction? transaction,
     ParentEntityInclude? include,
@@ -327,8 +315,6 @@ class ParentEntityRepository {
       where: where?.call(ParentEntity.t),
       orderBy: orderBy?.call(ParentEntity.t),
       orderByList: orderByList?.call(ParentEntity.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -536,8 +522,6 @@ class ParentEntityRepository {
     int? offset,
     _i1.OrderByBuilder<ParentEntityTable>? orderBy,
     _i1.OrderByListBuilder<ParentEntityTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -548,8 +532,6 @@ class ParentEntityRepository {
       offset: offset,
       orderBy: orderBy?.call(ParentEntity.t),
       orderByList: orderByList?.call(ParentEntity.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -570,8 +552,6 @@ class ParentEntityRepository {
     _i1.DatabaseSession session,
     List<ParentEntity> rows, {
     _i1.OrderByBuilder<ParentEntityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ParentEntityTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -580,8 +560,6 @@ class ParentEntityRepository {
       rows,
       orderBy: orderBy?.call(ParentEntity.t),
       orderByList: orderByList?.call(ParentEntity.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -611,8 +589,6 @@ class ParentEntityRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ParentEntityTable> where,
     _i1.OrderByBuilder<ParentEntityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ParentEntityTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -621,8 +597,6 @@ class ParentEntityRepository {
       where: where(ParentEntity.t),
       orderBy: orderBy?.call(ParentEntity.t),
       orderByList: orderByList?.call(ParentEntity.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/inheritance/parent_class.dart
+++ b/tests/serverpod_test_server/lib/src/generated/inheritance/parent_class.dart
@@ -85,8 +85,6 @@ class ParentClass extends _i1.GrandparentClass
     int? limit,
     int? offset,
     _i2.OrderByBuilder<ParentClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ParentClassTable>? orderByList,
     ParentClassInclude? include,
   }) {
@@ -95,8 +93,6 @@ class ParentClass extends _i1.GrandparentClass
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ParentClass.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ParentClass.t),
       include: include,
     );
@@ -169,8 +165,6 @@ class ParentClassIncludeList extends _i2.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -215,8 +209,6 @@ class ParentClassRepository {
     int? limit,
     int? offset,
     _i2.OrderByBuilder<ParentClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ParentClassTable>? orderByList,
     _i2.Transaction? transaction,
     _i2.LockMode? lockMode,
@@ -226,8 +218,6 @@ class ParentClassRepository {
       where: where?.call(ParentClass.t),
       orderBy: orderBy?.call(ParentClass.t),
       orderByList: orderByList?.call(ParentClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -258,8 +248,6 @@ class ParentClassRepository {
     _i2.WhereExpressionBuilder<ParentClassTable>? where,
     int? offset,
     _i2.OrderByBuilder<ParentClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ParentClassTable>? orderByList,
     _i2.Transaction? transaction,
     _i2.LockMode? lockMode,
@@ -269,8 +257,6 @@ class ParentClassRepository {
       where: where?.call(ParentClass.t),
       orderBy: orderBy?.call(ParentClass.t),
       orderByList: orderByList?.call(ParentClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -475,8 +461,6 @@ class ParentClassRepository {
     int? offset,
     _i2.OrderByBuilder<ParentClassTable>? orderBy,
     _i2.OrderByListBuilder<ParentClassTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -487,8 +471,6 @@ class ParentClassRepository {
       offset: offset,
       orderBy: orderBy?.call(ParentClass.t),
       orderByList: orderByList?.call(ParentClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -509,8 +491,6 @@ class ParentClassRepository {
     _i2.DatabaseSession session,
     List<ParentClass> rows, {
     _i2.OrderByBuilder<ParentClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ParentClassTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -519,8 +499,6 @@ class ParentClassRepository {
       rows,
       orderBy: orderBy?.call(ParentClass.t),
       orderByList: orderByList?.call(ParentClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -550,8 +528,6 @@ class ParentClassRepository {
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<ParentClassTable> where,
     _i2.OrderByBuilder<ParentClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ParentClassTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -560,8 +536,6 @@ class ParentClassRepository {
       where: where(ParentClass.t),
       orderBy: orderBy?.call(ParentClass.t),
       orderByList: orderByList?.call(ParentClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -121,8 +121,6 @@ abstract class CityWithLongTableName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CityWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     CityWithLongTableNameInclude? include,
   }) {
@@ -131,8 +129,6 @@ abstract class CityWithLongTableName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CityWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CityWithLongTableName.t),
       include: include,
     );
@@ -335,8 +331,6 @@ class CityWithLongTableNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -389,8 +383,6 @@ class CityWithLongTableNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CityWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     CityWithLongTableNameInclude? include,
@@ -401,8 +393,6 @@ class CityWithLongTableNameRepository {
       where: where?.call(CityWithLongTableName.t),
       orderBy: orderBy?.call(CityWithLongTableName.t),
       orderByList: orderByList?.call(CityWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -434,8 +424,6 @@ class CityWithLongTableNameRepository {
     _i1.WhereExpressionBuilder<CityWithLongTableNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<CityWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     CityWithLongTableNameInclude? include,
@@ -446,8 +434,6 @@ class CityWithLongTableNameRepository {
       where: where?.call(CityWithLongTableName.t),
       orderBy: orderBy?.call(CityWithLongTableName.t),
       orderByList: orderByList?.call(CityWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -657,8 +643,6 @@ class CityWithLongTableNameRepository {
     int? offset,
     _i1.OrderByBuilder<CityWithLongTableNameTable>? orderBy,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -669,8 +653,6 @@ class CityWithLongTableNameRepository {
       offset: offset,
       orderBy: orderBy?.call(CityWithLongTableName.t),
       orderByList: orderByList?.call(CityWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -691,8 +673,6 @@ class CityWithLongTableNameRepository {
     _i1.DatabaseSession session,
     List<CityWithLongTableName> rows, {
     _i1.OrderByBuilder<CityWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -701,8 +681,6 @@ class CityWithLongTableNameRepository {
       rows,
       orderBy: orderBy?.call(CityWithLongTableName.t),
       orderByList: orderByList?.call(CityWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -732,8 +710,6 @@ class CityWithLongTableNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CityWithLongTableNameTable> where,
     _i1.OrderByBuilder<CityWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -742,8 +718,6 @@ class CityWithLongTableNameRepository {
       where: where(CityWithLongTableName.t),
       orderBy: orderBy?.call(CityWithLongTableName.t),
       orderByList: orderByList?.call(CityWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -125,8 +125,6 @@ abstract class OrganizationWithLongTableName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrganizationWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     OrganizationWithLongTableNameInclude? include,
   }) {
@@ -135,8 +133,6 @@ abstract class OrganizationWithLongTableName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
       include: include,
     );
@@ -324,8 +320,6 @@ class OrganizationWithLongTableNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -378,8 +372,6 @@ class OrganizationWithLongTableNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrganizationWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     OrganizationWithLongTableNameInclude? include,
@@ -390,8 +382,6 @@ class OrganizationWithLongTableNameRepository {
       where: where?.call(OrganizationWithLongTableName.t),
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -423,8 +413,6 @@ class OrganizationWithLongTableNameRepository {
     _i1.WhereExpressionBuilder<OrganizationWithLongTableNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<OrganizationWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     OrganizationWithLongTableNameInclude? include,
@@ -435,8 +423,6 @@ class OrganizationWithLongTableNameRepository {
       where: where?.call(OrganizationWithLongTableName.t),
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -653,8 +639,6 @@ class OrganizationWithLongTableNameRepository {
     int? offset,
     _i1.OrderByBuilder<OrganizationWithLongTableNameTable>? orderBy,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -665,8 +649,6 @@ class OrganizationWithLongTableNameRepository {
       offset: offset,
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -687,8 +669,6 @@ class OrganizationWithLongTableNameRepository {
     _i1.DatabaseSession session,
     List<OrganizationWithLongTableName> rows, {
     _i1.OrderByBuilder<OrganizationWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -697,8 +677,6 @@ class OrganizationWithLongTableNameRepository {
       rows,
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -729,8 +707,6 @@ class OrganizationWithLongTableNameRepository {
     required _i1.WhereExpressionBuilder<OrganizationWithLongTableNameTable>
     where,
     _i1.OrderByBuilder<OrganizationWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -739,8 +715,6 @@ class OrganizationWithLongTableNameRepository {
       where: where(OrganizationWithLongTableName.t),
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -115,8 +115,6 @@ abstract class PersonWithLongTableName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PersonWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     PersonWithLongTableNameInclude? include,
   }) {
@@ -125,8 +123,6 @@ abstract class PersonWithLongTableName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(PersonWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(PersonWithLongTableName.t),
       include: include,
     );
@@ -326,8 +322,6 @@ class PersonWithLongTableNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -376,8 +370,6 @@ class PersonWithLongTableNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PersonWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     PersonWithLongTableNameInclude? include,
@@ -388,8 +380,6 @@ class PersonWithLongTableNameRepository {
       where: where?.call(PersonWithLongTableName.t),
       orderBy: orderBy?.call(PersonWithLongTableName.t),
       orderByList: orderByList?.call(PersonWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -421,8 +411,6 @@ class PersonWithLongTableNameRepository {
     _i1.WhereExpressionBuilder<PersonWithLongTableNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<PersonWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     PersonWithLongTableNameInclude? include,
@@ -433,8 +421,6 @@ class PersonWithLongTableNameRepository {
       where: where?.call(PersonWithLongTableName.t),
       orderBy: orderBy?.call(PersonWithLongTableName.t),
       orderByList: orderByList?.call(PersonWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -644,8 +630,6 @@ class PersonWithLongTableNameRepository {
     int? offset,
     _i1.OrderByBuilder<PersonWithLongTableNameTable>? orderBy,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -656,8 +640,6 @@ class PersonWithLongTableNameRepository {
       offset: offset,
       orderBy: orderBy?.call(PersonWithLongTableName.t),
       orderByList: orderByList?.call(PersonWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -678,8 +660,6 @@ class PersonWithLongTableNameRepository {
     _i1.DatabaseSession session,
     List<PersonWithLongTableName> rows, {
     _i1.OrderByBuilder<PersonWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -688,8 +668,6 @@ class PersonWithLongTableNameRepository {
       rows,
       orderBy: orderBy?.call(PersonWithLongTableName.t),
       orderByList: orderByList?.call(PersonWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -719,8 +697,6 @@ class PersonWithLongTableNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PersonWithLongTableNameTable> where,
     _i1.OrderByBuilder<PersonWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -729,8 +705,6 @@ class PersonWithLongTableNameRepository {
       where: where(PersonWithLongTableName.t),
       orderBy: orderBy?.call(PersonWithLongTableName.t),
       orderByList: orderByList?.call(PersonWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/max_field_name.dart
@@ -82,8 +82,6 @@ abstract class MaxFieldName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     MaxFieldNameInclude? include,
   }) {
@@ -92,8 +90,6 @@ abstract class MaxFieldName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(MaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(MaxFieldName.t),
       include: include,
     );
@@ -185,8 +181,6 @@ class MaxFieldNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -231,8 +225,6 @@ class MaxFieldNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -242,8 +234,6 @@ class MaxFieldNameRepository {
       where: where?.call(MaxFieldName.t),
       orderBy: orderBy?.call(MaxFieldName.t),
       orderByList: orderByList?.call(MaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -274,8 +264,6 @@ class MaxFieldNameRepository {
     _i1.WhereExpressionBuilder<MaxFieldNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<MaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -285,8 +273,6 @@ class MaxFieldNameRepository {
       where: where?.call(MaxFieldName.t),
       orderBy: orderBy?.call(MaxFieldName.t),
       orderByList: orderByList?.call(MaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -491,8 +477,6 @@ class MaxFieldNameRepository {
     int? offset,
     _i1.OrderByBuilder<MaxFieldNameTable>? orderBy,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -503,8 +487,6 @@ class MaxFieldNameRepository {
       offset: offset,
       orderBy: orderBy?.call(MaxFieldName.t),
       orderByList: orderByList?.call(MaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -525,8 +507,6 @@ class MaxFieldNameRepository {
     _i1.DatabaseSession session,
     List<MaxFieldName> rows, {
     _i1.OrderByBuilder<MaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -535,8 +515,6 @@ class MaxFieldNameRepository {
       rows,
       orderBy: orderBy?.call(MaxFieldName.t),
       orderByList: orderByList?.call(MaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -566,8 +544,6 @@ class MaxFieldNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MaxFieldNameTable> where,
     _i1.OrderByBuilder<MaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -576,8 +552,6 @@ class MaxFieldNameRepository {
       where: where(MaxFieldName.t),
       orderBy: orderBy?.call(MaxFieldName.t),
       orderByList: orderByList?.call(MaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -86,8 +86,6 @@ abstract class LongImplicitIdField
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     LongImplicitIdFieldInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class LongImplicitIdField
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(LongImplicitIdField.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(LongImplicitIdField.t),
       include: include,
     );
@@ -235,8 +231,6 @@ class LongImplicitIdFieldIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -281,8 +275,6 @@ class LongImplicitIdFieldRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -292,8 +284,6 @@ class LongImplicitIdFieldRepository {
       where: where?.call(LongImplicitIdField.t),
       orderBy: orderBy?.call(LongImplicitIdField.t),
       orderByList: orderByList?.call(LongImplicitIdField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -324,8 +314,6 @@ class LongImplicitIdFieldRepository {
     _i1.WhereExpressionBuilder<LongImplicitIdFieldTable>? where,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -335,8 +323,6 @@ class LongImplicitIdFieldRepository {
       where: where?.call(LongImplicitIdField.t),
       orderBy: orderBy?.call(LongImplicitIdField.t),
       orderByList: orderByList?.call(LongImplicitIdField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -543,8 +529,6 @@ class LongImplicitIdFieldRepository {
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldTable>? orderBy,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -555,8 +539,6 @@ class LongImplicitIdFieldRepository {
       offset: offset,
       orderBy: orderBy?.call(LongImplicitIdField.t),
       orderByList: orderByList?.call(LongImplicitIdField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -577,8 +559,6 @@ class LongImplicitIdFieldRepository {
     _i1.DatabaseSession session,
     List<LongImplicitIdField> rows, {
     _i1.OrderByBuilder<LongImplicitIdFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -587,8 +567,6 @@ class LongImplicitIdFieldRepository {
       rows,
       orderBy: orderBy?.call(LongImplicitIdField.t),
       orderByList: orderByList?.call(LongImplicitIdField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -618,8 +596,6 @@ class LongImplicitIdFieldRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<LongImplicitIdFieldTable> where,
     _i1.OrderByBuilder<LongImplicitIdFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -628,8 +604,6 @@ class LongImplicitIdFieldRepository {
       where: where(LongImplicitIdField.t),
       orderBy: orderBy?.call(LongImplicitIdField.t),
       orderByList: orderByList?.call(LongImplicitIdField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -112,8 +112,6 @@ abstract class LongImplicitIdFieldCollection
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     LongImplicitIdFieldCollectionInclude? include,
   }) {
@@ -122,8 +120,6 @@ abstract class LongImplicitIdFieldCollection
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
       include: include,
     );
@@ -295,8 +291,6 @@ class LongImplicitIdFieldCollectionIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -349,8 +343,6 @@ class LongImplicitIdFieldCollectionRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     LongImplicitIdFieldCollectionInclude? include,
@@ -361,8 +353,6 @@ class LongImplicitIdFieldCollectionRepository {
       where: where?.call(LongImplicitIdFieldCollection.t),
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -394,8 +384,6 @@ class LongImplicitIdFieldCollectionRepository {
     _i1.WhereExpressionBuilder<LongImplicitIdFieldCollectionTable>? where,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     LongImplicitIdFieldCollectionInclude? include,
@@ -406,8 +394,6 @@ class LongImplicitIdFieldCollectionRepository {
       where: where?.call(LongImplicitIdFieldCollection.t),
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -624,8 +610,6 @@ class LongImplicitIdFieldCollectionRepository {
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldCollectionTable>? orderBy,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -636,8 +620,6 @@ class LongImplicitIdFieldCollectionRepository {
       offset: offset,
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -658,8 +640,6 @@ class LongImplicitIdFieldCollectionRepository {
     _i1.DatabaseSession session,
     List<LongImplicitIdFieldCollection> rows, {
     _i1.OrderByBuilder<LongImplicitIdFieldCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -668,8 +648,6 @@ class LongImplicitIdFieldCollectionRepository {
       rows,
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -700,8 +678,6 @@ class LongImplicitIdFieldCollectionRepository {
     required _i1.WhereExpressionBuilder<LongImplicitIdFieldCollectionTable>
     where,
     _i1.OrderByBuilder<LongImplicitIdFieldCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -710,8 +686,6 @@ class LongImplicitIdFieldCollectionRepository {
       where: where(LongImplicitIdFieldCollection.t),
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -104,8 +104,6 @@ abstract class RelationToMultipleMaxFieldName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelationToMultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     RelationToMultipleMaxFieldNameInclude? include,
   }) {
@@ -114,8 +112,6 @@ abstract class RelationToMultipleMaxFieldName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
       include: include,
     );
@@ -266,8 +262,6 @@ class RelationToMultipleMaxFieldNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -320,8 +314,6 @@ class RelationToMultipleMaxFieldNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelationToMultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     RelationToMultipleMaxFieldNameInclude? include,
@@ -332,8 +324,6 @@ class RelationToMultipleMaxFieldNameRepository {
       where: where?.call(RelationToMultipleMaxFieldName.t),
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -365,8 +355,6 @@ class RelationToMultipleMaxFieldNameRepository {
     _i1.WhereExpressionBuilder<RelationToMultipleMaxFieldNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<RelationToMultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     RelationToMultipleMaxFieldNameInclude? include,
@@ -377,8 +365,6 @@ class RelationToMultipleMaxFieldNameRepository {
       where: where?.call(RelationToMultipleMaxFieldName.t),
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -597,8 +583,6 @@ class RelationToMultipleMaxFieldNameRepository {
     int? offset,
     _i1.OrderByBuilder<RelationToMultipleMaxFieldNameTable>? orderBy,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -609,8 +593,6 @@ class RelationToMultipleMaxFieldNameRepository {
       offset: offset,
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -631,8 +613,6 @@ class RelationToMultipleMaxFieldNameRepository {
     _i1.DatabaseSession session,
     List<RelationToMultipleMaxFieldName> rows, {
     _i1.OrderByBuilder<RelationToMultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -641,8 +621,6 @@ class RelationToMultipleMaxFieldNameRepository {
       rows,
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -673,8 +651,6 @@ class RelationToMultipleMaxFieldNameRepository {
     required _i1.WhereExpressionBuilder<RelationToMultipleMaxFieldNameTable>
     where,
     _i1.OrderByBuilder<RelationToMultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -683,8 +659,6 @@ class RelationToMultipleMaxFieldNameRepository {
       where: where(RelationToMultipleMaxFieldName.t),
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
@@ -86,8 +86,6 @@ abstract class UserNote
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     UserNoteInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class UserNote
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UserNote.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UserNote.t),
       include: include,
     );
@@ -232,8 +228,6 @@ class UserNoteIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -278,8 +272,6 @@ class UserNoteRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -289,8 +281,6 @@ class UserNoteRepository {
       where: where?.call(UserNote.t),
       orderBy: orderBy?.call(UserNote.t),
       orderByList: orderByList?.call(UserNote.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -321,8 +311,6 @@ class UserNoteRepository {
     _i1.WhereExpressionBuilder<UserNoteTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserNoteTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -332,8 +320,6 @@ class UserNoteRepository {
       where: where?.call(UserNote.t),
       orderBy: orderBy?.call(UserNote.t),
       orderByList: orderByList?.call(UserNote.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -538,8 +524,6 @@ class UserNoteRepository {
     int? offset,
     _i1.OrderByBuilder<UserNoteTable>? orderBy,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -550,8 +534,6 @@ class UserNoteRepository {
       offset: offset,
       orderBy: orderBy?.call(UserNote.t),
       orderByList: orderByList?.call(UserNote.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -572,8 +554,6 @@ class UserNoteRepository {
     _i1.DatabaseSession session,
     List<UserNote> rows, {
     _i1.OrderByBuilder<UserNoteTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -582,8 +562,6 @@ class UserNoteRepository {
       rows,
       orderBy: orderBy?.call(UserNote.t),
       orderByList: orderByList?.call(UserNote.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -613,8 +591,6 @@ class UserNoteRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteTable> where,
     _i1.OrderByBuilder<UserNoteTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -623,8 +599,6 @@ class UserNoteRepository {
       where: where(UserNote.t),
       orderBy: orderBy?.call(UserNote.t),
       orderByList: orderByList?.call(UserNote.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -102,8 +102,6 @@ abstract class UserNoteCollection
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     UserNoteCollectionInclude? include,
   }) {
@@ -112,8 +110,6 @@ abstract class UserNoteCollection
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UserNoteCollection.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UserNoteCollection.t),
       include: include,
     );
@@ -262,8 +258,6 @@ class UserNoteCollectionIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -316,8 +310,6 @@ class UserNoteCollectionRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     UserNoteCollectionInclude? include,
@@ -328,8 +320,6 @@ class UserNoteCollectionRepository {
       where: where?.call(UserNoteCollection.t),
       orderBy: orderBy?.call(UserNoteCollection.t),
       orderByList: orderByList?.call(UserNoteCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -361,8 +351,6 @@ class UserNoteCollectionRepository {
     _i1.WhereExpressionBuilder<UserNoteCollectionTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     UserNoteCollectionInclude? include,
@@ -373,8 +361,6 @@ class UserNoteCollectionRepository {
       where: where?.call(UserNoteCollection.t),
       orderBy: orderBy?.call(UserNoteCollection.t),
       orderByList: orderByList?.call(UserNoteCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -584,8 +570,6 @@ class UserNoteCollectionRepository {
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionTable>? orderBy,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -596,8 +580,6 @@ class UserNoteCollectionRepository {
       offset: offset,
       orderBy: orderBy?.call(UserNoteCollection.t),
       orderByList: orderByList?.call(UserNoteCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -618,8 +600,6 @@ class UserNoteCollectionRepository {
     _i1.DatabaseSession session,
     List<UserNoteCollection> rows, {
     _i1.OrderByBuilder<UserNoteCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -628,8 +608,6 @@ class UserNoteCollectionRepository {
       rows,
       orderBy: orderBy?.call(UserNoteCollection.t),
       orderByList: orderByList?.call(UserNoteCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -659,8 +637,6 @@ class UserNoteCollectionRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteCollectionTable> where,
     _i1.OrderByBuilder<UserNoteCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -669,8 +645,6 @@ class UserNoteCollectionRepository {
       where: where(UserNoteCollection.t),
       orderBy: orderBy?.call(UserNoteCollection.t),
       orderByList: orderByList?.call(UserNoteCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -98,8 +98,6 @@ abstract class UserNoteCollectionWithALongName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     UserNoteCollectionWithALongNameInclude? include,
   }) {
@@ -108,8 +106,6 @@ abstract class UserNoteCollectionWithALongName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
       include: include,
     );
@@ -257,8 +253,6 @@ class UserNoteCollectionWithALongNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -313,8 +307,6 @@ class UserNoteCollectionWithALongNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     UserNoteCollectionWithALongNameInclude? include,
@@ -325,8 +317,6 @@ class UserNoteCollectionWithALongNameRepository {
       where: where?.call(UserNoteCollectionWithALongName.t),
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -358,8 +348,6 @@ class UserNoteCollectionWithALongNameRepository {
     _i1.WhereExpressionBuilder<UserNoteCollectionWithALongNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     UserNoteCollectionWithALongNameInclude? include,
@@ -370,8 +358,6 @@ class UserNoteCollectionWithALongNameRepository {
       where: where?.call(UserNoteCollectionWithALongName.t),
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -590,8 +576,6 @@ class UserNoteCollectionWithALongNameRepository {
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionWithALongNameTable>? orderBy,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -602,8 +586,6 @@ class UserNoteCollectionWithALongNameRepository {
       offset: offset,
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -624,8 +606,6 @@ class UserNoteCollectionWithALongNameRepository {
     _i1.DatabaseSession session,
     List<UserNoteCollectionWithALongName> rows, {
     _i1.OrderByBuilder<UserNoteCollectionWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -634,8 +614,6 @@ class UserNoteCollectionWithALongNameRepository {
       rows,
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -666,8 +644,6 @@ class UserNoteCollectionWithALongNameRepository {
     required _i1.WhereExpressionBuilder<UserNoteCollectionWithALongNameTable>
     where,
     _i1.OrderByBuilder<UserNoteCollectionWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -676,8 +652,6 @@ class UserNoteCollectionWithALongNameRepository {
       where: where(UserNoteCollectionWithALongName.t),
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -88,8 +88,6 @@ abstract class UserNoteWithALongName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     UserNoteWithALongNameInclude? include,
   }) {
@@ -98,8 +96,6 @@ abstract class UserNoteWithALongName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UserNoteWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UserNoteWithALongName.t),
       include: include,
     );
@@ -237,8 +233,6 @@ class UserNoteWithALongNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -283,8 +277,6 @@ class UserNoteWithALongNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -294,8 +286,6 @@ class UserNoteWithALongNameRepository {
       where: where?.call(UserNoteWithALongName.t),
       orderBy: orderBy?.call(UserNoteWithALongName.t),
       orderByList: orderByList?.call(UserNoteWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -326,8 +316,6 @@ class UserNoteWithALongNameRepository {
     _i1.WhereExpressionBuilder<UserNoteWithALongNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserNoteWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -337,8 +325,6 @@ class UserNoteWithALongNameRepository {
       where: where?.call(UserNoteWithALongName.t),
       orderBy: orderBy?.call(UserNoteWithALongName.t),
       orderByList: orderByList?.call(UserNoteWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -545,8 +531,6 @@ class UserNoteWithALongNameRepository {
     int? offset,
     _i1.OrderByBuilder<UserNoteWithALongNameTable>? orderBy,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -557,8 +541,6 @@ class UserNoteWithALongNameRepository {
       offset: offset,
       orderBy: orderBy?.call(UserNoteWithALongName.t),
       orderByList: orderByList?.call(UserNoteWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -579,8 +561,6 @@ class UserNoteWithALongNameRepository {
     _i1.DatabaseSession session,
     List<UserNoteWithALongName> rows, {
     _i1.OrderByBuilder<UserNoteWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -589,8 +569,6 @@ class UserNoteWithALongNameRepository {
       rows,
       orderBy: orderBy?.call(UserNoteWithALongName.t),
       orderByList: orderByList?.call(UserNoteWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -620,8 +598,6 @@ class UserNoteWithALongNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteWithALongNameTable> where,
     _i1.OrderByBuilder<UserNoteWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -630,8 +606,6 @@ class UserNoteWithALongNameRepository {
       where: where(UserNoteWithALongName.t),
       orderBy: orderBy?.call(UserNoteWithALongName.t),
       orderByList: orderByList?.call(UserNoteWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
@@ -106,8 +106,6 @@ abstract class MultipleMaxFieldName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     MultipleMaxFieldNameInclude? include,
   }) {
@@ -116,8 +114,6 @@ abstract class MultipleMaxFieldName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
       include: include,
     );
@@ -299,8 +295,6 @@ class MultipleMaxFieldNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -345,8 +339,6 @@ class MultipleMaxFieldNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -356,8 +348,6 @@ class MultipleMaxFieldNameRepository {
       where: where?.call(MultipleMaxFieldName.t),
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -388,8 +378,6 @@ class MultipleMaxFieldNameRepository {
     _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<MultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -399,8 +387,6 @@ class MultipleMaxFieldNameRepository {
       where: where?.call(MultipleMaxFieldName.t),
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -607,8 +593,6 @@ class MultipleMaxFieldNameRepository {
     int? offset,
     _i1.OrderByBuilder<MultipleMaxFieldNameTable>? orderBy,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -619,8 +603,6 @@ class MultipleMaxFieldNameRepository {
       offset: offset,
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -641,8 +623,6 @@ class MultipleMaxFieldNameRepository {
     _i1.DatabaseSession session,
     List<MultipleMaxFieldName> rows, {
     _i1.OrderByBuilder<MultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -651,8 +631,6 @@ class MultipleMaxFieldNameRepository {
       rows,
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -682,8 +660,6 @@ class MultipleMaxFieldNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable> where,
     _i1.OrderByBuilder<MultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -692,8 +668,6 @@ class MultipleMaxFieldNameRepository {
       where: where(MultipleMaxFieldName.t),
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/city.dart
@@ -116,8 +116,6 @@ abstract class City implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     CityInclude? include,
   }) {
@@ -126,8 +124,6 @@ abstract class City implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(City.t),
       include: include,
     );
@@ -318,8 +314,6 @@ class CityIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -372,8 +366,6 @@ class CityRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     CityInclude? include,
@@ -384,8 +376,6 @@ class CityRepository {
       where: where?.call(City.t),
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -417,8 +407,6 @@ class CityRepository {
     _i1.WhereExpressionBuilder<CityTable>? where,
     int? offset,
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     CityInclude? include,
@@ -429,8 +417,6 @@ class CityRepository {
       where: where?.call(City.t),
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -638,8 +624,6 @@ class CityRepository {
     int? offset,
     _i1.OrderByBuilder<CityTable>? orderBy,
     _i1.OrderByListBuilder<CityTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -650,8 +634,6 @@ class CityRepository {
       offset: offset,
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -672,8 +654,6 @@ class CityRepository {
     _i1.DatabaseSession session,
     List<City> rows, {
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -682,8 +662,6 @@ class CityRepository {
       rows,
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -713,8 +691,6 @@ class CityRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CityTable> where,
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -723,8 +699,6 @@ class CityRepository {
       where: where(City.t),
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -119,8 +119,6 @@ abstract class Organization
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     OrganizationInclude? include,
   }) {
@@ -129,8 +127,6 @@ abstract class Organization
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Organization.t),
       include: include,
     );
@@ -314,8 +310,6 @@ class OrganizationIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -368,8 +362,6 @@ class OrganizationRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     OrganizationInclude? include,
@@ -380,8 +372,6 @@ class OrganizationRepository {
       where: where?.call(Organization.t),
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -413,8 +403,6 @@ class OrganizationRepository {
     _i1.WhereExpressionBuilder<OrganizationTable>? where,
     int? offset,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     OrganizationInclude? include,
@@ -425,8 +413,6 @@ class OrganizationRepository {
       where: where?.call(Organization.t),
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -634,8 +620,6 @@ class OrganizationRepository {
     int? offset,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -646,8 +630,6 @@ class OrganizationRepository {
       offset: offset,
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -668,8 +650,6 @@ class OrganizationRepository {
     _i1.DatabaseSession session,
     List<Organization> rows, {
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -678,8 +658,6 @@ class OrganizationRepository {
       rows,
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -709,8 +687,6 @@ class OrganizationRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrganizationTable> where,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -719,8 +695,6 @@ class OrganizationRepository {
       where: where(Organization.t),
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_list_relations/person.dart
@@ -105,8 +105,6 @@ abstract class Person implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     PersonInclude? include,
   }) {
@@ -115,8 +113,6 @@ abstract class Person implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Person.t),
       include: include,
     );
@@ -302,8 +298,6 @@ class PersonIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -352,8 +346,6 @@ class PersonRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     PersonInclude? include,
@@ -364,8 +356,6 @@ class PersonRepository {
       where: where?.call(Person.t),
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -397,8 +387,6 @@ class PersonRepository {
     _i1.WhereExpressionBuilder<PersonTable>? where,
     int? offset,
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     PersonInclude? include,
@@ -409,8 +397,6 @@ class PersonRepository {
       where: where?.call(Person.t),
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -618,8 +604,6 @@ class PersonRepository {
     int? offset,
     _i1.OrderByBuilder<PersonTable>? orderBy,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -630,8 +614,6 @@ class PersonRepository {
       offset: offset,
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -652,8 +634,6 @@ class PersonRepository {
     _i1.DatabaseSession session,
     List<Person> rows, {
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -662,8 +642,6 @@ class PersonRepository {
       rows,
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -693,8 +671,6 @@ class PersonRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PersonTable> where,
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -703,8 +679,6 @@ class PersonRepository {
       where: where(Person.t),
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/column_alias_collision/bleed_child.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/column_alias_collision/bleed_child.dart
@@ -84,8 +84,6 @@ abstract class BleedChild
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BleedChildTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BleedChildTable>? orderByList,
     BleedChildInclude? include,
   }) {
@@ -94,8 +92,6 @@ abstract class BleedChild
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BleedChild.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BleedChild.t),
       include: include,
     );
@@ -179,8 +175,6 @@ class BleedChildIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -225,8 +219,6 @@ class BleedChildRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BleedChildTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BleedChildTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -236,8 +228,6 @@ class BleedChildRepository {
       where: where?.call(BleedChild.t),
       orderBy: orderBy?.call(BleedChild.t),
       orderByList: orderByList?.call(BleedChild.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -268,8 +258,6 @@ class BleedChildRepository {
     _i1.WhereExpressionBuilder<BleedChildTable>? where,
     int? offset,
     _i1.OrderByBuilder<BleedChildTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BleedChildTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -279,8 +267,6 @@ class BleedChildRepository {
       where: where?.call(BleedChild.t),
       orderBy: orderBy?.call(BleedChild.t),
       orderByList: orderByList?.call(BleedChild.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -485,8 +471,6 @@ class BleedChildRepository {
     int? offset,
     _i1.OrderByBuilder<BleedChildTable>? orderBy,
     _i1.OrderByListBuilder<BleedChildTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -497,8 +481,6 @@ class BleedChildRepository {
       offset: offset,
       orderBy: orderBy?.call(BleedChild.t),
       orderByList: orderByList?.call(BleedChild.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -519,8 +501,6 @@ class BleedChildRepository {
     _i1.DatabaseSession session,
     List<BleedChild> rows, {
     _i1.OrderByBuilder<BleedChildTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BleedChildTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -529,8 +509,6 @@ class BleedChildRepository {
       rows,
       orderBy: orderBy?.call(BleedChild.t),
       orderByList: orderByList?.call(BleedChild.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -560,8 +538,6 @@ class BleedChildRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BleedChildTable> where,
     _i1.OrderByBuilder<BleedChildTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BleedChildTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -570,8 +546,6 @@ class BleedChildRepository {
       where: where(BleedChild.t),
       orderBy: orderBy?.call(BleedChild.t),
       orderByList: orderByList?.call(BleedChild.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/column_alias_collision/bleed_root.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/column_alias_collision/bleed_root.dart
@@ -155,8 +155,6 @@ abstract class BleedRoot
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BleedRootTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BleedRootTable>? orderByList,
     BleedRootInclude? include,
   }) {
@@ -165,8 +163,6 @@ abstract class BleedRoot
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BleedRoot.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BleedRoot.t),
       include: include,
     );
@@ -367,8 +363,6 @@ class BleedRootIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -417,8 +411,6 @@ class BleedRootRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BleedRootTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BleedRootTable>? orderByList,
     _i1.Transaction? transaction,
     BleedRootInclude? include,
@@ -429,8 +421,6 @@ class BleedRootRepository {
       where: where?.call(BleedRoot.t),
       orderBy: orderBy?.call(BleedRoot.t),
       orderByList: orderByList?.call(BleedRoot.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -462,8 +452,6 @@ class BleedRootRepository {
     _i1.WhereExpressionBuilder<BleedRootTable>? where,
     int? offset,
     _i1.OrderByBuilder<BleedRootTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BleedRootTable>? orderByList,
     _i1.Transaction? transaction,
     BleedRootInclude? include,
@@ -474,8 +462,6 @@ class BleedRootRepository {
       where: where?.call(BleedRoot.t),
       orderBy: orderBy?.call(BleedRoot.t),
       orderByList: orderByList?.call(BleedRoot.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -683,8 +669,6 @@ class BleedRootRepository {
     int? offset,
     _i1.OrderByBuilder<BleedRootTable>? orderBy,
     _i1.OrderByListBuilder<BleedRootTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -695,8 +679,6 @@ class BleedRootRepository {
       offset: offset,
       orderBy: orderBy?.call(BleedRoot.t),
       orderByList: orderByList?.call(BleedRoot.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -717,8 +699,6 @@ class BleedRootRepository {
     _i1.DatabaseSession session,
     List<BleedRoot> rows, {
     _i1.OrderByBuilder<BleedRootTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BleedRootTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -727,8 +707,6 @@ class BleedRootRepository {
       rows,
       orderBy: orderBy?.call(BleedRoot.t),
       orderByList: orderByList?.call(BleedRoot.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -758,8 +736,6 @@ class BleedRootRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BleedRootTable> where,
     _i1.OrderByBuilder<BleedRootTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BleedRootTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -768,8 +744,6 @@ class BleedRootRepository {
       where: where(BleedRoot.t),
       orderBy: orderBy?.call(BleedRoot.t),
       orderByList: orderByList?.call(BleedRoot.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -95,8 +95,6 @@ abstract class Course implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     CourseInclude? include,
   }) {
@@ -105,8 +103,6 @@ abstract class Course implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Course.t),
       include: include,
     );
@@ -243,8 +239,6 @@ class CourseIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -297,8 +291,6 @@ class CourseRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     CourseInclude? include,
@@ -309,8 +301,6 @@ class CourseRepository {
       where: where?.call(Course.t),
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -342,8 +332,6 @@ class CourseRepository {
     _i1.WhereExpressionBuilder<CourseTable>? where,
     int? offset,
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     CourseInclude? include,
@@ -354,8 +342,6 @@ class CourseRepository {
       where: where?.call(Course.t),
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -563,8 +549,6 @@ class CourseRepository {
     int? offset,
     _i1.OrderByBuilder<CourseTable>? orderBy,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -575,8 +559,6 @@ class CourseRepository {
       offset: offset,
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -597,8 +579,6 @@ class CourseRepository {
     _i1.DatabaseSession session,
     List<Course> rows, {
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -607,8 +587,6 @@ class CourseRepository {
       rows,
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -638,8 +616,6 @@ class CourseRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CourseTable> where,
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -648,8 +624,6 @@ class CourseRepository {
       where: where(Course.t),
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -117,8 +117,6 @@ abstract class Enrollment
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     EnrollmentInclude? include,
   }) {
@@ -127,8 +125,6 @@ abstract class Enrollment
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Enrollment.t),
       include: include,
     );
@@ -289,8 +285,6 @@ class EnrollmentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -337,8 +331,6 @@ class EnrollmentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     EnrollmentInclude? include,
@@ -349,8 +341,6 @@ class EnrollmentRepository {
       where: where?.call(Enrollment.t),
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -382,8 +372,6 @@ class EnrollmentRepository {
     _i1.WhereExpressionBuilder<EnrollmentTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     EnrollmentInclude? include,
@@ -394,8 +382,6 @@ class EnrollmentRepository {
       where: where?.call(Enrollment.t),
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -603,8 +589,6 @@ class EnrollmentRepository {
     int? offset,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -615,8 +599,6 @@ class EnrollmentRepository {
       offset: offset,
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -637,8 +619,6 @@ class EnrollmentRepository {
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -647,8 +627,6 @@ class EnrollmentRepository {
       rows,
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -678,8 +656,6 @@ class EnrollmentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnrollmentTable> where,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -688,8 +664,6 @@ class EnrollmentRepository {
       where: where(Enrollment.t),
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -96,8 +96,6 @@ abstract class Student
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     StudentInclude? include,
   }) {
@@ -106,8 +104,6 @@ abstract class Student
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Student.t),
       include: include,
     );
@@ -244,8 +240,6 @@ class StudentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -294,8 +288,6 @@ class StudentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     StudentInclude? include,
@@ -306,8 +298,6 @@ class StudentRepository {
       where: where?.call(Student.t),
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -339,8 +329,6 @@ class StudentRepository {
     _i1.WhereExpressionBuilder<StudentTable>? where,
     int? offset,
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     StudentInclude? include,
@@ -351,8 +339,6 @@ class StudentRepository {
       where: where?.call(Student.t),
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -560,8 +546,6 @@ class StudentRepository {
     int? offset,
     _i1.OrderByBuilder<StudentTable>? orderBy,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -572,8 +556,6 @@ class StudentRepository {
       offset: offset,
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -594,8 +576,6 @@ class StudentRepository {
     _i1.DatabaseSession session,
     List<Student> rows, {
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -604,8 +584,6 @@ class StudentRepository {
       rows,
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -635,8 +613,6 @@ class StudentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StudentTable> where,
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -645,8 +621,6 @@ class StudentRepository {
       where: where(Student.t),
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/object_user.dart
@@ -100,8 +100,6 @@ abstract class ObjectUser
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectUserTable>? orderByList,
     ObjectUserInclude? include,
   }) {
@@ -110,8 +108,6 @@ abstract class ObjectUser
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectUser.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectUser.t),
       include: include,
     );
@@ -243,8 +239,6 @@ class ObjectUserIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -291,8 +285,6 @@ class ObjectUserRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectUserTable>? orderByList,
     _i1.Transaction? transaction,
     ObjectUserInclude? include,
@@ -303,8 +295,6 @@ class ObjectUserRepository {
       where: where?.call(ObjectUser.t),
       orderBy: orderBy?.call(ObjectUser.t),
       orderByList: orderByList?.call(ObjectUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -336,8 +326,6 @@ class ObjectUserRepository {
     _i1.WhereExpressionBuilder<ObjectUserTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectUserTable>? orderByList,
     _i1.Transaction? transaction,
     ObjectUserInclude? include,
@@ -348,8 +336,6 @@ class ObjectUserRepository {
       where: where?.call(ObjectUser.t),
       orderBy: orderBy?.call(ObjectUser.t),
       orderByList: orderByList?.call(ObjectUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -557,8 +543,6 @@ class ObjectUserRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectUserTable>? orderBy,
     _i1.OrderByListBuilder<ObjectUserTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -569,8 +553,6 @@ class ObjectUserRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectUser.t),
       orderByList: orderByList?.call(ObjectUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -591,8 +573,6 @@ class ObjectUserRepository {
     _i1.DatabaseSession session,
     List<ObjectUser> rows, {
     _i1.OrderByBuilder<ObjectUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectUserTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -601,8 +581,6 @@ class ObjectUserRepository {
       rows,
       orderBy: orderBy?.call(ObjectUser.t),
       orderByList: orderByList?.call(ObjectUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -632,8 +610,6 @@ class ObjectUserRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectUserTable> where,
     _i1.OrderByBuilder<ObjectUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectUserTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -642,8 +618,6 @@ class ObjectUserRepository {
       where: where(ObjectUser.t),
       orderBy: orderBy?.call(ObjectUser.t),
       orderByList: orderByList?.call(ObjectUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/module/parent_user.dart
@@ -85,8 +85,6 @@ abstract class ParentUser
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ParentUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ParentUserTable>? orderByList,
     ParentUserInclude? include,
   }) {
@@ -95,8 +93,6 @@ abstract class ParentUser
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ParentUser.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ParentUser.t),
       include: include,
     );
@@ -195,8 +191,6 @@ class ParentUserIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -241,8 +235,6 @@ class ParentUserRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ParentUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ParentUserTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -252,8 +244,6 @@ class ParentUserRepository {
       where: where?.call(ParentUser.t),
       orderBy: orderBy?.call(ParentUser.t),
       orderByList: orderByList?.call(ParentUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -284,8 +274,6 @@ class ParentUserRepository {
     _i1.WhereExpressionBuilder<ParentUserTable>? where,
     int? offset,
     _i1.OrderByBuilder<ParentUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ParentUserTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -295,8 +283,6 @@ class ParentUserRepository {
       where: where?.call(ParentUser.t),
       orderBy: orderBy?.call(ParentUser.t),
       orderByList: orderByList?.call(ParentUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -501,8 +487,6 @@ class ParentUserRepository {
     int? offset,
     _i1.OrderByBuilder<ParentUserTable>? orderBy,
     _i1.OrderByListBuilder<ParentUserTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -513,8 +497,6 @@ class ParentUserRepository {
       offset: offset,
       orderBy: orderBy?.call(ParentUser.t),
       orderByList: orderByList?.call(ParentUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -535,8 +517,6 @@ class ParentUserRepository {
     _i1.DatabaseSession session,
     List<ParentUser> rows, {
     _i1.OrderByBuilder<ParentUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ParentUserTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -545,8 +525,6 @@ class ParentUserRepository {
       rows,
       orderBy: orderBy?.call(ParentUser.t),
       orderByList: orderByList?.call(ParentUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -576,8 +554,6 @@ class ParentUserRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ParentUserTable> where,
     _i1.OrderByBuilder<ParentUserTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ParentUserTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -586,8 +562,6 @@ class ParentUserRepository {
       where: where(ParentUser.t),
       orderBy: orderBy?.call(ParentUser.t),
       orderByList: orderByList?.call(ParentUser.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -89,8 +89,6 @@ abstract class Arena implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     ArenaInclude? include,
   }) {
@@ -99,8 +97,6 @@ abstract class Arena implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Arena.t),
       include: include,
     );
@@ -214,8 +210,6 @@ class ArenaIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -264,8 +258,6 @@ class ArenaRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     ArenaInclude? include,
@@ -276,8 +268,6 @@ class ArenaRepository {
       where: where?.call(Arena.t),
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -309,8 +299,6 @@ class ArenaRepository {
     _i1.WhereExpressionBuilder<ArenaTable>? where,
     int? offset,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     ArenaInclude? include,
@@ -321,8 +309,6 @@ class ArenaRepository {
       where: where?.call(Arena.t),
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -530,8 +516,6 @@ class ArenaRepository {
     int? offset,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -542,8 +526,6 @@ class ArenaRepository {
       offset: offset,
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -564,8 +546,6 @@ class ArenaRepository {
     _i1.DatabaseSession session,
     List<Arena> rows, {
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -574,8 +554,6 @@ class ArenaRepository {
       rows,
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -605,8 +583,6 @@ class ArenaRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ArenaTable> where,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -615,8 +591,6 @@ class ArenaRepository {
       where: where(Arena.t),
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -97,8 +97,6 @@ abstract class Player implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     PlayerInclude? include,
   }) {
@@ -107,8 +105,6 @@ abstract class Player implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Player.t),
       include: include,
     );
@@ -238,8 +234,6 @@ class PlayerIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -288,8 +282,6 @@ class PlayerRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     PlayerInclude? include,
@@ -300,8 +292,6 @@ class PlayerRepository {
       where: where?.call(Player.t),
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -333,8 +323,6 @@ class PlayerRepository {
     _i1.WhereExpressionBuilder<PlayerTable>? where,
     int? offset,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     PlayerInclude? include,
@@ -345,8 +333,6 @@ class PlayerRepository {
       where: where?.call(Player.t),
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -554,8 +540,6 @@ class PlayerRepository {
     int? offset,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -566,8 +550,6 @@ class PlayerRepository {
       offset: offset,
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -588,8 +570,6 @@ class PlayerRepository {
     _i1.DatabaseSession session,
     List<Player> rows, {
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -598,8 +578,6 @@ class PlayerRepository {
       rows,
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -629,8 +607,6 @@ class PlayerRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PlayerTable> where,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -639,8 +615,6 @@ class PlayerRepository {
       where: where(Player.t),
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -118,8 +118,6 @@ abstract class Team implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     TeamInclude? include,
   }) {
@@ -128,8 +126,6 @@ abstract class Team implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Team.t),
       include: include,
     );
@@ -313,8 +309,6 @@ class TeamIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -367,8 +361,6 @@ class TeamRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     TeamInclude? include,
@@ -379,8 +371,6 @@ class TeamRepository {
       where: where?.call(Team.t),
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -412,8 +402,6 @@ class TeamRepository {
     _i1.WhereExpressionBuilder<TeamTable>? where,
     int? offset,
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     TeamInclude? include,
@@ -424,8 +412,6 @@ class TeamRepository {
       where: where?.call(Team.t),
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -633,8 +619,6 @@ class TeamRepository {
     int? offset,
     _i1.OrderByBuilder<TeamTable>? orderBy,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -645,8 +629,6 @@ class TeamRepository {
       offset: offset,
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -667,8 +649,6 @@ class TeamRepository {
     _i1.DatabaseSession session,
     List<Team> rows, {
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -677,8 +657,6 @@ class TeamRepository {
       rows,
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -708,8 +686,6 @@ class TeamRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TeamTable> where,
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -718,8 +694,6 @@ class TeamRepository {
       where: where(Team.t),
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -98,8 +98,6 @@ abstract class Comment
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     CommentInclude? include,
   }) {
@@ -108,8 +106,6 @@ abstract class Comment
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Comment.t),
       include: include,
     );
@@ -239,8 +235,6 @@ class CommentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -287,8 +281,6 @@ class CommentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     CommentInclude? include,
@@ -299,8 +291,6 @@ class CommentRepository {
       where: where?.call(Comment.t),
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -332,8 +322,6 @@ class CommentRepository {
     _i1.WhereExpressionBuilder<CommentTable>? where,
     int? offset,
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     CommentInclude? include,
@@ -344,8 +332,6 @@ class CommentRepository {
       where: where?.call(Comment.t),
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -553,8 +539,6 @@ class CommentRepository {
     int? offset,
     _i1.OrderByBuilder<CommentTable>? orderBy,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -565,8 +549,6 @@ class CommentRepository {
       offset: offset,
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -587,8 +569,6 @@ class CommentRepository {
     _i1.DatabaseSession session,
     List<Comment> rows, {
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -597,8 +577,6 @@ class CommentRepository {
       rows,
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -628,8 +606,6 @@ class CommentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CommentTable> where,
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -638,8 +614,6 @@ class CommentRepository {
       where: where(Comment.t),
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -94,8 +94,6 @@ abstract class Customer
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     CustomerInclude? include,
   }) {
@@ -104,8 +102,6 @@ abstract class Customer
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Customer.t),
       include: include,
     );
@@ -242,8 +238,6 @@ class CustomerIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -296,8 +290,6 @@ class CustomerRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     CustomerInclude? include,
@@ -308,8 +300,6 @@ class CustomerRepository {
       where: where?.call(Customer.t),
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -341,8 +331,6 @@ class CustomerRepository {
     _i1.WhereExpressionBuilder<CustomerTable>? where,
     int? offset,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     CustomerInclude? include,
@@ -353,8 +341,6 @@ class CustomerRepository {
       where: where?.call(Customer.t),
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -562,8 +548,6 @@ class CustomerRepository {
     int? offset,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -574,8 +558,6 @@ class CustomerRepository {
       offset: offset,
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -596,8 +578,6 @@ class CustomerRepository {
     _i1.DatabaseSession session,
     List<Customer> rows, {
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -606,8 +586,6 @@ class CustomerRepository {
       rows,
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -637,8 +615,6 @@ class CustomerRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CustomerTable> where,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -647,8 +623,6 @@ class CustomerRepository {
       where: where(Customer.t),
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/implicit/book.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/implicit/book.dart
@@ -94,8 +94,6 @@ abstract class Book implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     BookInclude? include,
   }) {
@@ -104,8 +102,6 @@ abstract class Book implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Book.t),
       include: include,
     );
@@ -242,8 +238,6 @@ class BookIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -296,8 +290,6 @@ class BookRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
     BookInclude? include,
@@ -308,8 +300,6 @@ class BookRepository {
       where: where?.call(Book.t),
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -341,8 +331,6 @@ class BookRepository {
     _i1.WhereExpressionBuilder<BookTable>? where,
     int? offset,
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
     BookInclude? include,
@@ -353,8 +341,6 @@ class BookRepository {
       where: where?.call(Book.t),
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -562,8 +548,6 @@ class BookRepository {
     int? offset,
     _i1.OrderByBuilder<BookTable>? orderBy,
     _i1.OrderByListBuilder<BookTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -574,8 +558,6 @@ class BookRepository {
       offset: offset,
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -596,8 +578,6 @@ class BookRepository {
     _i1.DatabaseSession session,
     List<Book> rows, {
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -606,8 +586,6 @@ class BookRepository {
       rows,
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -637,8 +615,6 @@ class BookRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BookTable> where,
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -647,8 +623,6 @@ class BookRepository {
       where: where(Book.t),
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/implicit/chapter.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/implicit/chapter.dart
@@ -82,8 +82,6 @@ abstract class Chapter
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     ChapterInclude? include,
   }) {
@@ -92,8 +90,6 @@ abstract class Chapter
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Chapter.t),
       include: include,
     );
@@ -221,8 +217,6 @@ class ChapterIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -267,8 +261,6 @@ class ChapterRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -278,8 +270,6 @@ class ChapterRepository {
       where: where?.call(Chapter.t),
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -310,8 +300,6 @@ class ChapterRepository {
     _i1.WhereExpressionBuilder<ChapterTable>? where,
     int? offset,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -321,8 +309,6 @@ class ChapterRepository {
       where: where?.call(Chapter.t),
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -527,8 +513,6 @@ class ChapterRepository {
     int? offset,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -539,8 +523,6 @@ class ChapterRepository {
       offset: offset,
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -561,8 +543,6 @@ class ChapterRepository {
     _i1.DatabaseSession session,
     List<Chapter> rows, {
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -571,8 +551,6 @@ class ChapterRepository {
       rows,
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -602,8 +580,6 @@ class ChapterRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChapterTable> where,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -612,8 +588,6 @@ class ChapterRepository {
       where: where(Chapter.t),
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -120,8 +120,6 @@ abstract class Order implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     OrderInclude? include,
   }) {
@@ -130,8 +128,6 @@ abstract class Order implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Order.t),
       include: include,
     );
@@ -317,8 +313,6 @@ class OrderIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -367,8 +361,6 @@ class OrderRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     OrderInclude? include,
@@ -379,8 +371,6 @@ class OrderRepository {
       where: where?.call(Order.t),
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -412,8 +402,6 @@ class OrderRepository {
     _i1.WhereExpressionBuilder<OrderTable>? where,
     int? offset,
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     OrderInclude? include,
@@ -424,8 +412,6 @@ class OrderRepository {
       where: where?.call(Order.t),
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -633,8 +619,6 @@ class OrderRepository {
     int? offset,
     _i1.OrderByBuilder<OrderTable>? orderBy,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -645,8 +629,6 @@ class OrderRepository {
       offset: offset,
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -667,8 +649,6 @@ class OrderRepository {
     _i1.DatabaseSession session,
     List<Order> rows, {
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -677,8 +657,6 @@ class OrderRepository {
       rows,
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -708,8 +686,6 @@ class OrderRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrderTable> where,
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -718,8 +694,6 @@ class OrderRepository {
       where: where(Order.t),
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -100,8 +100,6 @@ abstract class Address
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     AddressInclude? include,
   }) {
@@ -110,8 +108,6 @@ abstract class Address
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Address.t),
       include: include,
     );
@@ -243,8 +239,6 @@ class AddressIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -293,8 +287,6 @@ class AddressRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     AddressInclude? include,
@@ -305,8 +297,6 @@ class AddressRepository {
       where: where?.call(Address.t),
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -338,8 +328,6 @@ class AddressRepository {
     _i1.WhereExpressionBuilder<AddressTable>? where,
     int? offset,
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     AddressInclude? include,
@@ -350,8 +338,6 @@ class AddressRepository {
       where: where?.call(Address.t),
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -559,8 +545,6 @@ class AddressRepository {
     int? offset,
     _i1.OrderByBuilder<AddressTable>? orderBy,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -571,8 +555,6 @@ class AddressRepository {
       offset: offset,
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -593,8 +575,6 @@ class AddressRepository {
     _i1.DatabaseSession session,
     List<Address> rows, {
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -603,8 +583,6 @@ class AddressRepository {
       rows,
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -634,8 +612,6 @@ class AddressRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AddressTable> where,
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -644,8 +620,6 @@ class AddressRepository {
       where: where(Address.t),
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -141,8 +141,6 @@ abstract class Citizen
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     CitizenInclude? include,
   }) {
@@ -151,8 +149,6 @@ abstract class Citizen
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Citizen.t),
       include: include,
     );
@@ -358,8 +354,6 @@ class CitizenIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -408,8 +402,6 @@ class CitizenRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     CitizenInclude? include,
@@ -420,8 +412,6 @@ class CitizenRepository {
       where: where?.call(Citizen.t),
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -453,8 +443,6 @@ class CitizenRepository {
     _i1.WhereExpressionBuilder<CitizenTable>? where,
     int? offset,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     CitizenInclude? include,
@@ -465,8 +453,6 @@ class CitizenRepository {
       where: where?.call(Citizen.t),
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -674,8 +660,6 @@ class CitizenRepository {
     int? offset,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -686,8 +670,6 @@ class CitizenRepository {
       offset: offset,
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -708,8 +690,6 @@ class CitizenRepository {
     _i1.DatabaseSession session,
     List<Citizen> rows, {
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -718,8 +698,6 @@ class CitizenRepository {
       rows,
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -749,8 +727,6 @@ class CitizenRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CitizenTable> where,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -759,8 +735,6 @@ class CitizenRepository {
       where: where(Citizen.t),
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -98,8 +98,6 @@ abstract class Company
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     CompanyInclude? include,
   }) {
@@ -108,8 +106,6 @@ abstract class Company
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Company.t),
       include: include,
     );
@@ -239,8 +235,6 @@ class CompanyIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -287,8 +281,6 @@ class CompanyRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     CompanyInclude? include,
@@ -299,8 +291,6 @@ class CompanyRepository {
       where: where?.call(Company.t),
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -332,8 +322,6 @@ class CompanyRepository {
     _i1.WhereExpressionBuilder<CompanyTable>? where,
     int? offset,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     CompanyInclude? include,
@@ -344,8 +332,6 @@ class CompanyRepository {
       where: where?.call(Company.t),
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -553,8 +539,6 @@ class CompanyRepository {
     int? offset,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -565,8 +549,6 @@ class CompanyRepository {
       offset: offset,
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -587,8 +569,6 @@ class CompanyRepository {
     _i1.DatabaseSession session,
     List<Company> rows, {
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -597,8 +577,6 @@ class CompanyRepository {
       rows,
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -628,8 +606,6 @@ class CompanyRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CompanyTable> where,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -638,8 +614,6 @@ class CompanyRepository {
       where: where(Company.t),
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -97,8 +97,6 @@ abstract class Town implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     TownInclude? include,
   }) {
@@ -107,8 +105,6 @@ abstract class Town implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Town.t),
       include: include,
     );
@@ -238,8 +234,6 @@ class TownIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -288,8 +282,6 @@ class TownRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     TownInclude? include,
@@ -300,8 +292,6 @@ class TownRepository {
       where: where?.call(Town.t),
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -333,8 +323,6 @@ class TownRepository {
     _i1.WhereExpressionBuilder<TownTable>? where,
     int? offset,
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     TownInclude? include,
@@ -345,8 +333,6 @@ class TownRepository {
       where: where?.call(Town.t),
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -554,8 +540,6 @@ class TownRepository {
     int? offset,
     _i1.OrderByBuilder<TownTable>? orderBy,
     _i1.OrderByListBuilder<TownTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -566,8 +550,6 @@ class TownRepository {
       offset: offset,
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -588,8 +570,6 @@ class TownRepository {
     _i1.DatabaseSession session,
     List<Town> rows, {
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -598,8 +578,6 @@ class TownRepository {
       rows,
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -629,8 +607,6 @@ class TownRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TownTable> where,
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -639,8 +615,6 @@ class TownRepository {
       where: where(Town.t),
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -119,8 +119,6 @@ abstract class Blocking
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     BlockingInclude? include,
   }) {
@@ -129,8 +127,6 @@ abstract class Blocking
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Blocking.t),
       include: include,
     );
@@ -293,8 +289,6 @@ class BlockingIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -341,8 +335,6 @@ class BlockingRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     BlockingInclude? include,
@@ -353,8 +345,6 @@ class BlockingRepository {
       where: where?.call(Blocking.t),
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -386,8 +376,6 @@ class BlockingRepository {
     _i1.WhereExpressionBuilder<BlockingTable>? where,
     int? offset,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     BlockingInclude? include,
@@ -398,8 +386,6 @@ class BlockingRepository {
       where: where?.call(Blocking.t),
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -607,8 +593,6 @@ class BlockingRepository {
     int? offset,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -619,8 +603,6 @@ class BlockingRepository {
       offset: offset,
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -641,8 +623,6 @@ class BlockingRepository {
     _i1.DatabaseSession session,
     List<Blocking> rows, {
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -651,8 +631,6 @@ class BlockingRepository {
       rows,
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -682,8 +660,6 @@ class BlockingRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BlockingTable> where,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -692,8 +668,6 @@ class BlockingRepository {
       where: where(Blocking.t),
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -116,8 +116,6 @@ abstract class Member implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     MemberInclude? include,
   }) {
@@ -126,8 +124,6 @@ abstract class Member implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Member.t),
       include: include,
     );
@@ -318,8 +314,6 @@ class MemberIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -368,8 +362,6 @@ class MemberRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     MemberInclude? include,
@@ -380,8 +372,6 @@ class MemberRepository {
       where: where?.call(Member.t),
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -413,8 +403,6 @@ class MemberRepository {
     _i1.WhereExpressionBuilder<MemberTable>? where,
     int? offset,
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     MemberInclude? include,
@@ -425,8 +413,6 @@ class MemberRepository {
       where: where?.call(Member.t),
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -634,8 +620,6 @@ class MemberRepository {
     int? offset,
     _i1.OrderByBuilder<MemberTable>? orderBy,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -646,8 +630,6 @@ class MemberRepository {
       offset: offset,
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -668,8 +650,6 @@ class MemberRepository {
     _i1.DatabaseSession session,
     List<Member> rows, {
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -678,8 +658,6 @@ class MemberRepository {
       rows,
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -709,8 +687,6 @@ class MemberRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MemberTable> where,
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -719,8 +695,6 @@ class MemberRepository {
       where: where(Member.t),
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -118,8 +118,6 @@ abstract class Cat implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     CatInclude? include,
   }) {
@@ -128,8 +126,6 @@ abstract class Cat implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Cat.t),
       include: include,
     );
@@ -313,8 +309,6 @@ class CatIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -367,8 +361,6 @@ class CatRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     CatInclude? include,
@@ -379,8 +371,6 @@ class CatRepository {
       where: where?.call(Cat.t),
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -412,8 +402,6 @@ class CatRepository {
     _i1.WhereExpressionBuilder<CatTable>? where,
     int? offset,
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     CatInclude? include,
@@ -424,8 +412,6 @@ class CatRepository {
       where: where?.call(Cat.t),
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -633,8 +619,6 @@ class CatRepository {
     int? offset,
     _i1.OrderByBuilder<CatTable>? orderBy,
     _i1.OrderByListBuilder<CatTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -645,8 +629,6 @@ class CatRepository {
       offset: offset,
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -667,8 +649,6 @@ class CatRepository {
     _i1.DatabaseSession session,
     List<Cat> rows, {
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -677,8 +657,6 @@ class CatRepository {
       rows,
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -708,8 +686,6 @@ class CatRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CatTable> where,
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -718,8 +694,6 @@ class CatRepository {
       where: where(Cat.t),
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -114,8 +114,6 @@ abstract class Post implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     PostInclude? include,
   }) {
@@ -124,8 +122,6 @@ abstract class Post implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Post.t),
       include: include,
     );
@@ -286,8 +282,6 @@ class PostIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -336,8 +330,6 @@ class PostRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     PostInclude? include,
@@ -348,8 +340,6 @@ class PostRepository {
       where: where?.call(Post.t),
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -381,8 +371,6 @@ class PostRepository {
     _i1.WhereExpressionBuilder<PostTable>? where,
     int? offset,
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     PostInclude? include,
@@ -393,8 +381,6 @@ class PostRepository {
       where: where?.call(Post.t),
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -602,8 +588,6 @@ class PostRepository {
     int? offset,
     _i1.OrderByBuilder<PostTable>? orderBy,
     _i1.OrderByListBuilder<PostTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -614,8 +598,6 @@ class PostRepository {
       offset: offset,
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -636,8 +618,6 @@ class PostRepository {
     _i1.DatabaseSession session,
     List<Post> rows, {
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -646,8 +626,6 @@ class PostRepository {
       rows,
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -677,8 +655,6 @@ class PostRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PostTable> where,
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -687,8 +663,6 @@ class PostRepository {
       where: where(Post.t),
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_persist.dart
@@ -99,8 +99,6 @@ abstract class ObjectFieldPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     ObjectFieldPersistInclude? include,
   }) {
@@ -109,8 +107,6 @@ abstract class ObjectFieldPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectFieldPersist.t),
       include: include,
     );
@@ -203,8 +199,6 @@ class ObjectFieldPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -249,8 +243,6 @@ class ObjectFieldPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -260,8 +252,6 @@ class ObjectFieldPersistRepository {
       where: where?.call(ObjectFieldPersist.t),
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -292,8 +282,6 @@ class ObjectFieldPersistRepository {
     _i1.WhereExpressionBuilder<ObjectFieldPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -303,8 +291,6 @@ class ObjectFieldPersistRepository {
       where: where?.call(ObjectFieldPersist.t),
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -511,8 +497,6 @@ class ObjectFieldPersistRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -523,8 +507,6 @@ class ObjectFieldPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -545,8 +527,6 @@ class ObjectFieldPersistRepository {
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -555,8 +535,6 @@ class ObjectFieldPersistRepository {
       rows,
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -586,8 +564,6 @@ class ObjectFieldPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectFieldPersistTable> where,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -596,8 +572,6 @@ class ObjectFieldPersistRepository {
       where: where(ObjectFieldPersist.t),
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_field_scopes.dart
@@ -92,8 +92,6 @@ abstract class ObjectFieldScopes
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     ObjectFieldScopesInclude? include,
   }) {
@@ -102,8 +100,6 @@ abstract class ObjectFieldScopes
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectFieldScopes.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectFieldScopes.t),
       include: include,
     );
@@ -208,8 +204,6 @@ class ObjectFieldScopesIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -254,8 +248,6 @@ class ObjectFieldScopesRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -265,8 +257,6 @@ class ObjectFieldScopesRepository {
       where: where?.call(ObjectFieldScopes.t),
       orderBy: orderBy?.call(ObjectFieldScopes.t),
       orderByList: orderByList?.call(ObjectFieldScopes.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -297,8 +287,6 @@ class ObjectFieldScopesRepository {
     _i1.WhereExpressionBuilder<ObjectFieldScopesTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -308,8 +296,6 @@ class ObjectFieldScopesRepository {
       where: where?.call(ObjectFieldScopes.t),
       orderBy: orderBy?.call(ObjectFieldScopes.t),
       orderByList: orderByList?.call(ObjectFieldScopes.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -516,8 +502,6 @@ class ObjectFieldScopesRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -528,8 +512,6 @@ class ObjectFieldScopesRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectFieldScopes.t),
       orderByList: orderByList?.call(ObjectFieldScopes.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -550,8 +532,6 @@ class ObjectFieldScopesRepository {
     _i1.DatabaseSession session,
     List<ObjectFieldScopes> rows, {
     _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -560,8 +540,6 @@ class ObjectFieldScopesRepository {
       rows,
       orderBy: orderBy?.call(ObjectFieldScopes.t),
       orderByList: orderByList?.call(ObjectFieldScopes.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -591,8 +569,6 @@ class ObjectFieldScopesRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectFieldScopesTable> where,
     _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -601,8 +577,6 @@ class ObjectFieldScopesRepository {
       where: where(ObjectFieldScopes.t),
       orderBy: orderBy?.call(ObjectFieldScopes.t),
       orderByList: orderByList?.call(ObjectFieldScopes.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bit.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bit.dart
@@ -127,8 +127,6 @@ abstract class ObjectWithBit
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithBitTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     ObjectWithBitInclude? include,
   }) {
@@ -137,8 +135,6 @@ abstract class ObjectWithBit
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithBit.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithBit.t),
       include: include,
     );
@@ -319,8 +315,6 @@ class ObjectWithBitIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -365,8 +359,6 @@ class ObjectWithBitRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithBitTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -376,8 +368,6 @@ class ObjectWithBitRepository {
       where: where?.call(ObjectWithBit.t),
       orderBy: orderBy?.call(ObjectWithBit.t),
       orderByList: orderByList?.call(ObjectWithBit.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -408,8 +398,6 @@ class ObjectWithBitRepository {
     _i1.WhereExpressionBuilder<ObjectWithBitTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithBitTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -419,8 +407,6 @@ class ObjectWithBitRepository {
       where: where?.call(ObjectWithBit.t),
       orderBy: orderBy?.call(ObjectWithBit.t),
       orderByList: orderByList?.call(ObjectWithBit.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -625,8 +611,6 @@ class ObjectWithBitRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithBitTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -637,8 +621,6 @@ class ObjectWithBitRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithBit.t),
       orderByList: orderByList?.call(ObjectWithBit.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -659,8 +641,6 @@ class ObjectWithBitRepository {
     _i1.DatabaseSession session,
     List<ObjectWithBit> rows, {
     _i1.OrderByBuilder<ObjectWithBitTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -669,8 +649,6 @@ class ObjectWithBitRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithBit.t),
       orderByList: orderByList?.call(ObjectWithBit.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -700,8 +678,6 @@ class ObjectWithBitRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithBitTable> where,
     _i1.OrderByBuilder<ObjectWithBitTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -710,8 +686,6 @@ class ObjectWithBitRepository {
       where: where(ObjectWithBit.t),
       orderBy: orderBy?.call(ObjectWithBit.t),
       orderByList: orderByList?.call(ObjectWithBit.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_bytedata.dart
@@ -80,8 +80,6 @@ abstract class ObjectWithByteData
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     ObjectWithByteDataInclude? include,
   }) {
@@ -90,8 +88,6 @@ abstract class ObjectWithByteData
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithByteData.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithByteData.t),
       include: include,
     );
@@ -177,8 +173,6 @@ class ObjectWithByteDataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -223,8 +217,6 @@ class ObjectWithByteDataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -234,8 +226,6 @@ class ObjectWithByteDataRepository {
       where: where?.call(ObjectWithByteData.t),
       orderBy: orderBy?.call(ObjectWithByteData.t),
       orderByList: orderByList?.call(ObjectWithByteData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -266,8 +256,6 @@ class ObjectWithByteDataRepository {
     _i1.WhereExpressionBuilder<ObjectWithByteDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -277,8 +265,6 @@ class ObjectWithByteDataRepository {
       where: where?.call(ObjectWithByteData.t),
       orderBy: orderBy?.call(ObjectWithByteData.t),
       orderByList: orderByList?.call(ObjectWithByteData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -485,8 +471,6 @@ class ObjectWithByteDataRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -497,8 +481,6 @@ class ObjectWithByteDataRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithByteData.t),
       orderByList: orderByList?.call(ObjectWithByteData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -519,8 +501,6 @@ class ObjectWithByteDataRepository {
     _i1.DatabaseSession session,
     List<ObjectWithByteData> rows, {
     _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -529,8 +509,6 @@ class ObjectWithByteDataRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithByteData.t),
       orderByList: orderByList?.call(ObjectWithByteData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -560,8 +538,6 @@ class ObjectWithByteDataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithByteDataTable> where,
     _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -570,8 +546,6 @@ class ObjectWithByteDataRepository {
       where: where(ObjectWithByteData.t),
       orderBy: orderBy?.call(ObjectWithByteData.t),
       orderByList: orderByList?.call(ObjectWithByteData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_duration.dart
@@ -79,8 +79,6 @@ abstract class ObjectWithDuration
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     ObjectWithDurationInclude? include,
   }) {
@@ -89,8 +87,6 @@ abstract class ObjectWithDuration
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithDuration.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithDuration.t),
       include: include,
     );
@@ -176,8 +172,6 @@ class ObjectWithDurationIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -222,8 +216,6 @@ class ObjectWithDurationRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -233,8 +225,6 @@ class ObjectWithDurationRepository {
       where: where?.call(ObjectWithDuration.t),
       orderBy: orderBy?.call(ObjectWithDuration.t),
       orderByList: orderByList?.call(ObjectWithDuration.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -265,8 +255,6 @@ class ObjectWithDurationRepository {
     _i1.WhereExpressionBuilder<ObjectWithDurationTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -276,8 +264,6 @@ class ObjectWithDurationRepository {
       where: where?.call(ObjectWithDuration.t),
       orderBy: orderBy?.call(ObjectWithDuration.t),
       orderByList: orderByList?.call(ObjectWithDuration.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -484,8 +470,6 @@ class ObjectWithDurationRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -496,8 +480,6 @@ class ObjectWithDurationRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithDuration.t),
       orderByList: orderByList?.call(ObjectWithDuration.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -518,8 +500,6 @@ class ObjectWithDurationRepository {
     _i1.DatabaseSession session,
     List<ObjectWithDuration> rows, {
     _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -528,8 +508,6 @@ class ObjectWithDurationRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithDuration.t),
       orderByList: orderByList?.call(ObjectWithDuration.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -559,8 +537,6 @@ class ObjectWithDurationRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithDurationTable> where,
     _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -569,8 +545,6 @@ class ObjectWithDurationRepository {
       where: where(ObjectWithDuration.t),
       orderBy: orderBy?.call(ObjectWithDuration.t),
       orderByList: orderByList?.call(ObjectWithDuration.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_dynamic.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_dynamic.dart
@@ -170,8 +170,6 @@ abstract class ObjectWithDynamic
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithDynamicTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     ObjectWithDynamicInclude? include,
   }) {
@@ -180,8 +178,6 @@ abstract class ObjectWithDynamic
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithDynamic.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithDynamic.t),
       include: include,
     );
@@ -376,8 +372,6 @@ class ObjectWithDynamicIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -422,8 +416,6 @@ class ObjectWithDynamicRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithDynamicTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -433,8 +425,6 @@ class ObjectWithDynamicRepository {
       where: where?.call(ObjectWithDynamic.t),
       orderBy: orderBy?.call(ObjectWithDynamic.t),
       orderByList: orderByList?.call(ObjectWithDynamic.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -465,8 +455,6 @@ class ObjectWithDynamicRepository {
     _i1.WhereExpressionBuilder<ObjectWithDynamicTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithDynamicTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -476,8 +464,6 @@ class ObjectWithDynamicRepository {
       where: where?.call(ObjectWithDynamic.t),
       orderBy: orderBy?.call(ObjectWithDynamic.t),
       orderByList: orderByList?.call(ObjectWithDynamic.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -684,8 +670,6 @@ class ObjectWithDynamicRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithDynamicTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -696,8 +680,6 @@ class ObjectWithDynamicRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithDynamic.t),
       orderByList: orderByList?.call(ObjectWithDynamic.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -718,8 +700,6 @@ class ObjectWithDynamicRepository {
     _i1.DatabaseSession session,
     List<ObjectWithDynamic> rows, {
     _i1.OrderByBuilder<ObjectWithDynamicTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -728,8 +708,6 @@ class ObjectWithDynamicRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithDynamic.t),
       orderByList: orderByList?.call(ObjectWithDynamic.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -759,8 +737,6 @@ class ObjectWithDynamicRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithDynamicTable> where,
     _i1.OrderByBuilder<ObjectWithDynamicTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -769,8 +745,6 @@ class ObjectWithDynamicRepository {
       where: where(ObjectWithDynamic.t),
       orderBy: orderBy?.call(ObjectWithDynamic.t),
       orderByList: orderByList?.call(ObjectWithDynamic.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum.dart
@@ -127,8 +127,6 @@ abstract class ObjectWithEnum
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     ObjectWithEnumInclude? include,
   }) {
@@ -137,8 +135,6 @@ abstract class ObjectWithEnum
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithEnum.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithEnum.t),
       include: include,
     );
@@ -301,8 +297,6 @@ class ObjectWithEnumIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -347,8 +341,6 @@ class ObjectWithEnumRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -358,8 +350,6 @@ class ObjectWithEnumRepository {
       where: where?.call(ObjectWithEnum.t),
       orderBy: orderBy?.call(ObjectWithEnum.t),
       orderByList: orderByList?.call(ObjectWithEnum.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -390,8 +380,6 @@ class ObjectWithEnumRepository {
     _i1.WhereExpressionBuilder<ObjectWithEnumTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -401,8 +389,6 @@ class ObjectWithEnumRepository {
       where: where?.call(ObjectWithEnum.t),
       orderBy: orderBy?.call(ObjectWithEnum.t),
       orderByList: orderByList?.call(ObjectWithEnum.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -607,8 +593,6 @@ class ObjectWithEnumRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -619,8 +603,6 @@ class ObjectWithEnumRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithEnum.t),
       orderByList: orderByList?.call(ObjectWithEnum.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -641,8 +623,6 @@ class ObjectWithEnumRepository {
     _i1.DatabaseSession session,
     List<ObjectWithEnum> rows, {
     _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -651,8 +631,6 @@ class ObjectWithEnumRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithEnum.t),
       orderByList: orderByList?.call(ObjectWithEnum.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -682,8 +660,6 @@ class ObjectWithEnumRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithEnumTable> where,
     _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -692,8 +668,6 @@ class ObjectWithEnumRepository {
       where: where(ObjectWithEnum.t),
       orderBy: orderBy?.call(ObjectWithEnum.t),
       orderByList: orderByList?.call(ObjectWithEnum.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_enum_enhanced.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_enum_enhanced.dart
@@ -138,8 +138,6 @@ abstract class ObjectWithEnumEnhanced
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumEnhancedTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     ObjectWithEnumEnhancedInclude? include,
   }) {
@@ -148,8 +146,6 @@ abstract class ObjectWithEnumEnhanced
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithEnumEnhanced.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithEnumEnhanced.t),
       include: include,
     );
@@ -334,8 +330,6 @@ class ObjectWithEnumEnhancedIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -380,8 +374,6 @@ class ObjectWithEnumEnhancedRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumEnhancedTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -391,8 +383,6 @@ class ObjectWithEnumEnhancedRepository {
       where: where?.call(ObjectWithEnumEnhanced.t),
       orderBy: orderBy?.call(ObjectWithEnumEnhanced.t),
       orderByList: orderByList?.call(ObjectWithEnumEnhanced.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -423,8 +413,6 @@ class ObjectWithEnumEnhancedRepository {
     _i1.WhereExpressionBuilder<ObjectWithEnumEnhancedTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumEnhancedTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -434,8 +422,6 @@ class ObjectWithEnumEnhancedRepository {
       where: where?.call(ObjectWithEnumEnhanced.t),
       orderBy: orderBy?.call(ObjectWithEnumEnhanced.t),
       orderByList: orderByList?.call(ObjectWithEnumEnhanced.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -642,8 +628,6 @@ class ObjectWithEnumEnhancedRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumEnhancedTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -654,8 +638,6 @@ class ObjectWithEnumEnhancedRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithEnumEnhanced.t),
       orderByList: orderByList?.call(ObjectWithEnumEnhanced.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -676,8 +658,6 @@ class ObjectWithEnumEnhancedRepository {
     _i1.DatabaseSession session,
     List<ObjectWithEnumEnhanced> rows, {
     _i1.OrderByBuilder<ObjectWithEnumEnhancedTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -686,8 +666,6 @@ class ObjectWithEnumEnhancedRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithEnumEnhanced.t),
       orderByList: orderByList?.call(ObjectWithEnumEnhanced.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -717,8 +695,6 @@ class ObjectWithEnumEnhancedRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithEnumEnhancedTable> where,
     _i1.OrderByBuilder<ObjectWithEnumEnhancedTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -727,8 +703,6 @@ class ObjectWithEnumEnhancedRepository {
       where: where(ObjectWithEnumEnhanced.t),
       orderBy: orderBy?.call(ObjectWithEnumEnhanced.t),
       orderByList: orderByList?.call(ObjectWithEnumEnhanced.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_geography_geometry_collection.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_geography_geometry_collection.dart
@@ -106,8 +106,6 @@ abstract class ObjectWithGeographyGeometryCollection
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyGeometryCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyGeometryCollectionTable>?
     orderByList,
     ObjectWithGeographyGeometryCollectionInclude? include,
@@ -117,8 +115,6 @@ abstract class ObjectWithGeographyGeometryCollection
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithGeographyGeometryCollection.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithGeographyGeometryCollection.t),
       include: include,
     );
@@ -256,8 +252,6 @@ class ObjectWithGeographyGeometryCollectionIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -303,8 +297,6 @@ class ObjectWithGeographyGeometryCollectionRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyGeometryCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyGeometryCollectionTable>?
     orderByList,
     _i1.Transaction? transaction,
@@ -315,8 +307,6 @@ class ObjectWithGeographyGeometryCollectionRepository {
       where: where?.call(ObjectWithGeographyGeometryCollection.t),
       orderBy: orderBy?.call(ObjectWithGeographyGeometryCollection.t),
       orderByList: orderByList?.call(ObjectWithGeographyGeometryCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -348,8 +338,6 @@ class ObjectWithGeographyGeometryCollectionRepository {
     where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyGeometryCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyGeometryCollectionTable>?
     orderByList,
     _i1.Transaction? transaction,
@@ -360,8 +348,6 @@ class ObjectWithGeographyGeometryCollectionRepository {
       where: where?.call(ObjectWithGeographyGeometryCollection.t),
       orderBy: orderBy?.call(ObjectWithGeographyGeometryCollection.t),
       orderByList: orderByList?.call(ObjectWithGeographyGeometryCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -588,8 +574,6 @@ class ObjectWithGeographyGeometryCollectionRepository {
     _i1.OrderByBuilder<ObjectWithGeographyGeometryCollectionTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithGeographyGeometryCollectionTable>?
     orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -602,8 +586,6 @@ class ObjectWithGeographyGeometryCollectionRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithGeographyGeometryCollection.t),
       orderByList: orderByList?.call(ObjectWithGeographyGeometryCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -624,8 +606,6 @@ class ObjectWithGeographyGeometryCollectionRepository {
     _i1.DatabaseSession session,
     List<ObjectWithGeographyGeometryCollection> rows, {
     _i1.OrderByBuilder<ObjectWithGeographyGeometryCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyGeometryCollectionTable>?
     orderByList,
     _i1.Transaction? transaction,
@@ -635,8 +615,6 @@ class ObjectWithGeographyGeometryCollectionRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithGeographyGeometryCollection.t),
       orderByList: orderByList?.call(ObjectWithGeographyGeometryCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -669,8 +647,6 @@ class ObjectWithGeographyGeometryCollectionRepository {
     >
     where,
     _i1.OrderByBuilder<ObjectWithGeographyGeometryCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyGeometryCollectionTable>?
     orderByList,
     _i1.Transaction? transaction,
@@ -680,8 +656,6 @@ class ObjectWithGeographyGeometryCollectionRepository {
       where: where(ObjectWithGeographyGeometryCollection.t),
       orderBy: orderBy?.call(ObjectWithGeographyGeometryCollection.t),
       orderByList: orderByList?.call(ObjectWithGeographyGeometryCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_geography_line_string.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_geography_line_string.dart
@@ -101,8 +101,6 @@ abstract class ObjectWithGeographyLineString
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyLineStringTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyLineStringTable>? orderByList,
     ObjectWithGeographyLineStringInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class ObjectWithGeographyLineString
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithGeographyLineString.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithGeographyLineString.t),
       include: include,
     );
@@ -235,8 +231,6 @@ class ObjectWithGeographyLineStringIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -281,8 +275,6 @@ class ObjectWithGeographyLineStringRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyLineStringTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyLineStringTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -292,8 +284,6 @@ class ObjectWithGeographyLineStringRepository {
       where: where?.call(ObjectWithGeographyLineString.t),
       orderBy: orderBy?.call(ObjectWithGeographyLineString.t),
       orderByList: orderByList?.call(ObjectWithGeographyLineString.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -324,8 +314,6 @@ class ObjectWithGeographyLineStringRepository {
     _i1.WhereExpressionBuilder<ObjectWithGeographyLineStringTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyLineStringTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyLineStringTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -335,8 +323,6 @@ class ObjectWithGeographyLineStringRepository {
       where: where?.call(ObjectWithGeographyLineString.t),
       orderBy: orderBy?.call(ObjectWithGeographyLineString.t),
       orderByList: orderByList?.call(ObjectWithGeographyLineString.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -550,8 +536,6 @@ class ObjectWithGeographyLineStringRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyLineStringTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithGeographyLineStringTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -562,8 +546,6 @@ class ObjectWithGeographyLineStringRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithGeographyLineString.t),
       orderByList: orderByList?.call(ObjectWithGeographyLineString.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -584,8 +566,6 @@ class ObjectWithGeographyLineStringRepository {
     _i1.DatabaseSession session,
     List<ObjectWithGeographyLineString> rows, {
     _i1.OrderByBuilder<ObjectWithGeographyLineStringTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyLineStringTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -594,8 +574,6 @@ class ObjectWithGeographyLineStringRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithGeographyLineString.t),
       orderByList: orderByList?.call(ObjectWithGeographyLineString.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -626,8 +604,6 @@ class ObjectWithGeographyLineStringRepository {
     required _i1.WhereExpressionBuilder<ObjectWithGeographyLineStringTable>
     where,
     _i1.OrderByBuilder<ObjectWithGeographyLineStringTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyLineStringTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -636,8 +612,6 @@ class ObjectWithGeographyLineStringRepository {
       where: where(ObjectWithGeographyLineString.t),
       orderBy: orderBy?.call(ObjectWithGeographyLineString.t),
       orderByList: orderByList?.call(ObjectWithGeographyLineString.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_geography_point.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_geography_point.dart
@@ -101,8 +101,6 @@ abstract class ObjectWithGeographyPoint
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyPointTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyPointTable>? orderByList,
     ObjectWithGeographyPointInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class ObjectWithGeographyPoint
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithGeographyPoint.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithGeographyPoint.t),
       include: include,
     );
@@ -235,8 +231,6 @@ class ObjectWithGeographyPointIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -281,8 +275,6 @@ class ObjectWithGeographyPointRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyPointTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyPointTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -292,8 +284,6 @@ class ObjectWithGeographyPointRepository {
       where: where?.call(ObjectWithGeographyPoint.t),
       orderBy: orderBy?.call(ObjectWithGeographyPoint.t),
       orderByList: orderByList?.call(ObjectWithGeographyPoint.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -324,8 +314,6 @@ class ObjectWithGeographyPointRepository {
     _i1.WhereExpressionBuilder<ObjectWithGeographyPointTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyPointTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyPointTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -335,8 +323,6 @@ class ObjectWithGeographyPointRepository {
       where: where?.call(ObjectWithGeographyPoint.t),
       orderBy: orderBy?.call(ObjectWithGeographyPoint.t),
       orderByList: orderByList?.call(ObjectWithGeographyPoint.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -545,8 +531,6 @@ class ObjectWithGeographyPointRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyPointTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithGeographyPointTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -557,8 +541,6 @@ class ObjectWithGeographyPointRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithGeographyPoint.t),
       orderByList: orderByList?.call(ObjectWithGeographyPoint.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -579,8 +561,6 @@ class ObjectWithGeographyPointRepository {
     _i1.DatabaseSession session,
     List<ObjectWithGeographyPoint> rows, {
     _i1.OrderByBuilder<ObjectWithGeographyPointTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyPointTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -589,8 +569,6 @@ class ObjectWithGeographyPointRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithGeographyPoint.t),
       orderByList: orderByList?.call(ObjectWithGeographyPoint.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -620,8 +598,6 @@ class ObjectWithGeographyPointRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithGeographyPointTable> where,
     _i1.OrderByBuilder<ObjectWithGeographyPointTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyPointTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -630,8 +606,6 @@ class ObjectWithGeographyPointRepository {
       where: where(ObjectWithGeographyPoint.t),
       orderBy: orderBy?.call(ObjectWithGeographyPoint.t),
       orderByList: orderByList?.call(ObjectWithGeographyPoint.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_geography_polygon.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_geography_polygon.dart
@@ -101,8 +101,6 @@ abstract class ObjectWithGeographyPolygon
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyPolygonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyPolygonTable>? orderByList,
     ObjectWithGeographyPolygonInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class ObjectWithGeographyPolygon
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithGeographyPolygon.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithGeographyPolygon.t),
       include: include,
     );
@@ -233,8 +229,6 @@ class ObjectWithGeographyPolygonIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -279,8 +273,6 @@ class ObjectWithGeographyPolygonRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyPolygonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyPolygonTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -290,8 +282,6 @@ class ObjectWithGeographyPolygonRepository {
       where: where?.call(ObjectWithGeographyPolygon.t),
       orderBy: orderBy?.call(ObjectWithGeographyPolygon.t),
       orderByList: orderByList?.call(ObjectWithGeographyPolygon.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -322,8 +312,6 @@ class ObjectWithGeographyPolygonRepository {
     _i1.WhereExpressionBuilder<ObjectWithGeographyPolygonTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyPolygonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyPolygonTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -333,8 +321,6 @@ class ObjectWithGeographyPolygonRepository {
       where: where?.call(ObjectWithGeographyPolygon.t),
       orderBy: orderBy?.call(ObjectWithGeographyPolygon.t),
       orderByList: orderByList?.call(ObjectWithGeographyPolygon.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -543,8 +529,6 @@ class ObjectWithGeographyPolygonRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithGeographyPolygonTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithGeographyPolygonTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -555,8 +539,6 @@ class ObjectWithGeographyPolygonRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithGeographyPolygon.t),
       orderByList: orderByList?.call(ObjectWithGeographyPolygon.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -577,8 +559,6 @@ class ObjectWithGeographyPolygonRepository {
     _i1.DatabaseSession session,
     List<ObjectWithGeographyPolygon> rows, {
     _i1.OrderByBuilder<ObjectWithGeographyPolygonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyPolygonTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -587,8 +567,6 @@ class ObjectWithGeographyPolygonRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithGeographyPolygon.t),
       orderByList: orderByList?.call(ObjectWithGeographyPolygon.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -618,8 +596,6 @@ class ObjectWithGeographyPolygonRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithGeographyPolygonTable> where,
     _i1.OrderByBuilder<ObjectWithGeographyPolygonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithGeographyPolygonTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -628,8 +604,6 @@ class ObjectWithGeographyPolygonRepository {
       where: where(ObjectWithGeographyPolygon.t),
       orderBy: orderBy?.call(ObjectWithGeographyPolygon.t),
       orderByList: orderByList?.call(ObjectWithGeographyPolygon.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_half_vector.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_half_vector.dart
@@ -139,8 +139,6 @@ abstract class ObjectWithHalfVector
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithHalfVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     ObjectWithHalfVectorInclude? include,
   }) {
@@ -149,8 +147,6 @@ abstract class ObjectWithHalfVector
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithHalfVector.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithHalfVector.t),
       include: include,
     );
@@ -339,8 +335,6 @@ class ObjectWithHalfVectorIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -385,8 +379,6 @@ class ObjectWithHalfVectorRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithHalfVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -396,8 +388,6 @@ class ObjectWithHalfVectorRepository {
       where: where?.call(ObjectWithHalfVector.t),
       orderBy: orderBy?.call(ObjectWithHalfVector.t),
       orderByList: orderByList?.call(ObjectWithHalfVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -428,8 +418,6 @@ class ObjectWithHalfVectorRepository {
     _i1.WhereExpressionBuilder<ObjectWithHalfVectorTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithHalfVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -439,8 +427,6 @@ class ObjectWithHalfVectorRepository {
       where: where?.call(ObjectWithHalfVector.t),
       orderBy: orderBy?.call(ObjectWithHalfVector.t),
       orderByList: orderByList?.call(ObjectWithHalfVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -647,8 +633,6 @@ class ObjectWithHalfVectorRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithHalfVectorTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -659,8 +643,6 @@ class ObjectWithHalfVectorRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithHalfVector.t),
       orderByList: orderByList?.call(ObjectWithHalfVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -681,8 +663,6 @@ class ObjectWithHalfVectorRepository {
     _i1.DatabaseSession session,
     List<ObjectWithHalfVector> rows, {
     _i1.OrderByBuilder<ObjectWithHalfVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -691,8 +671,6 @@ class ObjectWithHalfVectorRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithHalfVector.t),
       orderByList: orderByList?.call(ObjectWithHalfVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -722,8 +700,6 @@ class ObjectWithHalfVectorRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithHalfVectorTable> where,
     _i1.OrderByBuilder<ObjectWithHalfVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -732,8 +708,6 @@ class ObjectWithHalfVectorRepository {
       where: where(ObjectWithHalfVector.t),
       orderBy: orderBy?.call(ObjectWithHalfVector.t),
       orderByList: orderByList?.call(ObjectWithHalfVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_index.dart
@@ -85,8 +85,6 @@ abstract class ObjectWithIndex
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     ObjectWithIndexInclude? include,
   }) {
@@ -95,8 +93,6 @@ abstract class ObjectWithIndex
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithIndex.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithIndex.t),
       include: include,
     );
@@ -196,8 +192,6 @@ class ObjectWithIndexIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -242,8 +236,6 @@ class ObjectWithIndexRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -253,8 +245,6 @@ class ObjectWithIndexRepository {
       where: where?.call(ObjectWithIndex.t),
       orderBy: orderBy?.call(ObjectWithIndex.t),
       orderByList: orderByList?.call(ObjectWithIndex.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -285,8 +275,6 @@ class ObjectWithIndexRepository {
     _i1.WhereExpressionBuilder<ObjectWithIndexTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -296,8 +284,6 @@ class ObjectWithIndexRepository {
       where: where?.call(ObjectWithIndex.t),
       orderBy: orderBy?.call(ObjectWithIndex.t),
       orderByList: orderByList?.call(ObjectWithIndex.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -504,8 +490,6 @@ class ObjectWithIndexRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -516,8 +500,6 @@ class ObjectWithIndexRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithIndex.t),
       orderByList: orderByList?.call(ObjectWithIndex.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -538,8 +520,6 @@ class ObjectWithIndexRepository {
     _i1.DatabaseSession session,
     List<ObjectWithIndex> rows, {
     _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -548,8 +528,6 @@ class ObjectWithIndexRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithIndex.t),
       orderByList: orderByList?.call(ObjectWithIndex.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -579,8 +557,6 @@ class ObjectWithIndexRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithIndexTable> where,
     _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -589,8 +565,6 @@ class ObjectWithIndexRepository {
       where: where(ObjectWithIndex.t),
       orderBy: orderBy?.call(ObjectWithIndex.t),
       orderByList: orderByList?.call(ObjectWithIndex.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_jsonb.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_jsonb.dart
@@ -163,8 +163,6 @@ abstract class ObjectWithJsonb
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     ObjectWithJsonbInclude? include,
   }) {
@@ -173,8 +171,6 @@ abstract class ObjectWithJsonb
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithJsonb.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithJsonb.t),
       include: include,
     );
@@ -419,8 +415,6 @@ class ObjectWithJsonbIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -465,8 +459,6 @@ class ObjectWithJsonbRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -476,8 +468,6 @@ class ObjectWithJsonbRepository {
       where: where?.call(ObjectWithJsonb.t),
       orderBy: orderBy?.call(ObjectWithJsonb.t),
       orderByList: orderByList?.call(ObjectWithJsonb.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -508,8 +498,6 @@ class ObjectWithJsonbRepository {
     _i1.WhereExpressionBuilder<ObjectWithJsonbTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -519,8 +507,6 @@ class ObjectWithJsonbRepository {
       where: where?.call(ObjectWithJsonb.t),
       orderBy: orderBy?.call(ObjectWithJsonb.t),
       orderByList: orderByList?.call(ObjectWithJsonb.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -727,8 +713,6 @@ class ObjectWithJsonbRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -739,8 +723,6 @@ class ObjectWithJsonbRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithJsonb.t),
       orderByList: orderByList?.call(ObjectWithJsonb.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -761,8 +743,6 @@ class ObjectWithJsonbRepository {
     _i1.DatabaseSession session,
     List<ObjectWithJsonb> rows, {
     _i1.OrderByBuilder<ObjectWithJsonbTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -771,8 +751,6 @@ class ObjectWithJsonbRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithJsonb.t),
       orderByList: orderByList?.call(ObjectWithJsonb.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -802,8 +780,6 @@ class ObjectWithJsonbRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithJsonbTable> where,
     _i1.OrderByBuilder<ObjectWithJsonbTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -812,8 +788,6 @@ class ObjectWithJsonbRepository {
       where: where(ObjectWithJsonb.t),
       orderBy: orderBy?.call(ObjectWithJsonb.t),
       orderByList: orderByList?.call(ObjectWithJsonb.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_jsonb_class_level.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_jsonb_class_level.dart
@@ -100,8 +100,6 @@ abstract class ObjectWithJsonbClassLevel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbClassLevelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     ObjectWithJsonbClassLevelInclude? include,
   }) {
@@ -110,8 +108,6 @@ abstract class ObjectWithJsonbClassLevel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithJsonbClassLevel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithJsonbClassLevel.t),
       include: include,
     );
@@ -235,8 +231,6 @@ class ObjectWithJsonbClassLevelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -281,8 +275,6 @@ class ObjectWithJsonbClassLevelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbClassLevelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -292,8 +284,6 @@ class ObjectWithJsonbClassLevelRepository {
       where: where?.call(ObjectWithJsonbClassLevel.t),
       orderBy: orderBy?.call(ObjectWithJsonbClassLevel.t),
       orderByList: orderByList?.call(ObjectWithJsonbClassLevel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -324,8 +314,6 @@ class ObjectWithJsonbClassLevelRepository {
     _i1.WhereExpressionBuilder<ObjectWithJsonbClassLevelTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbClassLevelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -335,8 +323,6 @@ class ObjectWithJsonbClassLevelRepository {
       where: where?.call(ObjectWithJsonbClassLevel.t),
       orderBy: orderBy?.call(ObjectWithJsonbClassLevel.t),
       orderByList: orderByList?.call(ObjectWithJsonbClassLevel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -545,8 +531,6 @@ class ObjectWithJsonbClassLevelRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbClassLevelTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -557,8 +541,6 @@ class ObjectWithJsonbClassLevelRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithJsonbClassLevel.t),
       orderByList: orderByList?.call(ObjectWithJsonbClassLevel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -579,8 +561,6 @@ class ObjectWithJsonbClassLevelRepository {
     _i1.DatabaseSession session,
     List<ObjectWithJsonbClassLevel> rows, {
     _i1.OrderByBuilder<ObjectWithJsonbClassLevelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -589,8 +569,6 @@ class ObjectWithJsonbClassLevelRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithJsonbClassLevel.t),
       orderByList: orderByList?.call(ObjectWithJsonbClassLevel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -620,8 +598,6 @@ class ObjectWithJsonbClassLevelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithJsonbClassLevelTable> where,
     _i1.OrderByBuilder<ObjectWithJsonbClassLevelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -630,8 +606,6 @@ class ObjectWithJsonbClassLevelRepository {
       where: where(ObjectWithJsonbClassLevel.t),
       orderBy: orderBy?.call(ObjectWithJsonbClassLevel.t),
       orderByList: orderByList?.call(ObjectWithJsonbClassLevel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_object.dart
@@ -220,8 +220,6 @@ abstract class ObjectWithObject
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     ObjectWithObjectInclude? include,
   }) {
@@ -230,8 +228,6 @@ abstract class ObjectWithObject
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithObject.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithObject.t),
       include: include,
     );
@@ -536,8 +532,6 @@ class ObjectWithObjectIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -582,8 +576,6 @@ class ObjectWithObjectRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -593,8 +585,6 @@ class ObjectWithObjectRepository {
       where: where?.call(ObjectWithObject.t),
       orderBy: orderBy?.call(ObjectWithObject.t),
       orderByList: orderByList?.call(ObjectWithObject.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -625,8 +615,6 @@ class ObjectWithObjectRepository {
     _i1.WhereExpressionBuilder<ObjectWithObjectTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -636,8 +624,6 @@ class ObjectWithObjectRepository {
       where: where?.call(ObjectWithObject.t),
       orderBy: orderBy?.call(ObjectWithObject.t),
       orderByList: orderByList?.call(ObjectWithObject.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -844,8 +830,6 @@ class ObjectWithObjectRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -856,8 +840,6 @@ class ObjectWithObjectRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithObject.t),
       orderByList: orderByList?.call(ObjectWithObject.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -878,8 +860,6 @@ class ObjectWithObjectRepository {
     _i1.DatabaseSession session,
     List<ObjectWithObject> rows, {
     _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -888,8 +868,6 @@ class ObjectWithObjectRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithObject.t),
       orderByList: orderByList?.call(ObjectWithObject.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -919,8 +897,6 @@ class ObjectWithObjectRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithObjectTable> where,
     _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -929,8 +905,6 @@ class ObjectWithObjectRepository {
       where: where(ObjectWithObject.t),
       orderBy: orderBy?.call(ObjectWithObject.t),
       orderByList: orderByList?.call(ObjectWithObject.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_parent.dart
@@ -77,8 +77,6 @@ abstract class ObjectWithParent
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     ObjectWithParentInclude? include,
   }) {
@@ -87,8 +85,6 @@ abstract class ObjectWithParent
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithParent.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithParent.t),
       include: include,
     );
@@ -173,8 +169,6 @@ class ObjectWithParentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -219,8 +213,6 @@ class ObjectWithParentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -230,8 +222,6 @@ class ObjectWithParentRepository {
       where: where?.call(ObjectWithParent.t),
       orderBy: orderBy?.call(ObjectWithParent.t),
       orderByList: orderByList?.call(ObjectWithParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -262,8 +252,6 @@ class ObjectWithParentRepository {
     _i1.WhereExpressionBuilder<ObjectWithParentTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -273,8 +261,6 @@ class ObjectWithParentRepository {
       where: where?.call(ObjectWithParent.t),
       orderBy: orderBy?.call(ObjectWithParent.t),
       orderByList: orderByList?.call(ObjectWithParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -481,8 +467,6 @@ class ObjectWithParentRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -493,8 +477,6 @@ class ObjectWithParentRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithParent.t),
       orderByList: orderByList?.call(ObjectWithParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -515,8 +497,6 @@ class ObjectWithParentRepository {
     _i1.DatabaseSession session,
     List<ObjectWithParent> rows, {
     _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -525,8 +505,6 @@ class ObjectWithParentRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithParent.t),
       orderByList: orderByList?.call(ObjectWithParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -556,8 +534,6 @@ class ObjectWithParentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithParentTable> where,
     _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -566,8 +542,6 @@ class ObjectWithParentRepository {
       where: where(ObjectWithParent.t),
       orderBy: orderBy?.call(ObjectWithParent.t),
       orderByList: orderByList?.call(ObjectWithParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_self_parent.dart
@@ -79,8 +79,6 @@ abstract class ObjectWithSelfParent
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     ObjectWithSelfParentInclude? include,
   }) {
@@ -89,8 +87,6 @@ abstract class ObjectWithSelfParent
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
       include: include,
     );
@@ -175,8 +171,6 @@ class ObjectWithSelfParentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -221,8 +215,6 @@ class ObjectWithSelfParentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -232,8 +224,6 @@ class ObjectWithSelfParentRepository {
       where: where?.call(ObjectWithSelfParent.t),
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -264,8 +254,6 @@ class ObjectWithSelfParentRepository {
     _i1.WhereExpressionBuilder<ObjectWithSelfParentTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -275,8 +263,6 @@ class ObjectWithSelfParentRepository {
       where: where?.call(ObjectWithSelfParent.t),
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -483,8 +469,6 @@ class ObjectWithSelfParentRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -495,8 +479,6 @@ class ObjectWithSelfParentRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -517,8 +499,6 @@ class ObjectWithSelfParentRepository {
     _i1.DatabaseSession session,
     List<ObjectWithSelfParent> rows, {
     _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -527,8 +507,6 @@ class ObjectWithSelfParentRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -558,8 +536,6 @@ class ObjectWithSelfParentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithSelfParentTable> where,
     _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -568,8 +544,6 @@ class ObjectWithSelfParentRepository {
       where: where(ObjectWithSelfParent.t),
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_sparse_vector.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_sparse_vector.dart
@@ -117,8 +117,6 @@ abstract class ObjectWithSparseVector
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithSparseVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     ObjectWithSparseVectorInclude? include,
   }) {
@@ -127,8 +125,6 @@ abstract class ObjectWithSparseVector
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithSparseVector.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithSparseVector.t),
       include: include,
     );
@@ -277,8 +273,6 @@ class ObjectWithSparseVectorIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -323,8 +317,6 @@ class ObjectWithSparseVectorRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithSparseVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -334,8 +326,6 @@ class ObjectWithSparseVectorRepository {
       where: where?.call(ObjectWithSparseVector.t),
       orderBy: orderBy?.call(ObjectWithSparseVector.t),
       orderByList: orderByList?.call(ObjectWithSparseVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -366,8 +356,6 @@ class ObjectWithSparseVectorRepository {
     _i1.WhereExpressionBuilder<ObjectWithSparseVectorTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithSparseVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -377,8 +365,6 @@ class ObjectWithSparseVectorRepository {
       where: where?.call(ObjectWithSparseVector.t),
       orderBy: orderBy?.call(ObjectWithSparseVector.t),
       orderByList: orderByList?.call(ObjectWithSparseVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -585,8 +571,6 @@ class ObjectWithSparseVectorRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithSparseVectorTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -597,8 +581,6 @@ class ObjectWithSparseVectorRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithSparseVector.t),
       orderByList: orderByList?.call(ObjectWithSparseVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -619,8 +601,6 @@ class ObjectWithSparseVectorRepository {
     _i1.DatabaseSession session,
     List<ObjectWithSparseVector> rows, {
     _i1.OrderByBuilder<ObjectWithSparseVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -629,8 +609,6 @@ class ObjectWithSparseVectorRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithSparseVector.t),
       orderByList: orderByList?.call(ObjectWithSparseVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -660,8 +638,6 @@ class ObjectWithSparseVectorRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithSparseVectorTable> where,
     _i1.OrderByBuilder<ObjectWithSparseVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -670,8 +646,6 @@ class ObjectWithSparseVectorRepository {
       where: where(ObjectWithSparseVector.t),
       orderBy: orderBy?.call(ObjectWithSparseVector.t),
       orderByList: orderByList?.call(ObjectWithSparseVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_uuid.dart
@@ -89,8 +89,6 @@ abstract class ObjectWithUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     ObjectWithUuidInclude? include,
   }) {
@@ -99,8 +97,6 @@ abstract class ObjectWithUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithUuid.t),
       include: include,
     );
@@ -205,8 +201,6 @@ class ObjectWithUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -251,8 +245,6 @@ class ObjectWithUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -262,8 +254,6 @@ class ObjectWithUuidRepository {
       where: where?.call(ObjectWithUuid.t),
       orderBy: orderBy?.call(ObjectWithUuid.t),
       orderByList: orderByList?.call(ObjectWithUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -294,8 +284,6 @@ class ObjectWithUuidRepository {
     _i1.WhereExpressionBuilder<ObjectWithUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -305,8 +293,6 @@ class ObjectWithUuidRepository {
       where: where?.call(ObjectWithUuid.t),
       orderBy: orderBy?.call(ObjectWithUuid.t),
       orderByList: orderByList?.call(ObjectWithUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -511,8 +497,6 @@ class ObjectWithUuidRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -523,8 +507,6 @@ class ObjectWithUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithUuid.t),
       orderByList: orderByList?.call(ObjectWithUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -545,8 +527,6 @@ class ObjectWithUuidRepository {
     _i1.DatabaseSession session,
     List<ObjectWithUuid> rows, {
     _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -555,8 +535,6 @@ class ObjectWithUuidRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithUuid.t),
       orderByList: orderByList?.call(ObjectWithUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -586,8 +564,6 @@ class ObjectWithUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithUuidTable> where,
     _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -596,8 +572,6 @@ class ObjectWithUuidRepository {
       where: where(ObjectWithUuid.t),
       orderBy: orderBy?.call(ObjectWithUuid.t),
       orderByList: orderByList?.call(ObjectWithUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/object_with_vector.dart
+++ b/tests/serverpod_test_server/lib/src/generated/object_with_vector.dart
@@ -129,8 +129,6 @@ abstract class ObjectWithVector
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     ObjectWithVectorInclude? include,
   }) {
@@ -139,8 +137,6 @@ abstract class ObjectWithVector
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithVector.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithVector.t),
       include: include,
     );
@@ -327,8 +323,6 @@ class ObjectWithVectorIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -373,8 +367,6 @@ class ObjectWithVectorRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -384,8 +376,6 @@ class ObjectWithVectorRepository {
       where: where?.call(ObjectWithVector.t),
       orderBy: orderBy?.call(ObjectWithVector.t),
       orderByList: orderByList?.call(ObjectWithVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -416,8 +406,6 @@ class ObjectWithVectorRepository {
     _i1.WhereExpressionBuilder<ObjectWithVectorTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -427,8 +415,6 @@ class ObjectWithVectorRepository {
       where: where?.call(ObjectWithVector.t),
       orderBy: orderBy?.call(ObjectWithVector.t),
       orderByList: orderByList?.call(ObjectWithVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -635,8 +621,6 @@ class ObjectWithVectorRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithVectorTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -647,8 +631,6 @@ class ObjectWithVectorRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithVector.t),
       orderByList: orderByList?.call(ObjectWithVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -669,8 +651,6 @@ class ObjectWithVectorRepository {
     _i1.DatabaseSession session,
     List<ObjectWithVector> rows, {
     _i1.OrderByBuilder<ObjectWithVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -679,8 +659,6 @@ class ObjectWithVectorRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithVector.t),
       orderByList: orderByList?.call(ObjectWithVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -710,8 +688,6 @@ class ObjectWithVectorRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithVectorTable> where,
     _i1.OrderByBuilder<ObjectWithVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -720,8 +696,6 @@ class ObjectWithVectorRepository {
       where: where(ObjectWithVector.t),
       orderBy: orderBy?.call(ObjectWithVector.t),
       orderByList: orderByList?.call(ObjectWithVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/related_unique_data.dart
@@ -100,8 +100,6 @@ abstract class RelatedUniqueData
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     RelatedUniqueDataInclude? include,
   }) {
@@ -110,8 +108,6 @@ abstract class RelatedUniqueData
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(RelatedUniqueData.t),
       include: include,
     );
@@ -245,8 +241,6 @@ class RelatedUniqueDataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -293,8 +287,6 @@ class RelatedUniqueDataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     RelatedUniqueDataInclude? include,
@@ -305,8 +297,6 @@ class RelatedUniqueDataRepository {
       where: where?.call(RelatedUniqueData.t),
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -338,8 +328,6 @@ class RelatedUniqueDataRepository {
     _i1.WhereExpressionBuilder<RelatedUniqueDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     RelatedUniqueDataInclude? include,
@@ -350,8 +338,6 @@ class RelatedUniqueDataRepository {
       where: where?.call(RelatedUniqueData.t),
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -561,8 +547,6 @@ class RelatedUniqueDataRepository {
     int? offset,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -573,8 +557,6 @@ class RelatedUniqueDataRepository {
       offset: offset,
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -595,8 +577,6 @@ class RelatedUniqueDataRepository {
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -605,8 +585,6 @@ class RelatedUniqueDataRepository {
       rows,
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -636,8 +614,6 @@ class RelatedUniqueDataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelatedUniqueDataTable> where,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -646,8 +622,6 @@ class RelatedUniqueDataRepository {
       where: where(RelatedUniqueData.t),
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/required/model_with_required_field.dart
+++ b/tests/serverpod_test_server/lib/src/generated/required/model_with_required_field.dart
@@ -95,8 +95,6 @@ abstract class ModelWithRequiredField
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     ModelWithRequiredFieldInclude? include,
   }) {
@@ -105,8 +103,6 @@ abstract class ModelWithRequiredField
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ModelWithRequiredField.t),
       include: include,
     );
@@ -223,8 +219,6 @@ class ModelWithRequiredFieldIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -269,8 +263,6 @@ class ModelWithRequiredFieldRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -280,8 +272,6 @@ class ModelWithRequiredFieldRepository {
       where: where?.call(ModelWithRequiredField.t),
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -312,8 +302,6 @@ class ModelWithRequiredFieldRepository {
     _i1.WhereExpressionBuilder<ModelWithRequiredFieldTable>? where,
     int? offset,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -323,8 +311,6 @@ class ModelWithRequiredFieldRepository {
       where: where?.call(ModelWithRequiredField.t),
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -531,8 +517,6 @@ class ModelWithRequiredFieldRepository {
     int? offset,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -543,8 +527,6 @@ class ModelWithRequiredFieldRepository {
       offset: offset,
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -565,8 +547,6 @@ class ModelWithRequiredFieldRepository {
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -575,8 +555,6 @@ class ModelWithRequiredFieldRepository {
       rows,
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -606,8 +584,6 @@ class ModelWithRequiredFieldRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ModelWithRequiredFieldTable> where,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -616,8 +592,6 @@ class ModelWithRequiredFieldRepository {
       where: where(ModelWithRequiredField.t),
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
+++ b/tests/serverpod_test_server/lib/src/generated/scopes/scope_none_fields.dart
@@ -77,8 +77,6 @@ abstract class ScopeNoneFields
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ScopeNoneFieldsTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ScopeNoneFieldsTable>? orderByList,
     ScopeNoneFieldsInclude? include,
   }) {
@@ -87,8 +85,6 @@ abstract class ScopeNoneFields
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ScopeNoneFields.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ScopeNoneFields.t),
       include: include,
     );
@@ -209,8 +205,6 @@ class ScopeNoneFieldsIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -255,8 +249,6 @@ class ScopeNoneFieldsRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ScopeNoneFieldsTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ScopeNoneFieldsTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -266,8 +258,6 @@ class ScopeNoneFieldsRepository {
       where: where?.call(ScopeNoneFields.t),
       orderBy: orderBy?.call(ScopeNoneFields.t),
       orderByList: orderByList?.call(ScopeNoneFields.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -298,8 +288,6 @@ class ScopeNoneFieldsRepository {
     _i1.WhereExpressionBuilder<ScopeNoneFieldsTable>? where,
     int? offset,
     _i1.OrderByBuilder<ScopeNoneFieldsTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ScopeNoneFieldsTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -309,8 +297,6 @@ class ScopeNoneFieldsRepository {
       where: where?.call(ScopeNoneFields.t),
       orderBy: orderBy?.call(ScopeNoneFields.t),
       orderByList: orderByList?.call(ScopeNoneFields.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -517,8 +503,6 @@ class ScopeNoneFieldsRepository {
     int? offset,
     _i1.OrderByBuilder<ScopeNoneFieldsTable>? orderBy,
     _i1.OrderByListBuilder<ScopeNoneFieldsTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -529,8 +513,6 @@ class ScopeNoneFieldsRepository {
       offset: offset,
       orderBy: orderBy?.call(ScopeNoneFields.t),
       orderByList: orderByList?.call(ScopeNoneFields.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -551,8 +533,6 @@ class ScopeNoneFieldsRepository {
     _i1.DatabaseSession session,
     List<ScopeNoneFields> rows, {
     _i1.OrderByBuilder<ScopeNoneFieldsTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ScopeNoneFieldsTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -561,8 +541,6 @@ class ScopeNoneFieldsRepository {
       rows,
       orderBy: orderBy?.call(ScopeNoneFields.t),
       orderByList: orderByList?.call(ScopeNoneFields.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -592,8 +570,6 @@ class ScopeNoneFieldsRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ScopeNoneFieldsTable> where,
     _i1.OrderByBuilder<ScopeNoneFieldsTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ScopeNoneFieldsTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -602,8 +578,6 @@ class ScopeNoneFieldsRepository {
       where: where(ScopeNoneFields.t),
       orderBy: orderBy?.call(ScopeNoneFields.t),
       orderByList: orderByList?.call(ScopeNoneFields.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/shared_model_container.dart
+++ b/tests/serverpod_test_server/lib/src/generated/shared_model_container.dart
@@ -386,8 +386,6 @@ abstract class SharedModelContainer
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SharedModelContainerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedModelContainerTable>? orderByList,
     SharedModelContainerInclude? include,
   }) {
@@ -396,8 +394,6 @@ abstract class SharedModelContainer
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(SharedModelContainer.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(SharedModelContainer.t),
       include: include,
     );
@@ -936,8 +932,6 @@ class SharedModelContainerIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -982,8 +976,6 @@ class SharedModelContainerRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SharedModelContainerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedModelContainerTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -993,8 +985,6 @@ class SharedModelContainerRepository {
       where: where?.call(SharedModelContainer.t),
       orderBy: orderBy?.call(SharedModelContainer.t),
       orderByList: orderByList?.call(SharedModelContainer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -1025,8 +1015,6 @@ class SharedModelContainerRepository {
     _i1.WhereExpressionBuilder<SharedModelContainerTable>? where,
     int? offset,
     _i1.OrderByBuilder<SharedModelContainerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedModelContainerTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -1036,8 +1024,6 @@ class SharedModelContainerRepository {
       where: where?.call(SharedModelContainer.t),
       orderBy: orderBy?.call(SharedModelContainer.t),
       orderByList: orderByList?.call(SharedModelContainer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -1244,8 +1230,6 @@ class SharedModelContainerRepository {
     int? offset,
     _i1.OrderByBuilder<SharedModelContainerTable>? orderBy,
     _i1.OrderByListBuilder<SharedModelContainerTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -1256,8 +1240,6 @@ class SharedModelContainerRepository {
       offset: offset,
       orderBy: orderBy?.call(SharedModelContainer.t),
       orderByList: orderByList?.call(SharedModelContainer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -1278,8 +1260,6 @@ class SharedModelContainerRepository {
     _i1.DatabaseSession session,
     List<SharedModelContainer> rows, {
     _i1.OrderByBuilder<SharedModelContainerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedModelContainerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -1288,8 +1268,6 @@ class SharedModelContainerRepository {
       rows,
       orderBy: orderBy?.call(SharedModelContainer.t),
       orderByList: orderByList?.call(SharedModelContainer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -1319,8 +1297,6 @@ class SharedModelContainerRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SharedModelContainerTable> where,
     _i1.OrderByBuilder<SharedModelContainerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedModelContainerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -1329,8 +1305,6 @@ class SharedModelContainerRepository {
       where: where(SharedModelContainer.t),
       orderBy: orderBy?.call(SharedModelContainer.t),
       orderByList: orderByList?.call(SharedModelContainer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_data.dart
@@ -81,8 +81,6 @@ abstract class SimpleData
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     SimpleDataInclude? include,
   }) {
@@ -91,8 +89,6 @@ abstract class SimpleData
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(SimpleData.t),
       include: include,
     );
@@ -178,8 +174,6 @@ class SimpleDataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -224,8 +218,6 @@ class SimpleDataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -235,8 +227,6 @@ class SimpleDataRepository {
       where: where?.call(SimpleData.t),
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -267,8 +257,6 @@ class SimpleDataRepository {
     _i1.WhereExpressionBuilder<SimpleDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -278,8 +266,6 @@ class SimpleDataRepository {
       where: where?.call(SimpleData.t),
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -484,8 +470,6 @@ class SimpleDataRepository {
     int? offset,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -496,8 +480,6 @@ class SimpleDataRepository {
       offset: offset,
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -518,8 +500,6 @@ class SimpleDataRepository {
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -528,8 +508,6 @@ class SimpleDataRepository {
       rows,
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -559,8 +537,6 @@ class SimpleDataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SimpleDataTable> where,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -569,8 +545,6 @@ class SimpleDataRepository {
       where: where(SimpleData.t),
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_server/lib/src/generated/simple_date_time.dart
@@ -81,8 +81,6 @@ abstract class SimpleDateTime
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     SimpleDateTimeInclude? include,
   }) {
@@ -91,8 +89,6 @@ abstract class SimpleDateTime
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(SimpleDateTime.t),
       include: include,
     );
@@ -178,8 +174,6 @@ class SimpleDateTimeIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -224,8 +218,6 @@ class SimpleDateTimeRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -235,8 +227,6 @@ class SimpleDateTimeRepository {
       where: where?.call(SimpleDateTime.t),
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -267,8 +257,6 @@ class SimpleDateTimeRepository {
     _i1.WhereExpressionBuilder<SimpleDateTimeTable>? where,
     int? offset,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -278,8 +266,6 @@ class SimpleDateTimeRepository {
       where: where?.call(SimpleDateTime.t),
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -484,8 +470,6 @@ class SimpleDateTimeRepository {
     int? offset,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -496,8 +480,6 @@ class SimpleDateTimeRepository {
       offset: offset,
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -518,8 +500,6 @@ class SimpleDateTimeRepository {
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -528,8 +508,6 @@ class SimpleDateTimeRepository {
       rows,
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -559,8 +537,6 @@ class SimpleDateTimeRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SimpleDateTimeTable> where,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -569,8 +545,6 @@ class SimpleDateTimeRepository {
       where: where(SimpleDateTime.t),
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_server/lib/src/generated/types.dart
@@ -333,8 +333,6 @@ abstract class Types implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     TypesInclude? include,
   }) {
@@ -343,8 +341,6 @@ abstract class Types implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Types.t),
       include: include,
     );
@@ -860,8 +856,6 @@ class TypesIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -906,8 +900,6 @@ class TypesRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -917,8 +909,6 @@ class TypesRepository {
       where: where?.call(Types.t),
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -949,8 +939,6 @@ class TypesRepository {
     _i1.WhereExpressionBuilder<TypesTable>? where,
     int? offset,
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -960,8 +948,6 @@ class TypesRepository {
       where: where?.call(Types.t),
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -1166,8 +1152,6 @@ class TypesRepository {
     int? offset,
     _i1.OrderByBuilder<TypesTable>? orderBy,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -1178,8 +1162,6 @@ class TypesRepository {
       offset: offset,
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -1200,8 +1182,6 @@ class TypesRepository {
     _i1.DatabaseSession session,
     List<Types> rows, {
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -1210,8 +1190,6 @@ class TypesRepository {
       rows,
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -1241,8 +1219,6 @@ class TypesRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TypesTable> where,
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -1251,8 +1227,6 @@ class TypesRepository {
       where: where(Types.t),
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data.dart
@@ -85,8 +85,6 @@ abstract class UniqueData
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     UniqueDataInclude? include,
   }) {
@@ -95,8 +93,6 @@ abstract class UniqueData
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UniqueData.t),
       include: include,
     );
@@ -195,8 +191,6 @@ class UniqueDataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -241,8 +235,6 @@ class UniqueDataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -252,8 +244,6 @@ class UniqueDataRepository {
       where: where?.call(UniqueData.t),
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -284,8 +274,6 @@ class UniqueDataRepository {
     _i1.WhereExpressionBuilder<UniqueDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -295,8 +283,6 @@ class UniqueDataRepository {
       where: where?.call(UniqueData.t),
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -501,8 +487,6 @@ class UniqueDataRepository {
     int? offset,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -513,8 +497,6 @@ class UniqueDataRepository {
       offset: offset,
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -535,8 +517,6 @@ class UniqueDataRepository {
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -545,8 +525,6 @@ class UniqueDataRepository {
       rows,
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -576,8 +554,6 @@ class UniqueDataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UniqueDataTable> where,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -586,8 +562,6 @@ class UniqueDataRepository {
       where: where(UniqueData.t),
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/unique_data_with_non_persist.dart
+++ b/tests/serverpod_test_server/lib/src/generated/unique_data_with_non_persist.dart
@@ -95,8 +95,6 @@ abstract class UniqueDataWithNonPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     UniqueDataWithNonPersistInclude? include,
   }) {
@@ -105,8 +103,6 @@ abstract class UniqueDataWithNonPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
       include: include,
     );
@@ -211,8 +207,6 @@ class UniqueDataWithNonPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -257,8 +251,6 @@ class UniqueDataWithNonPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -268,8 +260,6 @@ class UniqueDataWithNonPersistRepository {
       where: where?.call(UniqueDataWithNonPersist.t),
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -300,8 +290,6 @@ class UniqueDataWithNonPersistRepository {
     _i1.WhereExpressionBuilder<UniqueDataWithNonPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -311,8 +299,6 @@ class UniqueDataWithNonPersistRepository {
       where: where?.call(UniqueDataWithNonPersist.t),
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -521,8 +507,6 @@ class UniqueDataWithNonPersistRepository {
     int? offset,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -533,8 +517,6 @@ class UniqueDataWithNonPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -555,8 +537,6 @@ class UniqueDataWithNonPersistRepository {
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -565,8 +545,6 @@ class UniqueDataWithNonPersistRepository {
       rows,
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -596,8 +574,6 @@ class UniqueDataWithNonPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UniqueDataWithNonPersistTable> where,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -606,8 +582,6 @@ class UniqueDataWithNonPersistRepository {
       where: where(UniqueDataWithNonPersist.t),
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/lib/src/generated/upsert_test_model.dart
+++ b/tests/serverpod_test_server/lib/src/generated/upsert_test_model.dart
@@ -93,8 +93,6 @@ abstract class UpsertTestModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UpsertTestModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     UpsertTestModelInclude? include,
   }) {
@@ -103,8 +101,6 @@ abstract class UpsertTestModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UpsertTestModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UpsertTestModel.t),
       include: include,
     );
@@ -220,8 +216,6 @@ class UpsertTestModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -266,8 +260,6 @@ class UpsertTestModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UpsertTestModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -277,8 +269,6 @@ class UpsertTestModelRepository {
       where: where?.call(UpsertTestModel.t),
       orderBy: orderBy?.call(UpsertTestModel.t),
       orderByList: orderByList?.call(UpsertTestModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -309,8 +299,6 @@ class UpsertTestModelRepository {
     _i1.WhereExpressionBuilder<UpsertTestModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<UpsertTestModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -320,8 +308,6 @@ class UpsertTestModelRepository {
       where: where?.call(UpsertTestModel.t),
       orderBy: orderBy?.call(UpsertTestModel.t),
       orderByList: orderByList?.call(UpsertTestModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -528,8 +514,6 @@ class UpsertTestModelRepository {
     int? offset,
     _i1.OrderByBuilder<UpsertTestModelTable>? orderBy,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -540,8 +524,6 @@ class UpsertTestModelRepository {
       offset: offset,
       orderBy: orderBy?.call(UpsertTestModel.t),
       orderByList: orderByList?.call(UpsertTestModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -562,8 +544,6 @@ class UpsertTestModelRepository {
     _i1.DatabaseSession session,
     List<UpsertTestModel> rows, {
     _i1.OrderByBuilder<UpsertTestModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -572,8 +552,6 @@ class UpsertTestModelRepository {
       rows,
       orderBy: orderBy?.call(UpsertTestModel.t),
       orderByList: orderByList?.call(UpsertTestModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -603,8 +581,6 @@ class UpsertTestModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UpsertTestModelTable> where,
     _i1.OrderByBuilder<UpsertTestModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -613,8 +589,6 @@ class UpsertTestModelRepository {
       where: where(UpsertTestModel.t),
       orderBy: orderBy?.call(UpsertTestModel.t),
       orderByList: orderByList?.call(UpsertTestModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_server/test_integration/database_operations/crud/update_where_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/crud/update_where_test.dart
@@ -483,7 +483,7 @@ void main() {
         });
       });
 
-      group('when updating with orderDescending', () {
+      group('when updating in descending order', () {
         late List<Types> updated;
 
         setUp(() async {

--- a/tests/serverpod_test_shared/lib/src/generated/shared/shared_table_record.dart
+++ b/tests/serverpod_test_shared/lib/src/generated/shared/shared_table_record.dart
@@ -110,8 +110,6 @@ abstract class SharedTableRecord
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SharedTableRecordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedTableRecordTable>? orderByList,
     SharedTableRecordInclude? include,
   }) {
@@ -120,8 +118,6 @@ abstract class SharedTableRecord
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(SharedTableRecord.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(SharedTableRecord.t),
       include: include,
     );
@@ -262,8 +258,6 @@ class SharedTableRecordIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -308,8 +302,6 @@ class SharedTableRecordRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SharedTableRecordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedTableRecordTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -319,8 +311,6 @@ class SharedTableRecordRepository {
       where: where?.call(SharedTableRecord.t),
       orderBy: orderBy?.call(SharedTableRecord.t),
       orderByList: orderByList?.call(SharedTableRecord.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -351,8 +341,6 @@ class SharedTableRecordRepository {
     _i1.WhereExpressionBuilder<SharedTableRecordTable>? where,
     int? offset,
     _i1.OrderByBuilder<SharedTableRecordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedTableRecordTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -362,8 +350,6 @@ class SharedTableRecordRepository {
       where: where?.call(SharedTableRecord.t),
       orderBy: orderBy?.call(SharedTableRecord.t),
       orderByList: orderByList?.call(SharedTableRecord.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -570,8 +556,6 @@ class SharedTableRecordRepository {
     int? offset,
     _i1.OrderByBuilder<SharedTableRecordTable>? orderBy,
     _i1.OrderByListBuilder<SharedTableRecordTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -582,8 +566,6 @@ class SharedTableRecordRepository {
       offset: offset,
       orderBy: orderBy?.call(SharedTableRecord.t),
       orderByList: orderByList?.call(SharedTableRecord.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -604,8 +586,6 @@ class SharedTableRecordRepository {
     _i1.DatabaseSession session,
     List<SharedTableRecord> rows, {
     _i1.OrderByBuilder<SharedTableRecordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedTableRecordTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -614,8 +594,6 @@ class SharedTableRecordRepository {
       rows,
       orderBy: orderBy?.call(SharedTableRecord.t),
       orderByList: orderByList?.call(SharedTableRecord.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -645,8 +623,6 @@ class SharedTableRecordRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SharedTableRecordTable> where,
     _i1.OrderByBuilder<SharedTableRecordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedTableRecordTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -655,8 +631,6 @@ class SharedTableRecordRepository {
       where: where(SharedTableRecord.t),
       orderBy: orderBy?.call(SharedTableRecord.t),
       orderByList: orderByList?.call(SharedTableRecord.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/empty_model_relation_item.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/empty_model_relation_item.dart
@@ -88,8 +88,6 @@ abstract class EmptyModelRelationItem
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     EmptyModelRelationItemInclude? include,
   }) {
@@ -98,8 +96,6 @@ abstract class EmptyModelRelationItem
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
       include: include,
     );
@@ -234,8 +230,6 @@ class EmptyModelRelationItemIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -280,8 +274,6 @@ class EmptyModelRelationItemRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -291,8 +283,6 @@ class EmptyModelRelationItemRepository {
       where: where?.call(EmptyModelRelationItem.t),
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -323,8 +313,6 @@ class EmptyModelRelationItemRepository {
     _i1.WhereExpressionBuilder<EmptyModelRelationItemTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -334,8 +322,6 @@ class EmptyModelRelationItemRepository {
       where: where?.call(EmptyModelRelationItem.t),
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -542,8 +528,6 @@ class EmptyModelRelationItemRepository {
     int? offset,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -554,8 +538,6 @@ class EmptyModelRelationItemRepository {
       offset: offset,
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -576,8 +558,6 @@ class EmptyModelRelationItemRepository {
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -586,8 +566,6 @@ class EmptyModelRelationItemRepository {
       rows,
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -617,8 +595,6 @@ class EmptyModelRelationItemRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmptyModelRelationItemTable> where,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -627,8 +603,6 @@ class EmptyModelRelationItemRepository {
       where: where(EmptyModelRelationItem.t),
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/empty_model_with_table.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/empty_model_with_table.dart
@@ -62,8 +62,6 @@ abstract class EmptyModelWithTable
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     EmptyModelWithTableInclude? include,
   }) {
@@ -72,8 +70,6 @@ abstract class EmptyModelWithTable
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EmptyModelWithTable.t),
       include: include,
     );
@@ -132,8 +128,6 @@ class EmptyModelWithTableIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -178,8 +172,6 @@ class EmptyModelWithTableRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -189,8 +181,6 @@ class EmptyModelWithTableRepository {
       where: where?.call(EmptyModelWithTable.t),
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -221,8 +211,6 @@ class EmptyModelWithTableRepository {
     _i1.WhereExpressionBuilder<EmptyModelWithTableTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -232,8 +220,6 @@ class EmptyModelWithTableRepository {
       where: where?.call(EmptyModelWithTable.t),
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -440,8 +426,6 @@ class EmptyModelWithTableRepository {
     int? offset,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -452,8 +436,6 @@ class EmptyModelWithTableRepository {
       offset: offset,
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -474,8 +456,6 @@ class EmptyModelWithTableRepository {
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -484,8 +464,6 @@ class EmptyModelWithTableRepository {
       rows,
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -515,8 +493,6 @@ class EmptyModelWithTableRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmptyModelWithTableTable> where,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -525,8 +501,6 @@ class EmptyModelWithTableRepository {
       where: where(EmptyModelWithTable.t),
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/empty_model/relation_empy_model.dart
@@ -88,8 +88,6 @@ abstract class RelationEmptyModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     RelationEmptyModelInclude? include,
   }) {
@@ -98,8 +96,6 @@ abstract class RelationEmptyModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(RelationEmptyModel.t),
       include: include,
     );
@@ -226,8 +222,6 @@ class RelationEmptyModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -280,8 +274,6 @@ class RelationEmptyModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
     RelationEmptyModelInclude? include,
@@ -292,8 +284,6 @@ class RelationEmptyModelRepository {
       where: where?.call(RelationEmptyModel.t),
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -325,8 +315,6 @@ class RelationEmptyModelRepository {
     _i1.WhereExpressionBuilder<RelationEmptyModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
     RelationEmptyModelInclude? include,
@@ -337,8 +325,6 @@ class RelationEmptyModelRepository {
       where: where?.call(RelationEmptyModel.t),
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -548,8 +534,6 @@ class RelationEmptyModelRepository {
     int? offset,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -560,8 +544,6 @@ class RelationEmptyModelRepository {
       offset: offset,
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -582,8 +564,6 @@ class RelationEmptyModelRepository {
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -592,8 +572,6 @@ class RelationEmptyModelRepository {
       rows,
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -623,8 +601,6 @@ class RelationEmptyModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelationEmptyModelTable> where,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -633,8 +609,6 @@ class RelationEmptyModelRepository {
       where: where(RelationEmptyModel.t),
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/city.dart
@@ -117,8 +117,6 @@ abstract class City implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     CityInclude? include,
   }) {
@@ -127,8 +125,6 @@ abstract class City implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(City.t),
       include: include,
     );
@@ -319,8 +315,6 @@ class CityIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -373,8 +367,6 @@ class CityRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     CityInclude? include,
@@ -385,8 +377,6 @@ class CityRepository {
       where: where?.call(City.t),
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -418,8 +408,6 @@ class CityRepository {
     _i1.WhereExpressionBuilder<CityTable>? where,
     int? offset,
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     CityInclude? include,
@@ -430,8 +418,6 @@ class CityRepository {
       where: where?.call(City.t),
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -639,8 +625,6 @@ class CityRepository {
     int? offset,
     _i1.OrderByBuilder<CityTable>? orderBy,
     _i1.OrderByListBuilder<CityTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -651,8 +635,6 @@ class CityRepository {
       offset: offset,
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -673,8 +655,6 @@ class CityRepository {
     _i1.DatabaseSession session,
     List<City> rows, {
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -683,8 +663,6 @@ class CityRepository {
       rows,
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -714,8 +692,6 @@ class CityRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CityTable> where,
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -724,8 +700,6 @@ class CityRepository {
       where: where(City.t),
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/organization.dart
@@ -120,8 +120,6 @@ abstract class Organization
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     OrganizationInclude? include,
   }) {
@@ -130,8 +128,6 @@ abstract class Organization
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Organization.t),
       include: include,
     );
@@ -315,8 +311,6 @@ class OrganizationIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -369,8 +363,6 @@ class OrganizationRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     OrganizationInclude? include,
@@ -381,8 +373,6 @@ class OrganizationRepository {
       where: where?.call(Organization.t),
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -414,8 +404,6 @@ class OrganizationRepository {
     _i1.WhereExpressionBuilder<OrganizationTable>? where,
     int? offset,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     OrganizationInclude? include,
@@ -426,8 +414,6 @@ class OrganizationRepository {
       where: where?.call(Organization.t),
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -635,8 +621,6 @@ class OrganizationRepository {
     int? offset,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -647,8 +631,6 @@ class OrganizationRepository {
       offset: offset,
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -669,8 +651,6 @@ class OrganizationRepository {
     _i1.DatabaseSession session,
     List<Organization> rows, {
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -679,8 +659,6 @@ class OrganizationRepository {
       rows,
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -710,8 +688,6 @@ class OrganizationRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrganizationTable> where,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -720,8 +696,6 @@ class OrganizationRepository {
       where: where(Organization.t),
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_list_relations/person.dart
@@ -106,8 +106,6 @@ abstract class Person implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     PersonInclude? include,
   }) {
@@ -116,8 +114,6 @@ abstract class Person implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Person.t),
       include: include,
     );
@@ -303,8 +299,6 @@ class PersonIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -353,8 +347,6 @@ class PersonRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     PersonInclude? include,
@@ -365,8 +357,6 @@ class PersonRepository {
       where: where?.call(Person.t),
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -398,8 +388,6 @@ class PersonRepository {
     _i1.WhereExpressionBuilder<PersonTable>? where,
     int? offset,
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     PersonInclude? include,
@@ -410,8 +398,6 @@ class PersonRepository {
       where: where?.call(Person.t),
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -619,8 +605,6 @@ class PersonRepository {
     int? offset,
     _i1.OrderByBuilder<PersonTable>? orderBy,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -631,8 +615,6 @@ class PersonRepository {
       offset: offset,
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -653,8 +635,6 @@ class PersonRepository {
     _i1.DatabaseSession session,
     List<Person> rows, {
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -663,8 +643,6 @@ class PersonRepository {
       rows,
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -694,8 +672,6 @@ class PersonRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PersonTable> where,
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -704,8 +680,6 @@ class PersonRepository {
       where: where(Person.t),
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
@@ -96,8 +96,6 @@ abstract class Course implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     CourseInclude? include,
   }) {
@@ -106,8 +104,6 @@ abstract class Course implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Course.t),
       include: include,
     );
@@ -244,8 +240,6 @@ class CourseIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -298,8 +292,6 @@ class CourseRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     CourseInclude? include,
@@ -310,8 +302,6 @@ class CourseRepository {
       where: where?.call(Course.t),
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -343,8 +333,6 @@ class CourseRepository {
     _i1.WhereExpressionBuilder<CourseTable>? where,
     int? offset,
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     CourseInclude? include,
@@ -355,8 +343,6 @@ class CourseRepository {
       where: where?.call(Course.t),
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -564,8 +550,6 @@ class CourseRepository {
     int? offset,
     _i1.OrderByBuilder<CourseTable>? orderBy,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -576,8 +560,6 @@ class CourseRepository {
       offset: offset,
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -598,8 +580,6 @@ class CourseRepository {
     _i1.DatabaseSession session,
     List<Course> rows, {
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -608,8 +588,6 @@ class CourseRepository {
       rows,
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -639,8 +617,6 @@ class CourseRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CourseTable> where,
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -649,8 +625,6 @@ class CourseRepository {
       where: where(Course.t),
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/enrollment.dart
@@ -118,8 +118,6 @@ abstract class Enrollment
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     EnrollmentInclude? include,
   }) {
@@ -128,8 +126,6 @@ abstract class Enrollment
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Enrollment.t),
       include: include,
     );
@@ -290,8 +286,6 @@ class EnrollmentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -338,8 +332,6 @@ class EnrollmentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     EnrollmentInclude? include,
@@ -350,8 +342,6 @@ class EnrollmentRepository {
       where: where?.call(Enrollment.t),
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -383,8 +373,6 @@ class EnrollmentRepository {
     _i1.WhereExpressionBuilder<EnrollmentTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     EnrollmentInclude? include,
@@ -395,8 +383,6 @@ class EnrollmentRepository {
       where: where?.call(Enrollment.t),
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -604,8 +590,6 @@ class EnrollmentRepository {
     int? offset,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -616,8 +600,6 @@ class EnrollmentRepository {
       offset: offset,
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -638,8 +620,6 @@ class EnrollmentRepository {
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -648,8 +628,6 @@ class EnrollmentRepository {
       rows,
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -679,8 +657,6 @@ class EnrollmentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnrollmentTable> where,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -689,8 +665,6 @@ class EnrollmentRepository {
       where: where(Enrollment.t),
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/student.dart
@@ -97,8 +97,6 @@ abstract class Student
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     StudentInclude? include,
   }) {
@@ -107,8 +105,6 @@ abstract class Student
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Student.t),
       include: include,
     );
@@ -245,8 +241,6 @@ class StudentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -295,8 +289,6 @@ class StudentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     StudentInclude? include,
@@ -307,8 +299,6 @@ class StudentRepository {
       where: where?.call(Student.t),
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -340,8 +330,6 @@ class StudentRepository {
     _i1.WhereExpressionBuilder<StudentTable>? where,
     int? offset,
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     StudentInclude? include,
@@ -352,8 +340,6 @@ class StudentRepository {
       where: where?.call(Student.t),
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -561,8 +547,6 @@ class StudentRepository {
     int? offset,
     _i1.OrderByBuilder<StudentTable>? orderBy,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -573,8 +557,6 @@ class StudentRepository {
       offset: offset,
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -595,8 +577,6 @@ class StudentRepository {
     _i1.DatabaseSession session,
     List<Student> rows, {
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -605,8 +585,6 @@ class StudentRepository {
       rows,
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -636,8 +614,6 @@ class StudentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StudentTable> where,
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -646,8 +622,6 @@ class StudentRepository {
       where: where(Student.t),
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/arena.dart
@@ -90,8 +90,6 @@ abstract class Arena implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     ArenaInclude? include,
   }) {
@@ -100,8 +98,6 @@ abstract class Arena implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Arena.t),
       include: include,
     );
@@ -215,8 +211,6 @@ class ArenaIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -265,8 +259,6 @@ class ArenaRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     ArenaInclude? include,
@@ -277,8 +269,6 @@ class ArenaRepository {
       where: where?.call(Arena.t),
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -310,8 +300,6 @@ class ArenaRepository {
     _i1.WhereExpressionBuilder<ArenaTable>? where,
     int? offset,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     ArenaInclude? include,
@@ -322,8 +310,6 @@ class ArenaRepository {
       where: where?.call(Arena.t),
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -531,8 +517,6 @@ class ArenaRepository {
     int? offset,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -543,8 +527,6 @@ class ArenaRepository {
       offset: offset,
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -565,8 +547,6 @@ class ArenaRepository {
     _i1.DatabaseSession session,
     List<Arena> rows, {
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -575,8 +555,6 @@ class ArenaRepository {
       rows,
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -606,8 +584,6 @@ class ArenaRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ArenaTable> where,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -616,8 +592,6 @@ class ArenaRepository {
       where: where(Arena.t),
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/player.dart
@@ -98,8 +98,6 @@ abstract class Player implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     PlayerInclude? include,
   }) {
@@ -108,8 +106,6 @@ abstract class Player implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Player.t),
       include: include,
     );
@@ -239,8 +235,6 @@ class PlayerIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -289,8 +283,6 @@ class PlayerRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     PlayerInclude? include,
@@ -301,8 +293,6 @@ class PlayerRepository {
       where: where?.call(Player.t),
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -334,8 +324,6 @@ class PlayerRepository {
     _i1.WhereExpressionBuilder<PlayerTable>? where,
     int? offset,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     PlayerInclude? include,
@@ -346,8 +334,6 @@ class PlayerRepository {
       where: where?.call(Player.t),
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -555,8 +541,6 @@ class PlayerRepository {
     int? offset,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -567,8 +551,6 @@ class PlayerRepository {
       offset: offset,
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -589,8 +571,6 @@ class PlayerRepository {
     _i1.DatabaseSession session,
     List<Player> rows, {
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -599,8 +579,6 @@ class PlayerRepository {
       rows,
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -630,8 +608,6 @@ class PlayerRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PlayerTable> where,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -640,8 +616,6 @@ class PlayerRepository {
       where: where(Player.t),
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/nested_one_to_many/team.dart
@@ -119,8 +119,6 @@ abstract class Team implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     TeamInclude? include,
   }) {
@@ -129,8 +127,6 @@ abstract class Team implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Team.t),
       include: include,
     );
@@ -314,8 +310,6 @@ class TeamIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -368,8 +362,6 @@ class TeamRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     TeamInclude? include,
@@ -380,8 +372,6 @@ class TeamRepository {
       where: where?.call(Team.t),
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -413,8 +403,6 @@ class TeamRepository {
     _i1.WhereExpressionBuilder<TeamTable>? where,
     int? offset,
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     TeamInclude? include,
@@ -425,8 +413,6 @@ class TeamRepository {
       where: where?.call(Team.t),
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -634,8 +620,6 @@ class TeamRepository {
     int? offset,
     _i1.OrderByBuilder<TeamTable>? orderBy,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -646,8 +630,6 @@ class TeamRepository {
       offset: offset,
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -668,8 +650,6 @@ class TeamRepository {
     _i1.DatabaseSession session,
     List<Team> rows, {
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -678,8 +658,6 @@ class TeamRepository {
       rows,
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -709,8 +687,6 @@ class TeamRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TeamTable> where,
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -719,8 +695,6 @@ class TeamRepository {
       where: where(Team.t),
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/comment.dart
@@ -99,8 +99,6 @@ abstract class Comment
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     CommentInclude? include,
   }) {
@@ -109,8 +107,6 @@ abstract class Comment
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Comment.t),
       include: include,
     );
@@ -240,8 +236,6 @@ class CommentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -288,8 +282,6 @@ class CommentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     CommentInclude? include,
@@ -300,8 +292,6 @@ class CommentRepository {
       where: where?.call(Comment.t),
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -333,8 +323,6 @@ class CommentRepository {
     _i1.WhereExpressionBuilder<CommentTable>? where,
     int? offset,
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     CommentInclude? include,
@@ -345,8 +333,6 @@ class CommentRepository {
       where: where?.call(Comment.t),
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -554,8 +540,6 @@ class CommentRepository {
     int? offset,
     _i1.OrderByBuilder<CommentTable>? orderBy,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -566,8 +550,6 @@ class CommentRepository {
       offset: offset,
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -588,8 +570,6 @@ class CommentRepository {
     _i1.DatabaseSession session,
     List<Comment> rows, {
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -598,8 +578,6 @@ class CommentRepository {
       rows,
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -629,8 +607,6 @@ class CommentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CommentTable> where,
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -639,8 +615,6 @@ class CommentRepository {
       where: where(Comment.t),
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
@@ -95,8 +95,6 @@ abstract class Customer
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     CustomerInclude? include,
   }) {
@@ -105,8 +103,6 @@ abstract class Customer
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Customer.t),
       include: include,
     );
@@ -243,8 +239,6 @@ class CustomerIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -297,8 +291,6 @@ class CustomerRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     CustomerInclude? include,
@@ -309,8 +301,6 @@ class CustomerRepository {
       where: where?.call(Customer.t),
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -342,8 +332,6 @@ class CustomerRepository {
     _i1.WhereExpressionBuilder<CustomerTable>? where,
     int? offset,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     CustomerInclude? include,
@@ -354,8 +342,6 @@ class CustomerRepository {
       where: where?.call(Customer.t),
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -563,8 +549,6 @@ class CustomerRepository {
     int? offset,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -575,8 +559,6 @@ class CustomerRepository {
       offset: offset,
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -597,8 +579,6 @@ class CustomerRepository {
     _i1.DatabaseSession session,
     List<Customer> rows, {
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -607,8 +587,6 @@ class CustomerRepository {
       rows,
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -638,8 +616,6 @@ class CustomerRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CustomerTable> where,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -648,8 +624,6 @@ class CustomerRepository {
       where: where(Customer.t),
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/implicit/book.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/implicit/book.dart
@@ -95,8 +95,6 @@ abstract class Book implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     BookInclude? include,
   }) {
@@ -105,8 +103,6 @@ abstract class Book implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Book.t),
       include: include,
     );
@@ -243,8 +239,6 @@ class BookIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -297,8 +291,6 @@ class BookRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
     BookInclude? include,
@@ -309,8 +301,6 @@ class BookRepository {
       where: where?.call(Book.t),
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -342,8 +332,6 @@ class BookRepository {
     _i1.WhereExpressionBuilder<BookTable>? where,
     int? offset,
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
     BookInclude? include,
@@ -354,8 +342,6 @@ class BookRepository {
       where: where?.call(Book.t),
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -563,8 +549,6 @@ class BookRepository {
     int? offset,
     _i1.OrderByBuilder<BookTable>? orderBy,
     _i1.OrderByListBuilder<BookTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -575,8 +559,6 @@ class BookRepository {
       offset: offset,
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -597,8 +579,6 @@ class BookRepository {
     _i1.DatabaseSession session,
     List<Book> rows, {
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -607,8 +587,6 @@ class BookRepository {
       rows,
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -638,8 +616,6 @@ class BookRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BookTable> where,
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -648,8 +624,6 @@ class BookRepository {
       where: where(Book.t),
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/implicit/chapter.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/implicit/chapter.dart
@@ -83,8 +83,6 @@ abstract class Chapter
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     ChapterInclude? include,
   }) {
@@ -93,8 +91,6 @@ abstract class Chapter
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Chapter.t),
       include: include,
     );
@@ -222,8 +218,6 @@ class ChapterIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -268,8 +262,6 @@ class ChapterRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -279,8 +271,6 @@ class ChapterRepository {
       where: where?.call(Chapter.t),
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -311,8 +301,6 @@ class ChapterRepository {
     _i1.WhereExpressionBuilder<ChapterTable>? where,
     int? offset,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -322,8 +310,6 @@ class ChapterRepository {
       where: where?.call(Chapter.t),
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -528,8 +514,6 @@ class ChapterRepository {
     int? offset,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -540,8 +524,6 @@ class ChapterRepository {
       offset: offset,
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -562,8 +544,6 @@ class ChapterRepository {
     _i1.DatabaseSession session,
     List<Chapter> rows, {
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -572,8 +552,6 @@ class ChapterRepository {
       rows,
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -603,8 +581,6 @@ class ChapterRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChapterTable> where,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -613,8 +589,6 @@ class ChapterRepository {
       where: where(Chapter.t),
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/order.dart
@@ -121,8 +121,6 @@ abstract class Order implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     OrderInclude? include,
   }) {
@@ -131,8 +129,6 @@ abstract class Order implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Order.t),
       include: include,
     );
@@ -318,8 +314,6 @@ class OrderIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -368,8 +362,6 @@ class OrderRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     OrderInclude? include,
@@ -380,8 +372,6 @@ class OrderRepository {
       where: where?.call(Order.t),
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -413,8 +403,6 @@ class OrderRepository {
     _i1.WhereExpressionBuilder<OrderTable>? where,
     int? offset,
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     OrderInclude? include,
@@ -425,8 +413,6 @@ class OrderRepository {
       where: where?.call(Order.t),
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -634,8 +620,6 @@ class OrderRepository {
     int? offset,
     _i1.OrderByBuilder<OrderTable>? orderBy,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -646,8 +630,6 @@ class OrderRepository {
       offset: offset,
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -668,8 +650,6 @@ class OrderRepository {
     _i1.DatabaseSession session,
     List<Order> rows, {
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -678,8 +658,6 @@ class OrderRepository {
       rows,
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -709,8 +687,6 @@ class OrderRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrderTable> where,
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -719,8 +695,6 @@ class OrderRepository {
       where: where(Order.t),
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/address.dart
@@ -101,8 +101,6 @@ abstract class Address
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     AddressInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class Address
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Address.t),
       include: include,
     );
@@ -244,8 +240,6 @@ class AddressIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -294,8 +288,6 @@ class AddressRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     AddressInclude? include,
@@ -306,8 +298,6 @@ class AddressRepository {
       where: where?.call(Address.t),
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -339,8 +329,6 @@ class AddressRepository {
     _i1.WhereExpressionBuilder<AddressTable>? where,
     int? offset,
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     AddressInclude? include,
@@ -351,8 +339,6 @@ class AddressRepository {
       where: where?.call(Address.t),
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -560,8 +546,6 @@ class AddressRepository {
     int? offset,
     _i1.OrderByBuilder<AddressTable>? orderBy,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -572,8 +556,6 @@ class AddressRepository {
       offset: offset,
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -594,8 +576,6 @@ class AddressRepository {
     _i1.DatabaseSession session,
     List<Address> rows, {
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -604,8 +584,6 @@ class AddressRepository {
       rows,
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -635,8 +613,6 @@ class AddressRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AddressTable> where,
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -645,8 +621,6 @@ class AddressRepository {
       where: where(Address.t),
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/citizen.dart
@@ -142,8 +142,6 @@ abstract class Citizen
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     CitizenInclude? include,
   }) {
@@ -152,8 +150,6 @@ abstract class Citizen
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Citizen.t),
       include: include,
     );
@@ -359,8 +355,6 @@ class CitizenIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -409,8 +403,6 @@ class CitizenRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     CitizenInclude? include,
@@ -421,8 +413,6 @@ class CitizenRepository {
       where: where?.call(Citizen.t),
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -454,8 +444,6 @@ class CitizenRepository {
     _i1.WhereExpressionBuilder<CitizenTable>? where,
     int? offset,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     CitizenInclude? include,
@@ -466,8 +454,6 @@ class CitizenRepository {
       where: where?.call(Citizen.t),
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -675,8 +661,6 @@ class CitizenRepository {
     int? offset,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -687,8 +671,6 @@ class CitizenRepository {
       offset: offset,
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -709,8 +691,6 @@ class CitizenRepository {
     _i1.DatabaseSession session,
     List<Citizen> rows, {
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -719,8 +699,6 @@ class CitizenRepository {
       rows,
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -750,8 +728,6 @@ class CitizenRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CitizenTable> where,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -760,8 +736,6 @@ class CitizenRepository {
       where: where(Citizen.t),
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/company.dart
@@ -99,8 +99,6 @@ abstract class Company
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     CompanyInclude? include,
   }) {
@@ -109,8 +107,6 @@ abstract class Company
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Company.t),
       include: include,
     );
@@ -240,8 +236,6 @@ class CompanyIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -288,8 +282,6 @@ class CompanyRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     CompanyInclude? include,
@@ -300,8 +292,6 @@ class CompanyRepository {
       where: where?.call(Company.t),
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -333,8 +323,6 @@ class CompanyRepository {
     _i1.WhereExpressionBuilder<CompanyTable>? where,
     int? offset,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     CompanyInclude? include,
@@ -345,8 +333,6 @@ class CompanyRepository {
       where: where?.call(Company.t),
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -554,8 +540,6 @@ class CompanyRepository {
     int? offset,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -566,8 +550,6 @@ class CompanyRepository {
       offset: offset,
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -588,8 +570,6 @@ class CompanyRepository {
     _i1.DatabaseSession session,
     List<Company> rows, {
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -598,8 +578,6 @@ class CompanyRepository {
       rows,
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -629,8 +607,6 @@ class CompanyRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CompanyTable> where,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -639,8 +615,6 @@ class CompanyRepository {
       where: where(Company.t),
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_one/town.dart
@@ -98,8 +98,6 @@ abstract class Town implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     TownInclude? include,
   }) {
@@ -108,8 +106,6 @@ abstract class Town implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Town.t),
       include: include,
     );
@@ -239,8 +235,6 @@ class TownIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -289,8 +283,6 @@ class TownRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     TownInclude? include,
@@ -301,8 +293,6 @@ class TownRepository {
       where: where?.call(Town.t),
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -334,8 +324,6 @@ class TownRepository {
     _i1.WhereExpressionBuilder<TownTable>? where,
     int? offset,
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     TownInclude? include,
@@ -346,8 +334,6 @@ class TownRepository {
       where: where?.call(Town.t),
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -555,8 +541,6 @@ class TownRepository {
     int? offset,
     _i1.OrderByBuilder<TownTable>? orderBy,
     _i1.OrderByListBuilder<TownTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -567,8 +551,6 @@ class TownRepository {
       offset: offset,
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -589,8 +571,6 @@ class TownRepository {
     _i1.DatabaseSession session,
     List<Town> rows, {
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -599,8 +579,6 @@ class TownRepository {
       rows,
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -630,8 +608,6 @@ class TownRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TownTable> where,
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -640,8 +616,6 @@ class TownRepository {
       where: where(Town.t),
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -120,8 +120,6 @@ abstract class Blocking
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     BlockingInclude? include,
   }) {
@@ -130,8 +128,6 @@ abstract class Blocking
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Blocking.t),
       include: include,
     );
@@ -294,8 +290,6 @@ class BlockingIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -342,8 +336,6 @@ class BlockingRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     BlockingInclude? include,
@@ -354,8 +346,6 @@ class BlockingRepository {
       where: where?.call(Blocking.t),
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -387,8 +377,6 @@ class BlockingRepository {
     _i1.WhereExpressionBuilder<BlockingTable>? where,
     int? offset,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     BlockingInclude? include,
@@ -399,8 +387,6 @@ class BlockingRepository {
       where: where?.call(Blocking.t),
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -608,8 +594,6 @@ class BlockingRepository {
     int? offset,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -620,8 +604,6 @@ class BlockingRepository {
       offset: offset,
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -642,8 +624,6 @@ class BlockingRepository {
     _i1.DatabaseSession session,
     List<Blocking> rows, {
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -652,8 +632,6 @@ class BlockingRepository {
       rows,
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -683,8 +661,6 @@ class BlockingRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BlockingTable> where,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -693,8 +669,6 @@ class BlockingRepository {
       where: where(Blocking.t),
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/many_to_many/member.dart
@@ -117,8 +117,6 @@ abstract class Member implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     MemberInclude? include,
   }) {
@@ -127,8 +125,6 @@ abstract class Member implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Member.t),
       include: include,
     );
@@ -319,8 +315,6 @@ class MemberIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -369,8 +363,6 @@ class MemberRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     MemberInclude? include,
@@ -381,8 +373,6 @@ class MemberRepository {
       where: where?.call(Member.t),
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -414,8 +404,6 @@ class MemberRepository {
     _i1.WhereExpressionBuilder<MemberTable>? where,
     int? offset,
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     MemberInclude? include,
@@ -426,8 +414,6 @@ class MemberRepository {
       where: where?.call(Member.t),
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -635,8 +621,6 @@ class MemberRepository {
     int? offset,
     _i1.OrderByBuilder<MemberTable>? orderBy,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -647,8 +631,6 @@ class MemberRepository {
       offset: offset,
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -669,8 +651,6 @@ class MemberRepository {
     _i1.DatabaseSession session,
     List<Member> rows, {
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -679,8 +659,6 @@ class MemberRepository {
       rows,
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -710,8 +688,6 @@ class MemberRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MemberTable> where,
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -720,8 +696,6 @@ class MemberRepository {
       where: where(Member.t),
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/one_to_many/cat.dart
@@ -119,8 +119,6 @@ abstract class Cat implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     CatInclude? include,
   }) {
@@ -129,8 +127,6 @@ abstract class Cat implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Cat.t),
       include: include,
     );
@@ -314,8 +310,6 @@ class CatIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -368,8 +362,6 @@ class CatRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     CatInclude? include,
@@ -380,8 +372,6 @@ class CatRepository {
       where: where?.call(Cat.t),
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -413,8 +403,6 @@ class CatRepository {
     _i1.WhereExpressionBuilder<CatTable>? where,
     int? offset,
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     CatInclude? include,
@@ -425,8 +413,6 @@ class CatRepository {
       where: where?.call(Cat.t),
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -634,8 +620,6 @@ class CatRepository {
     int? offset,
     _i1.OrderByBuilder<CatTable>? orderBy,
     _i1.OrderByListBuilder<CatTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -646,8 +630,6 @@ class CatRepository {
       offset: offset,
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -668,8 +650,6 @@ class CatRepository {
     _i1.DatabaseSession session,
     List<Cat> rows, {
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -678,8 +658,6 @@ class CatRepository {
       rows,
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -709,8 +687,6 @@ class CatRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CatTable> where,
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -719,8 +695,6 @@ class CatRepository {
       where: where(Cat.t),
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/self_relation/one_to_one/post.dart
@@ -115,8 +115,6 @@ abstract class Post implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     PostInclude? include,
   }) {
@@ -125,8 +123,6 @@ abstract class Post implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Post.t),
       include: include,
     );
@@ -287,8 +283,6 @@ class PostIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -337,8 +331,6 @@ class PostRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     PostInclude? include,
@@ -349,8 +341,6 @@ class PostRepository {
       where: where?.call(Post.t),
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -382,8 +372,6 @@ class PostRepository {
     _i1.WhereExpressionBuilder<PostTable>? where,
     int? offset,
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     PostInclude? include,
@@ -394,8 +382,6 @@ class PostRepository {
       where: where?.call(Post.t),
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -603,8 +589,6 @@ class PostRepository {
     int? offset,
     _i1.OrderByBuilder<PostTable>? orderBy,
     _i1.OrderByListBuilder<PostTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -615,8 +599,6 @@ class PostRepository {
       offset: offset,
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -637,8 +619,6 @@ class PostRepository {
     _i1.DatabaseSession session,
     List<Post> rows, {
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -647,8 +627,6 @@ class PostRepository {
       rows,
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -678,8 +656,6 @@ class PostRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PostTable> where,
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -688,8 +664,6 @@ class PostRepository {
       where: where(Post.t),
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/object_field_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/object_field_persist.dart
@@ -100,8 +100,6 @@ abstract class ObjectFieldPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     ObjectFieldPersistInclude? include,
   }) {
@@ -110,8 +108,6 @@ abstract class ObjectFieldPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectFieldPersist.t),
       include: include,
     );
@@ -204,8 +200,6 @@ class ObjectFieldPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -250,8 +244,6 @@ class ObjectFieldPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -261,8 +253,6 @@ class ObjectFieldPersistRepository {
       where: where?.call(ObjectFieldPersist.t),
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -293,8 +283,6 @@ class ObjectFieldPersistRepository {
     _i1.WhereExpressionBuilder<ObjectFieldPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -304,8 +292,6 @@ class ObjectFieldPersistRepository {
       where: where?.call(ObjectFieldPersist.t),
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -512,8 +498,6 @@ class ObjectFieldPersistRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -524,8 +508,6 @@ class ObjectFieldPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -546,8 +528,6 @@ class ObjectFieldPersistRepository {
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -556,8 +536,6 @@ class ObjectFieldPersistRepository {
       rows,
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -587,8 +565,6 @@ class ObjectFieldPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectFieldPersistTable> where,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -597,8 +573,6 @@ class ObjectFieldPersistRepository {
       where: where(ObjectFieldPersist.t),
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/related_unique_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/related_unique_data.dart
@@ -101,8 +101,6 @@ abstract class RelatedUniqueData
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     RelatedUniqueDataInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class RelatedUniqueData
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(RelatedUniqueData.t),
       include: include,
     );
@@ -246,8 +242,6 @@ class RelatedUniqueDataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -294,8 +288,6 @@ class RelatedUniqueDataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     RelatedUniqueDataInclude? include,
@@ -306,8 +298,6 @@ class RelatedUniqueDataRepository {
       where: where?.call(RelatedUniqueData.t),
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -339,8 +329,6 @@ class RelatedUniqueDataRepository {
     _i1.WhereExpressionBuilder<RelatedUniqueDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     RelatedUniqueDataInclude? include,
@@ -351,8 +339,6 @@ class RelatedUniqueDataRepository {
       where: where?.call(RelatedUniqueData.t),
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -562,8 +548,6 @@ class RelatedUniqueDataRepository {
     int? offset,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -574,8 +558,6 @@ class RelatedUniqueDataRepository {
       offset: offset,
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -596,8 +578,6 @@ class RelatedUniqueDataRepository {
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -606,8 +586,6 @@ class RelatedUniqueDataRepository {
       rows,
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -637,8 +615,6 @@ class RelatedUniqueDataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelatedUniqueDataTable> where,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -647,8 +623,6 @@ class RelatedUniqueDataRepository {
       where: where(RelatedUniqueData.t),
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/required/model_with_required_field.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/required/model_with_required_field.dart
@@ -96,8 +96,6 @@ abstract class ModelWithRequiredField
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     ModelWithRequiredFieldInclude? include,
   }) {
@@ -106,8 +104,6 @@ abstract class ModelWithRequiredField
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ModelWithRequiredField.t),
       include: include,
     );
@@ -224,8 +220,6 @@ class ModelWithRequiredFieldIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -270,8 +264,6 @@ class ModelWithRequiredFieldRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -281,8 +273,6 @@ class ModelWithRequiredFieldRepository {
       where: where?.call(ModelWithRequiredField.t),
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -313,8 +303,6 @@ class ModelWithRequiredFieldRepository {
     _i1.WhereExpressionBuilder<ModelWithRequiredFieldTable>? where,
     int? offset,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -324,8 +312,6 @@ class ModelWithRequiredFieldRepository {
       where: where?.call(ModelWithRequiredField.t),
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -532,8 +518,6 @@ class ModelWithRequiredFieldRepository {
     int? offset,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -544,8 +528,6 @@ class ModelWithRequiredFieldRepository {
       offset: offset,
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -566,8 +548,6 @@ class ModelWithRequiredFieldRepository {
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -576,8 +556,6 @@ class ModelWithRequiredFieldRepository {
       rows,
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -607,8 +585,6 @@ class ModelWithRequiredFieldRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ModelWithRequiredFieldTable> where,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -617,8 +593,6 @@ class ModelWithRequiredFieldRepository {
       where: where(ModelWithRequiredField.t),
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/simple_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/simple_data.dart
@@ -82,8 +82,6 @@ abstract class SimpleData
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     SimpleDataInclude? include,
   }) {
@@ -92,8 +90,6 @@ abstract class SimpleData
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(SimpleData.t),
       include: include,
     );
@@ -179,8 +175,6 @@ class SimpleDataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -225,8 +219,6 @@ class SimpleDataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -236,8 +228,6 @@ class SimpleDataRepository {
       where: where?.call(SimpleData.t),
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -268,8 +258,6 @@ class SimpleDataRepository {
     _i1.WhereExpressionBuilder<SimpleDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -279,8 +267,6 @@ class SimpleDataRepository {
       where: where?.call(SimpleData.t),
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -485,8 +471,6 @@ class SimpleDataRepository {
     int? offset,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -497,8 +481,6 @@ class SimpleDataRepository {
       offset: offset,
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -519,8 +501,6 @@ class SimpleDataRepository {
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -529,8 +509,6 @@ class SimpleDataRepository {
       rows,
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -560,8 +538,6 @@ class SimpleDataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SimpleDataTable> where,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -570,8 +546,6 @@ class SimpleDataRepository {
       where: where(SimpleData.t),
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/simple_date_time.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/simple_date_time.dart
@@ -82,8 +82,6 @@ abstract class SimpleDateTime
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     SimpleDateTimeInclude? include,
   }) {
@@ -92,8 +90,6 @@ abstract class SimpleDateTime
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(SimpleDateTime.t),
       include: include,
     );
@@ -179,8 +175,6 @@ class SimpleDateTimeIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -225,8 +219,6 @@ class SimpleDateTimeRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -236,8 +228,6 @@ class SimpleDateTimeRepository {
       where: where?.call(SimpleDateTime.t),
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -268,8 +258,6 @@ class SimpleDateTimeRepository {
     _i1.WhereExpressionBuilder<SimpleDateTimeTable>? where,
     int? offset,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -279,8 +267,6 @@ class SimpleDateTimeRepository {
       where: where?.call(SimpleDateTime.t),
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -485,8 +471,6 @@ class SimpleDateTimeRepository {
     int? offset,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -497,8 +481,6 @@ class SimpleDateTimeRepository {
       offset: offset,
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -519,8 +501,6 @@ class SimpleDateTimeRepository {
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -529,8 +509,6 @@ class SimpleDateTimeRepository {
       rows,
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -560,8 +538,6 @@ class SimpleDateTimeRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SimpleDateTimeTable> where,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -570,8 +546,6 @@ class SimpleDateTimeRepository {
       where: where(SimpleDateTime.t),
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/types.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/types.dart
@@ -334,8 +334,6 @@ abstract class Types implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     TypesInclude? include,
   }) {
@@ -344,8 +342,6 @@ abstract class Types implements _i1.TableRow<int?>, _i2.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Types.t),
       include: include,
     );
@@ -861,8 +857,6 @@ class TypesIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -907,8 +901,6 @@ class TypesRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -918,8 +910,6 @@ class TypesRepository {
       where: where?.call(Types.t),
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -950,8 +940,6 @@ class TypesRepository {
     _i1.WhereExpressionBuilder<TypesTable>? where,
     int? offset,
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -961,8 +949,6 @@ class TypesRepository {
       where: where?.call(Types.t),
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -1167,8 +1153,6 @@ class TypesRepository {
     int? offset,
     _i1.OrderByBuilder<TypesTable>? orderBy,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -1179,8 +1163,6 @@ class TypesRepository {
       offset: offset,
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -1201,8 +1183,6 @@ class TypesRepository {
     _i1.DatabaseSession session,
     List<Types> rows, {
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -1211,8 +1191,6 @@ class TypesRepository {
       rows,
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -1242,8 +1220,6 @@ class TypesRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TypesTable> where,
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -1252,8 +1228,6 @@ class TypesRepository {
       where: where(Types.t),
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/unique_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/unique_data.dart
@@ -86,8 +86,6 @@ abstract class UniqueData
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     UniqueDataInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class UniqueData
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UniqueData.t),
       include: include,
     );
@@ -196,8 +192,6 @@ class UniqueDataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -242,8 +236,6 @@ class UniqueDataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -253,8 +245,6 @@ class UniqueDataRepository {
       where: where?.call(UniqueData.t),
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -285,8 +275,6 @@ class UniqueDataRepository {
     _i1.WhereExpressionBuilder<UniqueDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -296,8 +284,6 @@ class UniqueDataRepository {
       where: where?.call(UniqueData.t),
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -502,8 +488,6 @@ class UniqueDataRepository {
     int? offset,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -514,8 +498,6 @@ class UniqueDataRepository {
       offset: offset,
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -536,8 +518,6 @@ class UniqueDataRepository {
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -546,8 +526,6 @@ class UniqueDataRepository {
       rows,
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -577,8 +555,6 @@ class UniqueDataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UniqueDataTable> where,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -587,8 +563,6 @@ class UniqueDataRepository {
       where: where(UniqueData.t),
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/unique_data_with_non_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/unique_data_with_non_persist.dart
@@ -96,8 +96,6 @@ abstract class UniqueDataWithNonPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     UniqueDataWithNonPersistInclude? include,
   }) {
@@ -106,8 +104,6 @@ abstract class UniqueDataWithNonPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
       include: include,
     );
@@ -212,8 +208,6 @@ class UniqueDataWithNonPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -258,8 +252,6 @@ class UniqueDataWithNonPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -269,8 +261,6 @@ class UniqueDataWithNonPersistRepository {
       where: where?.call(UniqueDataWithNonPersist.t),
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -301,8 +291,6 @@ class UniqueDataWithNonPersistRepository {
     _i1.WhereExpressionBuilder<UniqueDataWithNonPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -312,8 +300,6 @@ class UniqueDataWithNonPersistRepository {
       where: where?.call(UniqueDataWithNonPersist.t),
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -522,8 +508,6 @@ class UniqueDataWithNonPersistRepository {
     int? offset,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -534,8 +518,6 @@ class UniqueDataWithNonPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -556,8 +538,6 @@ class UniqueDataWithNonPersistRepository {
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -566,8 +546,6 @@ class UniqueDataWithNonPersistRepository {
       rows,
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -597,8 +575,6 @@ class UniqueDataWithNonPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UniqueDataWithNonPersistTable> where,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -607,8 +583,6 @@ class UniqueDataWithNonPersistRepository {
       where: where(UniqueDataWithNonPersist.t),
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/test/crud/update_where_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/test/crud/update_where_test.dart
@@ -472,7 +472,7 @@ void main() {
         });
       });
 
-      group('when updating with orderDescending', () {
+      group('when updating in descending order', () {
         late List<Types> updated;
 
         setUp(() async {

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/course.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/course.dart
@@ -101,8 +101,6 @@ abstract class CourseUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CourseUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     CourseUuidInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class CourseUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CourseUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CourseUuid.t),
       include: include,
     );
@@ -249,8 +245,6 @@ class CourseUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -303,8 +297,6 @@ class CourseUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CourseUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     _i1.Transaction? transaction,
     CourseUuidInclude? include,
@@ -315,8 +307,6 @@ class CourseUuidRepository {
       where: where?.call(CourseUuid.t),
       orderBy: orderBy?.call(CourseUuid.t),
       orderByList: orderByList?.call(CourseUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -348,8 +338,6 @@ class CourseUuidRepository {
     _i1.WhereExpressionBuilder<CourseUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<CourseUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     _i1.Transaction? transaction,
     CourseUuidInclude? include,
@@ -360,8 +348,6 @@ class CourseUuidRepository {
       where: where?.call(CourseUuid.t),
       orderBy: orderBy?.call(CourseUuid.t),
       orderByList: orderByList?.call(CourseUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -569,8 +555,6 @@ class CourseUuidRepository {
     int? offset,
     _i1.OrderByBuilder<CourseUuidTable>? orderBy,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -581,8 +565,6 @@ class CourseUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(CourseUuid.t),
       orderByList: orderByList?.call(CourseUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -603,8 +585,6 @@ class CourseUuidRepository {
     _i1.DatabaseSession session,
     List<CourseUuid> rows, {
     _i1.OrderByBuilder<CourseUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -613,8 +593,6 @@ class CourseUuidRepository {
       rows,
       orderBy: orderBy?.call(CourseUuid.t),
       orderByList: orderByList?.call(CourseUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -644,8 +622,6 @@ class CourseUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CourseUuidTable> where,
     _i1.OrderByBuilder<CourseUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -654,8 +630,6 @@ class CourseUuidRepository {
       where: where(CourseUuid.t),
       orderBy: orderBy?.call(CourseUuid.t),
       orderByList: orderByList?.call(CourseUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/enrollment.dart
@@ -124,8 +124,6 @@ abstract class EnrollmentInt
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnrollmentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     EnrollmentIntInclude? include,
   }) {
@@ -134,8 +132,6 @@ abstract class EnrollmentInt
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EnrollmentInt.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EnrollmentInt.t),
       include: include,
     );
@@ -300,8 +296,6 @@ class EnrollmentIntIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -348,8 +342,6 @@ class EnrollmentIntRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnrollmentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     _i1.Transaction? transaction,
     EnrollmentIntInclude? include,
@@ -360,8 +352,6 @@ class EnrollmentIntRepository {
       where: where?.call(EnrollmentInt.t),
       orderBy: orderBy?.call(EnrollmentInt.t),
       orderByList: orderByList?.call(EnrollmentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -393,8 +383,6 @@ class EnrollmentIntRepository {
     _i1.WhereExpressionBuilder<EnrollmentIntTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnrollmentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     _i1.Transaction? transaction,
     EnrollmentIntInclude? include,
@@ -405,8 +393,6 @@ class EnrollmentIntRepository {
       where: where?.call(EnrollmentInt.t),
       orderBy: orderBy?.call(EnrollmentInt.t),
       orderByList: orderByList?.call(EnrollmentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -614,8 +600,6 @@ class EnrollmentIntRepository {
     int? offset,
     _i1.OrderByBuilder<EnrollmentIntTable>? orderBy,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -626,8 +610,6 @@ class EnrollmentIntRepository {
       offset: offset,
       orderBy: orderBy?.call(EnrollmentInt.t),
       orderByList: orderByList?.call(EnrollmentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -648,8 +630,6 @@ class EnrollmentIntRepository {
     _i1.DatabaseSession session,
     List<EnrollmentInt> rows, {
     _i1.OrderByBuilder<EnrollmentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -658,8 +638,6 @@ class EnrollmentIntRepository {
       rows,
       orderBy: orderBy?.call(EnrollmentInt.t),
       orderByList: orderByList?.call(EnrollmentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -689,8 +667,6 @@ class EnrollmentIntRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnrollmentIntTable> where,
     _i1.OrderByBuilder<EnrollmentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -699,8 +675,6 @@ class EnrollmentIntRepository {
       where: where(EnrollmentInt.t),
       orderBy: orderBy?.call(EnrollmentInt.t),
       orderByList: orderByList?.call(EnrollmentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/student.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/student.dart
@@ -101,8 +101,6 @@ abstract class StudentUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StudentUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     StudentUuidInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class StudentUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(StudentUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(StudentUuid.t),
       include: include,
     );
@@ -249,8 +245,6 @@ class StudentUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -299,8 +293,6 @@ class StudentUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StudentUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     _i1.Transaction? transaction,
     StudentUuidInclude? include,
@@ -311,8 +303,6 @@ class StudentUuidRepository {
       where: where?.call(StudentUuid.t),
       orderBy: orderBy?.call(StudentUuid.t),
       orderByList: orderByList?.call(StudentUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -344,8 +334,6 @@ class StudentUuidRepository {
     _i1.WhereExpressionBuilder<StudentUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<StudentUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     _i1.Transaction? transaction,
     StudentUuidInclude? include,
@@ -356,8 +344,6 @@ class StudentUuidRepository {
       where: where?.call(StudentUuid.t),
       orderBy: orderBy?.call(StudentUuid.t),
       orderByList: orderByList?.call(StudentUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -565,8 +551,6 @@ class StudentUuidRepository {
     int? offset,
     _i1.OrderByBuilder<StudentUuidTable>? orderBy,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -577,8 +561,6 @@ class StudentUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(StudentUuid.t),
       orderByList: orderByList?.call(StudentUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -599,8 +581,6 @@ class StudentUuidRepository {
     _i1.DatabaseSession session,
     List<StudentUuid> rows, {
     _i1.OrderByBuilder<StudentUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -609,8 +589,6 @@ class StudentUuidRepository {
       rows,
       orderBy: orderBy?.call(StudentUuid.t),
       orderByList: orderByList?.call(StudentUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -640,8 +618,6 @@ class StudentUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StudentUuidTable> where,
     _i1.OrderByBuilder<StudentUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -650,8 +626,6 @@ class StudentUuidRepository {
       where: where(StudentUuid.t),
       orderBy: orderBy?.call(StudentUuid.t),
       orderByList: orderByList?.call(StudentUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/arena.dart
@@ -93,8 +93,6 @@ abstract class ArenaUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ArenaUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     ArenaUuidInclude? include,
   }) {
@@ -103,8 +101,6 @@ abstract class ArenaUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ArenaUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ArenaUuid.t),
       include: include,
     );
@@ -218,8 +214,6 @@ class ArenaUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -268,8 +262,6 @@ class ArenaUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ArenaUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     _i1.Transaction? transaction,
     ArenaUuidInclude? include,
@@ -280,8 +272,6 @@ class ArenaUuidRepository {
       where: where?.call(ArenaUuid.t),
       orderBy: orderBy?.call(ArenaUuid.t),
       orderByList: orderByList?.call(ArenaUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -313,8 +303,6 @@ class ArenaUuidRepository {
     _i1.WhereExpressionBuilder<ArenaUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<ArenaUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     _i1.Transaction? transaction,
     ArenaUuidInclude? include,
@@ -325,8 +313,6 @@ class ArenaUuidRepository {
       where: where?.call(ArenaUuid.t),
       orderBy: orderBy?.call(ArenaUuid.t),
       orderByList: orderByList?.call(ArenaUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -534,8 +520,6 @@ class ArenaUuidRepository {
     int? offset,
     _i1.OrderByBuilder<ArenaUuidTable>? orderBy,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -546,8 +530,6 @@ class ArenaUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(ArenaUuid.t),
       orderByList: orderByList?.call(ArenaUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -568,8 +550,6 @@ class ArenaUuidRepository {
     _i1.DatabaseSession session,
     List<ArenaUuid> rows, {
     _i1.OrderByBuilder<ArenaUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -578,8 +558,6 @@ class ArenaUuidRepository {
       rows,
       orderBy: orderBy?.call(ArenaUuid.t),
       orderByList: orderByList?.call(ArenaUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -609,8 +587,6 @@ class ArenaUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ArenaUuidTable> where,
     _i1.OrderByBuilder<ArenaUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -619,8 +595,6 @@ class ArenaUuidRepository {
       where: where(ArenaUuid.t),
       orderBy: orderBy?.call(ArenaUuid.t),
       orderByList: orderByList?.call(ArenaUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/player.dart
@@ -101,8 +101,6 @@ abstract class PlayerUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PlayerUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     PlayerUuidInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class PlayerUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(PlayerUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(PlayerUuid.t),
       include: include,
     );
@@ -242,8 +238,6 @@ class PlayerUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -292,8 +286,6 @@ class PlayerUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PlayerUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     _i1.Transaction? transaction,
     PlayerUuidInclude? include,
@@ -304,8 +296,6 @@ class PlayerUuidRepository {
       where: where?.call(PlayerUuid.t),
       orderBy: orderBy?.call(PlayerUuid.t),
       orderByList: orderByList?.call(PlayerUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -337,8 +327,6 @@ class PlayerUuidRepository {
     _i1.WhereExpressionBuilder<PlayerUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<PlayerUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     _i1.Transaction? transaction,
     PlayerUuidInclude? include,
@@ -349,8 +337,6 @@ class PlayerUuidRepository {
       where: where?.call(PlayerUuid.t),
       orderBy: orderBy?.call(PlayerUuid.t),
       orderByList: orderByList?.call(PlayerUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -558,8 +544,6 @@ class PlayerUuidRepository {
     int? offset,
     _i1.OrderByBuilder<PlayerUuidTable>? orderBy,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -570,8 +554,6 @@ class PlayerUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(PlayerUuid.t),
       orderByList: orderByList?.call(PlayerUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -592,8 +574,6 @@ class PlayerUuidRepository {
     _i1.DatabaseSession session,
     List<PlayerUuid> rows, {
     _i1.OrderByBuilder<PlayerUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -602,8 +582,6 @@ class PlayerUuidRepository {
       rows,
       orderBy: orderBy?.call(PlayerUuid.t),
       orderByList: orderByList?.call(PlayerUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -633,8 +611,6 @@ class PlayerUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PlayerUuidTable> where,
     _i1.OrderByBuilder<PlayerUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -643,8 +619,6 @@ class PlayerUuidRepository {
       where: where(PlayerUuid.t),
       orderBy: orderBy?.call(PlayerUuid.t),
       orderByList: orderByList?.call(PlayerUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/nested_one_to_many/team.dart
@@ -124,8 +124,6 @@ abstract class TeamInt
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TeamIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     TeamIntInclude? include,
   }) {
@@ -134,8 +132,6 @@ abstract class TeamInt
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(TeamInt.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(TeamInt.t),
       include: include,
     );
@@ -320,8 +316,6 @@ class TeamIntIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -374,8 +368,6 @@ class TeamIntRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TeamIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     _i1.Transaction? transaction,
     TeamIntInclude? include,
@@ -386,8 +378,6 @@ class TeamIntRepository {
       where: where?.call(TeamInt.t),
       orderBy: orderBy?.call(TeamInt.t),
       orderByList: orderByList?.call(TeamInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -419,8 +409,6 @@ class TeamIntRepository {
     _i1.WhereExpressionBuilder<TeamIntTable>? where,
     int? offset,
     _i1.OrderByBuilder<TeamIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     _i1.Transaction? transaction,
     TeamIntInclude? include,
@@ -431,8 +419,6 @@ class TeamIntRepository {
       where: where?.call(TeamInt.t),
       orderBy: orderBy?.call(TeamInt.t),
       orderByList: orderByList?.call(TeamInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -640,8 +626,6 @@ class TeamIntRepository {
     int? offset,
     _i1.OrderByBuilder<TeamIntTable>? orderBy,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -652,8 +636,6 @@ class TeamIntRepository {
       offset: offset,
       orderBy: orderBy?.call(TeamInt.t),
       orderByList: orderByList?.call(TeamInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -674,8 +656,6 @@ class TeamIntRepository {
     _i1.DatabaseSession session,
     List<TeamInt> rows, {
     _i1.OrderByBuilder<TeamIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -684,8 +664,6 @@ class TeamIntRepository {
       rows,
       orderBy: orderBy?.call(TeamInt.t),
       orderByList: orderByList?.call(TeamInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -715,8 +693,6 @@ class TeamIntRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TeamIntTable> where,
     _i1.OrderByBuilder<TeamIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -725,8 +701,6 @@ class TeamIntRepository {
       where: where(TeamInt.t),
       orderBy: orderBy?.call(TeamInt.t),
       orderByList: orderByList?.call(TeamInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/comment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/comment.dart
@@ -103,8 +103,6 @@ abstract class CommentInt
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CommentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     CommentIntInclude? include,
   }) {
@@ -113,8 +111,6 @@ abstract class CommentInt
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CommentInt.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CommentInt.t),
       include: include,
     );
@@ -245,8 +241,6 @@ class CommentIntIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -293,8 +287,6 @@ class CommentIntRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CommentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     _i1.Transaction? transaction,
     CommentIntInclude? include,
@@ -305,8 +297,6 @@ class CommentIntRepository {
       where: where?.call(CommentInt.t),
       orderBy: orderBy?.call(CommentInt.t),
       orderByList: orderByList?.call(CommentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -338,8 +328,6 @@ class CommentIntRepository {
     _i1.WhereExpressionBuilder<CommentIntTable>? where,
     int? offset,
     _i1.OrderByBuilder<CommentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     _i1.Transaction? transaction,
     CommentIntInclude? include,
@@ -350,8 +338,6 @@ class CommentIntRepository {
       where: where?.call(CommentInt.t),
       orderBy: orderBy?.call(CommentInt.t),
       orderByList: orderByList?.call(CommentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -559,8 +545,6 @@ class CommentIntRepository {
     int? offset,
     _i1.OrderByBuilder<CommentIntTable>? orderBy,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -571,8 +555,6 @@ class CommentIntRepository {
       offset: offset,
       orderBy: orderBy?.call(CommentInt.t),
       orderByList: orderByList?.call(CommentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -593,8 +575,6 @@ class CommentIntRepository {
     _i1.DatabaseSession session,
     List<CommentInt> rows, {
     _i1.OrderByBuilder<CommentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -603,8 +583,6 @@ class CommentIntRepository {
       rows,
       orderBy: orderBy?.call(CommentInt.t),
       orderByList: orderByList?.call(CommentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -634,8 +612,6 @@ class CommentIntRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CommentIntTable> where,
     _i1.OrderByBuilder<CommentIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -644,8 +620,6 @@ class CommentIntRepository {
       where: where(CommentInt.t),
       orderBy: orderBy?.call(CommentInt.t),
       orderByList: orderByList?.call(CommentInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
@@ -95,8 +95,6 @@ abstract class CustomerInt
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CustomerIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     CustomerIntInclude? include,
   }) {
@@ -105,8 +103,6 @@ abstract class CustomerInt
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CustomerInt.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CustomerInt.t),
       include: include,
     );
@@ -243,8 +239,6 @@ class CustomerIntIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -297,8 +291,6 @@ class CustomerIntRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CustomerIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     _i1.Transaction? transaction,
     CustomerIntInclude? include,
@@ -309,8 +301,6 @@ class CustomerIntRepository {
       where: where?.call(CustomerInt.t),
       orderBy: orderBy?.call(CustomerInt.t),
       orderByList: orderByList?.call(CustomerInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -342,8 +332,6 @@ class CustomerIntRepository {
     _i1.WhereExpressionBuilder<CustomerIntTable>? where,
     int? offset,
     _i1.OrderByBuilder<CustomerIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     _i1.Transaction? transaction,
     CustomerIntInclude? include,
@@ -354,8 +342,6 @@ class CustomerIntRepository {
       where: where?.call(CustomerInt.t),
       orderBy: orderBy?.call(CustomerInt.t),
       orderByList: orderByList?.call(CustomerInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -563,8 +549,6 @@ class CustomerIntRepository {
     int? offset,
     _i1.OrderByBuilder<CustomerIntTable>? orderBy,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -575,8 +559,6 @@ class CustomerIntRepository {
       offset: offset,
       orderBy: orderBy?.call(CustomerInt.t),
       orderByList: orderByList?.call(CustomerInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -597,8 +579,6 @@ class CustomerIntRepository {
     _i1.DatabaseSession session,
     List<CustomerInt> rows, {
     _i1.OrderByBuilder<CustomerIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -607,8 +587,6 @@ class CustomerIntRepository {
       rows,
       orderBy: orderBy?.call(CustomerInt.t),
       orderByList: orderByList?.call(CustomerInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -638,8 +616,6 @@ class CustomerIntRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CustomerIntTable> where,
     _i1.OrderByBuilder<CustomerIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -648,8 +624,6 @@ class CustomerIntRepository {
       where: where(CustomerInt.t),
       orderBy: orderBy?.call(CustomerInt.t),
       orderByList: orderByList?.call(CustomerInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/order.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/order.dart
@@ -124,8 +124,6 @@ abstract class OrderUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrderUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     OrderUuidInclude? include,
   }) {
@@ -134,8 +132,6 @@ abstract class OrderUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(OrderUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(OrderUuid.t),
       include: include,
     );
@@ -321,8 +317,6 @@ class OrderUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -371,8 +365,6 @@ class OrderUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrderUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     _i1.Transaction? transaction,
     OrderUuidInclude? include,
@@ -383,8 +375,6 @@ class OrderUuidRepository {
       where: where?.call(OrderUuid.t),
       orderBy: orderBy?.call(OrderUuid.t),
       orderByList: orderByList?.call(OrderUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -416,8 +406,6 @@ class OrderUuidRepository {
     _i1.WhereExpressionBuilder<OrderUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<OrderUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     _i1.Transaction? transaction,
     OrderUuidInclude? include,
@@ -428,8 +416,6 @@ class OrderUuidRepository {
       where: where?.call(OrderUuid.t),
       orderBy: orderBy?.call(OrderUuid.t),
       orderByList: orderByList?.call(OrderUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -637,8 +623,6 @@ class OrderUuidRepository {
     int? offset,
     _i1.OrderByBuilder<OrderUuidTable>? orderBy,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -649,8 +633,6 @@ class OrderUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(OrderUuid.t),
       orderByList: orderByList?.call(OrderUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -671,8 +653,6 @@ class OrderUuidRepository {
     _i1.DatabaseSession session,
     List<OrderUuid> rows, {
     _i1.OrderByBuilder<OrderUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -681,8 +661,6 @@ class OrderUuidRepository {
       rows,
       orderBy: orderBy?.call(OrderUuid.t),
       orderByList: orderByList?.call(OrderUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -712,8 +690,6 @@ class OrderUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrderUuidTable> where,
     _i1.OrderByBuilder<OrderUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -722,8 +698,6 @@ class OrderUuidRepository {
       where: where(OrderUuid.t),
       orderBy: orderBy?.call(OrderUuid.t),
       orderByList: orderByList?.call(OrderUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/address.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/address.dart
@@ -103,8 +103,6 @@ abstract class AddressUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AddressUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     AddressUuidInclude? include,
   }) {
@@ -113,8 +111,6 @@ abstract class AddressUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(AddressUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(AddressUuid.t),
       include: include,
     );
@@ -246,8 +242,6 @@ class AddressUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -296,8 +290,6 @@ class AddressUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AddressUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     _i1.Transaction? transaction,
     AddressUuidInclude? include,
@@ -308,8 +300,6 @@ class AddressUuidRepository {
       where: where?.call(AddressUuid.t),
       orderBy: orderBy?.call(AddressUuid.t),
       orderByList: orderByList?.call(AddressUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -341,8 +331,6 @@ class AddressUuidRepository {
     _i1.WhereExpressionBuilder<AddressUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<AddressUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     _i1.Transaction? transaction,
     AddressUuidInclude? include,
@@ -353,8 +341,6 @@ class AddressUuidRepository {
       where: where?.call(AddressUuid.t),
       orderBy: orderBy?.call(AddressUuid.t),
       orderByList: orderByList?.call(AddressUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -562,8 +548,6 @@ class AddressUuidRepository {
     int? offset,
     _i1.OrderByBuilder<AddressUuidTable>? orderBy,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -574,8 +558,6 @@ class AddressUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(AddressUuid.t),
       orderByList: orderByList?.call(AddressUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -596,8 +578,6 @@ class AddressUuidRepository {
     _i1.DatabaseSession session,
     List<AddressUuid> rows, {
     _i1.OrderByBuilder<AddressUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -606,8 +586,6 @@ class AddressUuidRepository {
       rows,
       orderBy: orderBy?.call(AddressUuid.t),
       orderByList: orderByList?.call(AddressUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -637,8 +615,6 @@ class AddressUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AddressUuidTable> where,
     _i1.OrderByBuilder<AddressUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -647,8 +623,6 @@ class AddressUuidRepository {
       where: where(AddressUuid.t),
       orderBy: orderBy?.call(AddressUuid.t),
       orderByList: orderByList?.call(AddressUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/citizen.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/citizen.dart
@@ -148,8 +148,6 @@ abstract class CitizenInt
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CitizenIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     CitizenIntInclude? include,
   }) {
@@ -158,8 +156,6 @@ abstract class CitizenInt
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CitizenInt.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CitizenInt.t),
       include: include,
     );
@@ -371,8 +367,6 @@ class CitizenIntIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -421,8 +415,6 @@ class CitizenIntRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CitizenIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     _i1.Transaction? transaction,
     CitizenIntInclude? include,
@@ -433,8 +425,6 @@ class CitizenIntRepository {
       where: where?.call(CitizenInt.t),
       orderBy: orderBy?.call(CitizenInt.t),
       orderByList: orderByList?.call(CitizenInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -466,8 +456,6 @@ class CitizenIntRepository {
     _i1.WhereExpressionBuilder<CitizenIntTable>? where,
     int? offset,
     _i1.OrderByBuilder<CitizenIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     _i1.Transaction? transaction,
     CitizenIntInclude? include,
@@ -478,8 +466,6 @@ class CitizenIntRepository {
       where: where?.call(CitizenInt.t),
       orderBy: orderBy?.call(CitizenInt.t),
       orderByList: orderByList?.call(CitizenInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -687,8 +673,6 @@ class CitizenIntRepository {
     int? offset,
     _i1.OrderByBuilder<CitizenIntTable>? orderBy,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -699,8 +683,6 @@ class CitizenIntRepository {
       offset: offset,
       orderBy: orderBy?.call(CitizenInt.t),
       orderByList: orderByList?.call(CitizenInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -721,8 +703,6 @@ class CitizenIntRepository {
     _i1.DatabaseSession session,
     List<CitizenInt> rows, {
     _i1.OrderByBuilder<CitizenIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -731,8 +711,6 @@ class CitizenIntRepository {
       rows,
       orderBy: orderBy?.call(CitizenInt.t),
       orderByList: orderByList?.call(CitizenInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -762,8 +740,6 @@ class CitizenIntRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CitizenIntTable> where,
     _i1.OrderByBuilder<CitizenIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -772,8 +748,6 @@ class CitizenIntRepository {
       where: where(CitizenInt.t),
       orderBy: orderBy?.call(CitizenInt.t),
       orderByList: orderByList?.call(CitizenInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/company.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/company.dart
@@ -101,8 +101,6 @@ abstract class CompanyUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CompanyUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     CompanyUuidInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class CompanyUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CompanyUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CompanyUuid.t),
       include: include,
     );
@@ -242,8 +238,6 @@ class CompanyUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -290,8 +284,6 @@ class CompanyUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CompanyUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     _i1.Transaction? transaction,
     CompanyUuidInclude? include,
@@ -302,8 +294,6 @@ class CompanyUuidRepository {
       where: where?.call(CompanyUuid.t),
       orderBy: orderBy?.call(CompanyUuid.t),
       orderByList: orderByList?.call(CompanyUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -335,8 +325,6 @@ class CompanyUuidRepository {
     _i1.WhereExpressionBuilder<CompanyUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<CompanyUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     _i1.Transaction? transaction,
     CompanyUuidInclude? include,
@@ -347,8 +335,6 @@ class CompanyUuidRepository {
       where: where?.call(CompanyUuid.t),
       orderBy: orderBy?.call(CompanyUuid.t),
       orderByList: orderByList?.call(CompanyUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -556,8 +542,6 @@ class CompanyUuidRepository {
     int? offset,
     _i1.OrderByBuilder<CompanyUuidTable>? orderBy,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -568,8 +552,6 @@ class CompanyUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(CompanyUuid.t),
       orderByList: orderByList?.call(CompanyUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -590,8 +572,6 @@ class CompanyUuidRepository {
     _i1.DatabaseSession session,
     List<CompanyUuid> rows, {
     _i1.OrderByBuilder<CompanyUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -600,8 +580,6 @@ class CompanyUuidRepository {
       rows,
       orderBy: orderBy?.call(CompanyUuid.t),
       orderByList: orderByList?.call(CompanyUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -631,8 +609,6 @@ class CompanyUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CompanyUuidTable> where,
     _i1.OrderByBuilder<CompanyUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -641,8 +617,6 @@ class CompanyUuidRepository {
       where: where(CompanyUuid.t),
       orderBy: orderBy?.call(CompanyUuid.t),
       orderByList: orderByList?.call(CompanyUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/town.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_one/town.dart
@@ -101,8 +101,6 @@ abstract class TownInt
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TownIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     TownIntInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class TownInt
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(TownInt.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(TownInt.t),
       include: include,
     );
@@ -242,8 +238,6 @@ class TownIntIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -292,8 +286,6 @@ class TownIntRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TownIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     _i1.Transaction? transaction,
     TownIntInclude? include,
@@ -304,8 +296,6 @@ class TownIntRepository {
       where: where?.call(TownInt.t),
       orderBy: orderBy?.call(TownInt.t),
       orderByList: orderByList?.call(TownInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -337,8 +327,6 @@ class TownIntRepository {
     _i1.WhereExpressionBuilder<TownIntTable>? where,
     int? offset,
     _i1.OrderByBuilder<TownIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     _i1.Transaction? transaction,
     TownIntInclude? include,
@@ -349,8 +337,6 @@ class TownIntRepository {
       where: where?.call(TownInt.t),
       orderBy: orderBy?.call(TownInt.t),
       orderByList: orderByList?.call(TownInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -558,8 +544,6 @@ class TownIntRepository {
     int? offset,
     _i1.OrderByBuilder<TownIntTable>? orderBy,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -570,8 +554,6 @@ class TownIntRepository {
       offset: offset,
       orderBy: orderBy?.call(TownInt.t),
       orderByList: orderByList?.call(TownInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -592,8 +574,6 @@ class TownIntRepository {
     _i1.DatabaseSession session,
     List<TownInt> rows, {
     _i1.OrderByBuilder<TownIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -602,8 +582,6 @@ class TownIntRepository {
       rows,
       orderBy: orderBy?.call(TownInt.t),
       orderByList: orderByList?.call(TownInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -633,8 +611,6 @@ class TownIntRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TownIntTable> where,
     _i1.OrderByBuilder<TownIntTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownIntTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -643,8 +619,6 @@ class TownIntRepository {
       where: where(TownInt.t),
       orderBy: orderBy?.call(TownInt.t),
       orderByList: orderByList?.call(TownInt.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/self.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/self.dart
@@ -163,8 +163,6 @@ abstract class ChangedIdTypeSelf
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChangedIdTypeSelfTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     ChangedIdTypeSelfInclude? include,
   }) {
@@ -173,8 +171,6 @@ abstract class ChangedIdTypeSelf
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ChangedIdTypeSelf.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ChangedIdTypeSelf.t),
       include: include,
     );
@@ -437,8 +433,6 @@ class ChangedIdTypeSelfIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -491,8 +485,6 @@ class ChangedIdTypeSelfRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChangedIdTypeSelfTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     _i1.Transaction? transaction,
     ChangedIdTypeSelfInclude? include,
@@ -503,8 +495,6 @@ class ChangedIdTypeSelfRepository {
       where: where?.call(ChangedIdTypeSelf.t),
       orderBy: orderBy?.call(ChangedIdTypeSelf.t),
       orderByList: orderByList?.call(ChangedIdTypeSelf.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -536,8 +526,6 @@ class ChangedIdTypeSelfRepository {
     _i1.WhereExpressionBuilder<ChangedIdTypeSelfTable>? where,
     int? offset,
     _i1.OrderByBuilder<ChangedIdTypeSelfTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     _i1.Transaction? transaction,
     ChangedIdTypeSelfInclude? include,
@@ -548,8 +536,6 @@ class ChangedIdTypeSelfRepository {
       where: where?.call(ChangedIdTypeSelf.t),
       orderBy: orderBy?.call(ChangedIdTypeSelf.t),
       orderByList: orderByList?.call(ChangedIdTypeSelf.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -759,8 +745,6 @@ class ChangedIdTypeSelfRepository {
     int? offset,
     _i1.OrderByBuilder<ChangedIdTypeSelfTable>? orderBy,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -771,8 +755,6 @@ class ChangedIdTypeSelfRepository {
       offset: offset,
       orderBy: orderBy?.call(ChangedIdTypeSelf.t),
       orderByList: orderByList?.call(ChangedIdTypeSelf.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -793,8 +775,6 @@ class ChangedIdTypeSelfRepository {
     _i1.DatabaseSession session,
     List<ChangedIdTypeSelf> rows, {
     _i1.OrderByBuilder<ChangedIdTypeSelfTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -803,8 +783,6 @@ class ChangedIdTypeSelfRepository {
       rows,
       orderBy: orderBy?.call(ChangedIdTypeSelf.t),
       orderByList: orderByList?.call(ChangedIdTypeSelf.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -834,8 +812,6 @@ class ChangedIdTypeSelfRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChangedIdTypeSelfTable> where,
     _i1.OrderByBuilder<ChangedIdTypeSelfTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChangedIdTypeSelfTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -844,8 +820,6 @@ class ChangedIdTypeSelfRepository {
       where: where(ChangedIdTypeSelf.t),
       orderBy: orderBy?.call(ChangedIdTypeSelf.t),
       orderByList: orderByList?.call(ChangedIdTypeSelf.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/server_only.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/server_only.dart
@@ -65,8 +65,6 @@ abstract class ServerOnlyChangedIdFieldClass
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServerOnlyChangedIdFieldClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     ServerOnlyChangedIdFieldClassInclude? include,
   }) {
@@ -75,8 +73,6 @@ abstract class ServerOnlyChangedIdFieldClass
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ServerOnlyChangedIdFieldClass.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ServerOnlyChangedIdFieldClass.t),
       include: include,
     );
@@ -137,8 +133,6 @@ class ServerOnlyChangedIdFieldClassIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -183,8 +177,6 @@ class ServerOnlyChangedIdFieldClassRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServerOnlyChangedIdFieldClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -194,8 +186,6 @@ class ServerOnlyChangedIdFieldClassRepository {
       where: where?.call(ServerOnlyChangedIdFieldClass.t),
       orderBy: orderBy?.call(ServerOnlyChangedIdFieldClass.t),
       orderByList: orderByList?.call(ServerOnlyChangedIdFieldClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -226,8 +216,6 @@ class ServerOnlyChangedIdFieldClassRepository {
     _i1.WhereExpressionBuilder<ServerOnlyChangedIdFieldClassTable>? where,
     int? offset,
     _i1.OrderByBuilder<ServerOnlyChangedIdFieldClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -237,8 +225,6 @@ class ServerOnlyChangedIdFieldClassRepository {
       where: where?.call(ServerOnlyChangedIdFieldClass.t),
       orderBy: orderBy?.call(ServerOnlyChangedIdFieldClass.t),
       orderByList: orderByList?.call(ServerOnlyChangedIdFieldClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -452,8 +438,6 @@ class ServerOnlyChangedIdFieldClassRepository {
     int? offset,
     _i1.OrderByBuilder<ServerOnlyChangedIdFieldClassTable>? orderBy,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -464,8 +448,6 @@ class ServerOnlyChangedIdFieldClassRepository {
       offset: offset,
       orderBy: orderBy?.call(ServerOnlyChangedIdFieldClass.t),
       orderByList: orderByList?.call(ServerOnlyChangedIdFieldClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -486,8 +468,6 @@ class ServerOnlyChangedIdFieldClassRepository {
     _i1.DatabaseSession session,
     List<ServerOnlyChangedIdFieldClass> rows, {
     _i1.OrderByBuilder<ServerOnlyChangedIdFieldClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -496,8 +476,6 @@ class ServerOnlyChangedIdFieldClassRepository {
       rows,
       orderBy: orderBy?.call(ServerOnlyChangedIdFieldClass.t),
       orderByList: orderByList?.call(ServerOnlyChangedIdFieldClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -528,8 +506,6 @@ class ServerOnlyChangedIdFieldClassRepository {
     required _i1.WhereExpressionBuilder<ServerOnlyChangedIdFieldClassTable>
     where,
     _i1.OrderByBuilder<ServerOnlyChangedIdFieldClassTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServerOnlyChangedIdFieldClassTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -538,8 +514,6 @@ class ServerOnlyChangedIdFieldClassRepository {
       where: where(ServerOnlyChangedIdFieldClass.t),
       orderBy: orderBy?.call(ServerOnlyChangedIdFieldClass.t),
       orderByList: orderByList?.call(ServerOnlyChangedIdFieldClass.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default.dart
@@ -98,8 +98,6 @@ abstract class BigIntDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     BigIntDefaultInclude? include,
   }) {
@@ -108,8 +106,6 @@ abstract class BigIntDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BigIntDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BigIntDefault.t),
       include: include,
     );
@@ -215,8 +211,6 @@ class BigIntDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -261,8 +255,6 @@ class BigIntDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -272,8 +264,6 @@ class BigIntDefaultRepository {
       where: where?.call(BigIntDefault.t),
       orderBy: orderBy?.call(BigIntDefault.t),
       orderByList: orderByList?.call(BigIntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -304,8 +294,6 @@ class BigIntDefaultRepository {
     _i1.WhereExpressionBuilder<BigIntDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -315,8 +303,6 @@ class BigIntDefaultRepository {
       where: where?.call(BigIntDefault.t),
       orderBy: orderBy?.call(BigIntDefault.t),
       orderByList: orderByList?.call(BigIntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -521,8 +507,6 @@ class BigIntDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultTable>? orderBy,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -533,8 +517,6 @@ class BigIntDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(BigIntDefault.t),
       orderByList: orderByList?.call(BigIntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -555,8 +537,6 @@ class BigIntDefaultRepository {
     _i1.DatabaseSession session,
     List<BigIntDefault> rows, {
     _i1.OrderByBuilder<BigIntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -565,8 +545,6 @@ class BigIntDefaultRepository {
       rows,
       orderBy: orderBy?.call(BigIntDefault.t),
       orderByList: orderByList?.call(BigIntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -596,8 +574,6 @@ class BigIntDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultTable> where,
     _i1.OrderByBuilder<BigIntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -606,8 +582,6 @@ class BigIntDefaultRepository {
       where: where(BigIntDefault.t),
       orderBy: orderBy?.call(BigIntDefault.t),
       orderByList: orderByList?.call(BigIntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default_mix.dart
@@ -117,8 +117,6 @@ abstract class BigIntDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     BigIntDefaultMixInclude? include,
   }) {
@@ -127,8 +125,6 @@ abstract class BigIntDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BigIntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BigIntDefaultMix.t),
       include: include,
     );
@@ -258,8 +254,6 @@ class BigIntDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -304,8 +298,6 @@ class BigIntDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -315,8 +307,6 @@ class BigIntDefaultMixRepository {
       where: where?.call(BigIntDefaultMix.t),
       orderBy: orderBy?.call(BigIntDefaultMix.t),
       orderByList: orderByList?.call(BigIntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -347,8 +337,6 @@ class BigIntDefaultMixRepository {
     _i1.WhereExpressionBuilder<BigIntDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -358,8 +346,6 @@ class BigIntDefaultMixRepository {
       where: where?.call(BigIntDefaultMix.t),
       orderBy: orderBy?.call(BigIntDefaultMix.t),
       orderByList: orderByList?.call(BigIntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -566,8 +552,6 @@ class BigIntDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -578,8 +562,6 @@ class BigIntDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(BigIntDefaultMix.t),
       orderByList: orderByList?.call(BigIntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -600,8 +582,6 @@ class BigIntDefaultMixRepository {
     _i1.DatabaseSession session,
     List<BigIntDefaultMix> rows, {
     _i1.OrderByBuilder<BigIntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -610,8 +590,6 @@ class BigIntDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(BigIntDefaultMix.t),
       orderByList: orderByList?.call(BigIntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -641,8 +619,6 @@ class BigIntDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultMixTable> where,
     _i1.OrderByBuilder<BigIntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -651,8 +627,6 @@ class BigIntDefaultMixRepository {
       where: where(BigIntDefaultMix.t),
       orderBy: orderBy?.call(BigIntDefaultMix.t),
       orderByList: orderByList?.call(BigIntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default_model.dart
@@ -101,8 +101,6 @@ abstract class BigIntDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     BigIntDefaultModelInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class BigIntDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BigIntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BigIntDefaultModel.t),
       include: include,
     );
@@ -218,8 +214,6 @@ class BigIntDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -264,8 +258,6 @@ class BigIntDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -275,8 +267,6 @@ class BigIntDefaultModelRepository {
       where: where?.call(BigIntDefaultModel.t),
       orderBy: orderBy?.call(BigIntDefaultModel.t),
       orderByList: orderByList?.call(BigIntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -307,8 +297,6 @@ class BigIntDefaultModelRepository {
     _i1.WhereExpressionBuilder<BigIntDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -318,8 +306,6 @@ class BigIntDefaultModelRepository {
       where: where?.call(BigIntDefaultModel.t),
       orderBy: orderBy?.call(BigIntDefaultModel.t),
       orderByList: orderByList?.call(BigIntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -526,8 +512,6 @@ class BigIntDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -538,8 +522,6 @@ class BigIntDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(BigIntDefaultModel.t),
       orderByList: orderByList?.call(BigIntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -560,8 +542,6 @@ class BigIntDefaultModelRepository {
     _i1.DatabaseSession session,
     List<BigIntDefaultModel> rows, {
     _i1.OrderByBuilder<BigIntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -570,8 +550,6 @@ class BigIntDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(BigIntDefaultModel.t),
       orderByList: orderByList?.call(BigIntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -601,8 +579,6 @@ class BigIntDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultModelTable> where,
     _i1.OrderByBuilder<BigIntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -611,8 +587,6 @@ class BigIntDefaultModelRepository {
       where: where(BigIntDefaultModel.t),
       orderBy: orderBy?.call(BigIntDefaultModel.t),
       orderByList: orderByList?.call(BigIntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/bigint/bigint_default_persist.dart
@@ -86,8 +86,6 @@ abstract class BigIntDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     BigIntDefaultPersistInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class BigIntDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BigIntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BigIntDefaultPersist.t),
       include: include,
     );
@@ -186,8 +182,6 @@ class BigIntDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -232,8 +226,6 @@ class BigIntDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -243,8 +235,6 @@ class BigIntDefaultPersistRepository {
       where: where?.call(BigIntDefaultPersist.t),
       orderBy: orderBy?.call(BigIntDefaultPersist.t),
       orderByList: orderByList?.call(BigIntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -275,8 +265,6 @@ class BigIntDefaultPersistRepository {
     _i1.WhereExpressionBuilder<BigIntDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -286,8 +274,6 @@ class BigIntDefaultPersistRepository {
       where: where?.call(BigIntDefaultPersist.t),
       orderBy: orderBy?.call(BigIntDefaultPersist.t),
       orderByList: orderByList?.call(BigIntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -494,8 +480,6 @@ class BigIntDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<BigIntDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -506,8 +490,6 @@ class BigIntDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(BigIntDefaultPersist.t),
       orderByList: orderByList?.call(BigIntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -528,8 +510,6 @@ class BigIntDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<BigIntDefaultPersist> rows, {
     _i1.OrderByBuilder<BigIntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -538,8 +518,6 @@ class BigIntDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(BigIntDefaultPersist.t),
       orderByList: orderByList?.call(BigIntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -569,8 +547,6 @@ class BigIntDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BigIntDefaultPersistTable> where,
     _i1.OrderByBuilder<BigIntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BigIntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -579,8 +555,6 @@ class BigIntDefaultPersistRepository {
       where: where(BigIntDefaultPersist.t),
       orderBy: orderBy?.call(BigIntDefaultPersist.t),
       orderByList: orderByList?.call(BigIntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default.dart
@@ -109,8 +109,6 @@ abstract class BoolDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     BoolDefaultInclude? include,
   }) {
@@ -119,8 +117,6 @@ abstract class BoolDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BoolDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BoolDefault.t),
       include: include,
     );
@@ -241,8 +237,6 @@ class BoolDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -287,8 +281,6 @@ class BoolDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -298,8 +290,6 @@ class BoolDefaultRepository {
       where: where?.call(BoolDefault.t),
       orderBy: orderBy?.call(BoolDefault.t),
       orderByList: orderByList?.call(BoolDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -330,8 +320,6 @@ class BoolDefaultRepository {
     _i1.WhereExpressionBuilder<BoolDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -341,8 +329,6 @@ class BoolDefaultRepository {
       where: where?.call(BoolDefault.t),
       orderBy: orderBy?.call(BoolDefault.t),
       orderByList: orderByList?.call(BoolDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -547,8 +533,6 @@ class BoolDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<BoolDefaultTable>? orderBy,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -559,8 +543,6 @@ class BoolDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(BoolDefault.t),
       orderByList: orderByList?.call(BoolDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -581,8 +563,6 @@ class BoolDefaultRepository {
     _i1.DatabaseSession session,
     List<BoolDefault> rows, {
     _i1.OrderByBuilder<BoolDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -591,8 +571,6 @@ class BoolDefaultRepository {
       rows,
       orderBy: orderBy?.call(BoolDefault.t),
       orderByList: orderByList?.call(BoolDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -622,8 +600,6 @@ class BoolDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultTable> where,
     _i1.OrderByBuilder<BoolDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -632,8 +608,6 @@ class BoolDefaultRepository {
       where: where(BoolDefault.t),
       orderBy: orderBy?.call(BoolDefault.t),
       orderByList: orderByList?.call(BoolDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default_mix.dart
@@ -111,8 +111,6 @@ abstract class BoolDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     BoolDefaultMixInclude? include,
   }) {
@@ -121,8 +119,6 @@ abstract class BoolDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BoolDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BoolDefaultMix.t),
       include: include,
     );
@@ -248,8 +244,6 @@ class BoolDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -294,8 +288,6 @@ class BoolDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -305,8 +297,6 @@ class BoolDefaultMixRepository {
       where: where?.call(BoolDefaultMix.t),
       orderBy: orderBy?.call(BoolDefaultMix.t),
       orderByList: orderByList?.call(BoolDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -337,8 +327,6 @@ class BoolDefaultMixRepository {
     _i1.WhereExpressionBuilder<BoolDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -348,8 +336,6 @@ class BoolDefaultMixRepository {
       where: where?.call(BoolDefaultMix.t),
       orderBy: orderBy?.call(BoolDefaultMix.t),
       orderByList: orderByList?.call(BoolDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -554,8 +540,6 @@ class BoolDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<BoolDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -566,8 +550,6 @@ class BoolDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(BoolDefaultMix.t),
       orderByList: orderByList?.call(BoolDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -588,8 +570,6 @@ class BoolDefaultMixRepository {
     _i1.DatabaseSession session,
     List<BoolDefaultMix> rows, {
     _i1.OrderByBuilder<BoolDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -598,8 +578,6 @@ class BoolDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(BoolDefaultMix.t),
       orderByList: orderByList?.call(BoolDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -629,8 +607,6 @@ class BoolDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultMixTable> where,
     _i1.OrderByBuilder<BoolDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -639,8 +615,6 @@ class BoolDefaultMixRepository {
       where: where(BoolDefaultMix.t),
       orderBy: orderBy?.call(BoolDefaultMix.t),
       orderByList: orderByList?.call(BoolDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default_model.dart
@@ -108,8 +108,6 @@ abstract class BoolDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     BoolDefaultModelInclude? include,
   }) {
@@ -118,8 +116,6 @@ abstract class BoolDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BoolDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BoolDefaultModel.t),
       include: include,
     );
@@ -241,8 +237,6 @@ class BoolDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -287,8 +281,6 @@ class BoolDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -298,8 +290,6 @@ class BoolDefaultModelRepository {
       where: where?.call(BoolDefaultModel.t),
       orderBy: orderBy?.call(BoolDefaultModel.t),
       orderByList: orderByList?.call(BoolDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -330,8 +320,6 @@ class BoolDefaultModelRepository {
     _i1.WhereExpressionBuilder<BoolDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -341,8 +329,6 @@ class BoolDefaultModelRepository {
       where: where?.call(BoolDefaultModel.t),
       orderBy: orderBy?.call(BoolDefaultModel.t),
       orderByList: orderByList?.call(BoolDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -549,8 +535,6 @@ class BoolDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<BoolDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -561,8 +545,6 @@ class BoolDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(BoolDefaultModel.t),
       orderByList: orderByList?.call(BoolDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -583,8 +565,6 @@ class BoolDefaultModelRepository {
     _i1.DatabaseSession session,
     List<BoolDefaultModel> rows, {
     _i1.OrderByBuilder<BoolDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -593,8 +573,6 @@ class BoolDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(BoolDefaultModel.t),
       orderByList: orderByList?.call(BoolDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -624,8 +602,6 @@ class BoolDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultModelTable> where,
     _i1.OrderByBuilder<BoolDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -634,8 +610,6 @@ class BoolDefaultModelRepository {
       where: where(BoolDefaultModel.t),
       orderBy: orderBy?.call(BoolDefaultModel.t),
       orderByList: orderByList?.call(BoolDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/boolean/bool_default_persist.dart
@@ -99,8 +99,6 @@ abstract class BoolDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     BoolDefaultPersistInclude? include,
   }) {
@@ -109,8 +107,6 @@ abstract class BoolDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(BoolDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(BoolDefaultPersist.t),
       include: include,
     );
@@ -219,8 +215,6 @@ class BoolDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -265,8 +259,6 @@ class BoolDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -276,8 +268,6 @@ class BoolDefaultPersistRepository {
       where: where?.call(BoolDefaultPersist.t),
       orderBy: orderBy?.call(BoolDefaultPersist.t),
       orderByList: orderByList?.call(BoolDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -308,8 +298,6 @@ class BoolDefaultPersistRepository {
     _i1.WhereExpressionBuilder<BoolDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<BoolDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -319,8 +307,6 @@ class BoolDefaultPersistRepository {
       where: where?.call(BoolDefaultPersist.t),
       orderBy: orderBy?.call(BoolDefaultPersist.t),
       orderByList: orderByList?.call(BoolDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -527,8 +513,6 @@ class BoolDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<BoolDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -539,8 +523,6 @@ class BoolDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(BoolDefaultPersist.t),
       orderByList: orderByList?.call(BoolDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -561,8 +543,6 @@ class BoolDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<BoolDefaultPersist> rows, {
     _i1.OrderByBuilder<BoolDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -571,8 +551,6 @@ class BoolDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(BoolDefaultPersist.t),
       orderByList: orderByList?.call(BoolDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -602,8 +580,6 @@ class BoolDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BoolDefaultPersistTable> where,
     _i1.OrderByBuilder<BoolDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BoolDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -612,8 +588,6 @@ class BoolDefaultPersistRepository {
       where: where(BoolDefaultPersist.t),
       orderBy: orderBy?.call(BoolDefaultPersist.t),
       orderByList: orderByList?.call(BoolDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default.dart
@@ -112,8 +112,6 @@ abstract class DateTimeDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     DateTimeDefaultInclude? include,
   }) {
@@ -122,8 +120,6 @@ abstract class DateTimeDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DateTimeDefault.t),
       include: include,
     );
@@ -247,8 +243,6 @@ class DateTimeDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -293,8 +287,6 @@ class DateTimeDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -304,8 +296,6 @@ class DateTimeDefaultRepository {
       where: where?.call(DateTimeDefault.t),
       orderBy: orderBy?.call(DateTimeDefault.t),
       orderByList: orderByList?.call(DateTimeDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -336,8 +326,6 @@ class DateTimeDefaultRepository {
     _i1.WhereExpressionBuilder<DateTimeDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -347,8 +335,6 @@ class DateTimeDefaultRepository {
       where: where?.call(DateTimeDefault.t),
       orderBy: orderBy?.call(DateTimeDefault.t),
       orderByList: orderByList?.call(DateTimeDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -555,8 +541,6 @@ class DateTimeDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultTable>? orderBy,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -567,8 +551,6 @@ class DateTimeDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefault.t),
       orderByList: orderByList?.call(DateTimeDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -589,8 +571,6 @@ class DateTimeDefaultRepository {
     _i1.DatabaseSession session,
     List<DateTimeDefault> rows, {
     _i1.OrderByBuilder<DateTimeDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -599,8 +579,6 @@ class DateTimeDefaultRepository {
       rows,
       orderBy: orderBy?.call(DateTimeDefault.t),
       orderByList: orderByList?.call(DateTimeDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -630,8 +608,6 @@ class DateTimeDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultTable> where,
     _i1.OrderByBuilder<DateTimeDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -640,8 +616,6 @@ class DateTimeDefaultRepository {
       where: where(DateTimeDefault.t),
       orderBy: orderBy?.call(DateTimeDefault.t),
       orderByList: orderByList?.call(DateTimeDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default_mix.dart
@@ -120,8 +120,6 @@ abstract class DateTimeDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     DateTimeDefaultMixInclude? include,
   }) {
@@ -130,8 +128,6 @@ abstract class DateTimeDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DateTimeDefaultMix.t),
       include: include,
     );
@@ -263,8 +259,6 @@ class DateTimeDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -309,8 +303,6 @@ class DateTimeDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -320,8 +312,6 @@ class DateTimeDefaultMixRepository {
       where: where?.call(DateTimeDefaultMix.t),
       orderBy: orderBy?.call(DateTimeDefaultMix.t),
       orderByList: orderByList?.call(DateTimeDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -352,8 +342,6 @@ class DateTimeDefaultMixRepository {
     _i1.WhereExpressionBuilder<DateTimeDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -363,8 +351,6 @@ class DateTimeDefaultMixRepository {
       where: where?.call(DateTimeDefaultMix.t),
       orderBy: orderBy?.call(DateTimeDefaultMix.t),
       orderByList: orderByList?.call(DateTimeDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -571,8 +557,6 @@ class DateTimeDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -583,8 +567,6 @@ class DateTimeDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefaultMix.t),
       orderByList: orderByList?.call(DateTimeDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -605,8 +587,6 @@ class DateTimeDefaultMixRepository {
     _i1.DatabaseSession session,
     List<DateTimeDefaultMix> rows, {
     _i1.OrderByBuilder<DateTimeDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -615,8 +595,6 @@ class DateTimeDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(DateTimeDefaultMix.t),
       orderByList: orderByList?.call(DateTimeDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -646,8 +624,6 @@ class DateTimeDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultMixTable> where,
     _i1.OrderByBuilder<DateTimeDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -656,8 +632,6 @@ class DateTimeDefaultMixRepository {
       where: where(DateTimeDefaultMix.t),
       orderBy: orderBy?.call(DateTimeDefaultMix.t),
       orderByList: orderByList?.call(DateTimeDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default_model.dart
@@ -118,8 +118,6 @@ abstract class DateTimeDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     DateTimeDefaultModelInclude? include,
   }) {
@@ -128,8 +126,6 @@ abstract class DateTimeDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DateTimeDefaultModel.t),
       include: include,
     );
@@ -254,8 +250,6 @@ class DateTimeDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -300,8 +294,6 @@ class DateTimeDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -311,8 +303,6 @@ class DateTimeDefaultModelRepository {
       where: where?.call(DateTimeDefaultModel.t),
       orderBy: orderBy?.call(DateTimeDefaultModel.t),
       orderByList: orderByList?.call(DateTimeDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -343,8 +333,6 @@ class DateTimeDefaultModelRepository {
     _i1.WhereExpressionBuilder<DateTimeDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -354,8 +342,6 @@ class DateTimeDefaultModelRepository {
       where: where?.call(DateTimeDefaultModel.t),
       orderBy: orderBy?.call(DateTimeDefaultModel.t),
       orderByList: orderByList?.call(DateTimeDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -562,8 +548,6 @@ class DateTimeDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -574,8 +558,6 @@ class DateTimeDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefaultModel.t),
       orderByList: orderByList?.call(DateTimeDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -596,8 +578,6 @@ class DateTimeDefaultModelRepository {
     _i1.DatabaseSession session,
     List<DateTimeDefaultModel> rows, {
     _i1.OrderByBuilder<DateTimeDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -606,8 +586,6 @@ class DateTimeDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(DateTimeDefaultModel.t),
       orderByList: orderByList?.call(DateTimeDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -637,8 +615,6 @@ class DateTimeDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultModelTable> where,
     _i1.OrderByBuilder<DateTimeDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -647,8 +623,6 @@ class DateTimeDefaultModelRepository {
       where: where(DateTimeDefaultModel.t),
       orderBy: orderBy?.call(DateTimeDefaultModel.t),
       orderByList: orderByList?.call(DateTimeDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/datetime/datetime_default_persist.dart
@@ -101,8 +101,6 @@ abstract class DateTimeDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     DateTimeDefaultPersistInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class DateTimeDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DateTimeDefaultPersist.t),
       include: include,
     );
@@ -223,8 +219,6 @@ class DateTimeDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -269,8 +263,6 @@ class DateTimeDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -280,8 +272,6 @@ class DateTimeDefaultPersistRepository {
       where: where?.call(DateTimeDefaultPersist.t),
       orderBy: orderBy?.call(DateTimeDefaultPersist.t),
       orderByList: orderByList?.call(DateTimeDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -312,8 +302,6 @@ class DateTimeDefaultPersistRepository {
     _i1.WhereExpressionBuilder<DateTimeDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -323,8 +311,6 @@ class DateTimeDefaultPersistRepository {
       where: where?.call(DateTimeDefaultPersist.t),
       orderBy: orderBy?.call(DateTimeDefaultPersist.t),
       orderByList: orderByList?.call(DateTimeDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -531,8 +517,6 @@ class DateTimeDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<DateTimeDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -543,8 +527,6 @@ class DateTimeDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(DateTimeDefaultPersist.t),
       orderByList: orderByList?.call(DateTimeDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -565,8 +547,6 @@ class DateTimeDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<DateTimeDefaultPersist> rows, {
     _i1.OrderByBuilder<DateTimeDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -575,8 +555,6 @@ class DateTimeDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(DateTimeDefaultPersist.t),
       orderByList: orderByList?.call(DateTimeDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -606,8 +584,6 @@ class DateTimeDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DateTimeDefaultPersistTable> where,
     _i1.OrderByBuilder<DateTimeDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DateTimeDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -616,8 +592,6 @@ class DateTimeDefaultPersistRepository {
       where: where(DateTimeDefaultPersist.t),
       orderBy: orderBy?.call(DateTimeDefaultPersist.t),
       orderByList: orderByList?.call(DateTimeDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default.dart
@@ -87,8 +87,6 @@ abstract class DoubleDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     DoubleDefaultInclude? include,
   }) {
@@ -97,8 +95,6 @@ abstract class DoubleDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DoubleDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DoubleDefault.t),
       include: include,
     );
@@ -204,8 +200,6 @@ class DoubleDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -250,8 +244,6 @@ class DoubleDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -261,8 +253,6 @@ class DoubleDefaultRepository {
       where: where?.call(DoubleDefault.t),
       orderBy: orderBy?.call(DoubleDefault.t),
       orderByList: orderByList?.call(DoubleDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -293,8 +283,6 @@ class DoubleDefaultRepository {
     _i1.WhereExpressionBuilder<DoubleDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -304,8 +292,6 @@ class DoubleDefaultRepository {
       where: where?.call(DoubleDefault.t),
       orderBy: orderBy?.call(DoubleDefault.t),
       orderByList: orderByList?.call(DoubleDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -510,8 +496,6 @@ class DoubleDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultTable>? orderBy,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -522,8 +506,6 @@ class DoubleDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(DoubleDefault.t),
       orderByList: orderByList?.call(DoubleDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -544,8 +526,6 @@ class DoubleDefaultRepository {
     _i1.DatabaseSession session,
     List<DoubleDefault> rows, {
     _i1.OrderByBuilder<DoubleDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -554,8 +534,6 @@ class DoubleDefaultRepository {
       rows,
       orderBy: orderBy?.call(DoubleDefault.t),
       orderByList: orderByList?.call(DoubleDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -585,8 +563,6 @@ class DoubleDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultTable> where,
     _i1.OrderByBuilder<DoubleDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -595,8 +571,6 @@ class DoubleDefaultRepository {
       where: where(DoubleDefault.t),
       orderBy: orderBy?.call(DoubleDefault.t),
       orderByList: orderByList?.call(DoubleDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default_mix.dart
@@ -104,8 +104,6 @@ abstract class DoubleDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     DoubleDefaultMixInclude? include,
   }) {
@@ -114,8 +112,6 @@ abstract class DoubleDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DoubleDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DoubleDefaultMix.t),
       include: include,
     );
@@ -245,8 +241,6 @@ class DoubleDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -291,8 +285,6 @@ class DoubleDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -302,8 +294,6 @@ class DoubleDefaultMixRepository {
       where: where?.call(DoubleDefaultMix.t),
       orderBy: orderBy?.call(DoubleDefaultMix.t),
       orderByList: orderByList?.call(DoubleDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -334,8 +324,6 @@ class DoubleDefaultMixRepository {
     _i1.WhereExpressionBuilder<DoubleDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -345,8 +333,6 @@ class DoubleDefaultMixRepository {
       where: where?.call(DoubleDefaultMix.t),
       orderBy: orderBy?.call(DoubleDefaultMix.t),
       orderByList: orderByList?.call(DoubleDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -553,8 +539,6 @@ class DoubleDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -565,8 +549,6 @@ class DoubleDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(DoubleDefaultMix.t),
       orderByList: orderByList?.call(DoubleDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -587,8 +569,6 @@ class DoubleDefaultMixRepository {
     _i1.DatabaseSession session,
     List<DoubleDefaultMix> rows, {
     _i1.OrderByBuilder<DoubleDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -597,8 +577,6 @@ class DoubleDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(DoubleDefaultMix.t),
       orderByList: orderByList?.call(DoubleDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -628,8 +606,6 @@ class DoubleDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultMixTable> where,
     _i1.OrderByBuilder<DoubleDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -638,8 +614,6 @@ class DoubleDefaultMixRepository {
       where: where(DoubleDefaultMix.t),
       orderBy: orderBy?.call(DoubleDefaultMix.t),
       orderByList: orderByList?.call(DoubleDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default_model.dart
@@ -88,8 +88,6 @@ abstract class DoubleDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     DoubleDefaultModelInclude? include,
   }) {
@@ -98,8 +96,6 @@ abstract class DoubleDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DoubleDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DoubleDefaultModel.t),
       include: include,
     );
@@ -203,8 +199,6 @@ class DoubleDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -249,8 +243,6 @@ class DoubleDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -260,8 +252,6 @@ class DoubleDefaultModelRepository {
       where: where?.call(DoubleDefaultModel.t),
       orderBy: orderBy?.call(DoubleDefaultModel.t),
       orderByList: orderByList?.call(DoubleDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -292,8 +282,6 @@ class DoubleDefaultModelRepository {
     _i1.WhereExpressionBuilder<DoubleDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -303,8 +291,6 @@ class DoubleDefaultModelRepository {
       where: where?.call(DoubleDefaultModel.t),
       orderBy: orderBy?.call(DoubleDefaultModel.t),
       orderByList: orderByList?.call(DoubleDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -511,8 +497,6 @@ class DoubleDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -523,8 +507,6 @@ class DoubleDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(DoubleDefaultModel.t),
       orderByList: orderByList?.call(DoubleDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -545,8 +527,6 @@ class DoubleDefaultModelRepository {
     _i1.DatabaseSession session,
     List<DoubleDefaultModel> rows, {
     _i1.OrderByBuilder<DoubleDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -555,8 +535,6 @@ class DoubleDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(DoubleDefaultModel.t),
       orderByList: orderByList?.call(DoubleDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -586,8 +564,6 @@ class DoubleDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultModelTable> where,
     _i1.OrderByBuilder<DoubleDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -596,8 +572,6 @@ class DoubleDefaultModelRepository {
       where: where(DoubleDefaultModel.t),
       orderBy: orderBy?.call(DoubleDefaultModel.t),
       orderByList: orderByList?.call(DoubleDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/double/double_default_persist.dart
@@ -82,8 +82,6 @@ abstract class DoubleDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     DoubleDefaultPersistInclude? include,
   }) {
@@ -92,8 +90,6 @@ abstract class DoubleDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DoubleDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DoubleDefaultPersist.t),
       include: include,
     );
@@ -182,8 +178,6 @@ class DoubleDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -228,8 +222,6 @@ class DoubleDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -239,8 +231,6 @@ class DoubleDefaultPersistRepository {
       where: where?.call(DoubleDefaultPersist.t),
       orderBy: orderBy?.call(DoubleDefaultPersist.t),
       orderByList: orderByList?.call(DoubleDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -271,8 +261,6 @@ class DoubleDefaultPersistRepository {
     _i1.WhereExpressionBuilder<DoubleDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -282,8 +270,6 @@ class DoubleDefaultPersistRepository {
       where: where?.call(DoubleDefaultPersist.t),
       orderBy: orderBy?.call(DoubleDefaultPersist.t),
       orderByList: orderByList?.call(DoubleDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -490,8 +476,6 @@ class DoubleDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<DoubleDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -502,8 +486,6 @@ class DoubleDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(DoubleDefaultPersist.t),
       orderByList: orderByList?.call(DoubleDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -524,8 +506,6 @@ class DoubleDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<DoubleDefaultPersist> rows, {
     _i1.OrderByBuilder<DoubleDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -534,8 +514,6 @@ class DoubleDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(DoubleDefaultPersist.t),
       orderByList: orderByList?.call(DoubleDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -565,8 +543,6 @@ class DoubleDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DoubleDefaultPersistTable> where,
     _i1.OrderByBuilder<DoubleDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DoubleDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -575,8 +551,6 @@ class DoubleDefaultPersistRepository {
       where: where(DoubleDefaultPersist.t),
       orderBy: orderBy?.call(DoubleDefaultPersist.t),
       orderByList: orderByList?.call(DoubleDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default.dart
@@ -112,8 +112,6 @@ abstract class DurationDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     DurationDefaultInclude? include,
   }) {
@@ -122,8 +120,6 @@ abstract class DurationDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DurationDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DurationDefault.t),
       include: include,
     );
@@ -229,8 +225,6 @@ class DurationDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -275,8 +269,6 @@ class DurationDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -286,8 +278,6 @@ class DurationDefaultRepository {
       where: where?.call(DurationDefault.t),
       orderBy: orderBy?.call(DurationDefault.t),
       orderByList: orderByList?.call(DurationDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -318,8 +308,6 @@ class DurationDefaultRepository {
     _i1.WhereExpressionBuilder<DurationDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -329,8 +317,6 @@ class DurationDefaultRepository {
       where: where?.call(DurationDefault.t),
       orderBy: orderBy?.call(DurationDefault.t),
       orderByList: orderByList?.call(DurationDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -537,8 +523,6 @@ class DurationDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<DurationDefaultTable>? orderBy,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -549,8 +533,6 @@ class DurationDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(DurationDefault.t),
       orderByList: orderByList?.call(DurationDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -571,8 +553,6 @@ class DurationDefaultRepository {
     _i1.DatabaseSession session,
     List<DurationDefault> rows, {
     _i1.OrderByBuilder<DurationDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -581,8 +561,6 @@ class DurationDefaultRepository {
       rows,
       orderBy: orderBy?.call(DurationDefault.t),
       orderByList: orderByList?.call(DurationDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -612,8 +590,6 @@ class DurationDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultTable> where,
     _i1.OrderByBuilder<DurationDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -622,8 +598,6 @@ class DurationDefaultRepository {
       where: where(DurationDefault.t),
       orderBy: orderBy?.call(DurationDefault.t),
       orderByList: orderByList?.call(DurationDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default_mix.dart
@@ -138,8 +138,6 @@ abstract class DurationDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     DurationDefaultMixInclude? include,
   }) {
@@ -148,8 +146,6 @@ abstract class DurationDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DurationDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DurationDefaultMix.t),
       include: include,
     );
@@ -281,8 +277,6 @@ class DurationDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -327,8 +321,6 @@ class DurationDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -338,8 +330,6 @@ class DurationDefaultMixRepository {
       where: where?.call(DurationDefaultMix.t),
       orderBy: orderBy?.call(DurationDefaultMix.t),
       orderByList: orderByList?.call(DurationDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -370,8 +360,6 @@ class DurationDefaultMixRepository {
     _i1.WhereExpressionBuilder<DurationDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -381,8 +369,6 @@ class DurationDefaultMixRepository {
       where: where?.call(DurationDefaultMix.t),
       orderBy: orderBy?.call(DurationDefaultMix.t),
       orderByList: orderByList?.call(DurationDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -589,8 +575,6 @@ class DurationDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<DurationDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -601,8 +585,6 @@ class DurationDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(DurationDefaultMix.t),
       orderByList: orderByList?.call(DurationDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -623,8 +605,6 @@ class DurationDefaultMixRepository {
     _i1.DatabaseSession session,
     List<DurationDefaultMix> rows, {
     _i1.OrderByBuilder<DurationDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -633,8 +613,6 @@ class DurationDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(DurationDefaultMix.t),
       orderByList: orderByList?.call(DurationDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -664,8 +642,6 @@ class DurationDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultMixTable> where,
     _i1.OrderByBuilder<DurationDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -674,8 +650,6 @@ class DurationDefaultMixRepository {
       where: where(DurationDefaultMix.t),
       orderBy: orderBy?.call(DurationDefaultMix.t),
       orderByList: orderByList?.call(DurationDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default_model.dart
@@ -115,8 +115,6 @@ abstract class DurationDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     DurationDefaultModelInclude? include,
   }) {
@@ -125,8 +123,6 @@ abstract class DurationDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DurationDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DurationDefaultModel.t),
       include: include,
     );
@@ -232,8 +228,6 @@ class DurationDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -278,8 +272,6 @@ class DurationDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -289,8 +281,6 @@ class DurationDefaultModelRepository {
       where: where?.call(DurationDefaultModel.t),
       orderBy: orderBy?.call(DurationDefaultModel.t),
       orderByList: orderByList?.call(DurationDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -321,8 +311,6 @@ class DurationDefaultModelRepository {
     _i1.WhereExpressionBuilder<DurationDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -332,8 +320,6 @@ class DurationDefaultModelRepository {
       where: where?.call(DurationDefaultModel.t),
       orderBy: orderBy?.call(DurationDefaultModel.t),
       orderByList: orderByList?.call(DurationDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -540,8 +526,6 @@ class DurationDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<DurationDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -552,8 +536,6 @@ class DurationDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(DurationDefaultModel.t),
       orderByList: orderByList?.call(DurationDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -574,8 +556,6 @@ class DurationDefaultModelRepository {
     _i1.DatabaseSession session,
     List<DurationDefaultModel> rows, {
     _i1.OrderByBuilder<DurationDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -584,8 +564,6 @@ class DurationDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(DurationDefaultModel.t),
       orderByList: orderByList?.call(DurationDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -615,8 +593,6 @@ class DurationDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultModelTable> where,
     _i1.OrderByBuilder<DurationDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -625,8 +601,6 @@ class DurationDefaultModelRepository {
       where: where(DurationDefaultModel.t),
       orderBy: orderBy?.call(DurationDefaultModel.t),
       orderByList: orderByList?.call(DurationDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/duration/duration_default_persist.dart
@@ -86,8 +86,6 @@ abstract class DurationDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     DurationDefaultPersistInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class DurationDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(DurationDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(DurationDefaultPersist.t),
       include: include,
     );
@@ -186,8 +182,6 @@ class DurationDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -232,8 +226,6 @@ class DurationDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -243,8 +235,6 @@ class DurationDefaultPersistRepository {
       where: where?.call(DurationDefaultPersist.t),
       orderBy: orderBy?.call(DurationDefaultPersist.t),
       orderByList: orderByList?.call(DurationDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -275,8 +265,6 @@ class DurationDefaultPersistRepository {
     _i1.WhereExpressionBuilder<DurationDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<DurationDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -286,8 +274,6 @@ class DurationDefaultPersistRepository {
       where: where?.call(DurationDefaultPersist.t),
       orderBy: orderBy?.call(DurationDefaultPersist.t),
       orderByList: orderByList?.call(DurationDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -494,8 +480,6 @@ class DurationDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<DurationDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -506,8 +490,6 @@ class DurationDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(DurationDefaultPersist.t),
       orderByList: orderByList?.call(DurationDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -528,8 +510,6 @@ class DurationDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<DurationDefaultPersist> rows, {
     _i1.OrderByBuilder<DurationDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -538,8 +518,6 @@ class DurationDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(DurationDefaultPersist.t),
       orderByList: orderByList?.call(DurationDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -569,8 +547,6 @@ class DurationDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DurationDefaultPersistTable> where,
     _i1.OrderByBuilder<DurationDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DurationDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -579,8 +555,6 @@ class DurationDefaultPersistRepository {
       where: where(DurationDefaultPersist.t),
       orderBy: orderBy?.call(DurationDefaultPersist.t),
       orderByList: orderByList?.call(DurationDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default.dart
@@ -128,8 +128,6 @@ abstract class EnumDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     EnumDefaultInclude? include,
   }) {
@@ -138,8 +136,6 @@ abstract class EnumDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EnumDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EnumDefault.t),
       include: include,
     );
@@ -290,8 +286,6 @@ class EnumDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -336,8 +330,6 @@ class EnumDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -347,8 +339,6 @@ class EnumDefaultRepository {
       where: where?.call(EnumDefault.t),
       orderBy: orderBy?.call(EnumDefault.t),
       orderByList: orderByList?.call(EnumDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -379,8 +369,6 @@ class EnumDefaultRepository {
     _i1.WhereExpressionBuilder<EnumDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -390,8 +378,6 @@ class EnumDefaultRepository {
       where: where?.call(EnumDefault.t),
       orderBy: orderBy?.call(EnumDefault.t),
       orderByList: orderByList?.call(EnumDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -596,8 +582,6 @@ class EnumDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<EnumDefaultTable>? orderBy,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -608,8 +592,6 @@ class EnumDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(EnumDefault.t),
       orderByList: orderByList?.call(EnumDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -630,8 +612,6 @@ class EnumDefaultRepository {
     _i1.DatabaseSession session,
     List<EnumDefault> rows, {
     _i1.OrderByBuilder<EnumDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -640,8 +620,6 @@ class EnumDefaultRepository {
       rows,
       orderBy: orderBy?.call(EnumDefault.t),
       orderByList: orderByList?.call(EnumDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -671,8 +649,6 @@ class EnumDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultTable> where,
     _i1.OrderByBuilder<EnumDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -681,8 +657,6 @@ class EnumDefaultRepository {
       where: where(EnumDefault.t),
       orderBy: orderBy?.call(EnumDefault.t),
       orderByList: orderByList?.call(EnumDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default_mix.dart
@@ -122,8 +122,6 @@ abstract class EnumDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     EnumDefaultMixInclude? include,
   }) {
@@ -132,8 +130,6 @@ abstract class EnumDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EnumDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EnumDefaultMix.t),
       include: include,
     );
@@ -267,8 +263,6 @@ class EnumDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -313,8 +307,6 @@ class EnumDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -324,8 +316,6 @@ class EnumDefaultMixRepository {
       where: where?.call(EnumDefaultMix.t),
       orderBy: orderBy?.call(EnumDefaultMix.t),
       orderByList: orderByList?.call(EnumDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -356,8 +346,6 @@ class EnumDefaultMixRepository {
     _i1.WhereExpressionBuilder<EnumDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -367,8 +355,6 @@ class EnumDefaultMixRepository {
       where: where?.call(EnumDefaultMix.t),
       orderBy: orderBy?.call(EnumDefaultMix.t),
       orderByList: orderByList?.call(EnumDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -573,8 +559,6 @@ class EnumDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<EnumDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -585,8 +569,6 @@ class EnumDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(EnumDefaultMix.t),
       orderByList: orderByList?.call(EnumDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -607,8 +589,6 @@ class EnumDefaultMixRepository {
     _i1.DatabaseSession session,
     List<EnumDefaultMix> rows, {
     _i1.OrderByBuilder<EnumDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -617,8 +597,6 @@ class EnumDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(EnumDefaultMix.t),
       orderByList: orderByList?.call(EnumDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -648,8 +626,6 @@ class EnumDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultMixTable> where,
     _i1.OrderByBuilder<EnumDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -658,8 +634,6 @@ class EnumDefaultMixRepository {
       where: where(EnumDefaultMix.t),
       orderBy: orderBy?.call(EnumDefaultMix.t),
       orderByList: orderByList?.call(EnumDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default_model.dart
@@ -134,8 +134,6 @@ abstract class EnumDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     EnumDefaultModelInclude? include,
   }) {
@@ -144,8 +142,6 @@ abstract class EnumDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EnumDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EnumDefaultModel.t),
       include: include,
     );
@@ -297,8 +293,6 @@ class EnumDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -343,8 +337,6 @@ class EnumDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -354,8 +346,6 @@ class EnumDefaultModelRepository {
       where: where?.call(EnumDefaultModel.t),
       orderBy: orderBy?.call(EnumDefaultModel.t),
       orderByList: orderByList?.call(EnumDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -386,8 +376,6 @@ class EnumDefaultModelRepository {
     _i1.WhereExpressionBuilder<EnumDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -397,8 +385,6 @@ class EnumDefaultModelRepository {
       where: where?.call(EnumDefaultModel.t),
       orderBy: orderBy?.call(EnumDefaultModel.t),
       orderByList: orderByList?.call(EnumDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -605,8 +591,6 @@ class EnumDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<EnumDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -617,8 +601,6 @@ class EnumDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(EnumDefaultModel.t),
       orderByList: orderByList?.call(EnumDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -639,8 +621,6 @@ class EnumDefaultModelRepository {
     _i1.DatabaseSession session,
     List<EnumDefaultModel> rows, {
     _i1.OrderByBuilder<EnumDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -649,8 +629,6 @@ class EnumDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(EnumDefaultModel.t),
       orderByList: orderByList?.call(EnumDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -680,8 +658,6 @@ class EnumDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultModelTable> where,
     _i1.OrderByBuilder<EnumDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -690,8 +666,6 @@ class EnumDefaultModelRepository {
       where: where(EnumDefaultModel.t),
       orderBy: orderBy?.call(EnumDefaultModel.t),
       orderByList: orderByList?.call(EnumDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/enum/enum_default_persist.dart
@@ -101,8 +101,6 @@ abstract class EnumDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     EnumDefaultPersistInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class EnumDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EnumDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EnumDefaultPersist.t),
       include: include,
     );
@@ -225,8 +221,6 @@ class EnumDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -271,8 +265,6 @@ class EnumDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -282,8 +274,6 @@ class EnumDefaultPersistRepository {
       where: where?.call(EnumDefaultPersist.t),
       orderBy: orderBy?.call(EnumDefaultPersist.t),
       orderByList: orderByList?.call(EnumDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -314,8 +304,6 @@ class EnumDefaultPersistRepository {
     _i1.WhereExpressionBuilder<EnumDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnumDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -325,8 +313,6 @@ class EnumDefaultPersistRepository {
       where: where?.call(EnumDefaultPersist.t),
       orderBy: orderBy?.call(EnumDefaultPersist.t),
       orderByList: orderByList?.call(EnumDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -533,8 +519,6 @@ class EnumDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<EnumDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -545,8 +529,6 @@ class EnumDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(EnumDefaultPersist.t),
       orderByList: orderByList?.call(EnumDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -567,8 +549,6 @@ class EnumDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<EnumDefaultPersist> rows, {
     _i1.OrderByBuilder<EnumDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -577,8 +557,6 @@ class EnumDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(EnumDefaultPersist.t),
       orderByList: orderByList?.call(EnumDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -608,8 +586,6 @@ class EnumDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnumDefaultPersistTable> where,
     _i1.OrderByBuilder<EnumDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnumDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -618,8 +594,6 @@ class EnumDefaultPersistRepository {
       where: where(EnumDefaultPersist.t),
       orderBy: orderBy?.call(EnumDefaultPersist.t),
       orderByList: orderByList?.call(EnumDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default.dart
@@ -86,8 +86,6 @@ abstract class IntDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     IntDefaultInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class IntDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(IntDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(IntDefault.t),
       include: include,
     );
@@ -200,8 +196,6 @@ class IntDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -246,8 +240,6 @@ class IntDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -257,8 +249,6 @@ class IntDefaultRepository {
       where: where?.call(IntDefault.t),
       orderBy: orderBy?.call(IntDefault.t),
       orderByList: orderByList?.call(IntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -289,8 +279,6 @@ class IntDefaultRepository {
     _i1.WhereExpressionBuilder<IntDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<IntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -300,8 +288,6 @@ class IntDefaultRepository {
       where: where?.call(IntDefault.t),
       orderBy: orderBy?.call(IntDefault.t),
       orderByList: orderByList?.call(IntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -506,8 +492,6 @@ class IntDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<IntDefaultTable>? orderBy,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -518,8 +502,6 @@ class IntDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(IntDefault.t),
       orderByList: orderByList?.call(IntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -540,8 +522,6 @@ class IntDefaultRepository {
     _i1.DatabaseSession session,
     List<IntDefault> rows, {
     _i1.OrderByBuilder<IntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -550,8 +530,6 @@ class IntDefaultRepository {
       rows,
       orderBy: orderBy?.call(IntDefault.t),
       orderByList: orderByList?.call(IntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -581,8 +559,6 @@ class IntDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultTable> where,
     _i1.OrderByBuilder<IntDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -591,8 +567,6 @@ class IntDefaultRepository {
       where: where(IntDefault.t),
       orderBy: orderBy?.call(IntDefault.t),
       orderByList: orderByList?.call(IntDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default_mix.dart
@@ -99,8 +99,6 @@ abstract class IntDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     IntDefaultMixInclude? include,
   }) {
@@ -109,8 +107,6 @@ abstract class IntDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(IntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(IntDefaultMix.t),
       include: include,
     );
@@ -236,8 +232,6 @@ class IntDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -282,8 +276,6 @@ class IntDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -293,8 +285,6 @@ class IntDefaultMixRepository {
       where: where?.call(IntDefaultMix.t),
       orderBy: orderBy?.call(IntDefaultMix.t),
       orderByList: orderByList?.call(IntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -325,8 +315,6 @@ class IntDefaultMixRepository {
     _i1.WhereExpressionBuilder<IntDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<IntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -336,8 +324,6 @@ class IntDefaultMixRepository {
       where: where?.call(IntDefaultMix.t),
       orderBy: orderBy?.call(IntDefaultMix.t),
       orderByList: orderByList?.call(IntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -542,8 +528,6 @@ class IntDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<IntDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -554,8 +538,6 @@ class IntDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(IntDefaultMix.t),
       orderByList: orderByList?.call(IntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -576,8 +558,6 @@ class IntDefaultMixRepository {
     _i1.DatabaseSession session,
     List<IntDefaultMix> rows, {
     _i1.OrderByBuilder<IntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -586,8 +566,6 @@ class IntDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(IntDefaultMix.t),
       orderByList: orderByList?.call(IntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -617,8 +595,6 @@ class IntDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultMixTable> where,
     _i1.OrderByBuilder<IntDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -627,8 +603,6 @@ class IntDefaultMixRepository {
       where: where(IntDefaultMix.t),
       orderBy: orderBy?.call(IntDefaultMix.t),
       orderByList: orderByList?.call(IntDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default_model.dart
@@ -86,8 +86,6 @@ abstract class IntDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     IntDefaultModelInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class IntDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(IntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(IntDefaultModel.t),
       include: include,
     );
@@ -197,8 +193,6 @@ class IntDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -243,8 +237,6 @@ class IntDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -254,8 +246,6 @@ class IntDefaultModelRepository {
       where: where?.call(IntDefaultModel.t),
       orderBy: orderBy?.call(IntDefaultModel.t),
       orderByList: orderByList?.call(IntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -286,8 +276,6 @@ class IntDefaultModelRepository {
     _i1.WhereExpressionBuilder<IntDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<IntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -297,8 +285,6 @@ class IntDefaultModelRepository {
       where: where?.call(IntDefaultModel.t),
       orderBy: orderBy?.call(IntDefaultModel.t),
       orderByList: orderByList?.call(IntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -505,8 +491,6 @@ class IntDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<IntDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -517,8 +501,6 @@ class IntDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(IntDefaultModel.t),
       orderByList: orderByList?.call(IntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -539,8 +521,6 @@ class IntDefaultModelRepository {
     _i1.DatabaseSession session,
     List<IntDefaultModel> rows, {
     _i1.OrderByBuilder<IntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -549,8 +529,6 @@ class IntDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(IntDefaultModel.t),
       orderByList: orderByList?.call(IntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -580,8 +558,6 @@ class IntDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultModelTable> where,
     _i1.OrderByBuilder<IntDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -590,8 +566,6 @@ class IntDefaultModelRepository {
       where: where(IntDefaultModel.t),
       orderBy: orderBy?.call(IntDefaultModel.t),
       orderByList: orderByList?.call(IntDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/integer/int_default_persist.dart
@@ -77,8 +77,6 @@ abstract class IntDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     IntDefaultPersistInclude? include,
   }) {
@@ -87,8 +85,6 @@ abstract class IntDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(IntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(IntDefaultPersist.t),
       include: include,
     );
@@ -176,8 +172,6 @@ class IntDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -222,8 +216,6 @@ class IntDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<IntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -233,8 +225,6 @@ class IntDefaultPersistRepository {
       where: where?.call(IntDefaultPersist.t),
       orderBy: orderBy?.call(IntDefaultPersist.t),
       orderByList: orderByList?.call(IntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -265,8 +255,6 @@ class IntDefaultPersistRepository {
     _i1.WhereExpressionBuilder<IntDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<IntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -276,8 +264,6 @@ class IntDefaultPersistRepository {
       where: where?.call(IntDefaultPersist.t),
       orderBy: orderBy?.call(IntDefaultPersist.t),
       orderByList: orderByList?.call(IntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -484,8 +470,6 @@ class IntDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<IntDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -496,8 +480,6 @@ class IntDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(IntDefaultPersist.t),
       orderByList: orderByList?.call(IntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -518,8 +500,6 @@ class IntDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<IntDefaultPersist> rows, {
     _i1.OrderByBuilder<IntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -528,8 +508,6 @@ class IntDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(IntDefaultPersist.t),
       orderByList: orderByList?.call(IntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -559,8 +537,6 @@ class IntDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<IntDefaultPersistTable> where,
     _i1.OrderByBuilder<IntDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<IntDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -569,8 +545,6 @@ class IntDefaultPersistRepository {
       where: where(IntDefaultPersist.t),
       orderBy: orderBy?.call(IntDefaultPersist.t),
       orderByList: orderByList?.call(IntDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default.dart
@@ -86,8 +86,6 @@ abstract class StringDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     StringDefaultInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class StringDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(StringDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(StringDefault.t),
       include: include,
     );
@@ -203,8 +199,6 @@ class StringDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -249,8 +243,6 @@ class StringDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -260,8 +252,6 @@ class StringDefaultRepository {
       where: where?.call(StringDefault.t),
       orderBy: orderBy?.call(StringDefault.t),
       orderByList: orderByList?.call(StringDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -292,8 +282,6 @@ class StringDefaultRepository {
     _i1.WhereExpressionBuilder<StringDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<StringDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -303,8 +291,6 @@ class StringDefaultRepository {
       where: where?.call(StringDefault.t),
       orderBy: orderBy?.call(StringDefault.t),
       orderByList: orderByList?.call(StringDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -509,8 +495,6 @@ class StringDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<StringDefaultTable>? orderBy,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -521,8 +505,6 @@ class StringDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(StringDefault.t),
       orderByList: orderByList?.call(StringDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -543,8 +525,6 @@ class StringDefaultRepository {
     _i1.DatabaseSession session,
     List<StringDefault> rows, {
     _i1.OrderByBuilder<StringDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -553,8 +533,6 @@ class StringDefaultRepository {
       rows,
       orderBy: orderBy?.call(StringDefault.t),
       orderByList: orderByList?.call(StringDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -584,8 +562,6 @@ class StringDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultTable> where,
     _i1.OrderByBuilder<StringDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -594,8 +570,6 @@ class StringDefaultRepository {
       where: where(StringDefault.t),
       orderBy: orderBy?.call(StringDefault.t),
       orderByList: orderByList?.call(StringDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default_mix.dart
@@ -103,8 +103,6 @@ abstract class StringDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     StringDefaultMixInclude? include,
   }) {
@@ -113,8 +111,6 @@ abstract class StringDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(StringDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(StringDefaultMix.t),
       include: include,
     );
@@ -244,8 +240,6 @@ class StringDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -290,8 +284,6 @@ class StringDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -301,8 +293,6 @@ class StringDefaultMixRepository {
       where: where?.call(StringDefaultMix.t),
       orderBy: orderBy?.call(StringDefaultMix.t),
       orderByList: orderByList?.call(StringDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -333,8 +323,6 @@ class StringDefaultMixRepository {
     _i1.WhereExpressionBuilder<StringDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<StringDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -344,8 +332,6 @@ class StringDefaultMixRepository {
       where: where?.call(StringDefaultMix.t),
       orderBy: orderBy?.call(StringDefaultMix.t),
       orderByList: orderByList?.call(StringDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -552,8 +538,6 @@ class StringDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<StringDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -564,8 +548,6 @@ class StringDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(StringDefaultMix.t),
       orderByList: orderByList?.call(StringDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -586,8 +568,6 @@ class StringDefaultMixRepository {
     _i1.DatabaseSession session,
     List<StringDefaultMix> rows, {
     _i1.OrderByBuilder<StringDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -596,8 +576,6 @@ class StringDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(StringDefaultMix.t),
       orderByList: orderByList?.call(StringDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -627,8 +605,6 @@ class StringDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultMixTable> where,
     _i1.OrderByBuilder<StringDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -637,8 +613,6 @@ class StringDefaultMixRepository {
       where: where(StringDefaultMix.t),
       orderBy: orderBy?.call(StringDefaultMix.t),
       orderByList: orderByList?.call(StringDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default_model.dart
@@ -89,8 +89,6 @@ abstract class StringDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     StringDefaultModelInclude? include,
   }) {
@@ -99,8 +97,6 @@ abstract class StringDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(StringDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(StringDefaultModel.t),
       include: include,
     );
@@ -204,8 +200,6 @@ class StringDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -250,8 +244,6 @@ class StringDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -261,8 +253,6 @@ class StringDefaultModelRepository {
       where: where?.call(StringDefaultModel.t),
       orderBy: orderBy?.call(StringDefaultModel.t),
       orderByList: orderByList?.call(StringDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -293,8 +283,6 @@ class StringDefaultModelRepository {
     _i1.WhereExpressionBuilder<StringDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<StringDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -304,8 +292,6 @@ class StringDefaultModelRepository {
       where: where?.call(StringDefaultModel.t),
       orderBy: orderBy?.call(StringDefaultModel.t),
       orderByList: orderByList?.call(StringDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -512,8 +498,6 @@ class StringDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<StringDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -524,8 +508,6 @@ class StringDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(StringDefaultModel.t),
       orderByList: orderByList?.call(StringDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -546,8 +528,6 @@ class StringDefaultModelRepository {
     _i1.DatabaseSession session,
     List<StringDefaultModel> rows, {
     _i1.OrderByBuilder<StringDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -556,8 +536,6 @@ class StringDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(StringDefaultModel.t),
       orderByList: orderByList?.call(StringDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -587,8 +565,6 @@ class StringDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultModelTable> where,
     _i1.OrderByBuilder<StringDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -597,8 +573,6 @@ class StringDefaultModelRepository {
       where: where(StringDefaultModel.t),
       orderBy: orderBy?.call(StringDefaultModel.t),
       orderByList: orderByList?.call(StringDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/string/string_default_persist.dart
@@ -194,8 +194,6 @@ abstract class StringDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     StringDefaultPersistInclude? include,
   }) {
@@ -204,8 +202,6 @@ abstract class StringDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(StringDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(StringDefaultPersist.t),
       include: include,
     );
@@ -486,8 +482,6 @@ class StringDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -532,8 +526,6 @@ class StringDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StringDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -543,8 +535,6 @@ class StringDefaultPersistRepository {
       where: where?.call(StringDefaultPersist.t),
       orderBy: orderBy?.call(StringDefaultPersist.t),
       orderByList: orderByList?.call(StringDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -575,8 +565,6 @@ class StringDefaultPersistRepository {
     _i1.WhereExpressionBuilder<StringDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<StringDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -586,8 +574,6 @@ class StringDefaultPersistRepository {
       where: where?.call(StringDefaultPersist.t),
       orderBy: orderBy?.call(StringDefaultPersist.t),
       orderByList: orderByList?.call(StringDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -794,8 +780,6 @@ class StringDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<StringDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -806,8 +790,6 @@ class StringDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(StringDefaultPersist.t),
       orderByList: orderByList?.call(StringDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -828,8 +810,6 @@ class StringDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<StringDefaultPersist> rows, {
     _i1.OrderByBuilder<StringDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -838,8 +818,6 @@ class StringDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(StringDefaultPersist.t),
       orderByList: orderByList?.call(StringDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -869,8 +847,6 @@ class StringDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StringDefaultPersistTable> where,
     _i1.OrderByBuilder<StringDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StringDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -879,8 +855,6 @@ class StringDefaultPersistRepository {
       where: where(StringDefaultPersist.t),
       orderBy: orderBy?.call(StringDefaultPersist.t),
       orderByList: orderByList?.call(StringDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default.dart
@@ -91,8 +91,6 @@ abstract class UriDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     UriDefaultInclude? include,
   }) {
@@ -101,8 +99,6 @@ abstract class UriDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UriDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UriDefault.t),
       include: include,
     );
@@ -205,8 +201,6 @@ class UriDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -251,8 +245,6 @@ class UriDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -262,8 +254,6 @@ class UriDefaultRepository {
       where: where?.call(UriDefault.t),
       orderBy: orderBy?.call(UriDefault.t),
       orderByList: orderByList?.call(UriDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -294,8 +284,6 @@ class UriDefaultRepository {
     _i1.WhereExpressionBuilder<UriDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<UriDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -305,8 +293,6 @@ class UriDefaultRepository {
       where: where?.call(UriDefault.t),
       orderBy: orderBy?.call(UriDefault.t),
       orderByList: orderByList?.call(UriDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -511,8 +497,6 @@ class UriDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<UriDefaultTable>? orderBy,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -523,8 +507,6 @@ class UriDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(UriDefault.t),
       orderByList: orderByList?.call(UriDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -545,8 +527,6 @@ class UriDefaultRepository {
     _i1.DatabaseSession session,
     List<UriDefault> rows, {
     _i1.OrderByBuilder<UriDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -555,8 +535,6 @@ class UriDefaultRepository {
       rows,
       orderBy: orderBy?.call(UriDefault.t),
       orderByList: orderByList?.call(UriDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -586,8 +564,6 @@ class UriDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultTable> where,
     _i1.OrderByBuilder<UriDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -596,8 +572,6 @@ class UriDefaultRepository {
       where: where(UriDefault.t),
       orderBy: orderBy?.call(UriDefault.t),
       orderByList: orderByList?.call(UriDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default_mix.dart
@@ -118,8 +118,6 @@ abstract class UriDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     UriDefaultMixInclude? include,
   }) {
@@ -128,8 +126,6 @@ abstract class UriDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UriDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UriDefaultMix.t),
       include: include,
     );
@@ -255,8 +251,6 @@ class UriDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -301,8 +295,6 @@ class UriDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -312,8 +304,6 @@ class UriDefaultMixRepository {
       where: where?.call(UriDefaultMix.t),
       orderBy: orderBy?.call(UriDefaultMix.t),
       orderByList: orderByList?.call(UriDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -344,8 +334,6 @@ class UriDefaultMixRepository {
     _i1.WhereExpressionBuilder<UriDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<UriDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -355,8 +343,6 @@ class UriDefaultMixRepository {
       where: where?.call(UriDefaultMix.t),
       orderBy: orderBy?.call(UriDefaultMix.t),
       orderByList: orderByList?.call(UriDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -561,8 +547,6 @@ class UriDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<UriDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -573,8 +557,6 @@ class UriDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(UriDefaultMix.t),
       orderByList: orderByList?.call(UriDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -595,8 +577,6 @@ class UriDefaultMixRepository {
     _i1.DatabaseSession session,
     List<UriDefaultMix> rows, {
     _i1.OrderByBuilder<UriDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -605,8 +585,6 @@ class UriDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(UriDefaultMix.t),
       orderByList: orderByList?.call(UriDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -636,8 +614,6 @@ class UriDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultMixTable> where,
     _i1.OrderByBuilder<UriDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -646,8 +622,6 @@ class UriDefaultMixRepository {
       where: where(UriDefaultMix.t),
       orderBy: orderBy?.call(UriDefaultMix.t),
       orderByList: orderByList?.call(UriDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default_model.dart
@@ -97,8 +97,6 @@ abstract class UriDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     UriDefaultModelInclude? include,
   }) {
@@ -107,8 +105,6 @@ abstract class UriDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UriDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UriDefaultModel.t),
       include: include,
     );
@@ -210,8 +206,6 @@ class UriDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -256,8 +250,6 @@ class UriDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -267,8 +259,6 @@ class UriDefaultModelRepository {
       where: where?.call(UriDefaultModel.t),
       orderBy: orderBy?.call(UriDefaultModel.t),
       orderByList: orderByList?.call(UriDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -299,8 +289,6 @@ class UriDefaultModelRepository {
     _i1.WhereExpressionBuilder<UriDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<UriDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -310,8 +298,6 @@ class UriDefaultModelRepository {
       where: where?.call(UriDefaultModel.t),
       orderBy: orderBy?.call(UriDefaultModel.t),
       orderByList: orderByList?.call(UriDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -518,8 +504,6 @@ class UriDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<UriDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -530,8 +514,6 @@ class UriDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(UriDefaultModel.t),
       orderByList: orderByList?.call(UriDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -552,8 +534,6 @@ class UriDefaultModelRepository {
     _i1.DatabaseSession session,
     List<UriDefaultModel> rows, {
     _i1.OrderByBuilder<UriDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -562,8 +542,6 @@ class UriDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(UriDefaultModel.t),
       orderByList: orderByList?.call(UriDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -593,8 +571,6 @@ class UriDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultModelTable> where,
     _i1.OrderByBuilder<UriDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -603,8 +579,6 @@ class UriDefaultModelRepository {
       where: where(UriDefaultModel.t),
       orderBy: orderBy?.call(UriDefaultModel.t),
       orderByList: orderByList?.call(UriDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uri/uri_default_persist.dart
@@ -83,8 +83,6 @@ abstract class UriDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     UriDefaultPersistInclude? include,
   }) {
@@ -93,8 +91,6 @@ abstract class UriDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UriDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UriDefaultPersist.t),
       include: include,
     );
@@ -182,8 +178,6 @@ class UriDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -228,8 +222,6 @@ class UriDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UriDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -239,8 +231,6 @@ class UriDefaultPersistRepository {
       where: where?.call(UriDefaultPersist.t),
       orderBy: orderBy?.call(UriDefaultPersist.t),
       orderByList: orderByList?.call(UriDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -271,8 +261,6 @@ class UriDefaultPersistRepository {
     _i1.WhereExpressionBuilder<UriDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<UriDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -282,8 +270,6 @@ class UriDefaultPersistRepository {
       where: where?.call(UriDefaultPersist.t),
       orderBy: orderBy?.call(UriDefaultPersist.t),
       orderByList: orderByList?.call(UriDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -490,8 +476,6 @@ class UriDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<UriDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -502,8 +486,6 @@ class UriDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(UriDefaultPersist.t),
       orderByList: orderByList?.call(UriDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -524,8 +506,6 @@ class UriDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<UriDefaultPersist> rows, {
     _i1.OrderByBuilder<UriDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -534,8 +514,6 @@ class UriDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(UriDefaultPersist.t),
       orderByList: orderByList?.call(UriDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -565,8 +543,6 @@ class UriDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UriDefaultPersistTable> where,
     _i1.OrderByBuilder<UriDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UriDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -575,8 +551,6 @@ class UriDefaultPersistRepository {
       where: where(UriDefaultPersist.t),
       orderBy: orderBy?.call(UriDefaultPersist.t),
       orderByList: orderByList?.call(UriDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default.dart
@@ -142,8 +142,6 @@ abstract class UuidDefault
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     UuidDefaultInclude? include,
   }) {
@@ -152,8 +150,6 @@ abstract class UuidDefault
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UuidDefault.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UuidDefault.t),
       include: include,
     );
@@ -319,8 +315,6 @@ class UuidDefaultIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -365,8 +359,6 @@ class UuidDefaultRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -376,8 +368,6 @@ class UuidDefaultRepository {
       where: where?.call(UuidDefault.t),
       orderBy: orderBy?.call(UuidDefault.t),
       orderByList: orderByList?.call(UuidDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -408,8 +398,6 @@ class UuidDefaultRepository {
     _i1.WhereExpressionBuilder<UuidDefaultTable>? where,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -419,8 +407,6 @@ class UuidDefaultRepository {
       where: where?.call(UuidDefault.t),
       orderBy: orderBy?.call(UuidDefault.t),
       orderByList: orderByList?.call(UuidDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -625,8 +611,6 @@ class UuidDefaultRepository {
     int? offset,
     _i1.OrderByBuilder<UuidDefaultTable>? orderBy,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -637,8 +621,6 @@ class UuidDefaultRepository {
       offset: offset,
       orderBy: orderBy?.call(UuidDefault.t),
       orderByList: orderByList?.call(UuidDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -659,8 +641,6 @@ class UuidDefaultRepository {
     _i1.DatabaseSession session,
     List<UuidDefault> rows, {
     _i1.OrderByBuilder<UuidDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -669,8 +649,6 @@ class UuidDefaultRepository {
       rows,
       orderBy: orderBy?.call(UuidDefault.t),
       orderByList: orderByList?.call(UuidDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -700,8 +678,6 @@ class UuidDefaultRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultTable> where,
     _i1.OrderByBuilder<UuidDefaultTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -710,8 +686,6 @@ class UuidDefaultRepository {
       where: where(UuidDefault.t),
       orderBy: orderBy?.call(UuidDefault.t),
       orderByList: orderByList?.call(UuidDefault.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default_mix.dart
@@ -118,8 +118,6 @@ abstract class UuidDefaultMix
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     UuidDefaultMixInclude? include,
   }) {
@@ -128,8 +126,6 @@ abstract class UuidDefaultMix
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UuidDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UuidDefaultMix.t),
       include: include,
     );
@@ -257,8 +253,6 @@ class UuidDefaultMixIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -303,8 +297,6 @@ class UuidDefaultMixRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -314,8 +306,6 @@ class UuidDefaultMixRepository {
       where: where?.call(UuidDefaultMix.t),
       orderBy: orderBy?.call(UuidDefaultMix.t),
       orderByList: orderByList?.call(UuidDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -346,8 +336,6 @@ class UuidDefaultMixRepository {
     _i1.WhereExpressionBuilder<UuidDefaultMixTable>? where,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -357,8 +345,6 @@ class UuidDefaultMixRepository {
       where: where?.call(UuidDefaultMix.t),
       orderBy: orderBy?.call(UuidDefaultMix.t),
       orderByList: orderByList?.call(UuidDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -563,8 +549,6 @@ class UuidDefaultMixRepository {
     int? offset,
     _i1.OrderByBuilder<UuidDefaultMixTable>? orderBy,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -575,8 +559,6 @@ class UuidDefaultMixRepository {
       offset: offset,
       orderBy: orderBy?.call(UuidDefaultMix.t),
       orderByList: orderByList?.call(UuidDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -597,8 +579,6 @@ class UuidDefaultMixRepository {
     _i1.DatabaseSession session,
     List<UuidDefaultMix> rows, {
     _i1.OrderByBuilder<UuidDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -607,8 +587,6 @@ class UuidDefaultMixRepository {
       rows,
       orderBy: orderBy?.call(UuidDefaultMix.t),
       orderByList: orderByList?.call(UuidDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -638,8 +616,6 @@ class UuidDefaultMixRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultMixTable> where,
     _i1.OrderByBuilder<UuidDefaultMixTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultMixTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -648,8 +624,6 @@ class UuidDefaultMixRepository {
       where: where(UuidDefaultMix.t),
       orderBy: orderBy?.call(UuidDefaultMix.t),
       orderByList: orderByList?.call(UuidDefaultMix.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default_model.dart
@@ -148,8 +148,6 @@ abstract class UuidDefaultModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     UuidDefaultModelInclude? include,
   }) {
@@ -158,8 +156,6 @@ abstract class UuidDefaultModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UuidDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UuidDefaultModel.t),
       include: include,
     );
@@ -324,8 +320,6 @@ class UuidDefaultModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -370,8 +364,6 @@ class UuidDefaultModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -381,8 +373,6 @@ class UuidDefaultModelRepository {
       where: where?.call(UuidDefaultModel.t),
       orderBy: orderBy?.call(UuidDefaultModel.t),
       orderByList: orderByList?.call(UuidDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -413,8 +403,6 @@ class UuidDefaultModelRepository {
     _i1.WhereExpressionBuilder<UuidDefaultModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -424,8 +412,6 @@ class UuidDefaultModelRepository {
       where: where?.call(UuidDefaultModel.t),
       orderBy: orderBy?.call(UuidDefaultModel.t),
       orderByList: orderByList?.call(UuidDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -632,8 +618,6 @@ class UuidDefaultModelRepository {
     int? offset,
     _i1.OrderByBuilder<UuidDefaultModelTable>? orderBy,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -644,8 +628,6 @@ class UuidDefaultModelRepository {
       offset: offset,
       orderBy: orderBy?.call(UuidDefaultModel.t),
       orderByList: orderByList?.call(UuidDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -666,8 +648,6 @@ class UuidDefaultModelRepository {
     _i1.DatabaseSession session,
     List<UuidDefaultModel> rows, {
     _i1.OrderByBuilder<UuidDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -676,8 +656,6 @@ class UuidDefaultModelRepository {
       rows,
       orderBy: orderBy?.call(UuidDefaultModel.t),
       orderByList: orderByList?.call(UuidDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -707,8 +685,6 @@ class UuidDefaultModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultModelTable> where,
     _i1.OrderByBuilder<UuidDefaultModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -717,8 +693,6 @@ class UuidDefaultModelRepository {
       where: where(UuidDefaultModel.t),
       orderBy: orderBy?.call(UuidDefaultModel.t),
       orderByList: orderByList?.call(UuidDefaultModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/defaults/uuid/uuid_default_persist.dart
@@ -113,8 +113,6 @@ abstract class UuidDefaultPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     UuidDefaultPersistInclude? include,
   }) {
@@ -123,8 +121,6 @@ abstract class UuidDefaultPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UuidDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UuidDefaultPersist.t),
       include: include,
     );
@@ -256,8 +252,6 @@ class UuidDefaultPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -302,8 +296,6 @@ class UuidDefaultPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -313,8 +305,6 @@ class UuidDefaultPersistRepository {
       where: where?.call(UuidDefaultPersist.t),
       orderBy: orderBy?.call(UuidDefaultPersist.t),
       orderByList: orderByList?.call(UuidDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -345,8 +335,6 @@ class UuidDefaultPersistRepository {
     _i1.WhereExpressionBuilder<UuidDefaultPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<UuidDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -356,8 +344,6 @@ class UuidDefaultPersistRepository {
       where: where?.call(UuidDefaultPersist.t),
       orderBy: orderBy?.call(UuidDefaultPersist.t),
       orderByList: orderByList?.call(UuidDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -564,8 +550,6 @@ class UuidDefaultPersistRepository {
     int? offset,
     _i1.OrderByBuilder<UuidDefaultPersistTable>? orderBy,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -576,8 +560,6 @@ class UuidDefaultPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(UuidDefaultPersist.t),
       orderByList: orderByList?.call(UuidDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -598,8 +580,6 @@ class UuidDefaultPersistRepository {
     _i1.DatabaseSession session,
     List<UuidDefaultPersist> rows, {
     _i1.OrderByBuilder<UuidDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -608,8 +588,6 @@ class UuidDefaultPersistRepository {
       rows,
       orderBy: orderBy?.call(UuidDefaultPersist.t),
       orderByList: orderByList?.call(UuidDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -639,8 +617,6 @@ class UuidDefaultPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UuidDefaultPersistTable> where,
     _i1.OrderByBuilder<UuidDefaultPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UuidDefaultPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -649,8 +625,6 @@ class UuidDefaultPersistRepository {
       where: where(UuidDefaultPersist.t),
       orderBy: orderBy?.call(UuidDefaultPersist.t),
       orderByList: orderByList?.call(UuidDefaultPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/empty_model_relation_item.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/empty_model_relation_item.dart
@@ -87,8 +87,6 @@ abstract class EmptyModelRelationItem
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     EmptyModelRelationItemInclude? include,
   }) {
@@ -97,8 +95,6 @@ abstract class EmptyModelRelationItem
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
       include: include,
     );
@@ -233,8 +229,6 @@ class EmptyModelRelationItemIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -279,8 +273,6 @@ class EmptyModelRelationItemRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -290,8 +282,6 @@ class EmptyModelRelationItemRepository {
       where: where?.call(EmptyModelRelationItem.t),
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -322,8 +312,6 @@ class EmptyModelRelationItemRepository {
     _i1.WhereExpressionBuilder<EmptyModelRelationItemTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -333,8 +321,6 @@ class EmptyModelRelationItemRepository {
       where: where?.call(EmptyModelRelationItem.t),
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -541,8 +527,6 @@ class EmptyModelRelationItemRepository {
     int? offset,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -553,8 +537,6 @@ class EmptyModelRelationItemRepository {
       offset: offset,
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -575,8 +557,6 @@ class EmptyModelRelationItemRepository {
     _i1.DatabaseSession session,
     List<EmptyModelRelationItem> rows, {
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -585,8 +565,6 @@ class EmptyModelRelationItemRepository {
       rows,
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -616,8 +594,6 @@ class EmptyModelRelationItemRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmptyModelRelationItemTable> where,
     _i1.OrderByBuilder<EmptyModelRelationItemTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelRelationItemTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -626,8 +602,6 @@ class EmptyModelRelationItemRepository {
       where: where(EmptyModelRelationItem.t),
       orderBy: orderBy?.call(EmptyModelRelationItem.t),
       orderByList: orderByList?.call(EmptyModelRelationItem.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/empty_model_with_table.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/empty_model_with_table.dart
@@ -61,8 +61,6 @@ abstract class EmptyModelWithTable
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     EmptyModelWithTableInclude? include,
   }) {
@@ -71,8 +69,6 @@ abstract class EmptyModelWithTable
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(EmptyModelWithTable.t),
       include: include,
     );
@@ -131,8 +127,6 @@ class EmptyModelWithTableIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -177,8 +171,6 @@ class EmptyModelWithTableRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -188,8 +180,6 @@ class EmptyModelWithTableRepository {
       where: where?.call(EmptyModelWithTable.t),
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -220,8 +210,6 @@ class EmptyModelWithTableRepository {
     _i1.WhereExpressionBuilder<EmptyModelWithTableTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -231,8 +219,6 @@ class EmptyModelWithTableRepository {
       where: where?.call(EmptyModelWithTable.t),
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -439,8 +425,6 @@ class EmptyModelWithTableRepository {
     int? offset,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -451,8 +435,6 @@ class EmptyModelWithTableRepository {
       offset: offset,
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -473,8 +455,6 @@ class EmptyModelWithTableRepository {
     _i1.DatabaseSession session,
     List<EmptyModelWithTable> rows, {
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -483,8 +463,6 @@ class EmptyModelWithTableRepository {
       rows,
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -514,8 +492,6 @@ class EmptyModelWithTableRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmptyModelWithTableTable> where,
     _i1.OrderByBuilder<EmptyModelWithTableTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmptyModelWithTableTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -524,8 +500,6 @@ class EmptyModelWithTableRepository {
       where: where(EmptyModelWithTable.t),
       orderBy: orderBy?.call(EmptyModelWithTable.t),
       orderByList: orderByList?.call(EmptyModelWithTable.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/relation_empy_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/empty_model/relation_empy_model.dart
@@ -88,8 +88,6 @@ abstract class RelationEmptyModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     RelationEmptyModelInclude? include,
   }) {
@@ -98,8 +96,6 @@ abstract class RelationEmptyModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(RelationEmptyModel.t),
       include: include,
     );
@@ -226,8 +222,6 @@ class RelationEmptyModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -280,8 +274,6 @@ class RelationEmptyModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
     RelationEmptyModelInclude? include,
@@ -292,8 +284,6 @@ class RelationEmptyModelRepository {
       where: where?.call(RelationEmptyModel.t),
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -325,8 +315,6 @@ class RelationEmptyModelRepository {
     _i1.WhereExpressionBuilder<RelationEmptyModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
     RelationEmptyModelInclude? include,
@@ -337,8 +325,6 @@ class RelationEmptyModelRepository {
       where: where?.call(RelationEmptyModel.t),
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -548,8 +534,6 @@ class RelationEmptyModelRepository {
     int? offset,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -560,8 +544,6 @@ class RelationEmptyModelRepository {
       offset: offset,
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -582,8 +564,6 @@ class RelationEmptyModelRepository {
     _i1.DatabaseSession session,
     List<RelationEmptyModel> rows, {
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -592,8 +572,6 @@ class RelationEmptyModelRepository {
       rows,
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -623,8 +601,6 @@ class RelationEmptyModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelationEmptyModelTable> where,
     _i1.OrderByBuilder<RelationEmptyModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationEmptyModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -633,8 +609,6 @@ class RelationEmptyModelRepository {
       where: where(RelationEmptyModel.t),
       orderBy: orderBy?.call(RelationEmptyModel.t),
       orderByList: orderByList?.call(RelationEmptyModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/inheritance/child_class_explicit_column.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/inheritance/child_class_explicit_column.dart
@@ -87,8 +87,6 @@ abstract class ChildClassExplicitColumn extends _i1.NonTableParentClass
     int? limit,
     int? offset,
     _i2.OrderByBuilder<ChildClassExplicitColumnTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     ChildClassExplicitColumnInclude? include,
   }) {
@@ -97,8 +95,6 @@ abstract class ChildClassExplicitColumn extends _i1.NonTableParentClass
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ChildClassExplicitColumn.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ChildClassExplicitColumn.t),
       include: include,
     );
@@ -202,8 +198,6 @@ class ChildClassExplicitColumnIncludeList extends _i2.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -248,8 +242,6 @@ class ChildClassExplicitColumnRepository {
     int? limit,
     int? offset,
     _i2.OrderByBuilder<ChildClassExplicitColumnTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     _i2.Transaction? transaction,
     _i2.LockMode? lockMode,
@@ -259,8 +251,6 @@ class ChildClassExplicitColumnRepository {
       where: where?.call(ChildClassExplicitColumn.t),
       orderBy: orderBy?.call(ChildClassExplicitColumn.t),
       orderByList: orderByList?.call(ChildClassExplicitColumn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -291,8 +281,6 @@ class ChildClassExplicitColumnRepository {
     _i2.WhereExpressionBuilder<ChildClassExplicitColumnTable>? where,
     int? offset,
     _i2.OrderByBuilder<ChildClassExplicitColumnTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     _i2.Transaction? transaction,
     _i2.LockMode? lockMode,
@@ -302,8 +290,6 @@ class ChildClassExplicitColumnRepository {
       where: where?.call(ChildClassExplicitColumn.t),
       orderBy: orderBy?.call(ChildClassExplicitColumn.t),
       orderByList: orderByList?.call(ChildClassExplicitColumn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -512,8 +498,6 @@ class ChildClassExplicitColumnRepository {
     int? offset,
     _i2.OrderByBuilder<ChildClassExplicitColumnTable>? orderBy,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -524,8 +508,6 @@ class ChildClassExplicitColumnRepository {
       offset: offset,
       orderBy: orderBy?.call(ChildClassExplicitColumn.t),
       orderByList: orderByList?.call(ChildClassExplicitColumn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -546,8 +528,6 @@ class ChildClassExplicitColumnRepository {
     _i2.DatabaseSession session,
     List<ChildClassExplicitColumn> rows, {
     _i2.OrderByBuilder<ChildClassExplicitColumnTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -556,8 +536,6 @@ class ChildClassExplicitColumnRepository {
       rows,
       orderBy: orderBy?.call(ChildClassExplicitColumn.t),
       orderByList: orderByList?.call(ChildClassExplicitColumn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -587,8 +565,6 @@ class ChildClassExplicitColumnRepository {
     _i2.DatabaseSession session, {
     required _i2.WhereExpressionBuilder<ChildClassExplicitColumnTable> where,
     _i2.OrderByBuilder<ChildClassExplicitColumnTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i2.OrderByListBuilder<ChildClassExplicitColumnTable>? orderByList,
     _i2.Transaction? transaction,
     bool noReturn = false,
@@ -597,8 +573,6 @@ class ChildClassExplicitColumnRepository {
       where: where(ChildClassExplicitColumn.t),
       orderBy: orderBy?.call(ChildClassExplicitColumn.t),
       orderByList: orderByList?.call(ChildClassExplicitColumn.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/modified_column_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/modified_column_name.dart
@@ -85,8 +85,6 @@ abstract class ModifiedColumnName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ModifiedColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     ModifiedColumnNameInclude? include,
   }) {
@@ -95,8 +93,6 @@ abstract class ModifiedColumnName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ModifiedColumnName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ModifiedColumnName.t),
       include: include,
     );
@@ -200,8 +196,6 @@ class ModifiedColumnNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -246,8 +240,6 @@ class ModifiedColumnNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ModifiedColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -257,8 +249,6 @@ class ModifiedColumnNameRepository {
       where: where?.call(ModifiedColumnName.t),
       orderBy: orderBy?.call(ModifiedColumnName.t),
       orderByList: orderByList?.call(ModifiedColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -289,8 +279,6 @@ class ModifiedColumnNameRepository {
     _i1.WhereExpressionBuilder<ModifiedColumnNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<ModifiedColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -300,8 +288,6 @@ class ModifiedColumnNameRepository {
       where: where?.call(ModifiedColumnName.t),
       orderBy: orderBy?.call(ModifiedColumnName.t),
       orderByList: orderByList?.call(ModifiedColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -508,8 +494,6 @@ class ModifiedColumnNameRepository {
     int? offset,
     _i1.OrderByBuilder<ModifiedColumnNameTable>? orderBy,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -520,8 +504,6 @@ class ModifiedColumnNameRepository {
       offset: offset,
       orderBy: orderBy?.call(ModifiedColumnName.t),
       orderByList: orderByList?.call(ModifiedColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -542,8 +524,6 @@ class ModifiedColumnNameRepository {
     _i1.DatabaseSession session,
     List<ModifiedColumnName> rows, {
     _i1.OrderByBuilder<ModifiedColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -552,8 +532,6 @@ class ModifiedColumnNameRepository {
       rows,
       orderBy: orderBy?.call(ModifiedColumnName.t),
       orderByList: orderByList?.call(ModifiedColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -583,8 +561,6 @@ class ModifiedColumnNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ModifiedColumnNameTable> where,
     _i1.OrderByBuilder<ModifiedColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModifiedColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -593,8 +569,6 @@ class ModifiedColumnNameRepository {
       where: where(ModifiedColumnName.t),
       orderBy: orderBy?.call(ModifiedColumnName.t),
       orderByList: orderByList?.call(ModifiedColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_many/department.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_many/department.dart
@@ -98,8 +98,6 @@ abstract class Department
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DepartmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     DepartmentInclude? include,
   }) {
@@ -108,8 +106,6 @@ abstract class Department
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Department.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Department.t),
       include: include,
     );
@@ -246,8 +242,6 @@ class DepartmentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -296,8 +290,6 @@ class DepartmentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<DepartmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     _i1.Transaction? transaction,
     DepartmentInclude? include,
@@ -308,8 +300,6 @@ class DepartmentRepository {
       where: where?.call(Department.t),
       orderBy: orderBy?.call(Department.t),
       orderByList: orderByList?.call(Department.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -341,8 +331,6 @@ class DepartmentRepository {
     _i1.WhereExpressionBuilder<DepartmentTable>? where,
     int? offset,
     _i1.OrderByBuilder<DepartmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     _i1.Transaction? transaction,
     DepartmentInclude? include,
@@ -353,8 +341,6 @@ class DepartmentRepository {
       where: where?.call(Department.t),
       orderBy: orderBy?.call(Department.t),
       orderByList: orderByList?.call(Department.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -562,8 +548,6 @@ class DepartmentRepository {
     int? offset,
     _i1.OrderByBuilder<DepartmentTable>? orderBy,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -574,8 +558,6 @@ class DepartmentRepository {
       offset: offset,
       orderBy: orderBy?.call(Department.t),
       orderByList: orderByList?.call(Department.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -596,8 +578,6 @@ class DepartmentRepository {
     _i1.DatabaseSession session,
     List<Department> rows, {
     _i1.OrderByBuilder<DepartmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -606,8 +586,6 @@ class DepartmentRepository {
       rows,
       orderBy: orderBy?.call(Department.t),
       orderByList: orderByList?.call(Department.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -637,8 +615,6 @@ class DepartmentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<DepartmentTable> where,
     _i1.OrderByBuilder<DepartmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<DepartmentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -647,8 +623,6 @@ class DepartmentRepository {
       where: where(Department.t),
       orderBy: orderBy?.call(Department.t),
       orderByList: orderByList?.call(Department.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_many/employee.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_many/employee.dart
@@ -85,8 +85,6 @@ abstract class Employee
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmployeeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     EmployeeInclude? include,
   }) {
@@ -95,8 +93,6 @@ abstract class Employee
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Employee.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Employee.t),
       include: include,
     );
@@ -196,8 +192,6 @@ class EmployeeIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -242,8 +236,6 @@ class EmployeeRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EmployeeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -253,8 +245,6 @@ class EmployeeRepository {
       where: where?.call(Employee.t),
       orderBy: orderBy?.call(Employee.t),
       orderByList: orderByList?.call(Employee.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -285,8 +275,6 @@ class EmployeeRepository {
     _i1.WhereExpressionBuilder<EmployeeTable>? where,
     int? offset,
     _i1.OrderByBuilder<EmployeeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -296,8 +284,6 @@ class EmployeeRepository {
       where: where?.call(Employee.t),
       orderBy: orderBy?.call(Employee.t),
       orderByList: orderByList?.call(Employee.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -502,8 +488,6 @@ class EmployeeRepository {
     int? offset,
     _i1.OrderByBuilder<EmployeeTable>? orderBy,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -514,8 +498,6 @@ class EmployeeRepository {
       offset: offset,
       orderBy: orderBy?.call(Employee.t),
       orderByList: orderByList?.call(Employee.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -536,8 +518,6 @@ class EmployeeRepository {
     _i1.DatabaseSession session,
     List<Employee> rows, {
     _i1.OrderByBuilder<EmployeeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -546,8 +526,6 @@ class EmployeeRepository {
       rows,
       orderBy: orderBy?.call(Employee.t),
       orderByList: orderByList?.call(Employee.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -577,8 +555,6 @@ class EmployeeRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EmployeeTable> where,
     _i1.OrderByBuilder<EmployeeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EmployeeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -587,8 +563,6 @@ class EmployeeRepository {
       where: where(Employee.t),
       orderBy: orderBy?.call(Employee.t),
       orderByList: orderByList?.call(Employee.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_one/contractor.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_one/contractor.dart
@@ -101,8 +101,6 @@ abstract class Contractor
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ContractorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     ContractorInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class Contractor
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Contractor.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Contractor.t),
       include: include,
     );
@@ -245,8 +241,6 @@ class ContractorIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -295,8 +289,6 @@ class ContractorRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ContractorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     _i1.Transaction? transaction,
     ContractorInclude? include,
@@ -307,8 +299,6 @@ class ContractorRepository {
       where: where?.call(Contractor.t),
       orderBy: orderBy?.call(Contractor.t),
       orderByList: orderByList?.call(Contractor.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -340,8 +330,6 @@ class ContractorRepository {
     _i1.WhereExpressionBuilder<ContractorTable>? where,
     int? offset,
     _i1.OrderByBuilder<ContractorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     _i1.Transaction? transaction,
     ContractorInclude? include,
@@ -352,8 +340,6 @@ class ContractorRepository {
       where: where?.call(Contractor.t),
       orderBy: orderBy?.call(Contractor.t),
       orderByList: orderByList?.call(Contractor.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -561,8 +547,6 @@ class ContractorRepository {
     int? offset,
     _i1.OrderByBuilder<ContractorTable>? orderBy,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -573,8 +557,6 @@ class ContractorRepository {
       offset: offset,
       orderBy: orderBy?.call(Contractor.t),
       orderByList: orderByList?.call(Contractor.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -595,8 +577,6 @@ class ContractorRepository {
     _i1.DatabaseSession session,
     List<Contractor> rows, {
     _i1.OrderByBuilder<ContractorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -605,8 +585,6 @@ class ContractorRepository {
       rows,
       orderBy: orderBy?.call(Contractor.t),
       orderByList: orderByList?.call(Contractor.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -636,8 +614,6 @@ class ContractorRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ContractorTable> where,
     _i1.OrderByBuilder<ContractorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ContractorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -646,8 +622,6 @@ class ContractorRepository {
       where: where(Contractor.t),
       orderBy: orderBy?.call(Contractor.t),
       orderByList: orderByList?.call(Contractor.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_one/service.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/relations/one_to_one/service.dart
@@ -85,8 +85,6 @@ abstract class Service
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServiceTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     ServiceInclude? include,
   }) {
@@ -95,8 +93,6 @@ abstract class Service
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Service.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Service.t),
       include: include,
     );
@@ -195,8 +191,6 @@ class ServiceIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -241,8 +235,6 @@ class ServiceRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ServiceTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -252,8 +244,6 @@ class ServiceRepository {
       where: where?.call(Service.t),
       orderBy: orderBy?.call(Service.t),
       orderByList: orderByList?.call(Service.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -284,8 +274,6 @@ class ServiceRepository {
     _i1.WhereExpressionBuilder<ServiceTable>? where,
     int? offset,
     _i1.OrderByBuilder<ServiceTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -295,8 +283,6 @@ class ServiceRepository {
       where: where?.call(Service.t),
       orderBy: orderBy?.call(Service.t),
       orderByList: orderByList?.call(Service.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -501,8 +487,6 @@ class ServiceRepository {
     int? offset,
     _i1.OrderByBuilder<ServiceTable>? orderBy,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -513,8 +497,6 @@ class ServiceRepository {
       offset: offset,
       orderBy: orderBy?.call(Service.t),
       orderByList: orderByList?.call(Service.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -535,8 +517,6 @@ class ServiceRepository {
     _i1.DatabaseSession session,
     List<Service> rows, {
     _i1.OrderByBuilder<ServiceTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -545,8 +525,6 @@ class ServiceRepository {
       rows,
       orderBy: orderBy?.call(Service.t),
       orderByList: orderByList?.call(Service.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -576,8 +554,6 @@ class ServiceRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ServiceTable> where,
     _i1.OrderByBuilder<ServiceTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ServiceTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -586,8 +562,6 @@ class ServiceRepository {
       where: where(Service.t),
       orderBy: orderBy?.call(Service.t),
       orderByList: orderByList?.call(Service.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/table_with_explicit_column_names.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/explicit_column_name/table_with_explicit_column_names.dart
@@ -87,8 +87,6 @@ abstract class TableWithExplicitColumnName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TableWithExplicitColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     TableWithExplicitColumnNameInclude? include,
   }) {
@@ -97,8 +95,6 @@ abstract class TableWithExplicitColumnName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(TableWithExplicitColumnName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(TableWithExplicitColumnName.t),
       include: include,
     );
@@ -202,8 +198,6 @@ class TableWithExplicitColumnNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -248,8 +242,6 @@ class TableWithExplicitColumnNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TableWithExplicitColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -259,8 +251,6 @@ class TableWithExplicitColumnNameRepository {
       where: where?.call(TableWithExplicitColumnName.t),
       orderBy: orderBy?.call(TableWithExplicitColumnName.t),
       orderByList: orderByList?.call(TableWithExplicitColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -291,8 +281,6 @@ class TableWithExplicitColumnNameRepository {
     _i1.WhereExpressionBuilder<TableWithExplicitColumnNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<TableWithExplicitColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -302,8 +290,6 @@ class TableWithExplicitColumnNameRepository {
       where: where?.call(TableWithExplicitColumnName.t),
       orderBy: orderBy?.call(TableWithExplicitColumnName.t),
       orderByList: orderByList?.call(TableWithExplicitColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -512,8 +498,6 @@ class TableWithExplicitColumnNameRepository {
     int? offset,
     _i1.OrderByBuilder<TableWithExplicitColumnNameTable>? orderBy,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -524,8 +508,6 @@ class TableWithExplicitColumnNameRepository {
       offset: offset,
       orderBy: orderBy?.call(TableWithExplicitColumnName.t),
       orderByList: orderByList?.call(TableWithExplicitColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -546,8 +528,6 @@ class TableWithExplicitColumnNameRepository {
     _i1.DatabaseSession session,
     List<TableWithExplicitColumnName> rows, {
     _i1.OrderByBuilder<TableWithExplicitColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -556,8 +536,6 @@ class TableWithExplicitColumnNameRepository {
       rows,
       orderBy: orderBy?.call(TableWithExplicitColumnName.t),
       orderByList: orderByList?.call(TableWithExplicitColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -587,8 +565,6 @@ class TableWithExplicitColumnNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TableWithExplicitColumnNameTable> where,
     _i1.OrderByBuilder<TableWithExplicitColumnNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TableWithExplicitColumnNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -597,8 +573,6 @@ class TableWithExplicitColumnNameRepository {
       where: where(TableWithExplicitColumnName.t),
       orderBy: orderBy?.call(TableWithExplicitColumnName.t),
       orderByList: orderByList?.call(TableWithExplicitColumnName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/city_with_long_table_name.dart
@@ -122,8 +122,6 @@ abstract class CityWithLongTableName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CityWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     CityWithLongTableNameInclude? include,
   }) {
@@ -132,8 +130,6 @@ abstract class CityWithLongTableName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(CityWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(CityWithLongTableName.t),
       include: include,
     );
@@ -336,8 +332,6 @@ class CityWithLongTableNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -390,8 +384,6 @@ class CityWithLongTableNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CityWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     CityWithLongTableNameInclude? include,
@@ -402,8 +394,6 @@ class CityWithLongTableNameRepository {
       where: where?.call(CityWithLongTableName.t),
       orderBy: orderBy?.call(CityWithLongTableName.t),
       orderByList: orderByList?.call(CityWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -435,8 +425,6 @@ class CityWithLongTableNameRepository {
     _i1.WhereExpressionBuilder<CityWithLongTableNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<CityWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     CityWithLongTableNameInclude? include,
@@ -447,8 +435,6 @@ class CityWithLongTableNameRepository {
       where: where?.call(CityWithLongTableName.t),
       orderBy: orderBy?.call(CityWithLongTableName.t),
       orderByList: orderByList?.call(CityWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -658,8 +644,6 @@ class CityWithLongTableNameRepository {
     int? offset,
     _i1.OrderByBuilder<CityWithLongTableNameTable>? orderBy,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -670,8 +654,6 @@ class CityWithLongTableNameRepository {
       offset: offset,
       orderBy: orderBy?.call(CityWithLongTableName.t),
       orderByList: orderByList?.call(CityWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -692,8 +674,6 @@ class CityWithLongTableNameRepository {
     _i1.DatabaseSession session,
     List<CityWithLongTableName> rows, {
     _i1.OrderByBuilder<CityWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -702,8 +682,6 @@ class CityWithLongTableNameRepository {
       rows,
       orderBy: orderBy?.call(CityWithLongTableName.t),
       orderByList: orderByList?.call(CityWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -733,8 +711,6 @@ class CityWithLongTableNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CityWithLongTableNameTable> where,
     _i1.OrderByBuilder<CityWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -743,8 +719,6 @@ class CityWithLongTableNameRepository {
       where: where(CityWithLongTableName.t),
       orderBy: orderBy?.call(CityWithLongTableName.t),
       orderByList: orderByList?.call(CityWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/organization_with_long_table_name.dart
@@ -126,8 +126,6 @@ abstract class OrganizationWithLongTableName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrganizationWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     OrganizationWithLongTableNameInclude? include,
   }) {
@@ -136,8 +134,6 @@ abstract class OrganizationWithLongTableName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
       include: include,
     );
@@ -325,8 +321,6 @@ class OrganizationWithLongTableNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -379,8 +373,6 @@ class OrganizationWithLongTableNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrganizationWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     OrganizationWithLongTableNameInclude? include,
@@ -391,8 +383,6 @@ class OrganizationWithLongTableNameRepository {
       where: where?.call(OrganizationWithLongTableName.t),
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -424,8 +414,6 @@ class OrganizationWithLongTableNameRepository {
     _i1.WhereExpressionBuilder<OrganizationWithLongTableNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<OrganizationWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     OrganizationWithLongTableNameInclude? include,
@@ -436,8 +424,6 @@ class OrganizationWithLongTableNameRepository {
       where: where?.call(OrganizationWithLongTableName.t),
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -654,8 +640,6 @@ class OrganizationWithLongTableNameRepository {
     int? offset,
     _i1.OrderByBuilder<OrganizationWithLongTableNameTable>? orderBy,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -666,8 +650,6 @@ class OrganizationWithLongTableNameRepository {
       offset: offset,
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -688,8 +670,6 @@ class OrganizationWithLongTableNameRepository {
     _i1.DatabaseSession session,
     List<OrganizationWithLongTableName> rows, {
     _i1.OrderByBuilder<OrganizationWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -698,8 +678,6 @@ class OrganizationWithLongTableNameRepository {
       rows,
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -730,8 +708,6 @@ class OrganizationWithLongTableNameRepository {
     required _i1.WhereExpressionBuilder<OrganizationWithLongTableNameTable>
     where,
     _i1.OrderByBuilder<OrganizationWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -740,8 +716,6 @@ class OrganizationWithLongTableNameRepository {
       where: where(OrganizationWithLongTableName.t),
       orderBy: orderBy?.call(OrganizationWithLongTableName.t),
       orderByList: orderByList?.call(OrganizationWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/deep_includes/person_with_long_table_name.dart
@@ -116,8 +116,6 @@ abstract class PersonWithLongTableName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PersonWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     PersonWithLongTableNameInclude? include,
   }) {
@@ -126,8 +124,6 @@ abstract class PersonWithLongTableName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(PersonWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(PersonWithLongTableName.t),
       include: include,
     );
@@ -327,8 +323,6 @@ class PersonWithLongTableNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -377,8 +371,6 @@ class PersonWithLongTableNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PersonWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     PersonWithLongTableNameInclude? include,
@@ -389,8 +381,6 @@ class PersonWithLongTableNameRepository {
       where: where?.call(PersonWithLongTableName.t),
       orderBy: orderBy?.call(PersonWithLongTableName.t),
       orderByList: orderByList?.call(PersonWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -422,8 +412,6 @@ class PersonWithLongTableNameRepository {
     _i1.WhereExpressionBuilder<PersonWithLongTableNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<PersonWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     PersonWithLongTableNameInclude? include,
@@ -434,8 +422,6 @@ class PersonWithLongTableNameRepository {
       where: where?.call(PersonWithLongTableName.t),
       orderBy: orderBy?.call(PersonWithLongTableName.t),
       orderByList: orderByList?.call(PersonWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -645,8 +631,6 @@ class PersonWithLongTableNameRepository {
     int? offset,
     _i1.OrderByBuilder<PersonWithLongTableNameTable>? orderBy,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -657,8 +641,6 @@ class PersonWithLongTableNameRepository {
       offset: offset,
       orderBy: orderBy?.call(PersonWithLongTableName.t),
       orderByList: orderByList?.call(PersonWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -679,8 +661,6 @@ class PersonWithLongTableNameRepository {
     _i1.DatabaseSession session,
     List<PersonWithLongTableName> rows, {
     _i1.OrderByBuilder<PersonWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -689,8 +669,6 @@ class PersonWithLongTableNameRepository {
       rows,
       orderBy: orderBy?.call(PersonWithLongTableName.t),
       orderByList: orderByList?.call(PersonWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -720,8 +698,6 @@ class PersonWithLongTableNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PersonWithLongTableNameTable> where,
     _i1.OrderByBuilder<PersonWithLongTableNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonWithLongTableNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -730,8 +706,6 @@ class PersonWithLongTableNameRepository {
       where: where(PersonWithLongTableName.t),
       orderBy: orderBy?.call(PersonWithLongTableName.t),
       orderByList: orderByList?.call(PersonWithLongTableName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/max_field_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/max_field_name.dart
@@ -82,8 +82,6 @@ abstract class MaxFieldName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     MaxFieldNameInclude? include,
   }) {
@@ -92,8 +90,6 @@ abstract class MaxFieldName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(MaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(MaxFieldName.t),
       include: include,
     );
@@ -185,8 +181,6 @@ class MaxFieldNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -231,8 +225,6 @@ class MaxFieldNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -242,8 +234,6 @@ class MaxFieldNameRepository {
       where: where?.call(MaxFieldName.t),
       orderBy: orderBy?.call(MaxFieldName.t),
       orderByList: orderByList?.call(MaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -274,8 +264,6 @@ class MaxFieldNameRepository {
     _i1.WhereExpressionBuilder<MaxFieldNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<MaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -285,8 +273,6 @@ class MaxFieldNameRepository {
       where: where?.call(MaxFieldName.t),
       orderBy: orderBy?.call(MaxFieldName.t),
       orderByList: orderByList?.call(MaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -491,8 +477,6 @@ class MaxFieldNameRepository {
     int? offset,
     _i1.OrderByBuilder<MaxFieldNameTable>? orderBy,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -503,8 +487,6 @@ class MaxFieldNameRepository {
       offset: offset,
       orderBy: orderBy?.call(MaxFieldName.t),
       orderByList: orderByList?.call(MaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -525,8 +507,6 @@ class MaxFieldNameRepository {
     _i1.DatabaseSession session,
     List<MaxFieldName> rows, {
     _i1.OrderByBuilder<MaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -535,8 +515,6 @@ class MaxFieldNameRepository {
       rows,
       orderBy: orderBy?.call(MaxFieldName.t),
       orderByList: orderByList?.call(MaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -566,8 +544,6 @@ class MaxFieldNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MaxFieldNameTable> where,
     _i1.OrderByBuilder<MaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -576,8 +552,6 @@ class MaxFieldNameRepository {
       where: where(MaxFieldName.t),
       orderBy: orderBy?.call(MaxFieldName.t),
       orderByList: orderByList?.call(MaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field.dart
@@ -86,8 +86,6 @@ abstract class LongImplicitIdField
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     LongImplicitIdFieldInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class LongImplicitIdField
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(LongImplicitIdField.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(LongImplicitIdField.t),
       include: include,
     );
@@ -235,8 +231,6 @@ class LongImplicitIdFieldIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -281,8 +275,6 @@ class LongImplicitIdFieldRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -292,8 +284,6 @@ class LongImplicitIdFieldRepository {
       where: where?.call(LongImplicitIdField.t),
       orderBy: orderBy?.call(LongImplicitIdField.t),
       orderByList: orderByList?.call(LongImplicitIdField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -324,8 +314,6 @@ class LongImplicitIdFieldRepository {
     _i1.WhereExpressionBuilder<LongImplicitIdFieldTable>? where,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -335,8 +323,6 @@ class LongImplicitIdFieldRepository {
       where: where?.call(LongImplicitIdField.t),
       orderBy: orderBy?.call(LongImplicitIdField.t),
       orderByList: orderByList?.call(LongImplicitIdField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -543,8 +529,6 @@ class LongImplicitIdFieldRepository {
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldTable>? orderBy,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -555,8 +539,6 @@ class LongImplicitIdFieldRepository {
       offset: offset,
       orderBy: orderBy?.call(LongImplicitIdField.t),
       orderByList: orderByList?.call(LongImplicitIdField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -577,8 +559,6 @@ class LongImplicitIdFieldRepository {
     _i1.DatabaseSession session,
     List<LongImplicitIdField> rows, {
     _i1.OrderByBuilder<LongImplicitIdFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -587,8 +567,6 @@ class LongImplicitIdFieldRepository {
       rows,
       orderBy: orderBy?.call(LongImplicitIdField.t),
       orderByList: orderByList?.call(LongImplicitIdField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -618,8 +596,6 @@ class LongImplicitIdFieldRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<LongImplicitIdFieldTable> where,
     _i1.OrderByBuilder<LongImplicitIdFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -628,8 +604,6 @@ class LongImplicitIdFieldRepository {
       where: where(LongImplicitIdField.t),
       orderBy: orderBy?.call(LongImplicitIdField.t),
       orderByList: orderByList?.call(LongImplicitIdField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/long_implicit_id_field_collection.dart
@@ -113,8 +113,6 @@ abstract class LongImplicitIdFieldCollection
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     LongImplicitIdFieldCollectionInclude? include,
   }) {
@@ -123,8 +121,6 @@ abstract class LongImplicitIdFieldCollection
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
       include: include,
     );
@@ -296,8 +292,6 @@ class LongImplicitIdFieldCollectionIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -350,8 +344,6 @@ class LongImplicitIdFieldCollectionRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     LongImplicitIdFieldCollectionInclude? include,
@@ -362,8 +354,6 @@ class LongImplicitIdFieldCollectionRepository {
       where: where?.call(LongImplicitIdFieldCollection.t),
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -395,8 +385,6 @@ class LongImplicitIdFieldCollectionRepository {
     _i1.WhereExpressionBuilder<LongImplicitIdFieldCollectionTable>? where,
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     LongImplicitIdFieldCollectionInclude? include,
@@ -407,8 +395,6 @@ class LongImplicitIdFieldCollectionRepository {
       where: where?.call(LongImplicitIdFieldCollection.t),
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -625,8 +611,6 @@ class LongImplicitIdFieldCollectionRepository {
     int? offset,
     _i1.OrderByBuilder<LongImplicitIdFieldCollectionTable>? orderBy,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -637,8 +621,6 @@ class LongImplicitIdFieldCollectionRepository {
       offset: offset,
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -659,8 +641,6 @@ class LongImplicitIdFieldCollectionRepository {
     _i1.DatabaseSession session,
     List<LongImplicitIdFieldCollection> rows, {
     _i1.OrderByBuilder<LongImplicitIdFieldCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -669,8 +649,6 @@ class LongImplicitIdFieldCollectionRepository {
       rows,
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -701,8 +679,6 @@ class LongImplicitIdFieldCollectionRepository {
     required _i1.WhereExpressionBuilder<LongImplicitIdFieldCollectionTable>
     where,
     _i1.OrderByBuilder<LongImplicitIdFieldCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<LongImplicitIdFieldCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -711,8 +687,6 @@ class LongImplicitIdFieldCollectionRepository {
       where: where(LongImplicitIdFieldCollection.t),
       orderBy: orderBy?.call(LongImplicitIdFieldCollection.t),
       orderByList: orderByList?.call(LongImplicitIdFieldCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/relation_to_mutiple_max_field_name.dart
@@ -105,8 +105,6 @@ abstract class RelationToMultipleMaxFieldName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelationToMultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     RelationToMultipleMaxFieldNameInclude? include,
   }) {
@@ -115,8 +113,6 @@ abstract class RelationToMultipleMaxFieldName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
       include: include,
     );
@@ -267,8 +263,6 @@ class RelationToMultipleMaxFieldNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -321,8 +315,6 @@ class RelationToMultipleMaxFieldNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelationToMultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     RelationToMultipleMaxFieldNameInclude? include,
@@ -333,8 +325,6 @@ class RelationToMultipleMaxFieldNameRepository {
       where: where?.call(RelationToMultipleMaxFieldName.t),
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -366,8 +356,6 @@ class RelationToMultipleMaxFieldNameRepository {
     _i1.WhereExpressionBuilder<RelationToMultipleMaxFieldNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<RelationToMultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     RelationToMultipleMaxFieldNameInclude? include,
@@ -378,8 +366,6 @@ class RelationToMultipleMaxFieldNameRepository {
       where: where?.call(RelationToMultipleMaxFieldName.t),
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -598,8 +584,6 @@ class RelationToMultipleMaxFieldNameRepository {
     int? offset,
     _i1.OrderByBuilder<RelationToMultipleMaxFieldNameTable>? orderBy,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -610,8 +594,6 @@ class RelationToMultipleMaxFieldNameRepository {
       offset: offset,
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -632,8 +614,6 @@ class RelationToMultipleMaxFieldNameRepository {
     _i1.DatabaseSession session,
     List<RelationToMultipleMaxFieldName> rows, {
     _i1.OrderByBuilder<RelationToMultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -642,8 +622,6 @@ class RelationToMultipleMaxFieldNameRepository {
       rows,
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -674,8 +652,6 @@ class RelationToMultipleMaxFieldNameRepository {
     required _i1.WhereExpressionBuilder<RelationToMultipleMaxFieldNameTable>
     where,
     _i1.OrderByBuilder<RelationToMultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelationToMultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -684,8 +660,6 @@ class RelationToMultipleMaxFieldNameRepository {
       where: where(RelationToMultipleMaxFieldName.t),
       orderBy: orderBy?.call(RelationToMultipleMaxFieldName.t),
       orderByList: orderByList?.call(RelationToMultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note.dart
@@ -86,8 +86,6 @@ abstract class UserNote
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     UserNoteInclude? include,
   }) {
@@ -96,8 +94,6 @@ abstract class UserNote
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UserNote.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UserNote.t),
       include: include,
     );
@@ -232,8 +228,6 @@ class UserNoteIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -278,8 +272,6 @@ class UserNoteRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -289,8 +281,6 @@ class UserNoteRepository {
       where: where?.call(UserNote.t),
       orderBy: orderBy?.call(UserNote.t),
       orderByList: orderByList?.call(UserNote.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -321,8 +311,6 @@ class UserNoteRepository {
     _i1.WhereExpressionBuilder<UserNoteTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserNoteTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -332,8 +320,6 @@ class UserNoteRepository {
       where: where?.call(UserNote.t),
       orderBy: orderBy?.call(UserNote.t),
       orderByList: orderByList?.call(UserNote.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -538,8 +524,6 @@ class UserNoteRepository {
     int? offset,
     _i1.OrderByBuilder<UserNoteTable>? orderBy,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -550,8 +534,6 @@ class UserNoteRepository {
       offset: offset,
       orderBy: orderBy?.call(UserNote.t),
       orderByList: orderByList?.call(UserNote.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -572,8 +554,6 @@ class UserNoteRepository {
     _i1.DatabaseSession session,
     List<UserNote> rows, {
     _i1.OrderByBuilder<UserNoteTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -582,8 +562,6 @@ class UserNoteRepository {
       rows,
       orderBy: orderBy?.call(UserNote.t),
       orderByList: orderByList?.call(UserNote.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -613,8 +591,6 @@ class UserNoteRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteTable> where,
     _i1.OrderByBuilder<UserNoteTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -623,8 +599,6 @@ class UserNoteRepository {
       where: where(UserNote.t),
       orderBy: orderBy?.call(UserNote.t),
       orderByList: orderByList?.call(UserNote.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection.dart
@@ -103,8 +103,6 @@ abstract class UserNoteCollection
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     UserNoteCollectionInclude? include,
   }) {
@@ -113,8 +111,6 @@ abstract class UserNoteCollection
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UserNoteCollection.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UserNoteCollection.t),
       include: include,
     );
@@ -263,8 +259,6 @@ class UserNoteCollectionIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -317,8 +311,6 @@ class UserNoteCollectionRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     UserNoteCollectionInclude? include,
@@ -329,8 +321,6 @@ class UserNoteCollectionRepository {
       where: where?.call(UserNoteCollection.t),
       orderBy: orderBy?.call(UserNoteCollection.t),
       orderByList: orderByList?.call(UserNoteCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -362,8 +352,6 @@ class UserNoteCollectionRepository {
     _i1.WhereExpressionBuilder<UserNoteCollectionTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     UserNoteCollectionInclude? include,
@@ -374,8 +362,6 @@ class UserNoteCollectionRepository {
       where: where?.call(UserNoteCollection.t),
       orderBy: orderBy?.call(UserNoteCollection.t),
       orderByList: orderByList?.call(UserNoteCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -585,8 +571,6 @@ class UserNoteCollectionRepository {
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionTable>? orderBy,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -597,8 +581,6 @@ class UserNoteCollectionRepository {
       offset: offset,
       orderBy: orderBy?.call(UserNoteCollection.t),
       orderByList: orderByList?.call(UserNoteCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -619,8 +601,6 @@ class UserNoteCollectionRepository {
     _i1.DatabaseSession session,
     List<UserNoteCollection> rows, {
     _i1.OrderByBuilder<UserNoteCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -629,8 +609,6 @@ class UserNoteCollectionRepository {
       rows,
       orderBy: orderBy?.call(UserNoteCollection.t),
       orderByList: orderByList?.call(UserNoteCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -660,8 +638,6 @@ class UserNoteCollectionRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteCollectionTable> where,
     _i1.OrderByBuilder<UserNoteCollectionTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -670,8 +646,6 @@ class UserNoteCollectionRepository {
       where: where(UserNoteCollection.t),
       orderBy: orderBy?.call(UserNoteCollection.t),
       orderByList: orderByList?.call(UserNoteCollection.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_collection_with_a_long_name.dart
@@ -99,8 +99,6 @@ abstract class UserNoteCollectionWithALongName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     UserNoteCollectionWithALongNameInclude? include,
   }) {
@@ -109,8 +107,6 @@ abstract class UserNoteCollectionWithALongName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
       include: include,
     );
@@ -258,8 +254,6 @@ class UserNoteCollectionWithALongNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -314,8 +308,6 @@ class UserNoteCollectionWithALongNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     UserNoteCollectionWithALongNameInclude? include,
@@ -326,8 +318,6 @@ class UserNoteCollectionWithALongNameRepository {
       where: where?.call(UserNoteCollectionWithALongName.t),
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -359,8 +349,6 @@ class UserNoteCollectionWithALongNameRepository {
     _i1.WhereExpressionBuilder<UserNoteCollectionWithALongNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     UserNoteCollectionWithALongNameInclude? include,
@@ -371,8 +359,6 @@ class UserNoteCollectionWithALongNameRepository {
       where: where?.call(UserNoteCollectionWithALongName.t),
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -591,8 +577,6 @@ class UserNoteCollectionWithALongNameRepository {
     int? offset,
     _i1.OrderByBuilder<UserNoteCollectionWithALongNameTable>? orderBy,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -603,8 +587,6 @@ class UserNoteCollectionWithALongNameRepository {
       offset: offset,
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -625,8 +607,6 @@ class UserNoteCollectionWithALongNameRepository {
     _i1.DatabaseSession session,
     List<UserNoteCollectionWithALongName> rows, {
     _i1.OrderByBuilder<UserNoteCollectionWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -635,8 +615,6 @@ class UserNoteCollectionWithALongNameRepository {
       rows,
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -667,8 +645,6 @@ class UserNoteCollectionWithALongNameRepository {
     required _i1.WhereExpressionBuilder<UserNoteCollectionWithALongNameTable>
     where,
     _i1.OrderByBuilder<UserNoteCollectionWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteCollectionWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -677,8 +653,6 @@ class UserNoteCollectionWithALongNameRepository {
       where: where(UserNoteCollectionWithALongName.t),
       orderBy: orderBy?.call(UserNoteCollectionWithALongName.t),
       orderByList: orderByList?.call(UserNoteCollectionWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/models_with_relations/user_note_with_a_long_name.dart
@@ -88,8 +88,6 @@ abstract class UserNoteWithALongName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     UserNoteWithALongNameInclude? include,
   }) {
@@ -98,8 +96,6 @@ abstract class UserNoteWithALongName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UserNoteWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UserNoteWithALongName.t),
       include: include,
     );
@@ -237,8 +233,6 @@ class UserNoteWithALongNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -283,8 +277,6 @@ class UserNoteWithALongNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UserNoteWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -294,8 +286,6 @@ class UserNoteWithALongNameRepository {
       where: where?.call(UserNoteWithALongName.t),
       orderBy: orderBy?.call(UserNoteWithALongName.t),
       orderByList: orderByList?.call(UserNoteWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -326,8 +316,6 @@ class UserNoteWithALongNameRepository {
     _i1.WhereExpressionBuilder<UserNoteWithALongNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<UserNoteWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -337,8 +325,6 @@ class UserNoteWithALongNameRepository {
       where: where?.call(UserNoteWithALongName.t),
       orderBy: orderBy?.call(UserNoteWithALongName.t),
       orderByList: orderByList?.call(UserNoteWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -545,8 +531,6 @@ class UserNoteWithALongNameRepository {
     int? offset,
     _i1.OrderByBuilder<UserNoteWithALongNameTable>? orderBy,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -557,8 +541,6 @@ class UserNoteWithALongNameRepository {
       offset: offset,
       orderBy: orderBy?.call(UserNoteWithALongName.t),
       orderByList: orderByList?.call(UserNoteWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -579,8 +561,6 @@ class UserNoteWithALongNameRepository {
     _i1.DatabaseSession session,
     List<UserNoteWithALongName> rows, {
     _i1.OrderByBuilder<UserNoteWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -589,8 +569,6 @@ class UserNoteWithALongNameRepository {
       rows,
       orderBy: orderBy?.call(UserNoteWithALongName.t),
       orderByList: orderByList?.call(UserNoteWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -620,8 +598,6 @@ class UserNoteWithALongNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UserNoteWithALongNameTable> where,
     _i1.OrderByBuilder<UserNoteWithALongNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UserNoteWithALongNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -630,8 +606,6 @@ class UserNoteWithALongNameRepository {
       where: where(UserNoteWithALongName.t),
       orderBy: orderBy?.call(UserNoteWithALongName.t),
       orderByList: orderByList?.call(UserNoteWithALongName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/long_identifiers/multiple_max_field_name.dart
@@ -106,8 +106,6 @@ abstract class MultipleMaxFieldName
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     MultipleMaxFieldNameInclude? include,
   }) {
@@ -116,8 +114,6 @@ abstract class MultipleMaxFieldName
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
       include: include,
     );
@@ -299,8 +295,6 @@ class MultipleMaxFieldNameIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -345,8 +339,6 @@ class MultipleMaxFieldNameRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -356,8 +348,6 @@ class MultipleMaxFieldNameRepository {
       where: where?.call(MultipleMaxFieldName.t),
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -388,8 +378,6 @@ class MultipleMaxFieldNameRepository {
     _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable>? where,
     int? offset,
     _i1.OrderByBuilder<MultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -399,8 +387,6 @@ class MultipleMaxFieldNameRepository {
       where: where?.call(MultipleMaxFieldName.t),
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -607,8 +593,6 @@ class MultipleMaxFieldNameRepository {
     int? offset,
     _i1.OrderByBuilder<MultipleMaxFieldNameTable>? orderBy,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -619,8 +603,6 @@ class MultipleMaxFieldNameRepository {
       offset: offset,
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -641,8 +623,6 @@ class MultipleMaxFieldNameRepository {
     _i1.DatabaseSession session,
     List<MultipleMaxFieldName> rows, {
     _i1.OrderByBuilder<MultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -651,8 +631,6 @@ class MultipleMaxFieldNameRepository {
       rows,
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -682,8 +660,6 @@ class MultipleMaxFieldNameRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MultipleMaxFieldNameTable> where,
     _i1.OrderByBuilder<MultipleMaxFieldNameTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MultipleMaxFieldNameTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -692,8 +668,6 @@ class MultipleMaxFieldNameRepository {
       where: where(MultipleMaxFieldName.t),
       orderBy: orderBy?.call(MultipleMaxFieldName.t),
       orderByList: orderByList?.call(MultipleMaxFieldName.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/city.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/city.dart
@@ -117,8 +117,6 @@ abstract class City implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     CityInclude? include,
   }) {
@@ -127,8 +125,6 @@ abstract class City implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(City.t),
       include: include,
     );
@@ -319,8 +315,6 @@ class CityIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -373,8 +367,6 @@ class CityRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     CityInclude? include,
@@ -385,8 +377,6 @@ class CityRepository {
       where: where?.call(City.t),
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -418,8 +408,6 @@ class CityRepository {
     _i1.WhereExpressionBuilder<CityTable>? where,
     int? offset,
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     CityInclude? include,
@@ -430,8 +418,6 @@ class CityRepository {
       where: where?.call(City.t),
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -639,8 +625,6 @@ class CityRepository {
     int? offset,
     _i1.OrderByBuilder<CityTable>? orderBy,
     _i1.OrderByListBuilder<CityTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -651,8 +635,6 @@ class CityRepository {
       offset: offset,
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -673,8 +655,6 @@ class CityRepository {
     _i1.DatabaseSession session,
     List<City> rows, {
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -683,8 +663,6 @@ class CityRepository {
       rows,
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -714,8 +692,6 @@ class CityRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CityTable> where,
     _i1.OrderByBuilder<CityTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CityTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -724,8 +700,6 @@ class CityRepository {
       where: where(City.t),
       orderBy: orderBy?.call(City.t),
       orderByList: orderByList?.call(City.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/organization.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/organization.dart
@@ -120,8 +120,6 @@ abstract class Organization
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     OrganizationInclude? include,
   }) {
@@ -130,8 +128,6 @@ abstract class Organization
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Organization.t),
       include: include,
     );
@@ -315,8 +311,6 @@ class OrganizationIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -369,8 +363,6 @@ class OrganizationRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     OrganizationInclude? include,
@@ -381,8 +373,6 @@ class OrganizationRepository {
       where: where?.call(Organization.t),
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -414,8 +404,6 @@ class OrganizationRepository {
     _i1.WhereExpressionBuilder<OrganizationTable>? where,
     int? offset,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     OrganizationInclude? include,
@@ -426,8 +414,6 @@ class OrganizationRepository {
       where: where?.call(Organization.t),
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -635,8 +621,6 @@ class OrganizationRepository {
     int? offset,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -647,8 +631,6 @@ class OrganizationRepository {
       offset: offset,
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -669,8 +651,6 @@ class OrganizationRepository {
     _i1.DatabaseSession session,
     List<Organization> rows, {
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -679,8 +659,6 @@ class OrganizationRepository {
       rows,
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -710,8 +688,6 @@ class OrganizationRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrganizationTable> where,
     _i1.OrderByBuilder<OrganizationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrganizationTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -720,8 +696,6 @@ class OrganizationRepository {
       where: where(Organization.t),
       orderBy: orderBy?.call(Organization.t),
       orderByList: orderByList?.call(Organization.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/person.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_list_relations/person.dart
@@ -106,8 +106,6 @@ abstract class Person implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     PersonInclude? include,
   }) {
@@ -116,8 +114,6 @@ abstract class Person implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Person.t),
       include: include,
     );
@@ -303,8 +299,6 @@ class PersonIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -353,8 +347,6 @@ class PersonRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     PersonInclude? include,
@@ -365,8 +357,6 @@ class PersonRepository {
       where: where?.call(Person.t),
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -398,8 +388,6 @@ class PersonRepository {
     _i1.WhereExpressionBuilder<PersonTable>? where,
     int? offset,
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     PersonInclude? include,
@@ -410,8 +398,6 @@ class PersonRepository {
       where: where?.call(Person.t),
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -619,8 +605,6 @@ class PersonRepository {
     int? offset,
     _i1.OrderByBuilder<PersonTable>? orderBy,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -631,8 +615,6 @@ class PersonRepository {
       offset: offset,
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -653,8 +635,6 @@ class PersonRepository {
     _i1.DatabaseSession session,
     List<Person> rows, {
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -663,8 +643,6 @@ class PersonRepository {
       rows,
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -694,8 +672,6 @@ class PersonRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PersonTable> where,
     _i1.OrderByBuilder<PersonTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PersonTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -704,8 +680,6 @@ class PersonRepository {
       where: where(Person.t),
       orderBy: orderBy?.call(Person.t),
       orderByList: orderByList?.call(Person.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -96,8 +96,6 @@ abstract class Course implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     CourseInclude? include,
   }) {
@@ -106,8 +104,6 @@ abstract class Course implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Course.t),
       include: include,
     );
@@ -244,8 +240,6 @@ class CourseIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -298,8 +292,6 @@ class CourseRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     CourseInclude? include,
@@ -310,8 +302,6 @@ class CourseRepository {
       where: where?.call(Course.t),
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -343,8 +333,6 @@ class CourseRepository {
     _i1.WhereExpressionBuilder<CourseTable>? where,
     int? offset,
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     CourseInclude? include,
@@ -355,8 +343,6 @@ class CourseRepository {
       where: where?.call(Course.t),
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -564,8 +550,6 @@ class CourseRepository {
     int? offset,
     _i1.OrderByBuilder<CourseTable>? orderBy,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -576,8 +560,6 @@ class CourseRepository {
       offset: offset,
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -598,8 +580,6 @@ class CourseRepository {
     _i1.DatabaseSession session,
     List<Course> rows, {
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -608,8 +588,6 @@ class CourseRepository {
       rows,
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -639,8 +617,6 @@ class CourseRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CourseTable> where,
     _i1.OrderByBuilder<CourseTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CourseTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -649,8 +625,6 @@ class CourseRepository {
       where: where(Course.t),
       orderBy: orderBy?.call(Course.t),
       orderByList: orderByList?.call(Course.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/enrollment.dart
@@ -118,8 +118,6 @@ abstract class Enrollment
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     EnrollmentInclude? include,
   }) {
@@ -128,8 +126,6 @@ abstract class Enrollment
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Enrollment.t),
       include: include,
     );
@@ -290,8 +286,6 @@ class EnrollmentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -338,8 +332,6 @@ class EnrollmentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     EnrollmentInclude? include,
@@ -350,8 +342,6 @@ class EnrollmentRepository {
       where: where?.call(Enrollment.t),
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -383,8 +373,6 @@ class EnrollmentRepository {
     _i1.WhereExpressionBuilder<EnrollmentTable>? where,
     int? offset,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     EnrollmentInclude? include,
@@ -395,8 +383,6 @@ class EnrollmentRepository {
       where: where?.call(Enrollment.t),
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -604,8 +590,6 @@ class EnrollmentRepository {
     int? offset,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -616,8 +600,6 @@ class EnrollmentRepository {
       offset: offset,
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -638,8 +620,6 @@ class EnrollmentRepository {
     _i1.DatabaseSession session,
     List<Enrollment> rows, {
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -648,8 +628,6 @@ class EnrollmentRepository {
       rows,
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -679,8 +657,6 @@ class EnrollmentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<EnrollmentTable> where,
     _i1.OrderByBuilder<EnrollmentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<EnrollmentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -689,8 +665,6 @@ class EnrollmentRepository {
       where: where(Enrollment.t),
       orderBy: orderBy?.call(Enrollment.t),
       orderByList: orderByList?.call(Enrollment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/student.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/student.dart
@@ -97,8 +97,6 @@ abstract class Student
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     StudentInclude? include,
   }) {
@@ -107,8 +105,6 @@ abstract class Student
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Student.t),
       include: include,
     );
@@ -245,8 +241,6 @@ class StudentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -295,8 +289,6 @@ class StudentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     StudentInclude? include,
@@ -307,8 +299,6 @@ class StudentRepository {
       where: where?.call(Student.t),
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -340,8 +330,6 @@ class StudentRepository {
     _i1.WhereExpressionBuilder<StudentTable>? where,
     int? offset,
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     StudentInclude? include,
@@ -352,8 +340,6 @@ class StudentRepository {
       where: where?.call(Student.t),
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -561,8 +547,6 @@ class StudentRepository {
     int? offset,
     _i1.OrderByBuilder<StudentTable>? orderBy,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -573,8 +557,6 @@ class StudentRepository {
       offset: offset,
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -595,8 +577,6 @@ class StudentRepository {
     _i1.DatabaseSession session,
     List<Student> rows, {
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -605,8 +585,6 @@ class StudentRepository {
       rows,
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -636,8 +614,6 @@ class StudentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<StudentTable> where,
     _i1.OrderByBuilder<StudentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<StudentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -646,8 +622,6 @@ class StudentRepository {
       where: where(Student.t),
       orderBy: orderBy?.call(Student.t),
       orderByList: orderByList?.call(Student.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/arena.dart
@@ -90,8 +90,6 @@ abstract class Arena implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     ArenaInclude? include,
   }) {
@@ -100,8 +98,6 @@ abstract class Arena implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Arena.t),
       include: include,
     );
@@ -215,8 +211,6 @@ class ArenaIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -265,8 +259,6 @@ class ArenaRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     ArenaInclude? include,
@@ -277,8 +269,6 @@ class ArenaRepository {
       where: where?.call(Arena.t),
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -310,8 +300,6 @@ class ArenaRepository {
     _i1.WhereExpressionBuilder<ArenaTable>? where,
     int? offset,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     ArenaInclude? include,
@@ -322,8 +310,6 @@ class ArenaRepository {
       where: where?.call(Arena.t),
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -531,8 +517,6 @@ class ArenaRepository {
     int? offset,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -543,8 +527,6 @@ class ArenaRepository {
       offset: offset,
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -565,8 +547,6 @@ class ArenaRepository {
     _i1.DatabaseSession session,
     List<Arena> rows, {
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -575,8 +555,6 @@ class ArenaRepository {
       rows,
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -606,8 +584,6 @@ class ArenaRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ArenaTable> where,
     _i1.OrderByBuilder<ArenaTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ArenaTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -616,8 +592,6 @@ class ArenaRepository {
       where: where(Arena.t),
       orderBy: orderBy?.call(Arena.t),
       orderByList: orderByList?.call(Arena.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/player.dart
@@ -98,8 +98,6 @@ abstract class Player implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     PlayerInclude? include,
   }) {
@@ -108,8 +106,6 @@ abstract class Player implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Player.t),
       include: include,
     );
@@ -239,8 +235,6 @@ class PlayerIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -289,8 +283,6 @@ class PlayerRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     PlayerInclude? include,
@@ -301,8 +293,6 @@ class PlayerRepository {
       where: where?.call(Player.t),
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -334,8 +324,6 @@ class PlayerRepository {
     _i1.WhereExpressionBuilder<PlayerTable>? where,
     int? offset,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     PlayerInclude? include,
@@ -346,8 +334,6 @@ class PlayerRepository {
       where: where?.call(Player.t),
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -555,8 +541,6 @@ class PlayerRepository {
     int? offset,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -567,8 +551,6 @@ class PlayerRepository {
       offset: offset,
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -589,8 +571,6 @@ class PlayerRepository {
     _i1.DatabaseSession session,
     List<Player> rows, {
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -599,8 +579,6 @@ class PlayerRepository {
       rows,
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -630,8 +608,6 @@ class PlayerRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PlayerTable> where,
     _i1.OrderByBuilder<PlayerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PlayerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -640,8 +616,6 @@ class PlayerRepository {
       where: where(Player.t),
       orderBy: orderBy?.call(Player.t),
       orderByList: orderByList?.call(Player.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/nested_one_to_many/team.dart
@@ -119,8 +119,6 @@ abstract class Team implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     TeamInclude? include,
   }) {
@@ -129,8 +127,6 @@ abstract class Team implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Team.t),
       include: include,
     );
@@ -314,8 +310,6 @@ class TeamIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -368,8 +362,6 @@ class TeamRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     TeamInclude? include,
@@ -380,8 +372,6 @@ class TeamRepository {
       where: where?.call(Team.t),
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -413,8 +403,6 @@ class TeamRepository {
     _i1.WhereExpressionBuilder<TeamTable>? where,
     int? offset,
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     TeamInclude? include,
@@ -425,8 +413,6 @@ class TeamRepository {
       where: where?.call(Team.t),
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -634,8 +620,6 @@ class TeamRepository {
     int? offset,
     _i1.OrderByBuilder<TeamTable>? orderBy,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -646,8 +630,6 @@ class TeamRepository {
       offset: offset,
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -668,8 +650,6 @@ class TeamRepository {
     _i1.DatabaseSession session,
     List<Team> rows, {
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -678,8 +658,6 @@ class TeamRepository {
       rows,
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -709,8 +687,6 @@ class TeamRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TeamTable> where,
     _i1.OrderByBuilder<TeamTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TeamTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -719,8 +695,6 @@ class TeamRepository {
       where: where(Team.t),
       orderBy: orderBy?.call(Team.t),
       orderByList: orderByList?.call(Team.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/comment.dart
@@ -99,8 +99,6 @@ abstract class Comment
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     CommentInclude? include,
   }) {
@@ -109,8 +107,6 @@ abstract class Comment
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Comment.t),
       include: include,
     );
@@ -240,8 +236,6 @@ class CommentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -288,8 +282,6 @@ class CommentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     CommentInclude? include,
@@ -300,8 +292,6 @@ class CommentRepository {
       where: where?.call(Comment.t),
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -333,8 +323,6 @@ class CommentRepository {
     _i1.WhereExpressionBuilder<CommentTable>? where,
     int? offset,
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     CommentInclude? include,
@@ -345,8 +333,6 @@ class CommentRepository {
       where: where?.call(Comment.t),
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -554,8 +540,6 @@ class CommentRepository {
     int? offset,
     _i1.OrderByBuilder<CommentTable>? orderBy,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -566,8 +550,6 @@ class CommentRepository {
       offset: offset,
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -588,8 +570,6 @@ class CommentRepository {
     _i1.DatabaseSession session,
     List<Comment> rows, {
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -598,8 +578,6 @@ class CommentRepository {
       rows,
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -629,8 +607,6 @@ class CommentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CommentTable> where,
     _i1.OrderByBuilder<CommentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CommentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -639,8 +615,6 @@ class CommentRepository {
       where: where(Comment.t),
       orderBy: orderBy?.call(Comment.t),
       orderByList: orderByList?.call(Comment.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -95,8 +95,6 @@ abstract class Customer
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     CustomerInclude? include,
   }) {
@@ -105,8 +103,6 @@ abstract class Customer
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Customer.t),
       include: include,
     );
@@ -243,8 +239,6 @@ class CustomerIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -297,8 +291,6 @@ class CustomerRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     CustomerInclude? include,
@@ -309,8 +301,6 @@ class CustomerRepository {
       where: where?.call(Customer.t),
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -342,8 +332,6 @@ class CustomerRepository {
     _i1.WhereExpressionBuilder<CustomerTable>? where,
     int? offset,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     CustomerInclude? include,
@@ -354,8 +342,6 @@ class CustomerRepository {
       where: where?.call(Customer.t),
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -563,8 +549,6 @@ class CustomerRepository {
     int? offset,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -575,8 +559,6 @@ class CustomerRepository {
       offset: offset,
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -597,8 +579,6 @@ class CustomerRepository {
     _i1.DatabaseSession session,
     List<Customer> rows, {
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -607,8 +587,6 @@ class CustomerRepository {
       rows,
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -638,8 +616,6 @@ class CustomerRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CustomerTable> where,
     _i1.OrderByBuilder<CustomerTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CustomerTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -648,8 +624,6 @@ class CustomerRepository {
       where: where(Customer.t),
       orderBy: orderBy?.call(Customer.t),
       orderByList: orderByList?.call(Customer.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/implicit/book.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/implicit/book.dart
@@ -95,8 +95,6 @@ abstract class Book implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     BookInclude? include,
   }) {
@@ -105,8 +103,6 @@ abstract class Book implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Book.t),
       include: include,
     );
@@ -243,8 +239,6 @@ class BookIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -297,8 +291,6 @@ class BookRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
     BookInclude? include,
@@ -309,8 +301,6 @@ class BookRepository {
       where: where?.call(Book.t),
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -342,8 +332,6 @@ class BookRepository {
     _i1.WhereExpressionBuilder<BookTable>? where,
     int? offset,
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
     BookInclude? include,
@@ -354,8 +342,6 @@ class BookRepository {
       where: where?.call(Book.t),
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -563,8 +549,6 @@ class BookRepository {
     int? offset,
     _i1.OrderByBuilder<BookTable>? orderBy,
     _i1.OrderByListBuilder<BookTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -575,8 +559,6 @@ class BookRepository {
       offset: offset,
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -597,8 +579,6 @@ class BookRepository {
     _i1.DatabaseSession session,
     List<Book> rows, {
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -607,8 +587,6 @@ class BookRepository {
       rows,
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -638,8 +616,6 @@ class BookRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BookTable> where,
     _i1.OrderByBuilder<BookTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BookTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -648,8 +624,6 @@ class BookRepository {
       where: where(Book.t),
       orderBy: orderBy?.call(Book.t),
       orderByList: orderByList?.call(Book.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/implicit/chapter.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/implicit/chapter.dart
@@ -82,8 +82,6 @@ abstract class Chapter
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     ChapterInclude? include,
   }) {
@@ -92,8 +90,6 @@ abstract class Chapter
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Chapter.t),
       include: include,
     );
@@ -221,8 +217,6 @@ class ChapterIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -267,8 +261,6 @@ class ChapterRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -278,8 +270,6 @@ class ChapterRepository {
       where: where?.call(Chapter.t),
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -310,8 +300,6 @@ class ChapterRepository {
     _i1.WhereExpressionBuilder<ChapterTable>? where,
     int? offset,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -321,8 +309,6 @@ class ChapterRepository {
       where: where?.call(Chapter.t),
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -527,8 +513,6 @@ class ChapterRepository {
     int? offset,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -539,8 +523,6 @@ class ChapterRepository {
       offset: offset,
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -561,8 +543,6 @@ class ChapterRepository {
     _i1.DatabaseSession session,
     List<Chapter> rows, {
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -571,8 +551,6 @@ class ChapterRepository {
       rows,
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -602,8 +580,6 @@ class ChapterRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ChapterTable> where,
     _i1.OrderByBuilder<ChapterTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ChapterTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -612,8 +588,6 @@ class ChapterRepository {
       where: where(Chapter.t),
       orderBy: orderBy?.call(Chapter.t),
       orderByList: orderByList?.call(Chapter.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/order.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/order.dart
@@ -121,8 +121,6 @@ abstract class Order implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     OrderInclude? include,
   }) {
@@ -131,8 +129,6 @@ abstract class Order implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Order.t),
       include: include,
     );
@@ -318,8 +314,6 @@ class OrderIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -368,8 +362,6 @@ class OrderRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     OrderInclude? include,
@@ -380,8 +372,6 @@ class OrderRepository {
       where: where?.call(Order.t),
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -413,8 +403,6 @@ class OrderRepository {
     _i1.WhereExpressionBuilder<OrderTable>? where,
     int? offset,
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     OrderInclude? include,
@@ -425,8 +413,6 @@ class OrderRepository {
       where: where?.call(Order.t),
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -634,8 +620,6 @@ class OrderRepository {
     int? offset,
     _i1.OrderByBuilder<OrderTable>? orderBy,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -646,8 +630,6 @@ class OrderRepository {
       offset: offset,
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -668,8 +650,6 @@ class OrderRepository {
     _i1.DatabaseSession session,
     List<Order> rows, {
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -678,8 +658,6 @@ class OrderRepository {
       rows,
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -709,8 +687,6 @@ class OrderRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<OrderTable> where,
     _i1.OrderByBuilder<OrderTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<OrderTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -719,8 +695,6 @@ class OrderRepository {
       where: where(Order.t),
       orderBy: orderBy?.call(Order.t),
       orderByList: orderByList?.call(Order.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/address.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/address.dart
@@ -101,8 +101,6 @@ abstract class Address
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     AddressInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class Address
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Address.t),
       include: include,
     );
@@ -244,8 +240,6 @@ class AddressIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -294,8 +288,6 @@ class AddressRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     AddressInclude? include,
@@ -306,8 +298,6 @@ class AddressRepository {
       where: where?.call(Address.t),
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -339,8 +329,6 @@ class AddressRepository {
     _i1.WhereExpressionBuilder<AddressTable>? where,
     int? offset,
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     AddressInclude? include,
@@ -351,8 +339,6 @@ class AddressRepository {
       where: where?.call(Address.t),
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -560,8 +546,6 @@ class AddressRepository {
     int? offset,
     _i1.OrderByBuilder<AddressTable>? orderBy,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -572,8 +556,6 @@ class AddressRepository {
       offset: offset,
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -594,8 +576,6 @@ class AddressRepository {
     _i1.DatabaseSession session,
     List<Address> rows, {
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -604,8 +584,6 @@ class AddressRepository {
       rows,
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -635,8 +613,6 @@ class AddressRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<AddressTable> where,
     _i1.OrderByBuilder<AddressTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<AddressTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -645,8 +621,6 @@ class AddressRepository {
       where: where(Address.t),
       orderBy: orderBy?.call(Address.t),
       orderByList: orderByList?.call(Address.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/citizen.dart
@@ -142,8 +142,6 @@ abstract class Citizen
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     CitizenInclude? include,
   }) {
@@ -152,8 +150,6 @@ abstract class Citizen
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Citizen.t),
       include: include,
     );
@@ -359,8 +355,6 @@ class CitizenIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -409,8 +403,6 @@ class CitizenRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     CitizenInclude? include,
@@ -421,8 +413,6 @@ class CitizenRepository {
       where: where?.call(Citizen.t),
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -454,8 +444,6 @@ class CitizenRepository {
     _i1.WhereExpressionBuilder<CitizenTable>? where,
     int? offset,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     CitizenInclude? include,
@@ -466,8 +454,6 @@ class CitizenRepository {
       where: where?.call(Citizen.t),
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -675,8 +661,6 @@ class CitizenRepository {
     int? offset,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -687,8 +671,6 @@ class CitizenRepository {
       offset: offset,
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -709,8 +691,6 @@ class CitizenRepository {
     _i1.DatabaseSession session,
     List<Citizen> rows, {
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -719,8 +699,6 @@ class CitizenRepository {
       rows,
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -750,8 +728,6 @@ class CitizenRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CitizenTable> where,
     _i1.OrderByBuilder<CitizenTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CitizenTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -760,8 +736,6 @@ class CitizenRepository {
       where: where(Citizen.t),
       orderBy: orderBy?.call(Citizen.t),
       orderByList: orderByList?.call(Citizen.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/company.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/company.dart
@@ -99,8 +99,6 @@ abstract class Company
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     CompanyInclude? include,
   }) {
@@ -109,8 +107,6 @@ abstract class Company
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Company.t),
       include: include,
     );
@@ -240,8 +236,6 @@ class CompanyIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -288,8 +282,6 @@ class CompanyRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     CompanyInclude? include,
@@ -300,8 +292,6 @@ class CompanyRepository {
       where: where?.call(Company.t),
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -333,8 +323,6 @@ class CompanyRepository {
     _i1.WhereExpressionBuilder<CompanyTable>? where,
     int? offset,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     CompanyInclude? include,
@@ -345,8 +333,6 @@ class CompanyRepository {
       where: where?.call(Company.t),
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -554,8 +540,6 @@ class CompanyRepository {
     int? offset,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -566,8 +550,6 @@ class CompanyRepository {
       offset: offset,
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -588,8 +570,6 @@ class CompanyRepository {
     _i1.DatabaseSession session,
     List<Company> rows, {
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -598,8 +578,6 @@ class CompanyRepository {
       rows,
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -629,8 +607,6 @@ class CompanyRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CompanyTable> where,
     _i1.OrderByBuilder<CompanyTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CompanyTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -639,8 +615,6 @@ class CompanyRepository {
       where: where(Company.t),
       orderBy: orderBy?.call(Company.t),
       orderByList: orderByList?.call(Company.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/town.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_one/town.dart
@@ -98,8 +98,6 @@ abstract class Town implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     TownInclude? include,
   }) {
@@ -108,8 +106,6 @@ abstract class Town implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Town.t),
       include: include,
     );
@@ -239,8 +235,6 @@ class TownIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -289,8 +283,6 @@ class TownRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     TownInclude? include,
@@ -301,8 +293,6 @@ class TownRepository {
       where: where?.call(Town.t),
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -334,8 +324,6 @@ class TownRepository {
     _i1.WhereExpressionBuilder<TownTable>? where,
     int? offset,
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     TownInclude? include,
@@ -346,8 +334,6 @@ class TownRepository {
       where: where?.call(Town.t),
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -555,8 +541,6 @@ class TownRepository {
     int? offset,
     _i1.OrderByBuilder<TownTable>? orderBy,
     _i1.OrderByListBuilder<TownTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -567,8 +551,6 @@ class TownRepository {
       offset: offset,
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -589,8 +571,6 @@ class TownRepository {
     _i1.DatabaseSession session,
     List<Town> rows, {
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -599,8 +579,6 @@ class TownRepository {
       rows,
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -630,8 +608,6 @@ class TownRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TownTable> where,
     _i1.OrderByBuilder<TownTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TownTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -640,8 +616,6 @@ class TownRepository {
       where: where(Town.t),
       orderBy: orderBy?.call(Town.t),
       orderByList: orderByList?.call(Town.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/many_to_many/blocking.dart
@@ -120,8 +120,6 @@ abstract class Blocking
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     BlockingInclude? include,
   }) {
@@ -130,8 +128,6 @@ abstract class Blocking
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Blocking.t),
       include: include,
     );
@@ -294,8 +290,6 @@ class BlockingIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -342,8 +336,6 @@ class BlockingRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     BlockingInclude? include,
@@ -354,8 +346,6 @@ class BlockingRepository {
       where: where?.call(Blocking.t),
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -387,8 +377,6 @@ class BlockingRepository {
     _i1.WhereExpressionBuilder<BlockingTable>? where,
     int? offset,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     BlockingInclude? include,
@@ -399,8 +387,6 @@ class BlockingRepository {
       where: where?.call(Blocking.t),
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -608,8 +594,6 @@ class BlockingRepository {
     int? offset,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -620,8 +604,6 @@ class BlockingRepository {
       offset: offset,
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -642,8 +624,6 @@ class BlockingRepository {
     _i1.DatabaseSession session,
     List<Blocking> rows, {
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -652,8 +632,6 @@ class BlockingRepository {
       rows,
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -683,8 +661,6 @@ class BlockingRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<BlockingTable> where,
     _i1.OrderByBuilder<BlockingTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<BlockingTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -693,8 +669,6 @@ class BlockingRepository {
       where: where(Blocking.t),
       orderBy: orderBy?.call(Blocking.t),
       orderByList: orderByList?.call(Blocking.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/many_to_many/member.dart
@@ -117,8 +117,6 @@ abstract class Member implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     MemberInclude? include,
   }) {
@@ -127,8 +125,6 @@ abstract class Member implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Member.t),
       include: include,
     );
@@ -319,8 +315,6 @@ class MemberIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -369,8 +363,6 @@ class MemberRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     MemberInclude? include,
@@ -381,8 +373,6 @@ class MemberRepository {
       where: where?.call(Member.t),
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -414,8 +404,6 @@ class MemberRepository {
     _i1.WhereExpressionBuilder<MemberTable>? where,
     int? offset,
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     MemberInclude? include,
@@ -426,8 +414,6 @@ class MemberRepository {
       where: where?.call(Member.t),
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -635,8 +621,6 @@ class MemberRepository {
     int? offset,
     _i1.OrderByBuilder<MemberTable>? orderBy,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -647,8 +631,6 @@ class MemberRepository {
       offset: offset,
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -669,8 +651,6 @@ class MemberRepository {
     _i1.DatabaseSession session,
     List<Member> rows, {
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -679,8 +659,6 @@ class MemberRepository {
       rows,
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -710,8 +688,6 @@ class MemberRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<MemberTable> where,
     _i1.OrderByBuilder<MemberTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<MemberTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -720,8 +696,6 @@ class MemberRepository {
       where: where(Member.t),
       orderBy: orderBy?.call(Member.t),
       orderByList: orderByList?.call(Member.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/one_to_many/cat.dart
@@ -119,8 +119,6 @@ abstract class Cat implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     CatInclude? include,
   }) {
@@ -129,8 +127,6 @@ abstract class Cat implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Cat.t),
       include: include,
     );
@@ -314,8 +310,6 @@ class CatIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -368,8 +362,6 @@ class CatRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     CatInclude? include,
@@ -380,8 +372,6 @@ class CatRepository {
       where: where?.call(Cat.t),
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -413,8 +403,6 @@ class CatRepository {
     _i1.WhereExpressionBuilder<CatTable>? where,
     int? offset,
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     CatInclude? include,
@@ -425,8 +413,6 @@ class CatRepository {
       where: where?.call(Cat.t),
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -634,8 +620,6 @@ class CatRepository {
     int? offset,
     _i1.OrderByBuilder<CatTable>? orderBy,
     _i1.OrderByListBuilder<CatTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -646,8 +630,6 @@ class CatRepository {
       offset: offset,
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -668,8 +650,6 @@ class CatRepository {
     _i1.DatabaseSession session,
     List<Cat> rows, {
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -678,8 +658,6 @@ class CatRepository {
       rows,
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -709,8 +687,6 @@ class CatRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<CatTable> where,
     _i1.OrderByBuilder<CatTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<CatTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -719,8 +695,6 @@ class CatRepository {
       where: where(Cat.t),
       orderBy: orderBy?.call(Cat.t),
       orderByList: orderByList?.call(Cat.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/self_relation/one_to_one/post.dart
@@ -115,8 +115,6 @@ abstract class Post implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     PostInclude? include,
   }) {
@@ -125,8 +123,6 @@ abstract class Post implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Post.t),
       include: include,
     );
@@ -287,8 +283,6 @@ class PostIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -337,8 +331,6 @@ class PostRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     PostInclude? include,
@@ -349,8 +341,6 @@ class PostRepository {
       where: where?.call(Post.t),
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -382,8 +372,6 @@ class PostRepository {
     _i1.WhereExpressionBuilder<PostTable>? where,
     int? offset,
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     PostInclude? include,
@@ -394,8 +382,6 @@ class PostRepository {
       where: where?.call(Post.t),
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -603,8 +589,6 @@ class PostRepository {
     int? offset,
     _i1.OrderByBuilder<PostTable>? orderBy,
     _i1.OrderByListBuilder<PostTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -615,8 +599,6 @@ class PostRepository {
       offset: offset,
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -637,8 +619,6 @@ class PostRepository {
     _i1.DatabaseSession session,
     List<Post> rows, {
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -647,8 +627,6 @@ class PostRepository {
       rows,
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -678,8 +656,6 @@ class PostRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<PostTable> where,
     _i1.OrderByBuilder<PostTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<PostTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -688,8 +664,6 @@ class PostRepository {
       where: where(Post.t),
       orderBy: orderBy?.call(Post.t),
       orderByList: orderByList?.call(Post.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_field_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_field_persist.dart
@@ -100,8 +100,6 @@ abstract class ObjectFieldPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     ObjectFieldPersistInclude? include,
   }) {
@@ -110,8 +108,6 @@ abstract class ObjectFieldPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectFieldPersist.t),
       include: include,
     );
@@ -204,8 +200,6 @@ class ObjectFieldPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -250,8 +244,6 @@ class ObjectFieldPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -261,8 +253,6 @@ class ObjectFieldPersistRepository {
       where: where?.call(ObjectFieldPersist.t),
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -293,8 +283,6 @@ class ObjectFieldPersistRepository {
     _i1.WhereExpressionBuilder<ObjectFieldPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -304,8 +292,6 @@ class ObjectFieldPersistRepository {
       where: where?.call(ObjectFieldPersist.t),
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -512,8 +498,6 @@ class ObjectFieldPersistRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -524,8 +508,6 @@ class ObjectFieldPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -546,8 +528,6 @@ class ObjectFieldPersistRepository {
     _i1.DatabaseSession session,
     List<ObjectFieldPersist> rows, {
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -556,8 +536,6 @@ class ObjectFieldPersistRepository {
       rows,
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -587,8 +565,6 @@ class ObjectFieldPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectFieldPersistTable> where,
     _i1.OrderByBuilder<ObjectFieldPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -597,8 +573,6 @@ class ObjectFieldPersistRepository {
       where: where(ObjectFieldPersist.t),
       orderBy: orderBy?.call(ObjectFieldPersist.t),
       orderByList: orderByList?.call(ObjectFieldPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_field_scopes.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_field_scopes.dart
@@ -92,8 +92,6 @@ abstract class ObjectFieldScopes
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     ObjectFieldScopesInclude? include,
   }) {
@@ -102,8 +100,6 @@ abstract class ObjectFieldScopes
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectFieldScopes.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectFieldScopes.t),
       include: include,
     );
@@ -208,8 +204,6 @@ class ObjectFieldScopesIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -254,8 +248,6 @@ class ObjectFieldScopesRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -265,8 +257,6 @@ class ObjectFieldScopesRepository {
       where: where?.call(ObjectFieldScopes.t),
       orderBy: orderBy?.call(ObjectFieldScopes.t),
       orderByList: orderByList?.call(ObjectFieldScopes.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -297,8 +287,6 @@ class ObjectFieldScopesRepository {
     _i1.WhereExpressionBuilder<ObjectFieldScopesTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -308,8 +296,6 @@ class ObjectFieldScopesRepository {
       where: where?.call(ObjectFieldScopes.t),
       orderBy: orderBy?.call(ObjectFieldScopes.t),
       orderByList: orderByList?.call(ObjectFieldScopes.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -516,8 +502,6 @@ class ObjectFieldScopesRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -528,8 +512,6 @@ class ObjectFieldScopesRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectFieldScopes.t),
       orderByList: orderByList?.call(ObjectFieldScopes.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -550,8 +532,6 @@ class ObjectFieldScopesRepository {
     _i1.DatabaseSession session,
     List<ObjectFieldScopes> rows, {
     _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -560,8 +540,6 @@ class ObjectFieldScopesRepository {
       rows,
       orderBy: orderBy?.call(ObjectFieldScopes.t),
       orderByList: orderByList?.call(ObjectFieldScopes.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -591,8 +569,6 @@ class ObjectFieldScopesRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectFieldScopesTable> where,
     _i1.OrderByBuilder<ObjectFieldScopesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectFieldScopesTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -601,8 +577,6 @@ class ObjectFieldScopesRepository {
       where: where(ObjectFieldScopes.t),
       orderBy: orderBy?.call(ObjectFieldScopes.t),
       orderByList: orderByList?.call(ObjectFieldScopes.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_bit.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_bit.dart
@@ -127,8 +127,6 @@ abstract class ObjectWithBit
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithBitTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     ObjectWithBitInclude? include,
   }) {
@@ -137,8 +135,6 @@ abstract class ObjectWithBit
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithBit.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithBit.t),
       include: include,
     );
@@ -319,8 +315,6 @@ class ObjectWithBitIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -365,8 +359,6 @@ class ObjectWithBitRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithBitTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -376,8 +368,6 @@ class ObjectWithBitRepository {
       where: where?.call(ObjectWithBit.t),
       orderBy: orderBy?.call(ObjectWithBit.t),
       orderByList: orderByList?.call(ObjectWithBit.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -408,8 +398,6 @@ class ObjectWithBitRepository {
     _i1.WhereExpressionBuilder<ObjectWithBitTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithBitTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -419,8 +407,6 @@ class ObjectWithBitRepository {
       where: where?.call(ObjectWithBit.t),
       orderBy: orderBy?.call(ObjectWithBit.t),
       orderByList: orderByList?.call(ObjectWithBit.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -625,8 +611,6 @@ class ObjectWithBitRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithBitTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -637,8 +621,6 @@ class ObjectWithBitRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithBit.t),
       orderByList: orderByList?.call(ObjectWithBit.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -659,8 +641,6 @@ class ObjectWithBitRepository {
     _i1.DatabaseSession session,
     List<ObjectWithBit> rows, {
     _i1.OrderByBuilder<ObjectWithBitTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -669,8 +649,6 @@ class ObjectWithBitRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithBit.t),
       orderByList: orderByList?.call(ObjectWithBit.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -700,8 +678,6 @@ class ObjectWithBitRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithBitTable> where,
     _i1.OrderByBuilder<ObjectWithBitTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithBitTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -710,8 +686,6 @@ class ObjectWithBitRepository {
       where: where(ObjectWithBit.t),
       orderBy: orderBy?.call(ObjectWithBit.t),
       orderByList: orderByList?.call(ObjectWithBit.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_bytedata.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_bytedata.dart
@@ -80,8 +80,6 @@ abstract class ObjectWithByteData
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     ObjectWithByteDataInclude? include,
   }) {
@@ -90,8 +88,6 @@ abstract class ObjectWithByteData
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithByteData.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithByteData.t),
       include: include,
     );
@@ -177,8 +173,6 @@ class ObjectWithByteDataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -223,8 +217,6 @@ class ObjectWithByteDataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -234,8 +226,6 @@ class ObjectWithByteDataRepository {
       where: where?.call(ObjectWithByteData.t),
       orderBy: orderBy?.call(ObjectWithByteData.t),
       orderByList: orderByList?.call(ObjectWithByteData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -266,8 +256,6 @@ class ObjectWithByteDataRepository {
     _i1.WhereExpressionBuilder<ObjectWithByteDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -277,8 +265,6 @@ class ObjectWithByteDataRepository {
       where: where?.call(ObjectWithByteData.t),
       orderBy: orderBy?.call(ObjectWithByteData.t),
       orderByList: orderByList?.call(ObjectWithByteData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -485,8 +471,6 @@ class ObjectWithByteDataRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -497,8 +481,6 @@ class ObjectWithByteDataRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithByteData.t),
       orderByList: orderByList?.call(ObjectWithByteData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -519,8 +501,6 @@ class ObjectWithByteDataRepository {
     _i1.DatabaseSession session,
     List<ObjectWithByteData> rows, {
     _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -529,8 +509,6 @@ class ObjectWithByteDataRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithByteData.t),
       orderByList: orderByList?.call(ObjectWithByteData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -560,8 +538,6 @@ class ObjectWithByteDataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithByteDataTable> where,
     _i1.OrderByBuilder<ObjectWithByteDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithByteDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -570,8 +546,6 @@ class ObjectWithByteDataRepository {
       where: where(ObjectWithByteData.t),
       orderBy: orderBy?.call(ObjectWithByteData.t),
       orderByList: orderByList?.call(ObjectWithByteData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_duration.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_duration.dart
@@ -79,8 +79,6 @@ abstract class ObjectWithDuration
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     ObjectWithDurationInclude? include,
   }) {
@@ -89,8 +87,6 @@ abstract class ObjectWithDuration
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithDuration.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithDuration.t),
       include: include,
     );
@@ -176,8 +172,6 @@ class ObjectWithDurationIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -222,8 +216,6 @@ class ObjectWithDurationRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -233,8 +225,6 @@ class ObjectWithDurationRepository {
       where: where?.call(ObjectWithDuration.t),
       orderBy: orderBy?.call(ObjectWithDuration.t),
       orderByList: orderByList?.call(ObjectWithDuration.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -265,8 +255,6 @@ class ObjectWithDurationRepository {
     _i1.WhereExpressionBuilder<ObjectWithDurationTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -276,8 +264,6 @@ class ObjectWithDurationRepository {
       where: where?.call(ObjectWithDuration.t),
       orderBy: orderBy?.call(ObjectWithDuration.t),
       orderByList: orderByList?.call(ObjectWithDuration.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -484,8 +470,6 @@ class ObjectWithDurationRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -496,8 +480,6 @@ class ObjectWithDurationRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithDuration.t),
       orderByList: orderByList?.call(ObjectWithDuration.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -518,8 +500,6 @@ class ObjectWithDurationRepository {
     _i1.DatabaseSession session,
     List<ObjectWithDuration> rows, {
     _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -528,8 +508,6 @@ class ObjectWithDurationRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithDuration.t),
       orderByList: orderByList?.call(ObjectWithDuration.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -559,8 +537,6 @@ class ObjectWithDurationRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithDurationTable> where,
     _i1.OrderByBuilder<ObjectWithDurationTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDurationTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -569,8 +545,6 @@ class ObjectWithDurationRepository {
       where: where(ObjectWithDuration.t),
       orderBy: orderBy?.call(ObjectWithDuration.t),
       orderByList: orderByList?.call(ObjectWithDuration.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_dynamic.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_dynamic.dart
@@ -171,8 +171,6 @@ abstract class ObjectWithDynamic
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithDynamicTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     ObjectWithDynamicInclude? include,
   }) {
@@ -181,8 +179,6 @@ abstract class ObjectWithDynamic
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithDynamic.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithDynamic.t),
       include: include,
     );
@@ -377,8 +373,6 @@ class ObjectWithDynamicIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -423,8 +417,6 @@ class ObjectWithDynamicRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithDynamicTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -434,8 +426,6 @@ class ObjectWithDynamicRepository {
       where: where?.call(ObjectWithDynamic.t),
       orderBy: orderBy?.call(ObjectWithDynamic.t),
       orderByList: orderByList?.call(ObjectWithDynamic.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -466,8 +456,6 @@ class ObjectWithDynamicRepository {
     _i1.WhereExpressionBuilder<ObjectWithDynamicTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithDynamicTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -477,8 +465,6 @@ class ObjectWithDynamicRepository {
       where: where?.call(ObjectWithDynamic.t),
       orderBy: orderBy?.call(ObjectWithDynamic.t),
       orderByList: orderByList?.call(ObjectWithDynamic.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -685,8 +671,6 @@ class ObjectWithDynamicRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithDynamicTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -697,8 +681,6 @@ class ObjectWithDynamicRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithDynamic.t),
       orderByList: orderByList?.call(ObjectWithDynamic.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -719,8 +701,6 @@ class ObjectWithDynamicRepository {
     _i1.DatabaseSession session,
     List<ObjectWithDynamic> rows, {
     _i1.OrderByBuilder<ObjectWithDynamicTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -729,8 +709,6 @@ class ObjectWithDynamicRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithDynamic.t),
       orderByList: orderByList?.call(ObjectWithDynamic.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -760,8 +738,6 @@ class ObjectWithDynamicRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithDynamicTable> where,
     _i1.OrderByBuilder<ObjectWithDynamicTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithDynamicTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -770,8 +746,6 @@ class ObjectWithDynamicRepository {
       where: where(ObjectWithDynamic.t),
       orderBy: orderBy?.call(ObjectWithDynamic.t),
       orderByList: orderByList?.call(ObjectWithDynamic.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_enum.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_enum.dart
@@ -128,8 +128,6 @@ abstract class ObjectWithEnum
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     ObjectWithEnumInclude? include,
   }) {
@@ -138,8 +136,6 @@ abstract class ObjectWithEnum
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithEnum.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithEnum.t),
       include: include,
     );
@@ -302,8 +298,6 @@ class ObjectWithEnumIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -348,8 +342,6 @@ class ObjectWithEnumRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -359,8 +351,6 @@ class ObjectWithEnumRepository {
       where: where?.call(ObjectWithEnum.t),
       orderBy: orderBy?.call(ObjectWithEnum.t),
       orderByList: orderByList?.call(ObjectWithEnum.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -391,8 +381,6 @@ class ObjectWithEnumRepository {
     _i1.WhereExpressionBuilder<ObjectWithEnumTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -402,8 +390,6 @@ class ObjectWithEnumRepository {
       where: where?.call(ObjectWithEnum.t),
       orderBy: orderBy?.call(ObjectWithEnum.t),
       orderByList: orderByList?.call(ObjectWithEnum.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -608,8 +594,6 @@ class ObjectWithEnumRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -620,8 +604,6 @@ class ObjectWithEnumRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithEnum.t),
       orderByList: orderByList?.call(ObjectWithEnum.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -642,8 +624,6 @@ class ObjectWithEnumRepository {
     _i1.DatabaseSession session,
     List<ObjectWithEnum> rows, {
     _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -652,8 +632,6 @@ class ObjectWithEnumRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithEnum.t),
       orderByList: orderByList?.call(ObjectWithEnum.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -683,8 +661,6 @@ class ObjectWithEnumRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithEnumTable> where,
     _i1.OrderByBuilder<ObjectWithEnumTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -693,8 +669,6 @@ class ObjectWithEnumRepository {
       where: where(ObjectWithEnum.t),
       orderBy: orderBy?.call(ObjectWithEnum.t),
       orderByList: orderByList?.call(ObjectWithEnum.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_enum_enhanced.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_enum_enhanced.dart
@@ -139,8 +139,6 @@ abstract class ObjectWithEnumEnhanced
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumEnhancedTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     ObjectWithEnumEnhancedInclude? include,
   }) {
@@ -149,8 +147,6 @@ abstract class ObjectWithEnumEnhanced
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithEnumEnhanced.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithEnumEnhanced.t),
       include: include,
     );
@@ -335,8 +331,6 @@ class ObjectWithEnumEnhancedIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -381,8 +375,6 @@ class ObjectWithEnumEnhancedRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumEnhancedTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -392,8 +384,6 @@ class ObjectWithEnumEnhancedRepository {
       where: where?.call(ObjectWithEnumEnhanced.t),
       orderBy: orderBy?.call(ObjectWithEnumEnhanced.t),
       orderByList: orderByList?.call(ObjectWithEnumEnhanced.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -424,8 +414,6 @@ class ObjectWithEnumEnhancedRepository {
     _i1.WhereExpressionBuilder<ObjectWithEnumEnhancedTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumEnhancedTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -435,8 +423,6 @@ class ObjectWithEnumEnhancedRepository {
       where: where?.call(ObjectWithEnumEnhanced.t),
       orderBy: orderBy?.call(ObjectWithEnumEnhanced.t),
       orderByList: orderByList?.call(ObjectWithEnumEnhanced.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -643,8 +629,6 @@ class ObjectWithEnumEnhancedRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithEnumEnhancedTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -655,8 +639,6 @@ class ObjectWithEnumEnhancedRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithEnumEnhanced.t),
       orderByList: orderByList?.call(ObjectWithEnumEnhanced.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -677,8 +659,6 @@ class ObjectWithEnumEnhancedRepository {
     _i1.DatabaseSession session,
     List<ObjectWithEnumEnhanced> rows, {
     _i1.OrderByBuilder<ObjectWithEnumEnhancedTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -687,8 +667,6 @@ class ObjectWithEnumEnhancedRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithEnumEnhanced.t),
       orderByList: orderByList?.call(ObjectWithEnumEnhanced.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -718,8 +696,6 @@ class ObjectWithEnumEnhancedRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithEnumEnhancedTable> where,
     _i1.OrderByBuilder<ObjectWithEnumEnhancedTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithEnumEnhancedTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -728,8 +704,6 @@ class ObjectWithEnumEnhancedRepository {
       where: where(ObjectWithEnumEnhanced.t),
       orderBy: orderBy?.call(ObjectWithEnumEnhanced.t),
       orderByList: orderByList?.call(ObjectWithEnumEnhanced.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_half_vector.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_half_vector.dart
@@ -139,8 +139,6 @@ abstract class ObjectWithHalfVector
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithHalfVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     ObjectWithHalfVectorInclude? include,
   }) {
@@ -149,8 +147,6 @@ abstract class ObjectWithHalfVector
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithHalfVector.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithHalfVector.t),
       include: include,
     );
@@ -339,8 +335,6 @@ class ObjectWithHalfVectorIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -385,8 +379,6 @@ class ObjectWithHalfVectorRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithHalfVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -396,8 +388,6 @@ class ObjectWithHalfVectorRepository {
       where: where?.call(ObjectWithHalfVector.t),
       orderBy: orderBy?.call(ObjectWithHalfVector.t),
       orderByList: orderByList?.call(ObjectWithHalfVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -428,8 +418,6 @@ class ObjectWithHalfVectorRepository {
     _i1.WhereExpressionBuilder<ObjectWithHalfVectorTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithHalfVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -439,8 +427,6 @@ class ObjectWithHalfVectorRepository {
       where: where?.call(ObjectWithHalfVector.t),
       orderBy: orderBy?.call(ObjectWithHalfVector.t),
       orderByList: orderByList?.call(ObjectWithHalfVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -647,8 +633,6 @@ class ObjectWithHalfVectorRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithHalfVectorTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -659,8 +643,6 @@ class ObjectWithHalfVectorRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithHalfVector.t),
       orderByList: orderByList?.call(ObjectWithHalfVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -681,8 +663,6 @@ class ObjectWithHalfVectorRepository {
     _i1.DatabaseSession session,
     List<ObjectWithHalfVector> rows, {
     _i1.OrderByBuilder<ObjectWithHalfVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -691,8 +671,6 @@ class ObjectWithHalfVectorRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithHalfVector.t),
       orderByList: orderByList?.call(ObjectWithHalfVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -722,8 +700,6 @@ class ObjectWithHalfVectorRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithHalfVectorTable> where,
     _i1.OrderByBuilder<ObjectWithHalfVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithHalfVectorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -732,8 +708,6 @@ class ObjectWithHalfVectorRepository {
       where: where(ObjectWithHalfVector.t),
       orderBy: orderBy?.call(ObjectWithHalfVector.t),
       orderByList: orderByList?.call(ObjectWithHalfVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_index.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_index.dart
@@ -85,8 +85,6 @@ abstract class ObjectWithIndex
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     ObjectWithIndexInclude? include,
   }) {
@@ -95,8 +93,6 @@ abstract class ObjectWithIndex
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithIndex.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithIndex.t),
       include: include,
     );
@@ -196,8 +192,6 @@ class ObjectWithIndexIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -242,8 +236,6 @@ class ObjectWithIndexRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -253,8 +245,6 @@ class ObjectWithIndexRepository {
       where: where?.call(ObjectWithIndex.t),
       orderBy: orderBy?.call(ObjectWithIndex.t),
       orderByList: orderByList?.call(ObjectWithIndex.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -285,8 +275,6 @@ class ObjectWithIndexRepository {
     _i1.WhereExpressionBuilder<ObjectWithIndexTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -296,8 +284,6 @@ class ObjectWithIndexRepository {
       where: where?.call(ObjectWithIndex.t),
       orderBy: orderBy?.call(ObjectWithIndex.t),
       orderByList: orderByList?.call(ObjectWithIndex.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -504,8 +490,6 @@ class ObjectWithIndexRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -516,8 +500,6 @@ class ObjectWithIndexRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithIndex.t),
       orderByList: orderByList?.call(ObjectWithIndex.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -538,8 +520,6 @@ class ObjectWithIndexRepository {
     _i1.DatabaseSession session,
     List<ObjectWithIndex> rows, {
     _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -548,8 +528,6 @@ class ObjectWithIndexRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithIndex.t),
       orderByList: orderByList?.call(ObjectWithIndex.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -579,8 +557,6 @@ class ObjectWithIndexRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithIndexTable> where,
     _i1.OrderByBuilder<ObjectWithIndexTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithIndexTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -589,8 +565,6 @@ class ObjectWithIndexRepository {
       where: where(ObjectWithIndex.t),
       orderBy: orderBy?.call(ObjectWithIndex.t),
       orderByList: orderByList?.call(ObjectWithIndex.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_jsonb.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_jsonb.dart
@@ -164,8 +164,6 @@ abstract class ObjectWithJsonb
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     ObjectWithJsonbInclude? include,
   }) {
@@ -174,8 +172,6 @@ abstract class ObjectWithJsonb
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithJsonb.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithJsonb.t),
       include: include,
     );
@@ -420,8 +416,6 @@ class ObjectWithJsonbIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -466,8 +460,6 @@ class ObjectWithJsonbRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -477,8 +469,6 @@ class ObjectWithJsonbRepository {
       where: where?.call(ObjectWithJsonb.t),
       orderBy: orderBy?.call(ObjectWithJsonb.t),
       orderByList: orderByList?.call(ObjectWithJsonb.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -509,8 +499,6 @@ class ObjectWithJsonbRepository {
     _i1.WhereExpressionBuilder<ObjectWithJsonbTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -520,8 +508,6 @@ class ObjectWithJsonbRepository {
       where: where?.call(ObjectWithJsonb.t),
       orderBy: orderBy?.call(ObjectWithJsonb.t),
       orderByList: orderByList?.call(ObjectWithJsonb.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -728,8 +714,6 @@ class ObjectWithJsonbRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -740,8 +724,6 @@ class ObjectWithJsonbRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithJsonb.t),
       orderByList: orderByList?.call(ObjectWithJsonb.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -762,8 +744,6 @@ class ObjectWithJsonbRepository {
     _i1.DatabaseSession session,
     List<ObjectWithJsonb> rows, {
     _i1.OrderByBuilder<ObjectWithJsonbTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -772,8 +752,6 @@ class ObjectWithJsonbRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithJsonb.t),
       orderByList: orderByList?.call(ObjectWithJsonb.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -803,8 +781,6 @@ class ObjectWithJsonbRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithJsonbTable> where,
     _i1.OrderByBuilder<ObjectWithJsonbTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -813,8 +789,6 @@ class ObjectWithJsonbRepository {
       where: where(ObjectWithJsonb.t),
       orderBy: orderBy?.call(ObjectWithJsonb.t),
       orderByList: orderByList?.call(ObjectWithJsonb.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_jsonb_class_level.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_jsonb_class_level.dart
@@ -101,8 +101,6 @@ abstract class ObjectWithJsonbClassLevel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbClassLevelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     ObjectWithJsonbClassLevelInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class ObjectWithJsonbClassLevel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithJsonbClassLevel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithJsonbClassLevel.t),
       include: include,
     );
@@ -236,8 +232,6 @@ class ObjectWithJsonbClassLevelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -282,8 +276,6 @@ class ObjectWithJsonbClassLevelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbClassLevelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -293,8 +285,6 @@ class ObjectWithJsonbClassLevelRepository {
       where: where?.call(ObjectWithJsonbClassLevel.t),
       orderBy: orderBy?.call(ObjectWithJsonbClassLevel.t),
       orderByList: orderByList?.call(ObjectWithJsonbClassLevel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -325,8 +315,6 @@ class ObjectWithJsonbClassLevelRepository {
     _i1.WhereExpressionBuilder<ObjectWithJsonbClassLevelTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbClassLevelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -336,8 +324,6 @@ class ObjectWithJsonbClassLevelRepository {
       where: where?.call(ObjectWithJsonbClassLevel.t),
       orderBy: orderBy?.call(ObjectWithJsonbClassLevel.t),
       orderByList: orderByList?.call(ObjectWithJsonbClassLevel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -546,8 +532,6 @@ class ObjectWithJsonbClassLevelRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithJsonbClassLevelTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -558,8 +542,6 @@ class ObjectWithJsonbClassLevelRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithJsonbClassLevel.t),
       orderByList: orderByList?.call(ObjectWithJsonbClassLevel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -580,8 +562,6 @@ class ObjectWithJsonbClassLevelRepository {
     _i1.DatabaseSession session,
     List<ObjectWithJsonbClassLevel> rows, {
     _i1.OrderByBuilder<ObjectWithJsonbClassLevelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -590,8 +570,6 @@ class ObjectWithJsonbClassLevelRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithJsonbClassLevel.t),
       orderByList: orderByList?.call(ObjectWithJsonbClassLevel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -621,8 +599,6 @@ class ObjectWithJsonbClassLevelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithJsonbClassLevelTable> where,
     _i1.OrderByBuilder<ObjectWithJsonbClassLevelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithJsonbClassLevelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -631,8 +607,6 @@ class ObjectWithJsonbClassLevelRepository {
       where: where(ObjectWithJsonbClassLevel.t),
       orderBy: orderBy?.call(ObjectWithJsonbClassLevel.t),
       orderByList: orderByList?.call(ObjectWithJsonbClassLevel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_object.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_object.dart
@@ -221,8 +221,6 @@ abstract class ObjectWithObject
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     ObjectWithObjectInclude? include,
   }) {
@@ -231,8 +229,6 @@ abstract class ObjectWithObject
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithObject.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithObject.t),
       include: include,
     );
@@ -537,8 +533,6 @@ class ObjectWithObjectIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -583,8 +577,6 @@ class ObjectWithObjectRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -594,8 +586,6 @@ class ObjectWithObjectRepository {
       where: where?.call(ObjectWithObject.t),
       orderBy: orderBy?.call(ObjectWithObject.t),
       orderByList: orderByList?.call(ObjectWithObject.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -626,8 +616,6 @@ class ObjectWithObjectRepository {
     _i1.WhereExpressionBuilder<ObjectWithObjectTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -637,8 +625,6 @@ class ObjectWithObjectRepository {
       where: where?.call(ObjectWithObject.t),
       orderBy: orderBy?.call(ObjectWithObject.t),
       orderByList: orderByList?.call(ObjectWithObject.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -845,8 +831,6 @@ class ObjectWithObjectRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -857,8 +841,6 @@ class ObjectWithObjectRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithObject.t),
       orderByList: orderByList?.call(ObjectWithObject.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -879,8 +861,6 @@ class ObjectWithObjectRepository {
     _i1.DatabaseSession session,
     List<ObjectWithObject> rows, {
     _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -889,8 +869,6 @@ class ObjectWithObjectRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithObject.t),
       orderByList: orderByList?.call(ObjectWithObject.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -920,8 +898,6 @@ class ObjectWithObjectRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithObjectTable> where,
     _i1.OrderByBuilder<ObjectWithObjectTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithObjectTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -930,8 +906,6 @@ class ObjectWithObjectRepository {
       where: where(ObjectWithObject.t),
       orderBy: orderBy?.call(ObjectWithObject.t),
       orderByList: orderByList?.call(ObjectWithObject.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_parent.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_parent.dart
@@ -77,8 +77,6 @@ abstract class ObjectWithParent
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     ObjectWithParentInclude? include,
   }) {
@@ -87,8 +85,6 @@ abstract class ObjectWithParent
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithParent.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithParent.t),
       include: include,
     );
@@ -173,8 +169,6 @@ class ObjectWithParentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -219,8 +213,6 @@ class ObjectWithParentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -230,8 +222,6 @@ class ObjectWithParentRepository {
       where: where?.call(ObjectWithParent.t),
       orderBy: orderBy?.call(ObjectWithParent.t),
       orderByList: orderByList?.call(ObjectWithParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -262,8 +252,6 @@ class ObjectWithParentRepository {
     _i1.WhereExpressionBuilder<ObjectWithParentTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -273,8 +261,6 @@ class ObjectWithParentRepository {
       where: where?.call(ObjectWithParent.t),
       orderBy: orderBy?.call(ObjectWithParent.t),
       orderByList: orderByList?.call(ObjectWithParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -481,8 +467,6 @@ class ObjectWithParentRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -493,8 +477,6 @@ class ObjectWithParentRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithParent.t),
       orderByList: orderByList?.call(ObjectWithParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -515,8 +497,6 @@ class ObjectWithParentRepository {
     _i1.DatabaseSession session,
     List<ObjectWithParent> rows, {
     _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -525,8 +505,6 @@ class ObjectWithParentRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithParent.t),
       orderByList: orderByList?.call(ObjectWithParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -556,8 +534,6 @@ class ObjectWithParentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithParentTable> where,
     _i1.OrderByBuilder<ObjectWithParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithParentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -566,8 +542,6 @@ class ObjectWithParentRepository {
       where: where(ObjectWithParent.t),
       orderBy: orderBy?.call(ObjectWithParent.t),
       orderByList: orderByList?.call(ObjectWithParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_self_parent.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_self_parent.dart
@@ -79,8 +79,6 @@ abstract class ObjectWithSelfParent
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     ObjectWithSelfParentInclude? include,
   }) {
@@ -89,8 +87,6 @@ abstract class ObjectWithSelfParent
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
       include: include,
     );
@@ -175,8 +171,6 @@ class ObjectWithSelfParentIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -221,8 +215,6 @@ class ObjectWithSelfParentRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -232,8 +224,6 @@ class ObjectWithSelfParentRepository {
       where: where?.call(ObjectWithSelfParent.t),
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -264,8 +254,6 @@ class ObjectWithSelfParentRepository {
     _i1.WhereExpressionBuilder<ObjectWithSelfParentTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -275,8 +263,6 @@ class ObjectWithSelfParentRepository {
       where: where?.call(ObjectWithSelfParent.t),
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -483,8 +469,6 @@ class ObjectWithSelfParentRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -495,8 +479,6 @@ class ObjectWithSelfParentRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -517,8 +499,6 @@ class ObjectWithSelfParentRepository {
     _i1.DatabaseSession session,
     List<ObjectWithSelfParent> rows, {
     _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -527,8 +507,6 @@ class ObjectWithSelfParentRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -558,8 +536,6 @@ class ObjectWithSelfParentRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithSelfParentTable> where,
     _i1.OrderByBuilder<ObjectWithSelfParentTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSelfParentTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -568,8 +544,6 @@ class ObjectWithSelfParentRepository {
       where: where(ObjectWithSelfParent.t),
       orderBy: orderBy?.call(ObjectWithSelfParent.t),
       orderByList: orderByList?.call(ObjectWithSelfParent.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_sparse_vector.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_sparse_vector.dart
@@ -117,8 +117,6 @@ abstract class ObjectWithSparseVector
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithSparseVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     ObjectWithSparseVectorInclude? include,
   }) {
@@ -127,8 +125,6 @@ abstract class ObjectWithSparseVector
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithSparseVector.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithSparseVector.t),
       include: include,
     );
@@ -277,8 +273,6 @@ class ObjectWithSparseVectorIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -323,8 +317,6 @@ class ObjectWithSparseVectorRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithSparseVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -334,8 +326,6 @@ class ObjectWithSparseVectorRepository {
       where: where?.call(ObjectWithSparseVector.t),
       orderBy: orderBy?.call(ObjectWithSparseVector.t),
       orderByList: orderByList?.call(ObjectWithSparseVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -366,8 +356,6 @@ class ObjectWithSparseVectorRepository {
     _i1.WhereExpressionBuilder<ObjectWithSparseVectorTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithSparseVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -377,8 +365,6 @@ class ObjectWithSparseVectorRepository {
       where: where?.call(ObjectWithSparseVector.t),
       orderBy: orderBy?.call(ObjectWithSparseVector.t),
       orderByList: orderByList?.call(ObjectWithSparseVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -585,8 +571,6 @@ class ObjectWithSparseVectorRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithSparseVectorTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -597,8 +581,6 @@ class ObjectWithSparseVectorRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithSparseVector.t),
       orderByList: orderByList?.call(ObjectWithSparseVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -619,8 +601,6 @@ class ObjectWithSparseVectorRepository {
     _i1.DatabaseSession session,
     List<ObjectWithSparseVector> rows, {
     _i1.OrderByBuilder<ObjectWithSparseVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -629,8 +609,6 @@ class ObjectWithSparseVectorRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithSparseVector.t),
       orderByList: orderByList?.call(ObjectWithSparseVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -660,8 +638,6 @@ class ObjectWithSparseVectorRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithSparseVectorTable> where,
     _i1.OrderByBuilder<ObjectWithSparseVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithSparseVectorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -670,8 +646,6 @@ class ObjectWithSparseVectorRepository {
       where: where(ObjectWithSparseVector.t),
       orderBy: orderBy?.call(ObjectWithSparseVector.t),
       orderByList: orderByList?.call(ObjectWithSparseVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_uuid.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_uuid.dart
@@ -89,8 +89,6 @@ abstract class ObjectWithUuid
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     ObjectWithUuidInclude? include,
   }) {
@@ -99,8 +97,6 @@ abstract class ObjectWithUuid
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithUuid.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithUuid.t),
       include: include,
     );
@@ -205,8 +201,6 @@ class ObjectWithUuidIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -251,8 +245,6 @@ class ObjectWithUuidRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -262,8 +254,6 @@ class ObjectWithUuidRepository {
       where: where?.call(ObjectWithUuid.t),
       orderBy: orderBy?.call(ObjectWithUuid.t),
       orderByList: orderByList?.call(ObjectWithUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -294,8 +284,6 @@ class ObjectWithUuidRepository {
     _i1.WhereExpressionBuilder<ObjectWithUuidTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -305,8 +293,6 @@ class ObjectWithUuidRepository {
       where: where?.call(ObjectWithUuid.t),
       orderBy: orderBy?.call(ObjectWithUuid.t),
       orderByList: orderByList?.call(ObjectWithUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -511,8 +497,6 @@ class ObjectWithUuidRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -523,8 +507,6 @@ class ObjectWithUuidRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithUuid.t),
       orderByList: orderByList?.call(ObjectWithUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -545,8 +527,6 @@ class ObjectWithUuidRepository {
     _i1.DatabaseSession session,
     List<ObjectWithUuid> rows, {
     _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -555,8 +535,6 @@ class ObjectWithUuidRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithUuid.t),
       orderByList: orderByList?.call(ObjectWithUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -586,8 +564,6 @@ class ObjectWithUuidRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithUuidTable> where,
     _i1.OrderByBuilder<ObjectWithUuidTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithUuidTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -596,8 +572,6 @@ class ObjectWithUuidRepository {
       where: where(ObjectWithUuid.t),
       orderBy: orderBy?.call(ObjectWithUuid.t),
       orderByList: orderByList?.call(ObjectWithUuid.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_vector.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/object_with_vector.dart
@@ -129,8 +129,6 @@ abstract class ObjectWithVector
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     ObjectWithVectorInclude? include,
   }) {
@@ -139,8 +137,6 @@ abstract class ObjectWithVector
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ObjectWithVector.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ObjectWithVector.t),
       include: include,
     );
@@ -327,8 +323,6 @@ class ObjectWithVectorIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -373,8 +367,6 @@ class ObjectWithVectorRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ObjectWithVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -384,8 +376,6 @@ class ObjectWithVectorRepository {
       where: where?.call(ObjectWithVector.t),
       orderBy: orderBy?.call(ObjectWithVector.t),
       orderByList: orderByList?.call(ObjectWithVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -416,8 +406,6 @@ class ObjectWithVectorRepository {
     _i1.WhereExpressionBuilder<ObjectWithVectorTable>? where,
     int? offset,
     _i1.OrderByBuilder<ObjectWithVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -427,8 +415,6 @@ class ObjectWithVectorRepository {
       where: where?.call(ObjectWithVector.t),
       orderBy: orderBy?.call(ObjectWithVector.t),
       orderByList: orderByList?.call(ObjectWithVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -635,8 +621,6 @@ class ObjectWithVectorRepository {
     int? offset,
     _i1.OrderByBuilder<ObjectWithVectorTable>? orderBy,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -647,8 +631,6 @@ class ObjectWithVectorRepository {
       offset: offset,
       orderBy: orderBy?.call(ObjectWithVector.t),
       orderByList: orderByList?.call(ObjectWithVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -669,8 +651,6 @@ class ObjectWithVectorRepository {
     _i1.DatabaseSession session,
     List<ObjectWithVector> rows, {
     _i1.OrderByBuilder<ObjectWithVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -679,8 +659,6 @@ class ObjectWithVectorRepository {
       rows,
       orderBy: orderBy?.call(ObjectWithVector.t),
       orderByList: orderByList?.call(ObjectWithVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -710,8 +688,6 @@ class ObjectWithVectorRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ObjectWithVectorTable> where,
     _i1.OrderByBuilder<ObjectWithVectorTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ObjectWithVectorTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -720,8 +696,6 @@ class ObjectWithVectorRepository {
       where: where(ObjectWithVector.t),
       orderBy: orderBy?.call(ObjectWithVector.t),
       orderByList: orderByList?.call(ObjectWithVector.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/related_unique_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/related_unique_data.dart
@@ -101,8 +101,6 @@ abstract class RelatedUniqueData
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     RelatedUniqueDataInclude? include,
   }) {
@@ -111,8 +109,6 @@ abstract class RelatedUniqueData
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(RelatedUniqueData.t),
       include: include,
     );
@@ -246,8 +242,6 @@ class RelatedUniqueDataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -294,8 +288,6 @@ class RelatedUniqueDataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     RelatedUniqueDataInclude? include,
@@ -306,8 +298,6 @@ class RelatedUniqueDataRepository {
       where: where?.call(RelatedUniqueData.t),
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -339,8 +329,6 @@ class RelatedUniqueDataRepository {
     _i1.WhereExpressionBuilder<RelatedUniqueDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     RelatedUniqueDataInclude? include,
@@ -351,8 +339,6 @@ class RelatedUniqueDataRepository {
       where: where?.call(RelatedUniqueData.t),
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       include: include,
@@ -562,8 +548,6 @@ class RelatedUniqueDataRepository {
     int? offset,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -574,8 +558,6 @@ class RelatedUniqueDataRepository {
       offset: offset,
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -596,8 +578,6 @@ class RelatedUniqueDataRepository {
     _i1.DatabaseSession session,
     List<RelatedUniqueData> rows, {
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -606,8 +586,6 @@ class RelatedUniqueDataRepository {
       rows,
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -637,8 +615,6 @@ class RelatedUniqueDataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<RelatedUniqueDataTable> where,
     _i1.OrderByBuilder<RelatedUniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<RelatedUniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -647,8 +623,6 @@ class RelatedUniqueDataRepository {
       where: where(RelatedUniqueData.t),
       orderBy: orderBy?.call(RelatedUniqueData.t),
       orderByList: orderByList?.call(RelatedUniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/required/model_with_required_field.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/required/model_with_required_field.dart
@@ -95,8 +95,6 @@ abstract class ModelWithRequiredField
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     ModelWithRequiredFieldInclude? include,
   }) {
@@ -105,8 +103,6 @@ abstract class ModelWithRequiredField
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(ModelWithRequiredField.t),
       include: include,
     );
@@ -223,8 +219,6 @@ class ModelWithRequiredFieldIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -269,8 +263,6 @@ class ModelWithRequiredFieldRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -280,8 +272,6 @@ class ModelWithRequiredFieldRepository {
       where: where?.call(ModelWithRequiredField.t),
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -312,8 +302,6 @@ class ModelWithRequiredFieldRepository {
     _i1.WhereExpressionBuilder<ModelWithRequiredFieldTable>? where,
     int? offset,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -323,8 +311,6 @@ class ModelWithRequiredFieldRepository {
       where: where?.call(ModelWithRequiredField.t),
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -531,8 +517,6 @@ class ModelWithRequiredFieldRepository {
     int? offset,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -543,8 +527,6 @@ class ModelWithRequiredFieldRepository {
       offset: offset,
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -565,8 +547,6 @@ class ModelWithRequiredFieldRepository {
     _i1.DatabaseSession session,
     List<ModelWithRequiredField> rows, {
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -575,8 +555,6 @@ class ModelWithRequiredFieldRepository {
       rows,
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -606,8 +584,6 @@ class ModelWithRequiredFieldRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<ModelWithRequiredFieldTable> where,
     _i1.OrderByBuilder<ModelWithRequiredFieldTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<ModelWithRequiredFieldTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -616,8 +592,6 @@ class ModelWithRequiredFieldRepository {
       where: where(ModelWithRequiredField.t),
       orderBy: orderBy?.call(ModelWithRequiredField.t),
       orderByList: orderByList?.call(ModelWithRequiredField.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/simple_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/simple_data.dart
@@ -81,8 +81,6 @@ abstract class SimpleData
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     SimpleDataInclude? include,
   }) {
@@ -91,8 +89,6 @@ abstract class SimpleData
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(SimpleData.t),
       include: include,
     );
@@ -178,8 +174,6 @@ class SimpleDataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -224,8 +218,6 @@ class SimpleDataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -235,8 +227,6 @@ class SimpleDataRepository {
       where: where?.call(SimpleData.t),
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -267,8 +257,6 @@ class SimpleDataRepository {
     _i1.WhereExpressionBuilder<SimpleDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -278,8 +266,6 @@ class SimpleDataRepository {
       where: where?.call(SimpleData.t),
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -484,8 +470,6 @@ class SimpleDataRepository {
     int? offset,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -496,8 +480,6 @@ class SimpleDataRepository {
       offset: offset,
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -518,8 +500,6 @@ class SimpleDataRepository {
     _i1.DatabaseSession session,
     List<SimpleData> rows, {
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -528,8 +508,6 @@ class SimpleDataRepository {
       rows,
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -559,8 +537,6 @@ class SimpleDataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SimpleDataTable> where,
     _i1.OrderByBuilder<SimpleDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -569,8 +545,6 @@ class SimpleDataRepository {
       where: where(SimpleData.t),
       orderBy: orderBy?.call(SimpleData.t),
       orderByList: orderByList?.call(SimpleData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/simple_date_time.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/simple_date_time.dart
@@ -81,8 +81,6 @@ abstract class SimpleDateTime
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     SimpleDateTimeInclude? include,
   }) {
@@ -91,8 +89,6 @@ abstract class SimpleDateTime
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(SimpleDateTime.t),
       include: include,
     );
@@ -178,8 +174,6 @@ class SimpleDateTimeIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -224,8 +218,6 @@ class SimpleDateTimeRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -235,8 +227,6 @@ class SimpleDateTimeRepository {
       where: where?.call(SimpleDateTime.t),
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -267,8 +257,6 @@ class SimpleDateTimeRepository {
     _i1.WhereExpressionBuilder<SimpleDateTimeTable>? where,
     int? offset,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -278,8 +266,6 @@ class SimpleDateTimeRepository {
       where: where?.call(SimpleDateTime.t),
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -484,8 +470,6 @@ class SimpleDateTimeRepository {
     int? offset,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -496,8 +480,6 @@ class SimpleDateTimeRepository {
       offset: offset,
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -518,8 +500,6 @@ class SimpleDateTimeRepository {
     _i1.DatabaseSession session,
     List<SimpleDateTime> rows, {
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -528,8 +508,6 @@ class SimpleDateTimeRepository {
       rows,
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -559,8 +537,6 @@ class SimpleDateTimeRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SimpleDateTimeTable> where,
     _i1.OrderByBuilder<SimpleDateTimeTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SimpleDateTimeTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -569,8 +545,6 @@ class SimpleDateTimeRepository {
       where: where(SimpleDateTime.t),
       orderBy: orderBy?.call(SimpleDateTime.t),
       orderByList: orderByList?.call(SimpleDateTime.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/types.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/types.dart
@@ -334,8 +334,6 @@ abstract class Types implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     TypesInclude? include,
   }) {
@@ -344,8 +342,6 @@ abstract class Types implements _i1.TableRow<int?>, _i1.ProtocolSerialization {
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(Types.t),
       include: include,
     );
@@ -861,8 +857,6 @@ class TypesIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -907,8 +901,6 @@ class TypesRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -918,8 +910,6 @@ class TypesRepository {
       where: where?.call(Types.t),
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -950,8 +940,6 @@ class TypesRepository {
     _i1.WhereExpressionBuilder<TypesTable>? where,
     int? offset,
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -961,8 +949,6 @@ class TypesRepository {
       where: where?.call(Types.t),
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -1167,8 +1153,6 @@ class TypesRepository {
     int? offset,
     _i1.OrderByBuilder<TypesTable>? orderBy,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -1179,8 +1163,6 @@ class TypesRepository {
       offset: offset,
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -1201,8 +1183,6 @@ class TypesRepository {
     _i1.DatabaseSession session,
     List<Types> rows, {
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -1211,8 +1191,6 @@ class TypesRepository {
       rows,
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -1242,8 +1220,6 @@ class TypesRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<TypesTable> where,
     _i1.OrderByBuilder<TypesTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<TypesTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -1252,8 +1228,6 @@ class TypesRepository {
       where: where(Types.t),
       orderBy: orderBy?.call(Types.t),
       orderByList: orderByList?.call(Types.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/unique_data.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/unique_data.dart
@@ -85,8 +85,6 @@ abstract class UniqueData
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     UniqueDataInclude? include,
   }) {
@@ -95,8 +93,6 @@ abstract class UniqueData
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UniqueData.t),
       include: include,
     );
@@ -195,8 +191,6 @@ class UniqueDataIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -241,8 +235,6 @@ class UniqueDataRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -252,8 +244,6 @@ class UniqueDataRepository {
       where: where?.call(UniqueData.t),
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -284,8 +274,6 @@ class UniqueDataRepository {
     _i1.WhereExpressionBuilder<UniqueDataTable>? where,
     int? offset,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -295,8 +283,6 @@ class UniqueDataRepository {
       where: where?.call(UniqueData.t),
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -501,8 +487,6 @@ class UniqueDataRepository {
     int? offset,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -513,8 +497,6 @@ class UniqueDataRepository {
       offset: offset,
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -535,8 +517,6 @@ class UniqueDataRepository {
     _i1.DatabaseSession session,
     List<UniqueData> rows, {
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -545,8 +525,6 @@ class UniqueDataRepository {
       rows,
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -576,8 +554,6 @@ class UniqueDataRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UniqueDataTable> where,
     _i1.OrderByBuilder<UniqueDataTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -586,8 +562,6 @@ class UniqueDataRepository {
       where: where(UniqueData.t),
       orderBy: orderBy?.call(UniqueData.t),
       orderByList: orderByList?.call(UniqueData.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/unique_data_with_non_persist.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/unique_data_with_non_persist.dart
@@ -95,8 +95,6 @@ abstract class UniqueDataWithNonPersist
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     UniqueDataWithNonPersistInclude? include,
   }) {
@@ -105,8 +103,6 @@ abstract class UniqueDataWithNonPersist
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
       include: include,
     );
@@ -211,8 +207,6 @@ class UniqueDataWithNonPersistIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -257,8 +251,6 @@ class UniqueDataWithNonPersistRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -268,8 +260,6 @@ class UniqueDataWithNonPersistRepository {
       where: where?.call(UniqueDataWithNonPersist.t),
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -300,8 +290,6 @@ class UniqueDataWithNonPersistRepository {
     _i1.WhereExpressionBuilder<UniqueDataWithNonPersistTable>? where,
     int? offset,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -311,8 +299,6 @@ class UniqueDataWithNonPersistRepository {
       where: where?.call(UniqueDataWithNonPersist.t),
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -521,8 +507,6 @@ class UniqueDataWithNonPersistRepository {
     int? offset,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -533,8 +517,6 @@ class UniqueDataWithNonPersistRepository {
       offset: offset,
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -555,8 +537,6 @@ class UniqueDataWithNonPersistRepository {
     _i1.DatabaseSession session,
     List<UniqueDataWithNonPersist> rows, {
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -565,8 +545,6 @@ class UniqueDataWithNonPersistRepository {
       rows,
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -596,8 +574,6 @@ class UniqueDataWithNonPersistRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UniqueDataWithNonPersistTable> where,
     _i1.OrderByBuilder<UniqueDataWithNonPersistTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UniqueDataWithNonPersistTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -606,8 +582,6 @@ class UniqueDataWithNonPersistRepository {
       where: where(UniqueDataWithNonPersist.t),
       orderBy: orderBy?.call(UniqueDataWithNonPersist.t),
       orderByList: orderByList?.call(UniqueDataWithNonPersist.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/upsert_test_model.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/upsert_test_model.dart
@@ -93,8 +93,6 @@ abstract class UpsertTestModel
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UpsertTestModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     UpsertTestModelInclude? include,
   }) {
@@ -103,8 +101,6 @@ abstract class UpsertTestModel
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(UpsertTestModel.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(UpsertTestModel.t),
       include: include,
     );
@@ -220,8 +216,6 @@ class UpsertTestModelIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -266,8 +260,6 @@ class UpsertTestModelRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<UpsertTestModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -277,8 +269,6 @@ class UpsertTestModelRepository {
       where: where?.call(UpsertTestModel.t),
       orderBy: orderBy?.call(UpsertTestModel.t),
       orderByList: orderByList?.call(UpsertTestModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -309,8 +299,6 @@ class UpsertTestModelRepository {
     _i1.WhereExpressionBuilder<UpsertTestModelTable>? where,
     int? offset,
     _i1.OrderByBuilder<UpsertTestModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -320,8 +308,6 @@ class UpsertTestModelRepository {
       where: where?.call(UpsertTestModel.t),
       orderBy: orderBy?.call(UpsertTestModel.t),
       orderByList: orderByList?.call(UpsertTestModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -528,8 +514,6 @@ class UpsertTestModelRepository {
     int? offset,
     _i1.OrderByBuilder<UpsertTestModelTable>? orderBy,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -540,8 +524,6 @@ class UpsertTestModelRepository {
       offset: offset,
       orderBy: orderBy?.call(UpsertTestModel.t),
       orderByList: orderByList?.call(UpsertTestModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -562,8 +544,6 @@ class UpsertTestModelRepository {
     _i1.DatabaseSession session,
     List<UpsertTestModel> rows, {
     _i1.OrderByBuilder<UpsertTestModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -572,8 +552,6 @@ class UpsertTestModelRepository {
       rows,
       orderBy: orderBy?.call(UpsertTestModel.t),
       orderByList: orderByList?.call(UpsertTestModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -603,8 +581,6 @@ class UpsertTestModelRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<UpsertTestModelTable> where,
     _i1.OrderByBuilder<UpsertTestModelTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<UpsertTestModelTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -613,8 +589,6 @@ class UpsertTestModelRepository {
       where: where(UpsertTestModel.t),
       orderBy: orderBy?.call(UpsertTestModel.t),
       orderByList: orderByList?.call(UpsertTestModel.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_where_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/crud/update_where_test.dart
@@ -483,7 +483,7 @@ void main() {
         });
       });
 
-      group('when updating with orderDescending', () {
+      group('when updating in descending order', () {
         late List<Types> updated;
 
         setUp(() async {

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_shared/lib/src/generated/shared/shared_table_record.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_shared/lib/src/generated/shared/shared_table_record.dart
@@ -111,8 +111,6 @@ abstract class SharedTableRecord
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SharedTableRecordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedTableRecordTable>? orderByList,
     SharedTableRecordInclude? include,
   }) {
@@ -121,8 +119,6 @@ abstract class SharedTableRecord
       limit: limit,
       offset: offset,
       orderBy: orderBy?.call(SharedTableRecord.t),
-      orderDescending: // ignore: deprecated_member_use_from_same_package
-          orderDescending,
       orderByList: orderByList?.call(SharedTableRecord.t),
       include: include,
     );
@@ -263,8 +259,6 @@ class SharedTableRecordIncludeList extends _i1.IncludeList {
     super.limit,
     super.offset,
     super.orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    super.orderDescending,
     super.orderByList,
     super.include,
   }) {
@@ -309,8 +303,6 @@ class SharedTableRecordRepository {
     int? limit,
     int? offset,
     _i1.OrderByBuilder<SharedTableRecordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedTableRecordTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -320,8 +312,6 @@ class SharedTableRecordRepository {
       where: where?.call(SharedTableRecord.t),
       orderBy: orderBy?.call(SharedTableRecord.t),
       orderByList: orderByList?.call(SharedTableRecord.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       limit: limit,
       offset: offset,
       transaction: transaction,
@@ -352,8 +342,6 @@ class SharedTableRecordRepository {
     _i1.WhereExpressionBuilder<SharedTableRecordTable>? where,
     int? offset,
     _i1.OrderByBuilder<SharedTableRecordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedTableRecordTable>? orderByList,
     _i1.Transaction? transaction,
     _i1.LockMode? lockMode,
@@ -363,8 +351,6 @@ class SharedTableRecordRepository {
       where: where?.call(SharedTableRecord.t),
       orderBy: orderBy?.call(SharedTableRecord.t),
       orderByList: orderByList?.call(SharedTableRecord.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       offset: offset,
       transaction: transaction,
       lockMode: lockMode,
@@ -571,8 +557,6 @@ class SharedTableRecordRepository {
     int? offset,
     _i1.OrderByBuilder<SharedTableRecordTable>? orderBy,
     _i1.OrderByListBuilder<SharedTableRecordTable>? orderByList,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.Transaction? transaction,
     bool noReturn = false,
   }) async {
@@ -583,8 +567,6 @@ class SharedTableRecordRepository {
       offset: offset,
       orderBy: orderBy?.call(SharedTableRecord.t),
       orderByList: orderByList?.call(SharedTableRecord.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -605,8 +587,6 @@ class SharedTableRecordRepository {
     _i1.DatabaseSession session,
     List<SharedTableRecord> rows, {
     _i1.OrderByBuilder<SharedTableRecordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedTableRecordTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -615,8 +595,6 @@ class SharedTableRecordRepository {
       rows,
       orderBy: orderBy?.call(SharedTableRecord.t),
       orderByList: orderByList?.call(SharedTableRecord.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );
@@ -646,8 +624,6 @@ class SharedTableRecordRepository {
     _i1.DatabaseSession session, {
     required _i1.WhereExpressionBuilder<SharedTableRecordTable> where,
     _i1.OrderByBuilder<SharedTableRecordTable>? orderBy,
-    @Deprecated('Use desc() on the orderBy column instead.')
-    bool orderDescending = false,
     _i1.OrderByListBuilder<SharedTableRecordTable>? orderByList,
     _i1.Transaction? transaction,
     bool noReturn = false,
@@ -656,8 +632,6 @@ class SharedTableRecordRepository {
       where: where(SharedTableRecord.t),
       orderBy: orderBy?.call(SharedTableRecord.t),
       orderByList: orderByList?.call(SharedTableRecord.t),
-      orderDescending: // ignore: deprecated_member_use
-          orderDescending,
       transaction: transaction,
       noReturn: noReturn,
     );

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/class_generators/repository_classes.dart
@@ -339,14 +339,6 @@ class BuildRepositoryClass {
           ),
           Parameter(
             (p) => p
-              ..type = refer('bool')
-              ..name = 'orderDescending'
-              ..annotations.add(deprecatedOrderDescendingAnnotation())
-              ..defaultTo = const Code('false')
-              ..named = true,
-          ),
-          Parameter(
-            (p) => p
               ..type = typeOrderByListBuilder(className, serverCode)
               ..name = 'orderByList'
               ..named = true,
@@ -414,9 +406,6 @@ class BuildRepositoryClass {
                     .call(
                       [refer(className).property('t')],
                     ),
-                'orderDescending': const CodeExpression(
-                  Code('// ignore: deprecated_member_use\norderDescending'),
-                ),
                 'limit': refer('limit'),
                 'offset': refer('offset'),
                 'transaction': refer('transaction'),
@@ -503,14 +492,6 @@ class BuildRepositoryClass {
           ),
           Parameter(
             (p) => p
-              ..type = refer('bool')
-              ..name = 'orderDescending'
-              ..annotations.add(deprecatedOrderDescendingAnnotation())
-              ..defaultTo = const Code('false')
-              ..named = true,
-          ),
-          Parameter(
-            (p) => p
               ..type = typeOrderByListBuilder(className, serverCode)
               ..name = 'orderByList'
               ..named = true,
@@ -578,9 +559,6 @@ class BuildRepositoryClass {
                     .call(
                       [refer(className).property('t')],
                     ),
-                'orderDescending': const CodeExpression(
-                  Code('// ignore: deprecated_member_use\norderDescending'),
-                ),
                 'offset': refer('offset'),
                 'transaction': refer('transaction'),
                 if (objectRelationFields.isNotEmpty)
@@ -1358,14 +1336,6 @@ class BuildRepositoryClass {
           ),
           Parameter(
             (p) => p
-              ..name = 'orderDescending'
-              ..annotations.add(deprecatedOrderDescendingAnnotation())
-              ..named = true
-              ..defaultTo = const Code('false')
-              ..type = refer('bool'),
-          ),
-          Parameter(
-            (p) => p
               ..type = TypeReference(
                 (b) => b
                   ..isNullable = true
@@ -1404,9 +1374,6 @@ class BuildRepositoryClass {
                 'orderByList': refer('orderByList')
                     .nullSafeProperty('call')
                     .call([refer(className).property('t')]),
-                'orderDescending': const CodeExpression(
-                  Code('// ignore: deprecated_member_use\norderDescending'),
-                ),
                 'transaction': refer('transaction'),
                 'noReturn': refer('noReturn'),
               },
@@ -1469,14 +1436,6 @@ class BuildRepositoryClass {
           ),
           Parameter(
             (p) => p
-              ..type = refer('bool')
-              ..name = 'orderDescending'
-              ..annotations.add(deprecatedOrderDescendingAnnotation())
-              ..defaultTo = const Code('false')
-              ..named = true,
-          ),
-          Parameter(
-            (p) => p
               ..type = typeOrderByListBuilder(className, serverCode)
               ..name = 'orderByList'
               ..named = true,
@@ -1515,9 +1474,6 @@ class BuildRepositoryClass {
                     .call(
                       [refer(className).property('t')],
                     ),
-                'orderDescending': const CodeExpression(
-                  Code('// ignore: deprecated_member_use\norderDescending'),
-                ),
                 'transaction': refer('transaction'),
                 'noReturn': refer('noReturn'),
               },
@@ -1638,14 +1594,6 @@ class BuildRepositoryClass {
           ),
           Parameter(
             (p) => p
-              ..type = refer('bool')
-              ..name = 'orderDescending'
-              ..annotations.add(deprecatedOrderDescendingAnnotation())
-              ..defaultTo = const Code('false')
-              ..named = true,
-          ),
-          Parameter(
-            (p) => p
               ..type = typeOrderByListBuilder(className, serverCode)
               ..name = 'orderByList'
               ..named = true,
@@ -1685,9 +1633,6 @@ class BuildRepositoryClass {
                     .call(
                       [refer(className).property('t')],
                     ),
-                'orderDescending': const CodeExpression(
-                  Code('// ignore: deprecated_member_use\norderDescending'),
-                ),
                 'transaction': refer('transaction'),
                 'noReturn': refer('noReturn'),
               },

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -1500,14 +1500,6 @@ class SerializableModelLibraryGenerator {
           ),
           Parameter(
             (p) => p
-              ..name = 'orderDescending'
-              ..annotations.add(deprecatedOrderDescendingAnnotation())
-              ..named = true
-              ..defaultTo = const Code('false')
-              ..type = refer('bool'),
-          ),
-          Parameter(
-            (p) => p
               ..name = 'orderByList'
               ..named = true
               ..type = typeOrderByListBuilder(className, serverCode),
@@ -1527,11 +1519,6 @@ class SerializableModelLibraryGenerator {
               'offset': refer('offset'),
               'orderBy': refer('orderBy').nullSafeProperty('call').call(
                 [refer(className).property('t')],
-              ),
-              'orderDescending': const CodeExpression(
-                Code(
-                  '// ignore: deprecated_member_use_from_same_package\norderDescending',
-                ),
               ),
               'orderByList': refer('orderByList').nullSafeProperty('call').call(
                 [refer(className).property('t')],
@@ -3077,13 +3064,6 @@ class SerializableModelLibraryGenerator {
         Parameter(
           (p) => p
             ..name = 'orderBy'
-            ..toSuper = true
-            ..named = true,
-        ),
-        Parameter(
-          (p) => p
-            ..name = 'orderDescending'
-            ..annotations.add(deprecatedOrderDescendingAnnotation())
             ..toSuper = true
             ..named = true,
         ),

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/class_generators_util.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/util/class_generators_util.dart
@@ -87,13 +87,6 @@ TypeReference typeColumnValueListBuilder(
   );
 }
 
-/// Deprecation annotation for the [orderDescending] parameter.
-Expression deprecatedOrderDescendingAnnotation() {
-  return refer('Deprecated').call([
-    literalString('Use desc() on the orderBy column instead.'),
-  ]);
-}
-
 Expression buildFromJsonForField(
   SerializableModelFieldDefinition field,
   bool serverCode,

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_test.dart
@@ -133,13 +133,6 @@ void main() {
           );
         });
 
-        test('that takes the orderDescending bool as an optional param', () {
-          expect(
-            findMethod?.parameters?.toSource(),
-            contains('bool orderDescending'),
-          );
-        });
-
         test('that takes the orderByList as an optional param', () {
           expect(
             findMethod?.parameters?.toSource(),
@@ -234,17 +227,6 @@ void main() {
             contains('OrderByListBuilder<ExampleTable>? orderByList'),
           );
         });
-
-        test(
-          'that takes the orderDescending as a named param with the default value false',
-          () {
-            var params = findRowMethod?.parameters?.toSource();
-            expect(
-              params,
-              contains('bool orderDescending = false'),
-            );
-          },
-        );
 
         test('that takes the transaction object as an optional param', () {
           expect(
@@ -654,13 +636,6 @@ void main() {
           );
         });
 
-        test('that takes the orderDescending bool as an optional param', () {
-          expect(
-            deleteMethod?.parameters?.toSource(),
-            contains('bool orderDescending = false'),
-          );
-        });
-
         test('that takes the orderByList as an optional param', () {
           expect(
             deleteMethod?.parameters?.toSource(),
@@ -778,13 +753,6 @@ void main() {
           expect(
             deleteWhereMethod?.parameters?.toSource(),
             contains('OrderByBuilder<ExampleTable>? orderBy'),
-          );
-        });
-
-        test('that takes the orderDescending bool as an optional param', () {
-          expect(
-            deleteWhereMethod?.parameters?.toSource(),
-            contains('bool orderDescending = false'),
           );
         });
 
@@ -1010,13 +978,6 @@ void main() {
             contains(
               '_i1.OrderByListBuilder<${testClassName}Table>? orderByList',
             ),
-          );
-        });
-
-        test('that takes the orderDescending bool as an optional param', () {
-          expect(
-            updateWhereMethod?.parameters?.toSource(),
-            contains('bool orderDescending'),
           );
         });
 

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/include_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/include_class_test.dart
@@ -214,7 +214,6 @@ void main() {
             expect(params, contains('super.limit'));
             expect(params, contains('super.offset'));
             expect(params, contains('super.orderBy'));
-            expect(params, contains('super.orderDescending'));
             expect(params, contains('super.orderByList'));
             expect(params, contains('super.include'));
           });

--- a/tools/serverpod_cli/test/generator/dart/shared_code_generator/database_repository_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/shared_code_generator/database_repository_class_test.dart
@@ -146,13 +146,6 @@ void main() {
           );
         });
 
-        test('that takes the orderDescending bool as an optional param', () {
-          expect(
-            findMethod?.parameters?.toSource(),
-            contains('bool orderDescending'),
-          );
-        });
-
         test('that takes the orderByList as an optional param', () {
           expect(
             findMethod?.parameters?.toSource(),
@@ -247,17 +240,6 @@ void main() {
             contains('OrderByListBuilder<ExampleTable>? orderByList'),
           );
         });
-
-        test(
-          'that takes the orderDescending as a named param with the default value false',
-          () {
-            var params = findRowMethod?.parameters?.toSource();
-            expect(
-              params,
-              contains('bool orderDescending = false'),
-            );
-          },
-        );
 
         test('that takes the transaction object as an optional param', () {
           expect(
@@ -959,13 +941,6 @@ void main() {
             contains(
               'OrderByListBuilder<${testClassName}Table>? orderByList',
             ),
-          );
-        });
-
-        test('that takes the orderDescending bool as an optional param', () {
-          expect(
-            updateWhereMethod?.parameters?.toSource(),
-            contains('bool orderDescending'),
           );
         });
 


### PR DESCRIPTION
Removed deprecated orderDescending parameter and public Order constructor

Closes #5440 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

`orderDescending` parameter and public `Order` constructor are no longer available for use.