### PR TITLE
ci: Add 255 as retry code on CI since it can happen for build hooks failure

### DIFF
--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -45,6 +45,7 @@ runs:
         RETRY_BACKOFF: ${{ inputs.backoff }}
         RETRY_COMMAND: ${{ inputs.command }}
         RETRY_DELAY_SECONDS: ${{ inputs.delay_seconds }}
+        SERVERPOD_DART_RETRY_ACTIVE: "1"
         RETRY_EXIT_CODES: ${{ inputs.retry_exit_codes }}
         RETRY_TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
         RETRY_WORKING_DIRECTORY: ${{ inputs.working_directory }}
@@ -66,6 +67,7 @@ runs:
         RETRY_BACKOFF: ${{ inputs.backoff }}
         RETRY_COMMAND: ${{ inputs.command }}
         RETRY_DELAY_SECONDS: ${{ inputs.delay_seconds }}
+        SERVERPOD_DART_RETRY_ACTIVE: "1"
         RETRY_EXIT_CODES: ${{ inputs.retry_exit_codes }}
         RETRY_TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
         RETRY_WORKING_DIRECTORY: ${{ inputs.working_directory }}

--- a/.github/actions/retry/run_with_retry.dart
+++ b/.github/actions/retry/run_with_retry.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 const _timeoutExitCode = 124;
@@ -17,8 +18,9 @@ Future<void> main(List<String> arguments) async {
 
     final isRetriable =
         result.timedOut ||
-        options.retryExitCodes.isEmpty ||
-        options.retryExitCodes.contains(result.exitCode);
+        ((options.retryExitCodes.isEmpty ||
+                options.retryExitCodes.contains(result.exitCode)) &&
+            (options.retryOutputContains == null || result.outputMatched));
     if (!isRetriable || attempt == options.attempts) {
       exitCode = result.exitCode;
       return;
@@ -40,6 +42,14 @@ Future<void> main(List<String> arguments) async {
 }
 
 Future<_Result> _run(_Options options) async {
+  if (options.retryOutputContains == null) {
+    return _runWithInheritedStdio(options);
+  }
+
+  return _runWithCapturedStdio(options);
+}
+
+Future<_Result> _runWithInheritedStdio(_Options options) async {
   final process = await Process.start(
     options.command.first,
     options.command.skip(1).toList(),
@@ -49,24 +59,77 @@ Future<_Result> _run(_Options options) async {
   );
 
   if (options.timeout == null) {
-    return _Result(await process.exitCode, timedOut: false);
+    return _Result(
+      await process.exitCode,
+      timedOut: false,
+      outputMatched: false,
+    );
   }
 
+  return _waitForProcess(process, options.timeout!);
+}
+
+Future<_Result> _runWithCapturedStdio(_Options options) async {
+  final process = await Process.start(
+    options.command.first,
+    options.command.skip(1).toList(),
+    workingDirectory: options.workingDirectory,
+    runInShell: Platform.isWindows,
+  );
+  final pattern = options.retryOutputContains!;
+  final stdoutMatched = _forwardAndMatch(process.stdout, stdout, pattern);
+  final stderrMatched = _forwardAndMatch(process.stderr, stderr, pattern);
+
+  final result = options.timeout == null
+      ? _Result(
+          await process.exitCode,
+          timedOut: false,
+          outputMatched: false,
+        )
+      : await _waitForProcess(process, options.timeout!);
+  final matches = await Future.wait([stdoutMatched, stderrMatched]);
+  return _Result(
+    result.exitCode,
+    timedOut: result.timedOut,
+    outputMatched: matches.any((matched) => matched),
+  );
+}
+
+Future<_Result> _waitForProcess(Process process, Duration timeout) async {
   final timedOut = Completer<void>();
-  final timer = Timer(options.timeout!, timedOut.complete);
+  final timer = Timer(timeout, timedOut.complete);
   final result = await Future.any<Object?>([
     process.exitCode,
     timedOut.future,
   ]);
   timer.cancel();
 
-  if (result is int) return _Result(result, timedOut: false);
+  if (result is int) {
+    return _Result(result, timedOut: false, outputMatched: false);
+  }
 
   stderr.writeln(
-    '### Command timed out after ${options.timeout!.inSeconds} seconds.',
+    '### Command timed out after ${timeout.inSeconds} seconds.',
   );
   await _terminate(process);
-  return const _Result(_timeoutExitCode, timedOut: true);
+  return const _Result(
+    _timeoutExitCode,
+    timedOut: true,
+    outputMatched: false,
+  );
+}
+
+Future<bool> _forwardAndMatch(
+  Stream<List<int>> input,
+  IOSink output,
+  String pattern,
+) async {
+  final matcher = _BytePatternMatcher(utf8.encode(pattern));
+  await for (final bytes in input) {
+    output.add(bytes);
+    matcher.add(bytes);
+  }
+  return matcher.matched;
 }
 
 Future<void> _terminate(Process process) async {
@@ -136,6 +199,7 @@ class _Options {
     required this.backoff,
     required this.delaySeconds,
     required this.retryExitCodes,
+    required this.retryOutputContains,
     required this.timeout,
     required this.workingDirectory,
     required this.command,
@@ -145,6 +209,7 @@ class _Options {
   final _Backoff backoff;
   final int delaySeconds;
   final Set<int> retryExitCodes;
+  final String? retryOutputContains;
   final Duration? timeout;
   final String workingDirectory;
   final List<String> command;
@@ -154,6 +219,7 @@ class _Options {
     var backoff = _Backoff.linear;
     var delaySeconds = 1;
     var retryExitCodes = <int>{};
+    String? retryOutputContains;
     var timeoutSeconds = 120;
     var workingDirectory = '.';
     final separator = arguments.indexOf('--');
@@ -173,6 +239,8 @@ class _Options {
           delaySeconds = _nonNegativeInt(arguments, ++index, argument);
         case '--retry-exit-codes':
           retryExitCodes = _exitCodes(_value(arguments, ++index, argument));
+        case '--retry-output-contains':
+          retryOutputContains = _nonEmptyValue(arguments, ++index, argument);
         case '--timeout-seconds':
           timeoutSeconds = _nonNegativeInt(arguments, ++index, argument);
         case '--working-directory':
@@ -187,6 +255,7 @@ class _Options {
       backoff: backoff,
       delaySeconds: delaySeconds,
       retryExitCodes: retryExitCodes,
+      retryOutputContains: retryOutputContains,
       timeout: timeoutSeconds == 0 ? null : Duration(seconds: timeoutSeconds),
       workingDirectory: workingDirectory,
       command: arguments.sublist(separator + 1),
@@ -200,6 +269,16 @@ class _Options {
   ) {
     if (index >= arguments.length) _usage('Missing value for $option.');
     return arguments[index];
+  }
+
+  static String _nonEmptyValue(
+    List<String> arguments,
+    int index,
+    String option,
+  ) {
+    final value = _value(arguments, index, option);
+    if (value.isEmpty) _usage('$option must not be empty.');
+    return value;
   }
 
   static int _positiveInt(
@@ -258,7 +337,8 @@ class _Options {
       ..writeln(
         'Usage: dart run_with_retry.dart '
         '[--attempts N] [--backoff STRATEGY] [--delay-seconds N] '
-        '[--retry-exit-codes CODES] [--timeout-seconds N] '
+        '[--retry-exit-codes CODES] [--retry-output-contains TEXT] '
+        '[--timeout-seconds N] '
         '[--working-directory PATH] -- COMMAND [ARGUMENTS...]',
       );
     exit(64);
@@ -268,8 +348,45 @@ class _Options {
 enum _Backoff { fixed, linear }
 
 class _Result {
-  const _Result(this.exitCode, {required this.timedOut});
+  const _Result(
+    this.exitCode, {
+    required this.timedOut,
+    required this.outputMatched,
+  });
 
   final int exitCode;
   final bool timedOut;
+  final bool outputMatched;
+}
+
+class _BytePatternMatcher {
+  _BytePatternMatcher(this._pattern);
+
+  final List<int> _pattern;
+  var _tail = <int>[];
+  var matched = false;
+
+  void add(List<int> bytes) {
+    if (matched) return;
+
+    final combined = [..._tail, ...bytes];
+    for (var start = 0; start <= combined.length - _pattern.length; start++) {
+      var matches = true;
+      for (var offset = 0; offset < _pattern.length; offset++) {
+        if (combined[start + offset] != _pattern[offset]) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches) {
+        matched = true;
+        return;
+      }
+    }
+
+    final tailLength = _pattern.length - 1;
+    _tail = combined.length <= tailLength
+        ? combined
+        : combined.sublist(combined.length - tailLength);
+  }
 }

--- a/.github/actions/use-dart-test-retry/action.yml
+++ b/.github/actions/use-dart-test-retry/action.yml
@@ -1,5 +1,5 @@
 name: Use Dart test retry
-description: Wraps dart test to retry exit code 65 from transient native build-hook failures.
+description: Wraps dart test to retry exit code 65 or 255 from transient native build-hook failures.
 
 runs:
   using: composite

--- a/.github/actions/use-dart-test-retry/action.yml
+++ b/.github/actions/use-dart-test-retry/action.yml
@@ -1,5 +1,5 @@
-name: Use Dart test retry
-description: Wraps dart test to retry exit code 65 or 255 from transient native build-hook failures.
+name: Use Dart build-hook retry
+description: Retries failed Dart test, run, and build commands when native build hooks fail with exit code 65 or 255.
 
 runs:
   using: composite

--- a/.github/actions/use-dart-test-retry/bin/unix/dart
+++ b/.github/actions/use-dart-test-retry/bin/unix/dart
@@ -3,14 +3,22 @@
 : "${SERVERPOD_REAL_DART:?The real Dart executable was not configured.}"
 : "${SERVERPOD_RETRY_RUNNER:?The retry runner was not configured.}"
 
-# CI prepends this wrapper to PATH. Keep every Dart command except `dart test`
-# identical to local development.
-if [[ "${1:-}" != "test" ]]; then
+# The shared retry action already retries its entire command. Avoid multiplying
+# its attempts when that command invokes Dart again.
+if [[ "${SERVERPOD_DART_RETRY_ACTIVE:-}" == "1" ]]; then
   exec "$SERVERPOD_REAL_DART" "$@"
 fi
+
+# Build hooks run only for test, run, and build. Keep every other Dart command
+# identical to local development.
+case "${1:-}" in
+  test|run|build) ;;
+  *) exec "$SERVERPOD_REAL_DART" "$@" ;;
+esac
 
 exec "$SERVERPOD_REAL_DART" "$SERVERPOD_RETRY_RUNNER" \
   --attempts 3 \
   --retry-exit-codes 65,255 \
+  --retry-output-contains "Error: Running build hooks failed." \
   --timeout-seconds 0 \
   -- "$SERVERPOD_REAL_DART" "$@"

--- a/.github/actions/use-dart-test-retry/bin/unix/dart
+++ b/.github/actions/use-dart-test-retry/bin/unix/dart
@@ -11,6 +11,6 @@ fi
 
 exec "$SERVERPOD_REAL_DART" "$SERVERPOD_RETRY_RUNNER" \
   --attempts 3 \
-  --retry-exit-codes 65 \
+  --retry-exit-codes 65,255 \
   --timeout-seconds 0 \
   -- "$SERVERPOD_REAL_DART" "$@"

--- a/.github/actions/use-dart-test-retry/bin/windows/dart
+++ b/.github/actions/use-dart-test-retry/bin/windows/dart
@@ -12,6 +12,6 @@ fi
 
 exec "$SERVERPOD_REAL_DART" "$SERVERPOD_RETRY_RUNNER" \
   --attempts 3 \
-  --retry-exit-codes 65 \
+  --retry-exit-codes 65,255 \
   --timeout-seconds 0 \
   -- "$SERVERPOD_REAL_DART" "$@"

--- a/.github/actions/use-dart-test-retry/bin/windows/dart
+++ b/.github/actions/use-dart-test-retry/bin/windows/dart
@@ -5,13 +5,19 @@
 
 # Git Bash does not resolve the adjacent dart.cmd wrapper for a bare `dart`
 # command. Keep this extensionless wrapper alongside it so Bash-based Windows
-# jobs also retry transient `dart test` build-hook failures.
-if [[ "${1:-}" != "test" ]]; then
+# jobs also retry transient build-hook failures.
+if [[ "${SERVERPOD_DART_RETRY_ACTIVE:-}" == "1" ]]; then
   exec "$SERVERPOD_REAL_DART" "$@"
 fi
+
+case "${1:-}" in
+  test|run|build) ;;
+  *) exec "$SERVERPOD_REAL_DART" "$@" ;;
+esac
 
 exec "$SERVERPOD_REAL_DART" "$SERVERPOD_RETRY_RUNNER" \
   --attempts 3 \
   --retry-exit-codes 65,255 \
+  --retry-output-contains "Error: Running build hooks failed." \
   --timeout-seconds 0 \
   -- "$SERVERPOD_REAL_DART" "$@"

--- a/.github/actions/use-dart-test-retry/bin/windows/dart.cmd
+++ b/.github/actions/use-dart-test-retry/bin/windows/dart.cmd
@@ -15,5 +15,5 @@ if /I "%~1"=="test" goto run_test
 exit /b %ERRORLEVEL%
 
 :run_test
-"%SERVERPOD_REAL_DART%" "%SERVERPOD_RETRY_RUNNER%" --attempts 3 --retry-exit-codes 65 --timeout-seconds 0 -- "%SERVERPOD_REAL_DART%" %*
+"%SERVERPOD_REAL_DART%" "%SERVERPOD_RETRY_RUNNER%" --attempts 3 --retry-exit-codes 65,255 --timeout-seconds 0 -- "%SERVERPOD_REAL_DART%" %*
 exit /b %ERRORLEVEL%

--- a/.github/actions/use-dart-test-retry/bin/windows/dart.cmd
+++ b/.github/actions/use-dart-test-retry/bin/windows/dart.cmd
@@ -10,10 +10,15 @@ if not defined SERVERPOD_RETRY_RUNNER (
   >&2 echo The retry runner was not configured.
   exit /b 1
 )
-if /I "%~1"=="test" goto run_test
+if "%SERVERPOD_DART_RETRY_ACTIVE%"=="1" goto passthrough
+if /I "%~1"=="test" goto run_with_retry
+if /I "%~1"=="run" goto run_with_retry
+if /I "%~1"=="build" goto run_with_retry
+
+:passthrough
 "%SERVERPOD_REAL_DART%" %*
 exit /b %ERRORLEVEL%
 
-:run_test
-"%SERVERPOD_REAL_DART%" "%SERVERPOD_RETRY_RUNNER%" --attempts 3 --retry-exit-codes 65,255 --timeout-seconds 0 -- "%SERVERPOD_REAL_DART%" %*
+:run_with_retry
+"%SERVERPOD_REAL_DART%" "%SERVERPOD_RETRY_RUNNER%" --attempts 3 --retry-exit-codes 65,255 --retry-output-contains "Error: Running build hooks failed." --timeout-seconds 0 -- "%SERVERPOD_REAL_DART%" %*
 exit /b %ERRORLEVEL%

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -119,6 +119,7 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: "3.12.2"
+      - uses: ./.github/actions/use-dart-test-retry
       - uses: ./.github/actions/retry
         with:
           command: dart pub get
@@ -159,6 +160,7 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: "3.12.2"
+      - uses: ./.github/actions/use-dart-test-retry
       - uses: ./.github/actions/retry
         with:
           command: dart pub get
@@ -552,8 +554,7 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: stable
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - uses: ./.github/actions/use-embedded-pg
       - name: Install melos
         uses: ./.github/actions/retry
@@ -677,8 +678,7 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: ${{ matrix.sdk }}
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - name: Run unit tests
         shell: bash
         working-directory: ${{ matrix.project }}
@@ -705,8 +705,7 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: ${{ matrix.sdk }}
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - name: Run unit tests
         shell: bash
         working-directory: tools/serverpod_cli
@@ -791,8 +790,7 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: ${{ matrix.sdk }}
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - uses: ./.github/actions/use-embedded-pg
       - uses: ./.github/actions/use-pod-bundle
         with:
@@ -826,8 +824,7 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: ${{ matrix.sdk }}
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - uses: ./.github/actions/use-embedded-pg
       - uses: ./.github/actions/use-pod-bundle
         with:
@@ -882,6 +879,7 @@ jobs:
         with:
           flutter-version: ${{ matrix.flutter-version }}
           cache: false
+      - uses: ./.github/actions/use-dart-test-retry
       - name: Start containers
         run: docker compose --progress quiet up --build -V -d
         working-directory: ${{ matrix.module.server }}
@@ -924,8 +922,7 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: ${{ matrix.dart-version }}
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - uses: ./.github/actions/use-embedded-pg
       - name: Install melos
         uses: ./.github/actions/retry
@@ -957,8 +954,7 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: ${{ matrix.dart-version }}
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - uses: ./.github/actions/use-embedded-pg
       - name: Install melos
         uses: ./.github/actions/retry
@@ -987,8 +983,7 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: ${{ matrix.dart-version }}
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - name: Run SQLite integration tests
         run: util/run_tests_sqlite_integration
 
@@ -1011,8 +1006,7 @@ jobs:
         with:
           flutter-version: ${{ matrix.flutter-version }}
           cache: false
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - name: Cache PUB_CACHE
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -1060,8 +1054,7 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: ${{ matrix.sdk }}
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       # Redis is disabled on the server (SERVERPOD_REDIS_ENABLED=false in the run
       # script), so unlike the integration suite no Redis is needed.
       - uses: ./.github/actions/use-embedded-pg
@@ -1093,8 +1086,7 @@ jobs:
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: ${{ matrix.sdk }}
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - uses: ./.github/actions/use-cli-bundle
       - uses: ./.github/actions/use-pod-bundle
         with:
@@ -1119,8 +1111,7 @@ jobs:
         with:
           flutter-version: ${{ matrix.flutter-version }}
           cache: false
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - name: Setup docker (missing on MacOS)
         if: runner.os == 'macos'
         run: |
@@ -1199,8 +1190,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - uses: ./.github/actions/retry
         with:
           command: dart pub get
@@ -1222,8 +1212,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - uses: ./.github/actions/retry
         with:
           command: dart pub get
@@ -1245,8 +1234,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - uses: ./.github/actions/retry
         with:
           command: dart pub get
@@ -1265,8 +1253,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - uses: ./.github/actions/retry
         with:
           command: dart pub get
@@ -1288,8 +1275,7 @@ jobs:
         with:
           flutter-version: "3.38.4"
           cache: false
-      - name: Retry transient Dart build-hook failures
-        uses: ./.github/actions/use-dart-test-retry
+      - uses: ./.github/actions/use-dart-test-retry
       - name: Install melos
         uses: ./.github/actions/retry
         with:

--- a/.github/workflows/sync-cli-docs.yml
+++ b/.github/workflows/sync-cli-docs.yml
@@ -13,6 +13,7 @@ on:
       - "tools/serverpod_cli/bin/**"
       - "tools/serverpod_cli/scripts/generate_command_usages.dart"
       - ".github/actions/retry/**"
+      - ".github/actions/use-dart-test-retry/**"
       - ".github/workflows/sync-cli-docs.yml"
   workflow_dispatch:
 
@@ -56,6 +57,9 @@ jobs:
         uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: stable
+
+      - name: Retry transient Dart build-hook failures
+        uses: ./src/.github/actions/use-dart-test-retry
 
       - name: Resolve serverpod_cli dependencies
         uses: ./src/.github/actions/retry


### PR DESCRIPTION
While downloading files for build hooks, it is possible to hit a 255 due to 104 `ECONNRESET` - [as hit on this CI run for Serverpod integration tests (server) (3.12.2, 7)](https://github.com/serverpod/serverpod/actions/runs/30572456456/job/90972457682?pr=5523). This PR adds 255 to the retry.

```console
util/run_tests_integration 7 10
  shell: /usr/bin/bash -e {0}
  env:
    SERVERPOD_SILENCE_LIFECYCLE_MESSAGES: 1
    SERVERPOD_PG_CACHE_DIR: /home/runner/work/serverpod/serverpod/.pg-cache
    DART_HOME: /opt/hostedtoolcache/dart/3.12.2/x64
    PUB_CACHE: /home/runner/.pub-cache
    SERVERPOD_REAL_DART: /opt/hostedtoolcache/dart/3.12.2/x64/bin/dart
    SERVERPOD_RETRY_RUNNER: /home/runner/work/serverpod/serverpod/./.github/actions/use-dart-test-retry/../retry/run_with_retry.dart
### Apply migrations (embedded PG)
Running build hooks...Unhandled exception:
By default, this package downloads a pre-compiled SQLite library.
This failed (attepted to download https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-3.5.0/libsqlite3.x64.linux.so).
For alternatives to downloading SQLite, see https://pub.dev/documentation/sqlite3/latest/topics/hook-topic.html
Original cause: SocketException: Connection reset by peer (OS Error: Connection reset by peer, errno = 104), address = release-assets.githubusercontent.com, port = 48960

  Building assets for package:sqlite3 failed.
  build.dart returned with exit code: 255.
  To reproduce run:
  (cd /home/runner/.pub-cache/hosted/pub.dev/sqlite3-3.5.0/; /opt/hostedtoolcache/dart/3.12.2/x64/bin/dart --packages=/home/runner/work/serverpod/serverpod/tests/serverpod_test_server/.dart_tool/package_config.json /home/runner/work/serverpod/serverpod/tests/serverpod_test_server/.dart_tool/hooks_runner/sqlite3/6b4ebf10e7/hook.dill --config=/home/runner/work/serverpod/serverpod/tests/serverpod_test_server/.dart_tool/hooks_runner/sqlite3/6b4ebf10e7/input.json )
  stderr:
  Unhandled exception:
By default, this package downloads a pre-compiled SQLite library.
This failed (attepted to download https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-3.5.0/libsqlite3.x64.linux.so).
For alternatives to downloading SQLite, see https://pub.dev/documentation/sqlite3/latest/topics/hook-topic.html
Original cause: SocketException: Connection reset by peer (OS Error: Connection reset by peer, errno = 104), address = release-assets.githubusercontent.com, port = 48960

  stdout:
  
          
Running build hooks...Error: Running build hooks failed.
Error: Process completed with exit code 255.
```

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._