### PR TITLE
fix: Remove click to select hint from screens without clickable elements

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/main_screen.dart
@@ -83,6 +83,7 @@ class MainScreen extends StatelessComponent {
   Component _buildHeader(ServerpodThemeData theme, CreateConfigState state) {
     final showingSummary = state.form.isSummary;
     final creatingProject = state.creatingProject;
+    final showHint = !showingSummary && !creatingProject;
 
     final title = switch (creatingProject) {
       true => isUpgrade ? 'Upgrading project' : 'Creating project',
@@ -104,13 +105,14 @@ class MainScreen extends StatelessComponent {
             ),
           ),
           const Spacer(),
-          Text(
-            '💡 Click to select',
-            style: TextStyle(
-              color: theme.brightText,
-              fontWeight: FontWeight.bold,
+          if (showHint)
+            Text(
+              '💡 Click to select',
+              style: TextStyle(
+                color: theme.brightText,
+                fontWeight: FontWeight.bold,
+              ),
             ),
-          ),
         ],
       ),
     );

--- a/tools/serverpod_cli/test/commands/create/tui/multi_screen_test.dart
+++ b/tools/serverpod_cli/test/commands/create/tui/multi_screen_test.dart
@@ -53,6 +53,34 @@ void main() {
     );
 
     test(
+      'when a config screen is shown, '
+      'then the click-to-select hint is shown',
+      () {
+        expect(
+          tester.terminalState.containsText('💡 Click to select'),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'when the summary screen is shown, '
+      'then the click-to-select hint is not shown',
+      () async {
+        for (var i = 0; i < state.form.configScreenCount; i++) {
+          await _sendKeyAndPump(tester, LogicalKey.enter);
+        }
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(state.form.isSummary, isTrue);
+        expect(
+          tester.terminalState.containsText('💡 Click to select'),
+          isFalse,
+        );
+      },
+    );
+
+    test(
       'when Enter is pressed on the summary screen, '
       'then the state transitions to creating mode and onCreate is called',
       () async {
@@ -66,6 +94,23 @@ void main() {
 
         expect(state.creatingProject, isTrue);
         expect(createCalls, 1);
+      },
+    );
+
+    test(
+      'when project creation starts, '
+      'then the click-to-select hint is not shown',
+      () async {
+        for (var i = 0; i < state.form.configScreenCount + 1; i++) {
+          await _sendKeyAndPump(tester, LogicalKey.enter);
+        }
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(state.creatingProject, isTrue);
+        expect(
+          tester.terminalState.containsText('💡 Click to select'),
+          isFalse,
+        );
       },
     );
   });


### PR DESCRIPTION
Removed click to select hint for serverpod create from screens without clickable elements.

Closes #5497 

https://github.com/user-attachments/assets/7e8c5fb2-749d-428c-94e2-cb7f2a5dbd90

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None