### PR TITLE
fix(cli): Correct completion version message and add update alias with --check flag

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/upgrade.dart
+++ b/tools/serverpod_cli/lib/src/commands/upgrade.dart
@@ -3,23 +3,98 @@ import 'dart:io';
 
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
 import '../generated/version.dart';
 
-class UpgradeCommand extends ServerpodCommand {
+/// Options for the `upgrade` command.
+enum UpgradeOption<V> implements OptionDefinition<V> {
+  /// Option to check for available updates without installing.
+  check(
+    FlagOption(
+      argName: 'check',
+      argAbbrev: 'c',
+      helpText: 'Check for available updates without installing.',
+      negatable: false,
+      defaultsTo: false,
+    ),
+  ),
+  ;
+
+  const UpgradeOption(this.option);
+
+  @override
+  final ConfigOptionBase<V> option;
+}
+
+/// Command to upgrade Serverpod CLI to the latest version.
+class UpgradeCommand extends ServerpodCommand<UpgradeOption> {
   @override
   final name = 'upgrade';
 
   @override
+  final List<String> aliases = const ['update'];
+
+  @override
   final description = 'Upgrade Serverpod to the latest version.';
+
+  UpgradeCommand() : super(options: UpgradeOption.values);
 
   @override
   Future<void> runWithConfig(
-    final Configuration commandConfig,
+    final Configuration<UpgradeOption> commandConfig,
   ) async {
-    var success = await log.progress('Updating Serverpod Cli...', () async {
+    var currentVersion = Version.parse(templateVersion);
+    var isCheckOnly = commandConfig.value(UpgradeOption.check);
+
+    if (isCheckOnly) {
+      await _handleCheckOnly(currentVersion);
+      return;
+    }
+
+    var success = await _performUpgrade();
+    if (!success) {
+      log.info('Failed to update Serverpod.');
+      throw ExitException.error();
+    }
+
+    var latestVersion = await _fetchLatestVersion();
+    _reportUpgradeResult(currentVersion, latestVersion);
+  }
+
+  /// Fetches the latest stable version of `serverpod_cli` from pub.dev.
+  Future<Version?> _fetchLatestVersion() async {
+    var pubClient = PubApiClient();
+    try {
+      return await pubClient.tryFetchLatestStableVersion('serverpod_cli');
+    } catch (_) {
+      return null;
+    } finally {
+      pubClient.close();
+    }
+  }
+
+  /// Handles the `--check` flag execution by checking for updates without installing.
+  Future<void> _handleCheckOnly(Version currentVersion) async {
+    var latestVersion = await _fetchLatestVersion();
+
+    if (latestVersion == null) {
+      log.info('Failed to check for updates.');
+    } else if (currentVersion < latestVersion) {
+      log.info(
+        'A new version of Serverpod CLI is available: $latestVersion (installed: $currentVersion).\n'
+        'Run "serverpod upgrade" to update.',
+      );
+    } else {
+      log.info('Serverpod CLI is up to date: $currentVersion.');
+    }
+  }
+
+  /// Runs `dart install serverpod_cli` to upgrade the CLI to the latest version.
+  Future<bool> _performUpgrade() async {
+    return await log.progress('Updating Serverpod Cli...', () async {
       log.debug('Running `dart install serverpod_cli`...');
       var startProcess = await Process.start('dart', [
         'install',
@@ -29,12 +104,18 @@ class UpgradeCommand extends ServerpodCommand {
       startProcess.stderr.transform(const Utf8Decoder()).listen(log.error);
       return await startProcess.exitCode == 0;
     });
+  }
 
-    if (!success) {
-      log.info('Failed to update Serverpod.');
-      throw ExitException.error();
+  /// Reports the result of the upgrade operation to the user.
+  void _reportUpgradeResult(Version currentVersion, Version? latestVersion) {
+    if (latestVersion != null) {
+      if (currentVersion < latestVersion) {
+        log.info('Serverpod CLI updated to version $latestVersion.');
+      } else {
+        log.info('Serverpod CLI is up to date: $latestVersion.');
+      }
+    } else {
+      log.info('Serverpod CLI updated successfully.');
     }
-
-    log.info('Serverpod is up to date: $templateVersion version.');
   }
 }

--- a/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
+++ b/tools/serverpod_cli/lib/src/generated/completion_script_carapace.dart
@@ -132,6 +132,12 @@ commands:
       - [flutter, no-flutter]
 
   - name: upgrade
+    flags:
+      -c, --check: "Check for available updates without installing."
+
+  - name: upgrade
+    flags:
+      -c, --check: "Check for available updates without installing."
 
   - name: version
 

--- a/tools/serverpod_cli/test/commands/upgrade_command_test.dart
+++ b/tools/serverpod_cli/test/commands/upgrade_command_test.dart
@@ -1,0 +1,47 @@
+import 'package:serverpod_cli/src/commands/upgrade.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given an UpgradeCommand', () {
+    late UpgradeCommand command;
+
+    setUp(() {
+      command = UpgradeCommand();
+    });
+
+    tearDownAll(closeLogger);
+
+    test('then command name is upgrade', () {
+      expect(command.name, equals('upgrade'));
+    });
+
+    test('then command has update alias', () {
+      expect(command.aliases, contains('update'));
+    });
+
+    test('when parsing configuration with no args, then there are no errors', () {
+      final argResults = command.argParser.parse([]);
+      final config = command.resolveConfiguration(argResults);
+
+      expect(config.errors, isEmpty);
+      expect(config.value(UpgradeOption.check), isFalse);
+    });
+
+    test('when parsing configuration with --check, then check is true', () {
+      final argResults = command.argParser.parse(['--check']);
+      final config = command.resolveConfiguration(argResults);
+
+      expect(config.errors, isEmpty);
+      expect(config.value(UpgradeOption.check), isTrue);
+    });
+
+    test('when parsing configuration with -c, then check is true', () {
+      final argResults = command.argParser.parse(['-c']);
+      final config = command.resolveConfiguration(argResults);
+
+      expect(config.errors, isEmpty);
+      expect(config.value(UpgradeOption.check), isTrue);
+    });
+  });
+}

--- a/tools/serverpod_cli/test/commands/upgrade_command_test.dart
+++ b/tools/serverpod_cli/test/commands/upgrade_command_test.dart
@@ -20,13 +20,16 @@ void main() {
       expect(command.aliases, contains('update'));
     });
 
-    test('when parsing configuration with no args, then there are no errors', () {
-      final argResults = command.argParser.parse([]);
-      final config = command.resolveConfiguration(argResults);
+    test(
+      'when parsing configuration with no args, then there are no errors',
+      () {
+        final argResults = command.argParser.parse([]);
+        final config = command.resolveConfiguration(argResults);
 
-      expect(config.errors, isEmpty);
-      expect(config.value(UpgradeOption.check), isFalse);
-    });
+        expect(config.errors, isEmpty);
+        expect(config.value(UpgradeOption.check), isFalse);
+      },
+    );
 
     test('when parsing configuration with --check, then check is true', () {
       final argResults = command.argParser.parse(['--check']);


### PR DESCRIPTION
Fixes https://github.com/serverpod/serverpod/issues/5500

## Description
When running `serverpod upgrade` (or `serverpod update`), the CLI executes `dart install serverpod_cli` to download and install the latest version. However, upon completion, the log message displays:
```text
Serverpod is up to date: <INITIAL_VERSION> version.
```
Because `$templateVersion` is a constant compiled into the binary of the CLI process currently executing the command, it outputs the initial (pre-upgrade) version instead of the newly updated version.

## Changes Made
1. **Dynamic Version Lookup**: Query `pub.dev` (`PubApiClient`) after a successful upgrade to fetch the actual installed/latest version and report accurate completion messaging:
   - If updated: `Serverpod CLI updated to version X.Y.Z.`
   - If up-to-date: `Serverpod CLI is up to date: X.Y.Z.`
   - Offline fallback: `Serverpod CLI updated successfully.`
2. **Add Command Alias**: Added `aliases = const ['update'];` to `UpgradeCommand` so both `serverpod upgrade` and `serverpod update` work as aliases.
3. **Add `--check` (`-c`) Flag**: Added a `--check` flag allowing users to check for available CLI updates without triggering installation:
   ```bash
   serverpod upgrade --check
   serverpod update -c
   ```
4. **Unit Tests**: Added `test/commands/upgrade_command_test.dart` to verify properties, `update` alias, and `--check` / `-c` option parsing.

## Verification
- `dart analyze lib/src/commands/upgrade.dart test/commands/upgrade_command_test.dart`: Passed with 0 errors.
- `dart test test/commands/upgrade_command_test.dart`: 5/5 tests passed.