### PR TITLE
fix: Retry Dart tests from Windows Bash

### DIFF
--- a/.github/actions/use-dart-test-retry/action.yml
+++ b/.github/actions/use-dart-test-retry/action.yml
@@ -39,8 +39,10 @@ runs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
-        $resolvedDart = (Get-Command dart).Source
-        $expectedDart = Join-Path $env:GITHUB_ACTION_PATH 'bin\windows\dart.cmd'
+        $resolvedDart = (Resolve-Path (Get-Command dart).Source).Path
+        $expectedDart = (Resolve-Path (
+          Join-Path $env:GITHUB_ACTION_PATH 'bin\windows\dart.cmd'
+        )).Path
         if ($resolvedDart -ne $expectedDart) {
           throw "PowerShell resolved Dart to '$resolvedDart' instead of '$expectedDart'."
         }
@@ -55,9 +57,9 @@ runs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
-        resolved_dart="$(cygpath -aw "$(command -v dart)")"
-        expected_dart="$(cygpath -aw "$GITHUB_ACTION_PATH/bin/windows/dart")"
-        if [[ "${resolved_dart,,}" != "${expected_dart,,}" ]]; then
+        resolved_dart="$(command -v dart)"
+        expected_dart="$GITHUB_ACTION_PATH/bin/windows/dart"
+        if [[ ! "$resolved_dart" -ef "$expected_dart" ]]; then
           echo "::error::Bash resolved Dart to '$resolved_dart' instead of '$expected_dart'."
           exit 1
         fi

--- a/.github/actions/use-dart-test-retry/action.yml
+++ b/.github/actions/use-dart-test-retry/action.yml
@@ -39,6 +39,12 @@ runs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
+        $resolvedDart = (Get-Command dart).Source
+        $expectedDart = Join-Path $env:GITHUB_ACTION_PATH 'bin\windows\dart.cmd'
+        if ($resolvedDart -ne $expectedDart) {
+          throw "PowerShell resolved Dart to '$resolvedDart' instead of '$expectedDart'."
+        }
+
         $version = & dart --version 2>&1
         if ($LASTEXITCODE -ne 0 -or "$version" -notmatch '^Dart SDK version:') {
           throw "The Windows Dart wrapper did not delegate correctly: $version"
@@ -49,6 +55,13 @@ runs:
       if: runner.os == 'Windows'
       shell: bash
       run: |
+        resolved_dart="$(cygpath -aw "$(command -v dart)")"
+        expected_dart="$(cygpath -aw "$GITHUB_ACTION_PATH/bin/windows/dart")"
+        if [[ "${resolved_dart,,}" != "${expected_dart,,}" ]]; then
+          echo "::error::Bash resolved Dart to '$resolved_dart' instead of '$expected_dart'."
+          exit 1
+        fi
+
         version="$(dart --version 2>&1)"
         if [[ "$version" != Dart\ SDK\ version:* ]]; then
           echo "::error::The Windows Dart wrapper did not delegate correctly: $version"

--- a/.github/actions/use-dart-test-retry/bin/windows/dart
+++ b/.github/actions/use-dart-test-retry/bin/windows/dart
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+: "${SERVERPOD_REAL_DART:?The real Dart executable was not configured.}"
+: "${SERVERPOD_RETRY_RUNNER:?The retry runner was not configured.}"
+
+# Git Bash does not resolve the adjacent dart.cmd wrapper for a bare `dart`
+# command. Keep this extensionless wrapper alongside it so Bash-based Windows
+# jobs also retry transient `dart test` build-hook failures.
+if [[ "${1:-}" != "test" ]]; then
+  exec "$SERVERPOD_REAL_DART" "$@"
+fi
+
+exec "$SERVERPOD_REAL_DART" "$SERVERPOD_RETRY_RUNNER" \
+  --attempts 3 \
+  --retry-exit-codes 65 \
+  --timeout-seconds 0 \
+  -- "$SERVERPOD_REAL_DART" "$@"


### PR DESCRIPTION
Fixes Windows Git Bash jobs bypassing the Dart test retry wrapper. The retry action only exposed `dart.cmd`, so Bash resolved the real `dart.exe` and transient native build-hook failures exiting with code 65 were not retried.

This was exposed by the transient SQLite download failure in #5510. The fix adds an extensionless Windows Bash wrapper and verifies that PowerShell and Bash both resolve `dart` to their intended wrappers.

## Validation

- `bash -n` passes for the Unix and Windows Bash wrappers.
- The action YAML parses successfully.
- The Windows Bash wrapper enters the shared retry runner locally.
- Windows CI logs `### Attempt 1/3` on Dart 3.10.3 and 3.12.2.
- The original `serverpod_auth_test_server` jobs pass on both Windows SDKs.
- `git diff --check` passes.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.