### PR TITLE
fix: Fix generator failing when the client or shared package are imported on the server

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/analyzers.dart
+++ b/tools/serverpod_cli/lib/src/generator/analyzers.dart
@@ -156,61 +156,58 @@ class Analyzers {
     Set<String>? affectedPaths,
   }) async {
     bool success = true;
-    String? protocolBackup;
-    var stubOverlayActive = false;
-    var wroteStubToDisk = false;
+    final protocolBackups = <String, String>{};
+    final stubOverlayPaths = <String>[];
+    var wroteStubsToDisk = false;
     var wroteFullProtocol = false;
-    final protocolPath = p.joinAll(config.generatedServerProtocolFilePathParts);
-    // The exact path the analyzer resolves protocol.dart to; overlays must
-    // match it (same normalization as [refreshAnalysisContext]).
-    final analyzerProtocolPath = p.normalize(File(protocolPath).absolute.path);
+    final tempProtocolPaths = <String>[];
 
     try {
       log.debug('Analyzing serializable models in the protocol directory.');
 
-      final models = _models.validateAll(
-        reportIssuesForPaths: affectedPaths,
-      );
+      final models = _models.validateAll(reportIssuesForPaths: affectedPaths);
       success &= !_models.hasSevereErrors;
 
       List<String> generatedModelFiles = [];
 
-      // Generate model files and a temporary protocol.dart before analyzing
-      // future calls and endpoints. The temp protocol exports model classes so
-      // that endpoint and future call files can resolve `import protocol.dart`.
-      // The full protocol (with Protocol class, endpoint dispatch, etc.) is
-      // generated later by ServerpodCodeGenerator.generateProtocolDefinition.
+      // Generate model files and temporary protocol.dart stubs before analyzing
+      // future calls and endpoints. The temp protocols export model classes so
+      // imports against the server and client barrels resolve. The full
+      // protocols are generated later by
+      // ServerpodCodeGenerator.generateProtocolDefinition.
       if (requirements.generateModels) {
         log.debug('Generating files for serializable models.');
 
-        final stubContent = _temporaryProtocolContent(
+        final tempProtocols = _temporaryProtocols(
           models: models,
           config: config,
         );
+        tempProtocolPaths.addAll(tempProtocols.keys);
+
         final overlay = _overlay;
         if (overlay != null) {
-          // Shadow protocol.dart with the stub inside the analyzer only. The
-          // file on disk keeps the previous full protocol, so a generation
-          // whose output is unchanged never touches its timestamp - which
-          // matters because file watchers treat protocol.dart changes as a
-          // reason to recompile (and would otherwise fire on every run).
-          overlay.setOverlay(
-            analyzerProtocolPath,
-            content: stubContent,
-            modificationStamp: DateTime.now().microsecondsSinceEpoch,
-          );
-          stubOverlayActive = true;
-        } else {
-          // No overlay provider backing the analysis context; fall back to
-          // writing the stub to disk and restoring the previous protocol if
-          // the full one never gets written.
-          final protocolFile = File(protocolPath);
-          if (protocolFile.existsSync()) {
-            protocolBackup = await protocolFile.readAsString();
+          for (final entry in tempProtocols.entries) {
+            // Overlay paths must use the same normalization as
+            // refreshAnalysisContext.
+            final analyzerPath = p.normalize(File(entry.key).absolute.path);
+            overlay.setOverlay(
+              analyzerPath,
+              content: entry.value,
+              modificationStamp: DateTime.now().microsecondsSinceEpoch,
+            );
+            stubOverlayPaths.add(analyzerPath);
           }
-          await protocolFile.create(recursive: true);
-          await protocolFile.writeAsString(stubContent, flush: true);
-          wroteStubToDisk = true;
+        } else {
+          // No overlay provider backs the analysis context; fall back to disk.
+          for (final entry in tempProtocols.entries) {
+            final protocolFile = File(entry.key);
+            if (protocolFile.existsSync()) {
+              protocolBackups[entry.key] = await protocolFile.readAsString();
+            }
+            await protocolFile.create(recursive: true);
+            await protocolFile.writeAsString(entry.value, flush: true);
+          }
+          wroteStubsToDisk = true;
         }
 
         generatedModelFiles =
@@ -221,7 +218,7 @@ class Analyzers {
 
         await refreshAnalysisContext(
           _futureCalls.collection,
-          [...generatedModelFiles, protocolPath],
+          [...generatedModelFiles, ...tempProtocolPaths],
         );
       }
 
@@ -297,13 +294,17 @@ class Analyzers {
           );
       wroteFullProtocol = true;
 
-      // The full protocol is on disk now (or was already up to date); retire
-      // the stub overlay so analysis resolves protocol.dart to the real
-      // content from here on.
-      if (stubOverlayActive) {
-        _overlay!.removeOverlay(analyzerProtocolPath);
-        stubOverlayActive = false;
-        await refreshAnalysisContext(_futureCalls.collection, [protocolPath]);
+      // The full protocols are on disk now (or were already up to date); retire
+      // the stub overlays so analysis resolves their real content from here on.
+      if (stubOverlayPaths.isNotEmpty) {
+        for (final path in stubOverlayPaths) {
+          _overlay!.removeOverlay(path);
+        }
+        stubOverlayPaths.clear();
+        await refreshAnalysisContext(
+          _futureCalls.collection,
+          tempProtocolPaths,
+        );
       }
 
       log.debug('Cleaning old files.');
@@ -341,36 +342,40 @@ class Analyzers {
 
       return (success: success, generatedFiles: allGeneratedFiles);
     } finally {
-      // Retire a still-active stub (interrupted run, models-only generation,
-      // or an exception). With an overlay the file on disk was never touched;
-      // just drop the shadow. When the stub was written to disk instead,
-      // restore the previous protocol.dart so generated model files that call
-      // Protocol() can still compile.
-      if (stubOverlayActive) {
-        _overlay!.removeOverlay(analyzerProtocolPath);
-        await refreshAnalysisContext(_futureCalls.collection, [protocolPath]);
+      // Retire still-active stubs after an interrupted, models-only, or failed
+      // generation. Overlays only need to be removed; disk fallbacks restore
+      // any previous protocol contents.
+      if (stubOverlayPaths.isNotEmpty) {
+        for (final path in stubOverlayPaths) {
+          _overlay!.removeOverlay(path);
+        }
+        await refreshAnalysisContext(
+          _futureCalls.collection,
+          tempProtocolPaths,
+        );
       }
-      if (wroteStubToDisk && !wroteFullProtocol && protocolBackup != null) {
-        await File(protocolPath).writeAsString(protocolBackup, flush: true);
+      if (wroteStubsToDisk && !wroteFullProtocol) {
+        for (final protocolPath in tempProtocolPaths) {
+          final backup = protocolBackups[protocolPath];
+          if (backup != null) {
+            await File(protocolPath).writeAsString(backup, flush: true);
+          }
+        }
       }
     }
   }
 }
 
-/// Generates the content of a temporary protocol.dart that exports all model
-/// classes and a stub [Protocol] class.
+/// Generates temporary protocol.dart stubs for the server and client packages.
 ///
-/// Shadowing protocol.dart with this content allows endpoint and future call
-/// files to resolve their `import 'protocol.dart'` during analysis, and lets
-/// generated model files that call `Protocol()` compile before the full
-/// protocol exists. The full protocol (with endpoint dispatch, etc.) is
-/// written later via [ServerpodCodeGenerator.generateProtocolDefinition].
-String _temporaryProtocolContent({
+/// These stubs allow endpoint and future call imports to resolve before the
+/// full protocols are generated.
+Map<String, String> _temporaryProtocols({
   required List<SerializableModelDefinition> models,
   required GeneratorConfig config,
 }) {
-  return const DartTemporaryProtocolGenerator()
-      .generateSerializableModelsCode(models: models, config: config)
-      .values
-      .first;
+  return const DartTemporaryProtocolGenerator().generateSerializableModelsCode(
+    models: models,
+    config: config,
+  );
 }

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/model_library_generator.dart
@@ -3518,18 +3518,15 @@ class SerializableModelLibraryGenerator {
 
     library.name = 'protocol';
 
-    if (serverCode) {
-      library.directives.add(
-        Directive.import(
-          'package:serverpod_serialization/serverpod_serialization.dart',
-        ),
-      );
-    }
+    library.directives.add(
+      Directive.import(
+        'package:serverpod_serialization/serverpod_serialization.dart',
+      ),
+    );
 
     // exports
     library.directives.addAll([
       for (var classInfo in models) Directive.export(classInfo.fileRef()),
-      if (!serverCode) Directive.export('client.dart'),
     ]);
 
     library.body.add(_buildTemporaryProtocolStubClass());

--- a/tools/serverpod_cli/lib/src/generator/dart/temp_protocol_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/temp_protocol_generator.dart
@@ -3,12 +3,12 @@ import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/generator/code_generator.dart';
 import 'package:serverpod_cli/src/generator/dart/library_generators/model_library_generator.dart';
 
-/// A [CodeGenerator] that generates a temporary protocol.dart file required
-/// for analyzing the endpoints.
+/// A [CodeGenerator] that generates temporary protocol.dart files required
+/// for analyzing endpoints and future calls.
 ///
 /// Differently from the other generators, this class is not meant to be invoked
-/// by the [ServerpodCodeGenerator], since the temporary protocol file needs to
-/// exist for a proper analysis of future calls.
+/// by the [ServerpodCodeGenerator], since the temporary protocol files need to
+/// exist for a proper analysis of future calls and endpoints.
 class DartTemporaryProtocolGenerator extends CodeGenerator {
   const DartTemporaryProtocolGenerator();
 
@@ -21,13 +21,44 @@ class DartTemporaryProtocolGenerator extends CodeGenerator {
       serverCode: true,
       config: config,
     );
+    var clientSideGenerator = SerializableModelLibraryGenerator(
+      serverCode: false,
+      config: config,
+    );
+    var projectModels = models.where((model) => !model.isSharedModel).toList();
+    var clientModels = projectModels
+        .where((model) => !model.serverOnly)
+        .toList();
     return {
       p.joinAll([
         ...config.generatedServeModelPathParts,
         'protocol.dart',
       ]): serverSideGenerator
-          .generateTemporaryProtocol(models: models)
+          .generateTemporaryProtocol(models: projectModels)
           .generateCode(),
+      p.joinAll([
+        ...config.generatedDartClientModelPathParts,
+        'protocol.dart',
+      ]): clientSideGenerator
+          .generateTemporaryProtocol(models: clientModels)
+          .generateCode(),
+      for (final sharedPackage in config.sharedModelsSourcePathsParts.entries)
+        p.joinAll([
+          ...config.serverPackageDirectoryPathParts,
+          ...sharedPackage.value,
+          'lib',
+          'src',
+          'generated',
+          'protocol.dart',
+        ]): clientSideGenerator
+            .generateTemporaryProtocol(
+              models: models
+                  .where(
+                    (model) => model.sharedPackageName == sharedPackage.key,
+                  )
+                  .toList(),
+            )
+            .generateCode(),
     };
   }
 

--- a/tools/serverpod_cli/test/integration/generate/generate_from_scratch_test.dart
+++ b/tools/serverpod_cli/test/integration/generate/generate_from_scratch_test.dart
@@ -114,17 +114,25 @@ class MyFutureCall extends FutureCall {
     },
   );
 
-  group('Given a model and an endpoint using it with no generated files', () {
+  group('Given a model and endpoints using it with no generated files', () {
     late Directory projectDir;
     late Directory generatedDir;
+    late Directory generatedClientDir;
     late GeneratorConfig config;
     late Analyzers analyzers;
 
     tearDownAll(() => projectDir.deleteIfExists(recursive: true));
-    tearDown(() => generatedDir.deleteIfExists(recursive: true));
+    tearDown(() {
+      generatedDir.deleteIfExists(recursive: true);
+      generatedClientDir.deleteIfExists(recursive: true);
+    });
 
     setUpAll(() async {
       (projectDir, generatedDir) = await _buildProject();
+      await _createClientPackage(projectDir);
+      generatedClientDir = Directory(
+        path.join(projectDir.path, 'test_client', 'lib', 'src', 'protocol'),
+      );
 
       var modelFile = File(
         path.join(
@@ -161,6 +169,27 @@ import 'package:serverpod/serverpod.dart';
 import 'package:test_server/src/generated/protocol.dart';
 
 class ItemEndpoint extends Endpoint {
+  Future<Item> getItem(Session session, String name) async {
+    return Item(name: name);
+  }
+}
+''');
+
+      File(
+          path.join(
+            projectDir.path,
+            'lib',
+            'src',
+            'endpoints',
+            'client_item_endpoint.dart',
+          ),
+        )
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+import 'package:test_client/test_client.dart';
+
+class ClientItemEndpoint extends Endpoint {
   Future<Item> getItem(Session session, String name) async {
     return Item(name: name);
   }
@@ -265,4 +294,158 @@ fields:
       );
     },
   );
+
+  group(
+    'Given server and client imports of a shared model with no generated files',
+    () {
+      late Directory projectDir;
+      late GeneratorConfig config;
+      late Analyzers analyzers;
+
+      tearDownAll(() => projectDir.deleteIfExists(recursive: true));
+
+      setUpAll(() async {
+        (projectDir, _) = await _buildProject();
+        await _createSharedPackage(projectDir);
+        await _createClientPackage(projectDir, dependsOnSharedPackage: true);
+
+        for (final package in ['test_server', 'test_client']) {
+          File(
+              path.join(
+                projectDir.path,
+                'lib',
+                'src',
+                'endpoints',
+                '${package}_shared_model_endpoint.dart',
+              ),
+            )
+            ..createSync(recursive: true)
+            ..writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+import '${package == 'test_server' ? 'package:test_shared/test_shared.dart' : 'package:test_client/test_client.dart'}';
+
+class ${package == 'test_server' ? 'Server' : 'Client'}SharedModelEndpoint extends Endpoint {
+  Future<SharedModel> getItem(Session session, SharedModel item) async {
+    return item;
+  }
+}
+''');
+        }
+
+        config = buildTestServerConfig(
+          projectDir,
+          sharedModelsSourcePathsParts: {
+            'test_shared': ['test_shared'],
+          },
+        );
+        analyzers = await Analyzers.create(config);
+      });
+
+      test(
+        'when generating, '
+        'then generation succeeds on first run.',
+        () async {
+          final result = await analyzers.performGenerate(config: config);
+
+          expect(result.success, isTrue);
+        },
+      );
+    },
+  );
+}
+
+Future<void> _createClientPackage(
+  Directory projectDir, {
+  bool dependsOnSharedPackage = false,
+}) async {
+  final pathToServerpodRoot = await resolveServerpodRoot();
+  final clientDir = Directory(path.join(projectDir.path, 'test_client'));
+  final sharedDependency = dependsOnSharedPackage
+      ? '''
+  test_shared:
+    path: ../test_shared
+'''
+      : '';
+
+  File(path.join(clientDir.path, 'pubspec.yaml'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+name: test_client
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  serverpod_client:
+    path: $pathToServerpodRoot/packages/serverpod_client
+$sharedDependency
+''');
+
+  File(
+      path.join(clientDir.path, 'lib', 'test_client.dart'),
+    )
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+export 'src/protocol/protocol.dart';
+${dependsOnSharedPackage ? "export 'package:test_shared/test_shared.dart';" : ''}
+''');
+
+  final serverPubspec = File(path.join(projectDir.path, 'pubspec.yaml'));
+  serverPubspec.writeAsStringSync(
+    serverPubspec.readAsStringSync().replaceFirst(
+      'dependencies:\n',
+      'dependencies:\n'
+          '  test_client:\n'
+          '    path: test_client\n'
+          '${dependsOnSharedPackage ? '  test_shared:\n    path: test_shared\n' : ''}',
+    ),
+  );
+
+  final serverPubGet = await Process.run(
+    'dart',
+    ['pub', 'get'],
+    workingDirectory: projectDir.absolute.path,
+  );
+  assert(
+    serverPubGet.exitCode == 0,
+    'Failed to add the test client dependency: ${serverPubGet.stderr}',
+  );
+}
+
+Future<void> _createSharedPackage(Directory projectDir) async {
+  final pathToServerpodRoot = await resolveServerpodRoot();
+  final sharedDir = Directory(path.join(projectDir.path, 'test_shared'));
+
+  File(path.join(sharedDir.path, 'pubspec.yaml'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+name: test_shared
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  serverpod_serialization:
+    path: $pathToServerpodRoot/packages/serverpod_serialization
+''');
+
+  File(path.join(sharedDir.path, 'lib', 'test_shared.dart'))
+    ..createSync(recursive: true)
+    ..writeAsStringSync("export 'src/generated/protocol.dart';\n");
+
+  File(
+      path.join(
+        sharedDir.path,
+        'lib',
+        'src',
+        'models',
+        'shared_model.spy.yaml',
+      ),
+    )
+    ..createSync(recursive: true)
+    ..writeAsStringSync('''
+class: SharedModel
+fields:
+  name: String
+''');
 }

--- a/tools/serverpod_cli/test/test_util/builders/generator_config_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/generator_config_builder.dart
@@ -183,11 +183,15 @@ class GeneratorConfigBuilder {
 
 /// Builds a minimal server [GeneratorConfig] rooted at [projectDir], for
 /// integration tests that generate code from a temporary project.
-GeneratorConfig buildTestServerConfig(Directory projectDir) {
+GeneratorConfig buildTestServerConfig(
+  Directory projectDir, {
+  Map<String, List<String>> sharedModelsSourcePathsParts = const {},
+}) {
   return GeneratorConfigBuilder()
       .withName('test')
       .withServerPackageDirectoryPathParts([projectDir.path])
       .withRelativeDartClientPackagePathParts(['test_client'])
+      .withSharedModelsSourcePathsParts(sharedModelsSourcePathsParts)
       .withModules([
         ModuleConfig(
           type: PackageType.server,


### PR DESCRIPTION
Due to the temp protocol being generated only on the server, whenever we import the client or a shared protocol on the server, the server generation fails. This PR fixes it by stubbing both the client and shared packages also.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.