### PR TITLE
feat(database): Add UpdateQueryBuilder for PostgreSQL and SQLite

### DIFF
--- a/packages/serverpod_database/lib/src/adapters/postgres/database_connection.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/database_connection.dart
@@ -326,26 +326,12 @@ class PostgresDatabaseConnection
       selectedColumns.add(table.id);
     }
 
-    var selectedColumnNames = selectedColumns.map((e) => e.columnName);
-
-    var columnNames = selectedColumnNames
-        .map((columnName) => '"$columnName"')
-        .join(', ');
-
-    var values = _createQueryValueList(rows, selectedColumns);
-
-    var setColumns = selectedColumnNames
-        .map((columnName) => '"$columnName" = data."$columnName"')
-        .join(', ');
-
-    const tableAlias = 't';
-
-    var query =
-        'UPDATE "${table.tableName}" AS $tableAlias SET $setColumns FROM (VALUES $values) AS data($columnNames) WHERE data.id = $tableAlias.id';
-    if (!noReturn) {
-      var returning = buildReturningClause(table, tableAlias: tableAlias);
-      query += ' RETURNING $returning';
-    }
+    var query = UpdateQueryBuilder.forRows(
+      table: table,
+      dialect: DatabaseDialect.postgres,
+      rows: rows,
+      columns: selectedColumns,
+    ).withReturn(noReturn ? Returning.none : Returning.all).build();
 
     return (await _mappedResultsQuery(
           session,
@@ -392,17 +378,11 @@ class PostgresDatabaseConnection
       throw ArgumentError('columnValues cannot be empty');
     }
 
-    var setClause = columnValues
-        .map((cv) {
-          var value = poolManager.encoder.convert(cv.value);
-          return '"${cv.column.columnName}" = $value::${_convertToPostgresType(cv.column)}';
-        })
-        .join(', ');
-
-    var query =
-        'UPDATE "${table.tableName}" SET $setClause '
-        'WHERE "${table.id.columnName}" = ${poolManager.encoder.convert(id)} '
-        'RETURNING *';
+    var query = UpdateQueryBuilder.forColumnValues(
+      table: table,
+      dialect: DatabaseDialect.postgres,
+      columnValues: columnValues,
+    ).withId(id).build();
 
     var result = await _mappedResultsQuery(
       session,
@@ -439,14 +419,11 @@ class PostgresDatabaseConnection
       throw ArgumentError('columnValues cannot be empty');
     }
 
-    var setClause = columnValues
-        .map((cv) {
-          var value = poolManager.encoder.convert(cv.value);
-          return '"${cv.column.columnName}" = $value::${_convertToPostgresType(cv.column)}';
-        })
-        .join(', ');
-
-    String updateQuery;
+    var queryBuilder = UpdateQueryBuilder.forColumnValues(
+      table: table,
+      dialect: DatabaseDialect.postgres,
+      columnValues: columnValues,
+    ).withReturn(noReturn ? Returning.none : Returning.all);
 
     var requiresFilteredSubquery =
         limit != null ||
@@ -464,36 +441,12 @@ class PostgresDatabaseConnection
           .withOffset(offset)
           .build();
 
-      var idAlias = '${table.tableName}.${table.id.columnName}';
-
-      if (noReturn) {
-        // No rows are returned, so the wrapping SELECT and its ordering are
-        // unnecessary: run the UPDATE directly against the selected ids.
-        updateQuery =
-            'WITH rows_to_update AS ($subquery) '
-            'UPDATE "${table.tableName}" SET $setClause '
-            'WHERE "${table.id.columnName}" IN (SELECT "$idAlias" FROM rows_to_update)';
-      } else {
-        var orderByClause = switch (orders) {
-          != null when orders.isNotEmpty =>
-            ' ORDER BY '
-                '${orders.map((o) => o.toString().replaceAll('"${table.tableName}".', '')).join(', ')}',
-          _ => '',
-        };
-
-        updateQuery =
-            'WITH rows_to_update AS ($subquery), '
-            'updated AS ('
-            'UPDATE "${table.tableName}" SET $setClause '
-            'WHERE "${table.id.columnName}" IN (SELECT "$idAlias" FROM rows_to_update) '
-            'RETURNING *'
-            ') '
-            'SELECT * FROM updated$orderByClause';
-      }
+      queryBuilder.withFilteredSelection(subquery, orderBy: orders);
     } else {
-      updateQuery = 'UPDATE "${table.tableName}" SET $setClause WHERE $where';
-      if (!noReturn) updateQuery += ' RETURNING *';
+      queryBuilder.withWhere(where);
     }
+
+    var updateQuery = queryBuilder.build();
 
     var result = await _mappedResultsQuery(
       session,
@@ -1003,71 +956,6 @@ class PostgresDatabaseConnection
     }
     if (orderByList == null || orderByList.isEmpty) return null;
     return orderByList.asOrderBy();
-  }
-
-  String _createQueryValueList(
-    Iterable<TableRow> rows,
-    Iterable<Column> column,
-  ) {
-    return rows
-        .map((row) => row.toJsonForDatabase() as Map<String, dynamic>)
-        .map((row) {
-          var values = column
-              .map((column) {
-                var unformattedValue = row[column.columnName];
-
-                var formattedValue = poolManager.encoder.convert(
-                  unformattedValue,
-                );
-
-                return '$formattedValue::${_convertToPostgresType(column)}';
-              })
-              .join(', ');
-
-          return '($values)';
-        })
-        .join(', ');
-  }
-
-  String _convertToPostgresType(Column column) {
-    if (column is ColumnString) return 'text';
-    if (column is ColumnBool) return 'boolean';
-    if (column is ColumnInt) return 'bigint';
-    if (column is ColumnDouble) return 'double precision';
-    if (column is ColumnDateTime) return 'timestamp without time zone';
-    if (column is ColumnByteData) return 'bytea';
-    if (column is ColumnDuration) return 'bigint';
-    if (column is ColumnUuid) return 'uuid';
-    if (column is ColumnUri) return 'text';
-    if (column is ColumnBigInt) return 'text';
-    if (column is ColumnVector) return 'vector(${column.dimension})';
-    if (column is ColumnHalfVector) return 'halfvec(${column.dimension})';
-    if (column is ColumnSparseVector) return 'sparsevec(${column.dimension})';
-    if (column is ColumnBit) return 'bit(${column.dimension})';
-    if (column is ColumnGeographyPoint) {
-      return 'geography(Point,${Geography.defaultSrid})';
-    }
-    if (column is ColumnGeographyLineString) {
-      return 'geography(LineString,${Geography.defaultSrid})';
-    }
-    if (column is ColumnGeographyPolygon) {
-      return 'geography(Polygon,${Geography.defaultSrid})';
-    }
-    if (column is ColumnGeographyGeometryCollection) {
-      return 'geography(GeometryCollection,${Geography.defaultSrid})';
-    }
-    if (column is ColumnStructured) return 'jsonb';
-    if (column is ColumnSerializable) return 'json';
-    if (column is ColumnEnumExtended) {
-      switch (column.serialized) {
-        case EnumSerialization.byIndex:
-          return 'bigint';
-        case EnumSerialization.byName:
-          return 'text';
-      }
-    }
-
-    return 'json';
   }
 
   /// Merges the database result with the original non-persisted fields.

--- a/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/sql_query_builder.dart
@@ -2,6 +2,8 @@ import 'dart:collection';
 
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
+import 'package:serverpod_serialization/serverpod_serialization.dart'
+    show Geography;
 import 'package:serverpod_shared/serverpod_shared.dart';
 
 import '../../../serverpod_database.dart';
@@ -620,6 +622,306 @@ UNION ALL
 SELECT * FROM insertWithIdNotNull
 ''';
   }
+}
+
+/// Builds SQL queries for updating rows or selected column values.
+/// This is typically only used internally by the serverpod framework.
+@internal
+class UpdateQueryBuilder {
+  final Table _table;
+  final DatabaseDialect _dialect;
+  final List<TableRow>? _rows;
+  final Set<Column>? _columns;
+  final List<ColumnValue>? _columnValues;
+
+  Expression? _where;
+  Object? _id;
+  List<Object>? _ids;
+  String? _filteredSelection;
+  List<Order>? _filteredSelectionOrderBy;
+  Returning _returning = Returning.all;
+
+  /// Creates a builder for updating one or more complete rows.
+  UpdateQueryBuilder.forRows({
+    required Table table,
+    required DatabaseDialect dialect,
+    required List<TableRow> rows,
+    required Set<Column> columns,
+  }) : _table = table,
+       _dialect = dialect,
+       _rows = rows,
+       _columns = columns,
+       _columnValues = null {
+    if (rows.isEmpty) {
+      throw ArgumentError.value(rows, 'rows', 'Cannot be empty');
+    }
+    if (columns.isEmpty) {
+      throw ArgumentError.value(columns, 'columns', 'Cannot be empty');
+    }
+    if (dialect == DatabaseDialect.sqlite && rows.length != 1) {
+      throw ArgumentError.value(
+        rows,
+        'rows',
+        'SQLite row updates must be built one row at a time',
+      );
+    }
+  }
+
+  /// Creates a builder for updating a fixed set of column values.
+  UpdateQueryBuilder.forColumnValues({
+    required Table table,
+    required DatabaseDialect dialect,
+    required List<ColumnValue> columnValues,
+  }) : _table = table,
+       _dialect = dialect,
+       _rows = null,
+       _columns = null,
+       _columnValues = columnValues {
+    if (columnValues.isEmpty) {
+      throw ArgumentError.value(
+        columnValues,
+        'columnValues',
+        'Cannot be empty',
+      );
+    }
+  }
+
+  /// Restricts the update to rows matching [where].
+  UpdateQueryBuilder withWhere(Expression where) {
+    _where = where;
+    return this;
+  }
+
+  /// Restricts the update to the row matching [id].
+  UpdateQueryBuilder withId(Object id) {
+    _id = id;
+    return this;
+  }
+
+  /// Restricts the update to rows matching [ids].
+  UpdateQueryBuilder withIds(Iterable<Object> ids) {
+    _ids = ids.toList();
+    if (_ids!.isEmpty) {
+      throw ArgumentError.value(ids, 'ids', 'Cannot be empty');
+    }
+    return this;
+  }
+
+  /// Restricts a PostgreSQL update to ids produced by [query].
+  ///
+  /// If rows are returned, [orderBy] is used to order the final result in the
+  /// same way as the filtered selection.
+  UpdateQueryBuilder withFilteredSelection(
+    String query, {
+    List<Order>? orderBy,
+  }) {
+    if (_dialect != DatabaseDialect.postgres) {
+      throw UnsupportedError(
+        'Filtered update selections are only supported for PostgreSQL.',
+      );
+    }
+    _filteredSelection = query;
+    _filteredSelectionOrderBy = orderBy;
+    return this;
+  }
+
+  /// Configures which columns the query returns.
+  UpdateQueryBuilder withReturn(Returning returning) {
+    _returning = returning;
+    return this;
+  }
+
+  /// Builds the SQL query.
+  String build() {
+    if (_rows != null) return _buildRowsUpdate();
+    return _buildColumnValuesUpdate();
+  }
+
+  String _buildRowsUpdate() {
+    return switch (_dialect) {
+      DatabaseDialect.postgres => _buildPostgresRowsUpdate(),
+      DatabaseDialect.sqlite => _buildSqliteRowUpdate(),
+    };
+  }
+
+  String _buildPostgresRowsUpdate() {
+    var columns = _columns!;
+    var columnNames = columns.map((column) => column.columnName).toList();
+    var quotedColumnNames = columnNames
+        .map((columnName) => '"$columnName"')
+        .join(', ');
+    var values = _rows!
+        .map((row) => row.toJsonForDatabase() as Map<String, dynamic>)
+        .map((row) {
+          var encodedValues = columns
+              .map((column) {
+                var value = ValueEncoder.instance.encodeColumnValue(
+                  column,
+                  row[column.columnName],
+                );
+                return '$value::${_postgresTypeForColumn(column)}';
+              })
+              .join(', ');
+          return '($encodedValues)';
+        })
+        .join(', ');
+    var setClause = columnNames
+        .map((columnName) => '"$columnName" = data."$columnName"')
+        .join(', ');
+
+    const tableAlias = 't';
+    var query =
+        'UPDATE "${_table.tableName}" AS $tableAlias SET $setClause '
+        'FROM (VALUES $values) AS data($quotedColumnNames) '
+        'WHERE data.id = $tableAlias.id';
+    return query + _buildReturningClause(tableAlias: tableAlias);
+  }
+
+  String _buildSqliteRowUpdate() {
+    var row = _rows!.single;
+    var rowJson = row.toJsonForDatabase() as Map<String, dynamic>;
+    var setParts = _columns!
+        .where((column) => column.columnName != _table.id.columnName)
+        .map(
+          (column) =>
+              _buildColumnAssignment(column, rowJson[column.columnName]),
+        )
+        .toList();
+    var encodedId = ValueEncoder.instance.convert(row.id);
+    if (setParts.isEmpty) {
+      setParts.add('"${_table.id.columnName}" = $encodedId');
+    }
+
+    return 'UPDATE "${_table.tableName}" SET ${setParts.join(', ')} '
+        'WHERE "${_table.id.columnName}" = $encodedId'
+        '${_buildReturningClause()}';
+  }
+
+  String _buildColumnValuesUpdate() {
+    var setClause = _columnValues!
+        .map((columnValue) {
+          return _buildColumnAssignment(columnValue.column, columnValue.value);
+        })
+        .join(', ');
+
+    var filteredSelection = _filteredSelection;
+    if (filteredSelection != null) {
+      return _buildFilteredPostgresUpdate(setClause, filteredSelection);
+    }
+
+    var query = 'UPDATE "${_table.tableName}" SET $setClause';
+    var where = _buildPredicate();
+    if (where != null) query += ' WHERE $where';
+    return query + _buildReturningClause();
+  }
+
+  String _buildFilteredPostgresUpdate(
+    String setClause,
+    String filteredSelection,
+  ) {
+    var idAlias = '${_table.tableName}.${_table.id.columnName}';
+    var update =
+        'UPDATE "${_table.tableName}" SET $setClause '
+        'WHERE "${_table.id.columnName}" IN '
+        '(SELECT "$idAlias" FROM rows_to_update)';
+
+    if (_returning == Returning.none) {
+      return 'WITH rows_to_update AS ($filteredSelection) $update';
+    }
+
+    var orderBy = _filteredSelectionOrderBy;
+    if (_returning == Returning.id &&
+        orderBy != null &&
+        orderBy.any(
+          (order) =>
+              order.column.table.tableName != _table.tableName ||
+              order.column.columnName != _table.id.columnName,
+        )) {
+      throw const FormatException(
+        'Filtered updates returning only the id can only be ordered by the id '
+        'column.',
+      );
+    }
+    var orderByClause = switch (orderBy) {
+      != null when orderBy.isNotEmpty =>
+        ' ORDER BY '
+            '${orderBy.map((order) => order.toString().replaceAll('"${_table.tableName}".', '')).join(', ')}',
+      _ => '',
+    };
+    return 'WITH rows_to_update AS ($filteredSelection), '
+        'updated AS ($update${_buildReturningClause()}) '
+        'SELECT * FROM updated$orderByClause';
+  }
+
+  String? _buildPredicate() {
+    if (_id != null) {
+      return '"${_table.id.columnName}" = '
+          '${ValueEncoder.instance.convert(_id)}';
+    }
+    if (_ids != null) {
+      var ids = _ids!.map(ValueEncoder.instance.convert).join(', ');
+      return '"${_table.id.columnName}" IN ($ids)';
+    }
+    return _where?.toString();
+  }
+
+  String _buildColumnAssignment(Column column, dynamic value) {
+    var encoded = ValueEncoder.instance.encodeColumnValue(column, value);
+    var cast = _dialect == DatabaseDialect.postgres
+        ? '::${_postgresTypeForColumn(column)}'
+        : '';
+    return '"${column.columnName}" = $encoded$cast';
+  }
+
+  String _buildReturningClause({String? tableAlias}) {
+    return switch (_returning) {
+      Returning.none => '',
+      Returning.id when tableAlias != null =>
+        ' RETURNING "$tableAlias"."${_table.id.columnName}"',
+      Returning.id => ' RETURNING "${_table.id.columnName}"',
+      Returning.all when tableAlias != null =>
+        ' RETURNING ${buildReturningClause(_table, tableAlias: tableAlias)}',
+      Returning.all => ' RETURNING *',
+    };
+  }
+}
+
+String _postgresTypeForColumn(Column column) {
+  if (column is ColumnString) return 'text';
+  if (column is ColumnBool) return 'boolean';
+  if (column is ColumnInt) return 'bigint';
+  if (column is ColumnDouble) return 'double precision';
+  if (column is ColumnDateTime) return 'timestamp without time zone';
+  if (column is ColumnByteData) return 'bytea';
+  if (column is ColumnDuration) return 'bigint';
+  if (column is ColumnUuid) return 'uuid';
+  if (column is ColumnUri) return 'text';
+  if (column is ColumnBigInt) return 'text';
+  if (column is ColumnVector) return 'vector(${column.dimension})';
+  if (column is ColumnHalfVector) return 'halfvec(${column.dimension})';
+  if (column is ColumnSparseVector) return 'sparsevec(${column.dimension})';
+  if (column is ColumnBit) return 'bit(${column.dimension})';
+  if (column is ColumnGeographyPoint) {
+    return 'geography(Point,${Geography.defaultSrid})';
+  }
+  if (column is ColumnGeographyLineString) {
+    return 'geography(LineString,${Geography.defaultSrid})';
+  }
+  if (column is ColumnGeographyPolygon) {
+    return 'geography(Polygon,${Geography.defaultSrid})';
+  }
+  if (column is ColumnGeographyGeometryCollection) {
+    return 'geography(GeometryCollection,${Geography.defaultSrid})';
+  }
+  if (column is ColumnStructured) return 'jsonb';
+  if (column is ColumnSerializable) return 'json';
+  if (column is ColumnEnumExtended) {
+    return switch (column.serialized) {
+      EnumSerialization.byIndex => 'bigint',
+      EnumSerialization.byName => 'text',
+    };
+  }
+  return 'json';
 }
 
 /// Builds a SQL query for a count statement.

--- a/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
@@ -440,23 +440,15 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
       selectedColumns.add(table.id);
     }
 
-    var encoder = poolManager.encoder;
     var results = <Map<String, dynamic>>[];
 
     for (var row in rows) {
-      var rowJson = row.toJsonForDatabase() as Map<String, dynamic>;
-      var setParts = <String>[];
-      var idValue = encoder.convert(row.id);
-
-      for (var col in selectedColumns) {
-        if (col.columnName == 'id') continue;
-        final rawValue = rowJson[col.columnName];
-        setParts.add(_buildSetExpression(col, rawValue));
-      }
-      if (setParts.isEmpty) {
-        // No columns to update (e.g. columns: (t) => [t.id]); keep SQL valid.
-        setParts.add('"${table.id.columnName}" = $idValue');
-      }
+      var query = UpdateQueryBuilder.forRows(
+        table: table,
+        dialect: DatabaseDialect.sqlite,
+        rows: [row],
+        columns: selectedColumns,
+      ).withReturn(noReturn ? Returning.none : Returning.all).build();
 
       // No need to run in transaction or savepoint here, since we are already
       // ensure that any batch with more than 1 row has a transaction or
@@ -464,12 +456,7 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
       results.addAll(
         await _mappedResultsQuery(
           session,
-          _buildSqlUpdateWhereId(
-            table: table,
-            setClause: setParts.join(', '),
-            idSqlValue: idValue,
-            noReturn: noReturn,
-          ),
+          query,
           transaction: transaction,
           table: table,
         ),
@@ -516,16 +503,15 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
       throw ArgumentError('columnValues cannot be empty');
     }
 
-    var encoder = poolManager.encoder;
-    var setClause = _buildSetClause(columnValues);
+    var query = UpdateQueryBuilder.forColumnValues(
+      table: table,
+      dialect: DatabaseDialect.sqlite,
+      columnValues: columnValues,
+    ).withId(id).build();
 
     var result = await _mappedResultsQuery(
       session,
-      _buildSqlUpdateWhereId(
-        table: table,
-        setClause: setClause,
-        idSqlValue: encoder.convert(id),
-      ),
+      query,
       transaction: transaction,
       table: table,
     );
@@ -604,16 +590,19 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
         .whereType<Object>()
         .toList();
 
-    var idList = ids.map(poolManager.encoder.convert).join(', ');
+    var query =
+        UpdateQueryBuilder.forColumnValues(
+              table: table,
+              dialect: DatabaseDialect.sqlite,
+              columnValues: columnValues,
+            )
+            .withIds(ids)
+            .withReturn(noReturn ? Returning.none : Returning.all)
+            .build();
 
     var result = await _mappedResultsQuery(
       session,
-      _buildSqlUpdateWhereIdIn(
-        table: table,
-        setClause: _buildSetClause(columnValues),
-        idListSql: idList,
-        noReturn: noReturn,
-      ),
+      query,
       transaction: transaction,
       table: table,
     );
@@ -1108,22 +1097,6 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
     });
   }
 
-  String _buildSetClause(List<ColumnValue> columnValues) {
-    return columnValues
-        .map((columnValue) {
-          return _buildSetExpression(
-            columnValue.column,
-            columnValue.value,
-          );
-        })
-        .join(', ');
-  }
-
-  String _buildSetExpression(Column column, dynamic value) {
-    final encodedValue = poolManager.encoder.encodeColumnValue(column, value);
-    return '"${column.columnName}" = $encodedValue';
-  }
-
   /// SQLite applies `ORDER BY`, `LIMIT`, and `OFFSET` in the preliminary
   /// `SELECT id ...` used by `updateWhere`, but the subsequent
   /// `UPDATE ... WHERE id IN (...) RETURNING *` does not preserve that row
@@ -1459,30 +1432,6 @@ String _buildSqlSingleRowInsert({
   final values = encodedValues.join(', ');
   return 'INSERT INTO "${table.tableName}" ($columnNames) VALUES ($values)'
       '$onConflict$returning';
-}
-
-String _buildSqlUpdateWhereId({
-  required Table table,
-  required String setClause,
-  required String idSqlValue,
-  bool noReturn = false,
-}) {
-  final returning = noReturn ? '' : ' RETURNING *';
-  return 'UPDATE "${table.tableName}" SET $setClause '
-      'WHERE "${table.id.columnName}" = $idSqlValue'
-      '$returning';
-}
-
-String _buildSqlUpdateWhereIdIn({
-  required Table table,
-  required String setClause,
-  required String idListSql,
-  bool noReturn = false,
-}) {
-  final returning = noReturn ? '' : ' RETURNING *';
-  return 'UPDATE "${table.tableName}" SET $setClause '
-      'WHERE "${table.id.columnName}" IN ($idListSql)'
-      '$returning';
 }
 
 Table _getTableOrAssert<T>(

--- a/packages/serverpod_database/test/database_query/update_sql_query_test.dart
+++ b/packages/serverpod_database/test/database_query/update_sql_query_test.dart
@@ -1,0 +1,422 @@
+import 'package:serverpod_database/serverpod_database.dart';
+import 'package:serverpod_database/src/adapters/postgres/sql_query_builder.dart';
+import 'package:serverpod_database/src/adapters/postgres/value_encoder.dart';
+import 'package:serverpod_database/src/adapters/sqlite/value_encoder.dart';
+import 'package:test/test.dart';
+
+class _PersonTable extends Table<int?> {
+  late final ColumnString name;
+  late final ColumnInt age;
+  late final ColumnBool active;
+
+  _PersonTable() : super(tableName: 'person') {
+    name = ColumnString('full_name', this, fieldName: 'name');
+    age = ColumnInt('age', this);
+    active = ColumnBool('active', this);
+  }
+
+  @override
+  List<Column> get columns => [id, name, age, active];
+}
+
+class _Person implements TableRow<int?> {
+  @override
+  final int? id;
+  final String name;
+  final int? age;
+  final bool active;
+  final _PersonTable _table;
+
+  _Person({
+    required this.id,
+    required this.name,
+    required this.age,
+    required this.active,
+    required _PersonTable table,
+  }) : _table = table;
+
+  @override
+  Table<int?> get table => _table;
+
+  @override
+  Map<String, Object?> toJson() => {
+    'id': id,
+    'name': name,
+    'age': age,
+    'active': active,
+  };
+}
+
+void main() {
+  group('Given UpdateQueryBuilder for PostgreSQL', () {
+    late _PersonTable table;
+
+    setUp(() {
+      ValueEncoder.set(const PostgresValueEncoder());
+      table = _PersonTable();
+    });
+
+    test('when updating rows then it builds a typed VALUES update', () {
+      var rows = [
+        _Person(
+          id: 1,
+          name: 'Alex',
+          age: 33,
+          active: true,
+          table: table,
+        ),
+        _Person(
+          id: 2,
+          name: 'Bob',
+          age: 40,
+          active: false,
+          table: table,
+        ),
+      ];
+
+      var query = UpdateQueryBuilder.forRows(
+        table: table,
+        dialect: DatabaseDialect.postgres,
+        rows: rows,
+        columns: table.columns.toSet(),
+      ).build();
+
+      expect(
+        query,
+        'UPDATE "person" AS t SET "id" = data."id", '
+        '"full_name" = data."full_name", "age" = data."age", '
+        '"active" = data."active" FROM (VALUES '
+        '(1::bigint, \'Alex\'::text, 33::bigint, TRUE::boolean), '
+        '(2::bigint, \'Bob\'::text, 40::bigint, FALSE::boolean)) '
+        'AS data("id", "full_name", "age", "active") '
+        'WHERE data.id = t.id RETURNING '
+        '"t"."id" AS "id", "t"."full_name" AS "name", '
+        '"t"."age" AS "age", "t"."active" AS "active"',
+      );
+    });
+
+    test('when returning is disabled then RETURNING is omitted', () {
+      var row = _Person(
+        id: 1,
+        name: 'Alex',
+        age: 33,
+        active: true,
+        table: table,
+      );
+
+      var query = UpdateQueryBuilder.forRows(
+        table: table,
+        dialect: DatabaseDialect.postgres,
+        rows: [row],
+        columns: {table.id, table.name},
+      ).withReturn(Returning.none).build();
+
+      expect(query, isNot(contains('RETURNING')));
+    });
+
+    test('when a row update returns its id then the target is qualified', () {
+      var row = _Person(
+        id: 1,
+        name: 'Alex',
+        age: 33,
+        active: true,
+        table: table,
+      );
+
+      var query = UpdateQueryBuilder.forRows(
+        table: table,
+        dialect: DatabaseDialect.postgres,
+        rows: [row],
+        columns: {table.id, table.name},
+      ).withReturn(Returning.id).build();
+
+      expect(query, endsWith('WHERE data.id = t.id RETURNING "t"."id"'));
+    });
+
+    test('when only the id is returned then RETURNING selects the id', () {
+      var query = UpdateQueryBuilder.forColumnValues(
+        table: table,
+        dialect: DatabaseDialect.postgres,
+        columnValues: [ColumnValue(table.name, 'Updated')],
+      ).withId(7).withReturn(Returning.id).build();
+
+      expect(
+        query,
+        'UPDATE "person" SET "full_name" = \'Updated\'::text '
+        'WHERE "id" = 7 RETURNING "id"',
+      );
+    });
+
+    test('when updating column values by id then values are cast', () {
+      var query = UpdateQueryBuilder.forColumnValues(
+        table: table,
+        dialect: DatabaseDialect.postgres,
+        columnValues: [
+          ColumnValue(table.name, 'Updated'),
+          ColumnValue(table.age, null),
+        ],
+      ).withId(7).build();
+
+      expect(
+        query,
+        'UPDATE "person" SET "full_name" = \'Updated\'::text, '
+        '"age" = NULL::bigint WHERE "id" = 7 RETURNING *',
+      );
+    });
+
+    test('when updating with a where expression then it is preserved', () {
+      var query = UpdateQueryBuilder.forColumnValues(
+        table: table,
+        dialect: DatabaseDialect.postgres,
+        columnValues: [ColumnValue(table.active, false)],
+      ).withWhere(table.age > 20).build();
+
+      expect(
+        query,
+        'UPDATE "person" SET "active" = FALSE::boolean '
+        'WHERE "person"."age" > 20 RETURNING *',
+      );
+    });
+
+    test('when using a filtered selection then it builds an ordered CTE', () {
+      var orders = [table.age.desc()];
+      var selection = SelectQueryBuilder(table: table)
+          .withSelectFields([table.id])
+          .withWhere(table.active.equals(true))
+          .withOrderBy(orders)
+          .withLimit(2)
+          .withOffset(1)
+          .build();
+
+      var query = UpdateQueryBuilder.forColumnValues(
+        table: table,
+        dialect: DatabaseDialect.postgres,
+        columnValues: [ColumnValue(table.name, 'Updated')],
+      ).withFilteredSelection(selection, orderBy: orders).build();
+
+      expect(
+        query,
+        'WITH rows_to_update AS ($selection), updated AS ('
+        'UPDATE "person" SET "full_name" = \'Updated\'::text '
+        'WHERE "id" IN (SELECT "person.id" FROM rows_to_update) '
+        'RETURNING *) SELECT * FROM updated ORDER BY "age" DESC',
+      );
+    });
+
+    test('when a filtered update returns nothing then wrapping is omitted', () {
+      var selection = SelectQueryBuilder(
+        table: table,
+      ).withSelectFields([table.id]).withLimit(1).build();
+
+      var query = UpdateQueryBuilder.forColumnValues(
+        table: table,
+        dialect: DatabaseDialect.postgres,
+        columnValues: [ColumnValue(table.name, 'Updated')],
+      ).withFilteredSelection(selection).withReturn(Returning.none).build();
+
+      expect(
+        query,
+        'WITH rows_to_update AS ($selection) '
+        'UPDATE "person" SET "full_name" = \'Updated\'::text '
+        'WHERE "id" IN (SELECT "person.id" FROM rows_to_update)',
+      );
+    });
+
+    test(
+      'when a filtered update returns only its id then ordering by another '
+      'column throws',
+      () {
+        var builder =
+            UpdateQueryBuilder.forColumnValues(
+                table: table,
+                dialect: DatabaseDialect.postgres,
+                columnValues: [ColumnValue(table.name, 'Updated')],
+              )
+              ..withFilteredSelection(
+                'SELECT "id" AS "person.id" FROM "person"',
+                orderBy: [table.age.asc()],
+              )
+              ..withReturn(Returning.id);
+
+        expect(
+          builder.build,
+          throwsA(
+            isA<FormatException>().having(
+              (error) => error.message,
+              'message',
+              'Filtered updates returning only the id can only be ordered by '
+                  'the id column.',
+            ),
+          ),
+        );
+      },
+    );
+  });
+
+  group('Given UpdateQueryBuilder for SQLite', () {
+    late _PersonTable table;
+
+    setUp(() {
+      ValueEncoder.set(const SqliteValueEncoder());
+      table = _PersonTable();
+    });
+
+    test('when updating a row then it builds a single-row update', () {
+      var row = _Person(
+        id: 1,
+        name: 'Alex',
+        age: 33,
+        active: true,
+        table: table,
+      );
+
+      var query = UpdateQueryBuilder.forRows(
+        table: table,
+        dialect: DatabaseDialect.sqlite,
+        rows: [row],
+        columns: table.columns.toSet(),
+      ).build();
+
+      expect(
+        query,
+        'UPDATE "person" SET "full_name" = \'Alex\', "age" = 33, '
+        '"active" = 1 WHERE "id" = 1 RETURNING *',
+      );
+    });
+
+    test('when only the id is selected then it builds a valid no-op set', () {
+      var row = _Person(
+        id: 1,
+        name: 'Alex',
+        age: 33,
+        active: true,
+        table: table,
+      );
+
+      var query = UpdateQueryBuilder.forRows(
+        table: table,
+        dialect: DatabaseDialect.sqlite,
+        rows: [row],
+        columns: {table.id},
+      ).build();
+
+      expect(
+        query,
+        'UPDATE "person" SET "id" = 1 WHERE "id" = 1 RETURNING *',
+      );
+    });
+
+    test('when updating column values by id then SQLite values are used', () {
+      var query = UpdateQueryBuilder.forColumnValues(
+        table: table,
+        dialect: DatabaseDialect.sqlite,
+        columnValues: [
+          ColumnValue(table.name, 'Updated'),
+          ColumnValue(table.active, true),
+          ColumnValue(table.age, null),
+        ],
+      ).withId(7).build();
+
+      expect(
+        query,
+        'UPDATE "person" SET "full_name" = \'Updated\', "active" = 1, '
+        '"age" = NULL WHERE "id" = 7 RETURNING *',
+      );
+    });
+
+    test(
+      'when updating selected ids without return then it omits RETURNING',
+      () {
+        var query = UpdateQueryBuilder.forColumnValues(
+          table: table,
+          dialect: DatabaseDialect.sqlite,
+          columnValues: [ColumnValue(table.active, false)],
+        ).withIds([1, 2]).withReturn(Returning.none).build();
+
+        expect(
+          query,
+          'UPDATE "person" SET "active" = 0 WHERE "id" IN (1, 2)',
+        );
+      },
+    );
+
+    test('when using a filtered selection then it throws', () {
+      var builder = UpdateQueryBuilder.forColumnValues(
+        table: table,
+        dialect: DatabaseDialect.sqlite,
+        columnValues: [ColumnValue(table.name, 'Updated')],
+      );
+
+      expect(
+        () => builder.withFilteredSelection('SELECT "id" FROM "person"'),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
+  group('Given invalid UpdateQueryBuilder input', () {
+    test('when rows are empty then it throws an ArgumentError', () {
+      expect(
+        () => UpdateQueryBuilder.forRows(
+          table: _PersonTable(),
+          dialect: DatabaseDialect.postgres,
+          rows: [],
+          columns: {ColumnInt('id', _PersonTable())},
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('when column values are empty then it throws an ArgumentError', () {
+      expect(
+        () => UpdateQueryBuilder.forColumnValues(
+          table: _PersonTable(),
+          dialect: DatabaseDialect.postgres,
+          columnValues: [],
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('when SQLite rows contain multiple entries then it throws', () {
+      var table = _PersonTable();
+      var rows = [
+        _Person(
+          id: 1,
+          name: 'Alex',
+          age: 33,
+          active: true,
+          table: table,
+        ),
+        _Person(
+          id: 2,
+          name: 'Bob',
+          age: 40,
+          active: false,
+          table: table,
+        ),
+      ];
+
+      expect(
+        () => UpdateQueryBuilder.forRows(
+          table: table,
+          dialect: DatabaseDialect.sqlite,
+          rows: rows,
+          columns: {table.id, table.name},
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('when ids are empty then it throws an ArgumentError', () {
+      var table = _PersonTable();
+      var builder = UpdateQueryBuilder.forColumnValues(
+        table: table,
+        dialect: DatabaseDialect.postgres,
+        columnValues: [ColumnValue(table.name, 'Updated')],
+      );
+
+      expect(() => builder.withIds([]), throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds an internal UpdateQueryBuilder for PostgreSQL and SQLite and routes the existing update operations through it. It centralizes SQL generation for batch updates, partial column updates, predicates, filtered selections, dialect-specific value encoding, and returning modes while preserving the existing public ORM API and runtime behavior.

PostgreSQL and SQLite update paths now share consistent query-building logic, and obsolete adapter-specific SQL helpers have been removed. Focused tests cover both dialects, including explicit column mappings, typed and null values, ID predicates, filtered updates, validation, and returning modes.

Fixes #3862.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None. This is an internal refactor with no public API, generated-code, or schema changes.