### PR TITLE
refactor: Remove the native Google Sign-In web implementation

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_auth_controller.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_auth_controller.dart
@@ -56,11 +56,12 @@ class GoogleAuthController extends ChangeNotifier {
   /// initialized.
   ///
   /// The amount of allowable UI is up to the platform to determine, but it
-  /// should be minimal. Possible examples include FedCM on the web, and One Tap
-  /// on Android. Platforms may even show no UI, and only sign in if a previous
-  /// sign-in is being restored. This method is intended to be called as soon
-  /// as the application needs to know if the user is signed in, often at
-  /// initial launch.
+  /// should be minimal. Possible examples include One Tap on Android.
+  /// Platforms may even show no UI, and only sign in if a previous sign-in is
+  /// being restored. This method is intended to be called as soon as the
+  /// application needs to know if the user is signed in, often at initial
+  /// launch. Has no effect on web, where only the OAuth2 PKCE redirect flow
+  /// is supported.
   final bool attemptLightweightSignIn;
 
   /// Scopes to request from Google.
@@ -122,7 +123,7 @@ class GoogleAuthController extends ChangeNotifier {
     if (_isInitialized) return;
 
     // OAuth2 PKCE flow on web: no google_sign_in subscription needed.
-    if (kIsWeb && GoogleWebSignInService.instance.isInitialized) {
+    if (kIsWeb) {
       _isInitialized = true;
       _setState(GoogleAuthState.idle);
       return;
@@ -172,11 +173,10 @@ class GoogleAuthController extends ChangeNotifier {
   /// user will be signed in. On failure, transitions to error state with the
   /// error message.
   ///
-  /// On web with the redirect URI configured, opens the browser to Google's
-  /// authorization page using the OAuth2 PKCE redirect flow via
-  /// [GoogleWebSignInService].
+  /// On web, opens the browser to Google's authorization page using the
+  /// OAuth2 PKCE redirect flow via [GoogleWebSignInService].
   Future<void> signIn() async {
-    if (kIsWeb && GoogleWebSignInService.instance.isInitialized) {
+    if (kIsWeb) {
       await _signInWeb();
       return;
     }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_sign_in_service.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_sign_in_service.dart
@@ -6,8 +6,10 @@ import 'package:serverpod_auth_core_flutter/serverpod_auth_core_flutter.dart';
 
 import 'google_web_sign_in_service.dart';
 
-/// Service to manage Google Sign-In and ensure it is only initialized once
-/// throughout the app lifetime.
+/// Service to manage Google Sign-In on native platforms (iOS, Android, macOS)
+/// and ensure it is only initialized once throughout the app lifetime.
+///
+/// On web, [GoogleWebSignInService] is used instead.
 class GoogleSignInService {
   /// Singleton instance of the [GoogleSignInService].
   static final GoogleSignInService instance = GoogleSignInService._internal();
@@ -58,7 +60,7 @@ class GoogleSignInService {
 
       await googleSignIn.initialize(
         clientId: clientId,
-        serverClientId: !kIsWeb ? serverClientId : null,
+        serverClientId: serverClientId,
         nonce: nonce,
         hostedDomain: hostedDomain,
       );
@@ -128,10 +130,9 @@ extension DisconnectGoogleSignIn on FlutterAuthSessionManager {
   /// directly to the [GoogleSignIn] initialize method. See the documentation
   /// of [GoogleSignIn.initialize] for more details.
   ///
-  /// The [redirectUri] is optional and will be used to configure the OAuth2
-  /// PKCE redirect flow on web - which provides a better user experience than
-  /// the [google_sign_in_web] package. When [redirectUri] is absent on web,
-  /// the initialization will fallback to the [google_sign_in] package.
+  /// On web, [redirectUri] is required and configures the OAuth2 PKCE
+  /// redirect flow - the only supported Google sign-in flow on web. Throws
+  /// an [ArgumentError] when absent. On native platforms it is ignored.
   Future<void> initializeGoogleSignIn({
     String? clientId,
     String? serverClientId,
@@ -140,7 +141,15 @@ extension DisconnectGoogleSignIn on FlutterAuthSessionManager {
     String? redirectUri,
     Map<String, String> additionalAuthParams = const {},
   }) async {
-    if (kIsWeb && redirectUri != null) {
+    if (kIsWeb) {
+      if (redirectUri == null) {
+        throw ArgumentError(
+          'redirectUri is required when initializing Google Sign-In on web. '
+          'Web sign-in uses the OAuth2 PKCE redirect flow; see '
+          'GoogleWebSignInService for setup details.',
+        );
+      }
+
       clientId ??= _getClientIdFromEnvVar();
       if (clientId == null) {
         throw ArgumentError.notNull(
@@ -174,11 +183,10 @@ extension DisconnectGoogleSignIn on FlutterAuthSessionManager {
   /// flow again on the next sign-in, including the account picker and consent
   /// screens.
   ///
-  /// On web with the redirect URI configured, only signs out from the current
-  /// device without revoking Google access (native disconnect is not available
-  /// in the web flow).
+  /// On web, only signs out from the current device without revoking Google
+  /// access (native disconnect is not available in the web flow).
   Future<void> disconnectGoogleAccount() async {
-    if (kIsWeb && GoogleWebSignInService.instance.isInitialized) {
+    if (kIsWeb) {
       await signOutDevice();
       return;
     }
@@ -187,11 +195,6 @@ extension DisconnectGoogleSignIn on FlutterAuthSessionManager {
       auth: this,
     );
     await signIn.disconnect();
-
-    // NOTE: This delay prevents the Google Sign-In web button to render before
-    // the disconnect process is complete. Without this, the Sign-In screen will
-    // render the button on web still showing the user as signed in.
-    await Future.delayed(const Duration(milliseconds: 300));
     await signOutDevice();
   }
 }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_sign_in_widget.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_sign_in_widget.dart
@@ -75,11 +75,12 @@ class GoogleSignInWidget extends StatefulWidget {
   /// `attemptLightweightAuthentication` method after the widget is initialized.
   ///
   /// The amount of allowable UI is up to the platform to determine, but it
-  /// should be minimal. Possible examples include FedCM on the web, and One Tap
-  /// on Android. Platforms may even show no UI, and only sign in if a previous
-  /// sign-in is being restored. This method is intended to be called as soon
-  /// as the application needs to know if the user is signed in, often at
-  /// initial launch.
+  /// should be minimal. Possible examples include One Tap on Android.
+  /// Platforms may even show no UI, and only sign in if a previous sign-in is
+  /// being restored. This method is intended to be called as soon as the
+  /// application needs to know if the user is signed in, often at initial
+  /// launch. Has no effect on web, where only the OAuth2 PKCE redirect flow
+  /// is supported.
   final bool attemptLightweightSignIn;
 
   /// Scopes to request from Google.
@@ -183,12 +184,11 @@ class _GoogleSignInWidgetState extends State<GoogleSignInWidget> {
 
   @override
   Widget build(BuildContext context) {
-    // Native platforms (iOS, Android, macOS, etc.) and web with the OAuth2 flow
-    // initialized. Without a supported path (e.g. web without OAuth2), there is
-    // no Google button to show.
-    final hasSignInPath =
-        (kIsWeb && GoogleWebSignInService.instance.isInitialized) ||
-        GoogleSignIn.instance.supportsAuthenticate();
+    // Web requires the OAuth2 PKCE flow to be initialized; native platforms
+    // require google_sign_in support. Without a path there is no button.
+    final hasSignInPath = kIsWeb
+        ? GoogleWebSignInService.instance.isInitialized
+        : GoogleSignIn.instance.supportsAuthenticate();
     if (!hasSignInPath) return const SizedBox.shrink();
 
     return GoogleSignInNativeButton(

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_web_sign_in_service.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/google/google_web_sign_in_service.dart
@@ -36,7 +36,7 @@ typedef GoogleWebSignInResult = ({
 ///
 /// ```dart
 /// // Initialize once during app startup (web only)
-/// await client.auth.initializeGoogleWebSignIn(
+/// await client.auth.initializeGoogleSignIn(
 ///   clientId: 'your-client-id.apps.googleusercontent.com',
 ///   redirectUri: 'https://yourdomain.com/auth.html',
 /// );
@@ -71,8 +71,8 @@ class GoogleWebSignInService {
   /// When `true`, the OAuth2 PKCE web flow is active and [GoogleSignInWidget]
   /// will show a Flutter-rendered button that triggers [signIn].
   ///
-  /// When `false`, [GoogleSignInWidget] falls back to the Google-hosted iFrame
-  /// button or the native `google_sign_in` flow.
+  /// When `false`, there is no Google sign-in path on web and
+  /// [GoogleSignInWidget] renders nothing.
   bool get isInitialized => _config != null;
 
   /// Default OAuth scopes for Google sign-in.
@@ -155,7 +155,7 @@ class GoogleWebSignInService {
     if (_config == null) {
       throw StateError(
         'GoogleWebSignInService is not initialized. '
-        'Call ensureInitialized() or initializeGoogleWebSignIn() first.',
+        'Call ensureInitialized() or initializeGoogleSignIn() first.',
       );
     }
 

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
   flutter_web_auth_2: ^5.0.2
   google_fonts: ^8.1.0
   google_sign_in: ^7.2.0
-  google_sign_in_web: ^1.1.0
   pinput: '>=5.0.2 <7.0.0'
   provider: ^6.1.5
   serverpod_auth_core_flutter: 4.0.0-beta.0

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
   flutter_web_auth_2: ^5.0.2
   google_fonts: ^8.1.0
   google_sign_in: ^7.2.0
-  google_sign_in_web: ^1.1.0
   pinput: '>=5.0.2 <7.0.0'
   provider: ^6.1.5
   serverpod_auth_core_flutter: SERVERPOD_VERSION


### PR DESCRIPTION
With the OAuth2 (PKCE) web sign-in flow introduced in #5093, the native GSI-based web implementation in `serverpod_auth_idp_flutter` is no longer needed. The Google-hosted web button was already removed in #5384. 

This PR removes the remaining runtime fallback so the PKCE redirect flow is the only Google sign-in path on web.

- `initializeGoogleSignIn` now throws an ArgumentError on web when redirectUri is not provided, instead of silently falling back to the google_sign_in package.
- `GoogleAuthController` no longer initializes or subscribes to `google_sign_in` on web.
- Removed the `google_sign_in_web` dependency.
- Removed web-only workarounds that existed for the old button.

Note: this PR is stacked on #5384 and should be merged after it.

Fixes #5442 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
- On web, initializeGoogleSignIn requires redirectUri. Apps relying on the GSI fallback must configure the PKCE redirect flow.
- Lightweight sign-in (FedCM / One Tap) is no longer available on web; attemptLightweightSignIn now only has an effect on native platforms.