### PR TITLE
feat: Configure cache control for Flutter web apps

### DIFF
--- a/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
@@ -85,6 +85,13 @@ void run(List<String> args) async {
     pod.webServer.addRoute(
       FlutterRoute(
         appDir,
+        // Cache Flutter assets in the browser for one minute and in shared
+        // caches, such as the Serverpod Cloud CDN, for one day.
+        cacheControlFactory: (_, _) => CacheControlHeader(
+          publicCache: true,
+          maxAge: 60,
+          sMaxAge: 86400,
+        ),
         // If building the Flutter app with WASM, set the below parameter to
         // true and add the --wasm flag to the flutter build command.
         enableWasmHeaders: false,

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -268,6 +268,24 @@ void main() {
       );
 
       test(
+        'then the server server.dart configures cache control for Flutter assets',
+        () async {
+          final serverFile = File(
+            p.join(project.serverDir, 'lib', 'server.dart'),
+          );
+          final content = await serverFile.readAsString();
+
+          expect(
+            content,
+            contains('cacheControlFactory: (_, _) => CacheControlHeader('),
+          );
+          expect(content, contains('publicCache: true'));
+          expect(content, contains('maxAge: 60'));
+          expect(content, contains('sMaxAge: 86400'));
+        },
+      );
+
+      test(
         'then the server pubspec contains a Flutter build script without WASM',
         () async {
           final pubspec = File(p.join(project.serverDir, 'pubspec.yaml'));


### PR DESCRIPTION
Cache control headers are now configured by default for FlutterRoute for new serverpod projects to be compatible with Serverpod Cloud's CDN.

Closes #5515 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None