### PR TITLE
fix: Release sessions from MessageCentral when streams are cancelled before session close

### DIFF
--- a/packages/serverpod/lib/server.dart
+++ b/packages/serverpod/lib/server.dart
@@ -8,7 +8,7 @@ export 'src/server/future_call_dispatch.dart';
 export 'src/server/future_call_manager/cron.dart';
 export 'src/server/future_call_manager/future_call.dart';
 export 'src/server/future_call_manager/future_call_manager.dart';
-export 'src/server/message_central.dart';
+export 'src/server/message_central.dart' hide MessageCentralInternalMethods;
 export 'src/generated/protocol.dart'
     show
         CronFutureCallScheduling,

--- a/packages/serverpod/lib/src/server/message_central.dart
+++ b/packages/serverpod/lib/src/server/message_central.dart
@@ -246,6 +246,10 @@ class MessageCentral {
     }
   }
 
+}
+
+/// Internal methods for [MessageCentral].
+extension MessageCentralInternalMethods on MessageCentral {
   /// Whether [session] is still referenced by any internal lookup.
   @visibleForTesting
   bool hasSessionReferences(Session session) =>

--- a/packages/serverpod/lib/src/server/message_central.dart
+++ b/packages/serverpod/lib/src/server/message_central.dart
@@ -245,7 +245,6 @@ class MessageCentral {
       callback();
     }
   }
-
 }
 
 /// Internal methods for [MessageCentral].

--- a/packages/serverpod/lib/src/server/message_central.dart
+++ b/packages/serverpod/lib/src/server/message_central.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:serverpod/serverpod.dart';
 
 /// Channels that are listened to by the Serverpod Framework.
@@ -155,20 +156,20 @@ class MessageCentral {
   /// Removes all listeners from the specified [Session]. This method is
   /// automatically called when [StreamingSession] is closed.
   void removeListenersForSession(Session session) {
-    // Get subscribed channels
-    var channelNames = _sessionToChannelNamesLookup[session];
-    if (channelNames == null) return;
-    var listeners = _sessionToCallbacksLookup[session];
-    if (listeners == null) return;
+    var channelNames = _sessionToChannelNamesLookup.remove(session);
+    var listeners = _sessionToCallbacksLookup.remove(session);
 
-    for (var channelName in channelNames) {
-      for (var listener in listeners) {
-        _removeListener(session, channelName, listener);
+    if (channelNames != null && listeners != null) {
+      for (var channelName in channelNames) {
+        for (var listener in listeners) {
+          _removeListener(session, channelName, listener);
+        }
       }
     }
 
-    _sessionToChannelNamesLookup.remove(session);
-    _sessionToCallbacksLookup.remove(session);
+    // Executed unconditionally, so the session is fully released even if the
+    // listener lookups were already emptied by removeListener.
+    _executeCleanupCallbacks(session);
   }
 
   void _removeListener(
@@ -184,8 +185,6 @@ class MessageCentral {
         session.serverpod.redisController!.unsubscribe(channelName);
       }
     }
-
-    _executeCleanupCallbacks(session);
   }
 
   /// Creates a stream that listens to a specified channel.
@@ -233,16 +232,24 @@ class MessageCentral {
     if (callbacks == null) return;
 
     callbacks.remove(callback);
+    if (callbacks.isEmpty) {
+      _sessionToCleanupCallbacksLookup.remove(session);
+    }
   }
 
   void _executeCleanupCallbacks(Session session) {
-    var callbacks = _sessionToCleanupCallbacksLookup[session];
+    var callbacks = _sessionToCleanupCallbacksLookup.remove(session);
     if (callbacks == null) return;
 
     for (var callback in callbacks) {
       callback();
     }
-
-    _sessionToCleanupCallbacksLookup.remove(session);
   }
+
+  /// Whether [session] is still referenced by any internal lookup.
+  @visibleForTesting
+  bool hasSessionReferences(Session session) =>
+      _sessionToChannelNamesLookup.containsKey(session) ||
+      _sessionToCallbacksLookup.containsKey(session) ||
+      _sessionToCleanupCallbacksLookup.containsKey(session);
 }

--- a/packages/serverpod/test/server/message_central_test.dart
+++ b/packages/serverpod/test/server/message_central_test.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/generated/protocol.dart' as internal;
+import 'package:test/test.dart';
+
+import 'test_helpers/empty_endpoints.dart';
+
+void main() {
+  final portZeroConfig = ServerConfig(
+    port: 0,
+    publicScheme: 'http',
+    publicHost: 'localhost',
+    publicPort: 0,
+  );
+
+  group('Given a session with an open message central stream,', () {
+    late Serverpod pod;
+    late InternalSession session;
+    late MessageCentral messageCentral;
+    late StreamSubscription<SerializableModel> subscription;
+
+    setUp(() async {
+      pod = Serverpod(
+        [],
+        internal.Protocol(),
+        EmptyEndpoints(),
+        config: ServerpodConfig(
+          apiServer: portZeroConfig,
+          webServer: portZeroConfig,
+          database: null,
+          runMode: ServerpodRunMode.development,
+          healthCheckInterval: Duration.zero,
+        ),
+      );
+      session = await pod.createSession(enableLogging: false);
+      messageCentral = session.server.messageCentral;
+      subscription = session.messages
+          .createStream<SerializableModel>('test-channel')
+          .listen((_) {});
+    });
+
+    tearDown(() async {
+      await subscription.cancel();
+      await session.close();
+      await pod.shutdown(exitProcess: false);
+    });
+
+    test(
+      'when the stream subscription is cancelled, '
+      'then the message central retains no references to the session.',
+      () async {
+        await subscription.cancel();
+
+        expect(messageCentral.hasSessionReferences(session), isFalse);
+      },
+    );
+
+    test(
+      'when the stream subscription is cancelled before the session is '
+      'closed, then the message central retains no references to the session.',
+      () async {
+        await subscription.cancel();
+        await session.close();
+
+        expect(messageCentral.hasSessionReferences(session), isFalse);
+      },
+    );
+
+    test(
+      'when the session is closed while the stream subscription is active, '
+      'then the message central retains no references to the session.',
+      () async {
+        await session.close();
+
+        expect(messageCentral.hasSessionReferences(session), isFalse);
+      },
+    );
+  });
+}

--- a/packages/serverpod/test/server/message_central_test.dart
+++ b/packages/serverpod/test/server/message_central_test.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod/src/generated/protocol.dart' as internal;
+import 'package:serverpod/src/server/message_central.dart'
+    show MessageCentralInternalMethods;
 import 'package:test/test.dart';
 
 import 'test_helpers/empty_endpoints.dart';


### PR DESCRIPTION
`MessageCentral` keeps cleanup callbacks in a map keyed by `Session`. Cancelling a stream created with `createStream` emptied the session's callback set but left the entry in the map, and `removeListenersForSession` early returned before reaching it once the listener lookups were empty. So whenever a stream was cancelled before its session closed, the session stayed in the map for the lifetime of the server.

- `_removeCleanupCallback` removes the map entry when the callback set becomes empty
- `removeListenersForSession` now purges all session lookups and runs the cleanup callbacks unconditionally, so release no longer depends on teardown order
- Added `hasSessionReferences` (`@visibleForTesting`) and a regression test covering both orderings, the cancel-first tests fail without the fix

Fixes #5502 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None