### PR TITLE
fix: Serve flutter app config under root when project is created with webapp enabled only

### DIFF
--- a/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
@@ -70,7 +70,12 @@ void run(List<String> args) async {
   // the flutter app.
   pod.webServer.addRoute(
     AppConfigRoute(apiConfig: pod.config.apiServer),
+    // {{#website}}
     '/app/assets/assets/config.json',
+    // {{/website}}
+    // {{^website}}
+    '/assets/assets/config.json',
+    // {{/website}}
   );
 
   // Checks if the flutter web app has been built and serves it if it has.

--- a/tests/bootstrap_project/lib/src/util.dart
+++ b/tests/bootstrap_project/lib/src/util.dart
@@ -91,6 +91,7 @@ Future<Process> startProcessAndWaitForKeywords(
   Map<String, String>? environment,
   bool ignorePlatform = false,
   required List<String> keywords,
+  void Function(String output)? onOutput,
 }) async {
   final completer = Completer<Process>();
 
@@ -118,6 +119,7 @@ Future<Process> startProcessAndWaitForKeywords(
   });
   process.stdout.transform(utf8.decoder).listen((e) {
     print('COMMAND "$command" stdout: $e');
+    onOutput?.call(e);
     checkForKeywords(e);
   });
 

--- a/tests/bootstrap_project/lib/src/util.dart
+++ b/tests/bootstrap_project/lib/src/util.dart
@@ -94,6 +94,7 @@ Future<Process> startProcessAndWaitForKeywords(
   void Function(String output)? onOutput,
 }) async {
   final completer = Completer<Process>();
+  final output = StringBuffer();
 
   var process = await Process.start(
     _getCommandToRun(command, ignorePlatform),
@@ -102,10 +103,10 @@ Future<Process> startProcessAndWaitForKeywords(
     environment: environment,
   );
 
-  void checkForKeywords(String data) {
+  void checkForKeywords() {
     if (keywords.isEmpty) return;
     for (var keyword in keywords) {
-      if (data.contains(keyword)) {
+      if (output.toString().contains(keyword)) {
         if (!completer.isCompleted) {
           completer.complete(process);
         }
@@ -113,21 +114,56 @@ Future<Process> startProcessAndWaitForKeywords(
     }
   }
 
-  process.stderr.transform(utf8.decoder).listen((e) {
+  final stderrDone = process.stderr.transform(utf8.decoder).forEach((e) {
     print('COMMAND "$command" stderr: $e');
-    checkForKeywords(e);
+    output.write(e);
+    checkForKeywords();
   });
-  process.stdout.transform(utf8.decoder).listen((e) {
+  final stdoutDone = process.stdout.transform(utf8.decoder).forEach((e) {
     print('COMMAND "$command" stdout: $e');
+    output.write(e);
     onOutput?.call(e);
-    checkForKeywords(e);
+    checkForKeywords();
   });
+
+  unawaited(() async {
+    final exitCode = await process.exitCode;
+    await Future.wait([stdoutDone, stderrDone]);
+    if (!completer.isCompleted) {
+      completer.completeError(
+        StateError(
+          'Command "$command ${arguments.join(' ')}" exited with code '
+          '$exitCode before producing one of: ${keywords.join(', ')}.\n'
+          '$output',
+        ),
+      );
+    }
+  }());
 
   if (keywords.isEmpty && !completer.isCompleted) {
     completer.complete(process);
   }
 
   return completer.future;
+}
+
+/// Stops [process] and waits until all of its resources have been released.
+///
+/// Waiting for [Process.exitCode] is important on Windows, where starting a
+/// replacement process immediately after [Process.kill] can race with the old
+/// process releasing listening sockets and file handles.
+Future<int> stopProcess(
+  Process process, {
+  Duration timeout = const Duration(seconds: 10),
+}) async {
+  process.kill();
+  return process.exitCode.timeout(
+    timeout,
+    onTimeout: () {
+      process.kill(ProcessSignal.sigkill);
+      return process.exitCode;
+    },
+  );
 }
 
 Future<Process> startServerpodCli(

--- a/tests/bootstrap_project/test_perform_create/util.dart
+++ b/tests/bootstrap_project/test_perform_create/util.dart
@@ -42,7 +42,10 @@ class TempProject {
 /// Returns the [TempProject] whose paths the tests assert against.
 TempProject setUpPerformCreateInTempDir({required TemplateContext context}) {
   final project = TempProject(
-    'temp_test_${const Uuid().v4().replaceAll('-', '_').toLowerCase()}',
+    // The project name occurs twice in generated Flutter paths. Keep it short
+    // enough for nested tool-generated paths to stay below Windows' legacy
+    // MAX_PATH limit (for example, Flutter's generated Swift package path).
+    'tmp_${const Uuid().v4().replaceAll('-', '').substring(0, 12)}',
   );
   setUpAll(() async {
     setupForPerformCreateTest();

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -625,7 +625,13 @@ void main() {
         final testConfig = File(
           p.join(project.serverDir, 'config', 'test.yaml'),
         );
-        final config = await testConfig.readAsString();
+        // Templates checked out on Windows use CRLF. Normalize before matching
+        // the multiline YAML blocks below so the replacements work on every
+        // platform.
+        final config = (await testConfig.readAsString()).replaceAll(
+          '\r\n',
+          '\n',
+        );
         await testConfig.writeAsString(
           config
               .replaceFirst(

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -716,9 +716,6 @@ void main() {
         },
       );
     },
-    skip: Platform.isWindows
-        ? 'Windows does not support postgres in github actions'
-        : null,
   );
 
   group(
@@ -738,7 +735,7 @@ void main() {
       setUpAll(() async {
         startProjectProcess = await startProcessAndWaitForKeywords(
           'dart',
-          ['bin/main.dart', '--apply-migrations'],
+          ['bin/main.dart'],
           workingDirectory: project.serverDir,
           keywords: ['Webserver listening on'],
         );
@@ -799,7 +796,7 @@ void main() {
           startProjectProcess.kill();
           startProjectProcess = await startProcessAndWaitForKeywords(
             'dart',
-            ['bin/main.dart', '--apply-migrations'],
+            ['bin/main.dart'],
             workingDirectory: project.serverDir,
             keywords: ['Webserver listening on'],
           );
@@ -827,8 +824,5 @@ void main() {
         );
       });
     },
-    skip: Platform.isWindows
-        ? 'Windows does not support postgres in github actions'
-        : null,
   );
 }

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -716,6 +716,9 @@ void main() {
         },
       );
     },
+    skip: Platform.isWindows
+        ? 'Windows does not support postgres in github actions'
+        : null,
   );
 
   group(

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -688,9 +688,10 @@ void main() {
           };
       });
 
-      tearDownAll(() {
+      tearDownAll(() async {
         client?.close(force: true);
-        startProjectProcess?.kill();
+        final process = startProjectProcess;
+        if (process != null) await stopProcess(process);
       });
 
       test(
@@ -722,7 +723,8 @@ void main() {
     'Given a project is created with fullstack template and webapp and website enabled, '
     'and the pod is running',
     () {
-      late Process startProjectProcess;
+      Process? startProjectProcess;
+      late int webPort;
 
       final project = setUpPerformCreateInTempDir(
         context: TemplateContext(
@@ -732,23 +734,49 @@ void main() {
         ),
       );
 
-      setUpAll(() async {
-        startProjectProcess = await startProcessAndWaitForKeywords(
+      Future<void> startPod() async {
+        final serverOutput = StringBuffer();
+        final webServerStartedPattern = RegExp(
+          r'Webserver listening on http://localhost:(\d+)',
+        );
+        int? nextWebPort;
+        final process = await startProcessAndWaitForKeywords(
           'dart',
-          ['bin/main.dart'],
+          ['bin/main.dart', '--mode=test'],
           workingDirectory: project.serverDir,
           keywords: ['Webserver listening on'],
+          onOutput: (output) {
+            serverOutput.write(output);
+            final match = webServerStartedPattern.firstMatch(
+              serverOutput.toString(),
+            );
+            if (match != null) nextWebPort = int.parse(match.group(1)!);
+          },
         );
+        expect(
+          nextWebPort,
+          isNotNull,
+          reason: 'Could not determine the web server port.',
+        );
+        startProjectProcess = process;
+        webPort = nextWebPort!;
+      }
+
+      setUpAll(() async {
+        await startPod();
       });
 
-      tearDownAll(() {
-        startProjectProcess.kill();
+      tearDownAll(() async {
+        final process = startProjectProcess;
+        if (process != null) await stopProcess(process);
       });
 
       test(
         'when requesting the static website under / then it is is served',
         () async {
-          final response = await http.get(Uri.parse('http://localhost:8082'));
+          final response = await http.get(
+            Uri.parse('http://localhost:$webPort'),
+          );
           expect(response.statusCode, equals(200));
           expect(
             response.body,
@@ -763,7 +791,7 @@ void main() {
         'then the "Flutter web app not built" page is served',
         () async {
           final response = await http.get(
-            Uri.parse('http://localhost:8082/app'),
+            Uri.parse('http://localhost:$webPort/app'),
           );
           expect(response.statusCode, equals(200));
           expect(
@@ -783,6 +811,12 @@ void main() {
 
       group('Given the Flutter web app is built and the pod is restarted', () {
         setUp(() async {
+          final runningProcess = startProjectProcess;
+          if (runningProcess != null) {
+            await stopProcess(runningProcess);
+            startProjectProcess = null;
+          }
+
           final flutterBuildProcess = await startServerpodCli(
             ['run', 'flutter_build'],
             rootPath: rootPath,
@@ -793,13 +827,7 @@ void main() {
           );
           expect(await flutterBuildProcess.exitCode, 0);
 
-          startProjectProcess.kill();
-          startProjectProcess = await startProcessAndWaitForKeywords(
-            'dart',
-            ['bin/main.dart'],
-            workingDirectory: project.serverDir,
-            keywords: ['Webserver listening on'],
-          );
+          await startPod();
         });
 
         test(
@@ -807,7 +835,7 @@ void main() {
           'then the web app is served successfully',
           () async {
             final response = await http.get(
-              Uri.parse('http://localhost:8082/app'),
+              Uri.parse('http://localhost:$webPort/app'),
             );
             expect(response.statusCode, equals(200));
             expect(

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -660,36 +660,17 @@ void main() {
               ),
         );
 
-        final serverOutput = StringBuffer();
-        final webServerStartedPattern = RegExp(
-          r'Webserver listening on http://app\.managed\.host:(\d+)',
+        final startedPod = await _startPodAndCaptureWebPort(
+          project: project,
+          host: 'app.managed.host',
         );
-        int? webPort;
-        startProjectProcess = await startProcessAndWaitForKeywords(
-          'dart',
-          ['bin/main.dart', '--mode=test'],
-          workingDirectory: project.serverDir,
-          keywords: ['Webserver listening on'],
-          onOutput: (output) {
-            serverOutput.write(output);
-            final match = webServerStartedPattern.firstMatch(
-              serverOutput.toString(),
-            );
-            if (match != null) webPort = int.parse(match.group(1)!);
-          },
-        );
-        expect(
-          webPort,
-          isNotNull,
-          reason: 'Could not determine the web server port.',
-        );
-        final capturedWebPort = webPort!;
+        startProjectProcess = startedPod.process;
 
         client = HttpClient()
           ..connectionFactory = (uri, proxyHost, proxyPort) async {
             return Socket.startConnect(
               InternetAddress.loopbackIPv4,
-              capturedWebPort,
+              startedPod.webPort,
             );
           };
       });
@@ -727,7 +708,8 @@ void main() {
 
   group(
     'Given a project is created with fullstack template and webapp and website enabled, '
-    'and the pod is running',
+    'and the pod is running, '
+    'and Flutter web app is not built',
     () {
       Process? startProjectProcess;
       late int webPort;
@@ -740,36 +722,13 @@ void main() {
         ),
       );
 
-      Future<void> startPod() async {
-        final serverOutput = StringBuffer();
-        final webServerStartedPattern = RegExp(
-          r'Webserver listening on http://localhost:(\d+)',
-        );
-        int? nextWebPort;
-        final process = await startProcessAndWaitForKeywords(
-          'dart',
-          ['bin/main.dart', '--mode=test'],
-          workingDirectory: project.serverDir,
-          keywords: ['Webserver listening on'],
-          onOutput: (output) {
-            serverOutput.write(output);
-            final match = webServerStartedPattern.firstMatch(
-              serverOutput.toString(),
-            );
-            if (match != null) nextWebPort = int.parse(match.group(1)!);
-          },
-        );
-        expect(
-          nextWebPort,
-          isNotNull,
-          reason: 'Could not determine the web server port.',
-        );
-        startProjectProcess = process;
-        webPort = nextWebPort!;
-      }
-
       setUpAll(() async {
-        await startPod();
+        final startedPod = await _startPodAndCaptureWebPort(
+          project: project,
+          host: 'localhost',
+        );
+        startProjectProcess = startedPod.process;
+        webPort = startedPod.webPort;
       });
 
       tearDownAll(() async {
@@ -814,49 +773,98 @@ void main() {
           );
         },
       );
-
-      group('Given the Flutter web app is built and the pod is restarted', () {
-        setUp(() async {
-          final runningProcess = startProjectProcess;
-          if (runningProcess != null) {
-            await stopProcess(runningProcess);
-            startProjectProcess = null;
-          }
-
-          final flutterBuildProcess = await startServerpodCli(
-            ['run', 'flutter_build'],
-            rootPath: rootPath,
-            workingDirectory: project.serverDir,
-            environment: {
-              'SERVERPOD_HOME': rootPath,
-            },
-          );
-          expect(await flutterBuildProcess.exitCode, 0);
-
-          await startPod();
-        });
-
-        test(
-          'when requesting the Flutter web app under /app, '
-          'then the web app is served successfully',
-          () async {
-            final response = await http.get(
-              Uri.parse('http://localhost:$webPort/app'),
-            );
-            expect(response.statusCode, equals(200));
-            expect(
-              response.body,
-              isNot(contains('<title>Flutter web app not built</title>')),
-            );
-            expect(
-              response.body,
-              contains(
-                '<meta name="description" content="A new Flutter project.">',
-              ),
-            );
-          },
-        );
-      });
     },
   );
+
+  group(
+    'Given a project is created with fullstack template and webapp and website enabled, '
+    'and the Flutter web app is built, '
+    'and the pod is running',
+    () {
+      Process? startProjectProcess;
+      late int webPort;
+
+      final project = setUpPerformCreateInTempDir(
+        context: TemplateContext(
+          template: ServerpodTemplateType.fullstack,
+          webapp: true,
+          website: true,
+        ),
+      );
+
+      setUpAll(() async {
+        final flutterBuildProcess = await startServerpodCli(
+          ['run', 'flutter_build'],
+          rootPath: rootPath,
+          workingDirectory: project.serverDir,
+          environment: {
+            'SERVERPOD_HOME': rootPath,
+          },
+        );
+        expect(await flutterBuildProcess.exitCode, 0);
+
+        final startedPod = await _startPodAndCaptureWebPort(
+          project: project,
+          host: 'localhost',
+        );
+        startProjectProcess = startedPod.process;
+        webPort = startedPod.webPort;
+      });
+
+      tearDownAll(() async {
+        final process = startProjectProcess;
+        if (process != null) await stopProcess(process);
+      });
+
+      test(
+        'when requesting the Flutter web app under /app, '
+        'then the web app is served successfully',
+        () async {
+          final response = await http.get(
+            Uri.parse('http://localhost:$webPort/app'),
+          );
+          expect(response.statusCode, equals(200));
+          expect(
+            response.body,
+            isNot(contains('<title>Flutter web app not built</title>')),
+          );
+          expect(
+            response.body,
+            contains(
+              '<meta name="description" content="A new Flutter project.">',
+            ),
+          );
+        },
+      );
+    },
+  );
+}
+
+Future<({Process process, int webPort})> _startPodAndCaptureWebPort({
+  required TempProject project,
+  required String host,
+}) async {
+  final serverOutput = StringBuffer();
+  final webServerStartedPattern = RegExp(
+    'Webserver listening on http://${RegExp.escape(host)}:(\\d+)',
+  );
+  int? webPort;
+  final process = await startProcessAndWaitForKeywords(
+    'dart',
+    ['bin/main.dart', '--mode=test'],
+    workingDirectory: project.serverDir,
+    keywords: ['Webserver listening on'],
+    onOutput: (output) {
+      serverOutput.write(output);
+      final match = webServerStartedPattern.firstMatch(serverOutput.toString());
+      if (match != null) webPort = int.parse(match.group(1)!);
+    },
+  );
+  expect(
+    webPort,
+    isNotNull,
+    reason: 'Could not determine the web server port.',
+  );
+
+  return (process: process, webPort: webPort!);
 }

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -682,7 +682,7 @@ void main() {
         client = HttpClient()
           ..connectionFactory = (uri, proxyHost, proxyPort) async {
             return Socket.startConnect(
-              InternetAddress.loopbackIPv6,
+              InternetAddress.loopbackIPv4,
               capturedWebPort,
             );
           };

--- a/tests/bootstrap_project/test_perform_create/web_test.dart
+++ b/tests/bootstrap_project/test_perform_create/web_test.dart
@@ -1,4 +1,5 @@
 @Timeout(Duration(minutes: 5))
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:bootstrap_project/src/util.dart';
@@ -224,10 +225,6 @@ void main() {
           );
           expect(
             content,
-            contains('/app/assets/assets/config.json'),
-          );
-          expect(
-            content,
             contains(
               "final appDir = Directory(Uri(path: 'web/app').toFilePath());",
             ),
@@ -350,6 +347,17 @@ void main() {
       );
 
       test(
+        'then the server server.dart serves the app config under the root asset path',
+        () async {
+          final serverFile = File(
+            p.join(project.serverDir, 'lib', 'server.dart'),
+          );
+          final content = await serverFile.readAsString();
+          expect(content, contains("'/assets/assets/config.json'"));
+        },
+      );
+
+      test(
         'then the server.dart has a fallback middleware for the default route',
         () async {
           final serverFile = File(
@@ -408,6 +416,17 @@ void main() {
           );
           expect(content, contains("'/app'"));
           expect(content, contains("'/app/**'"));
+        },
+      );
+
+      test(
+        'then the server server.dart serves the app config under the /app asset path',
+        () async {
+          final serverFile = File(
+            p.join(project.serverDir, 'lib', 'server.dart'),
+          );
+          final content = await serverFile.readAsString();
+          expect(content, contains("'/app/assets/assets/config.json'"));
         },
       );
 
@@ -571,6 +590,129 @@ void main() {
           final file = File(p.join(project.serverDir, 'config', 'test.yaml'));
           final content = await file.readAsString();
           expect(content, contains('webServer:'));
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a project is created with fullstack template and webapp enabled with an injected config asset, '
+    'and the pod is running with managed public hosts',
+    () {
+      Process? startProjectProcess;
+      HttpClient? client;
+
+      final project = setUpPerformCreateInTempDir(
+        context: TemplateContext(
+          template: ServerpodTemplateType.fullstack,
+          webapp: true,
+        ),
+      );
+
+      setUpAll(() async {
+        final appDir = Directory(p.join(project.serverDir, 'web', 'app'));
+        final configAsset = File(
+          p.join(appDir.path, 'assets', 'assets', 'config.json'),
+        );
+        await configAsset.parent.create(recursive: true);
+        await File(p.join(appDir.path, 'index.html')).writeAsString(
+          '<html><body>Flutter app</body></html>',
+        );
+        await configAsset.writeAsString(
+          jsonEncode({'apiUrl': 'https://invalid.url'}),
+        );
+
+        final testConfig = File(
+          p.join(project.serverDir, 'config', 'test.yaml'),
+        );
+        final config = await testConfig.readAsString();
+        await testConfig.writeAsString(
+          config
+              .replaceFirst(
+                '''apiServer:
+  port: 0
+  publicHost: localhost
+  publicPort: 0
+  publicScheme: http''',
+                '''apiServer:
+  port: 0
+  publicHost: api.managed.host
+  publicPort: 443
+  publicScheme: https''',
+              )
+              .replaceFirst(
+                '''webServer:
+  port: 0
+  publicHost: localhost
+  publicPort: 0
+  publicScheme: http''',
+                '''webServer:
+  port: 0
+  publicHost: app.managed.host
+  publicPort: 80
+  publicScheme: http''',
+              ),
+        );
+
+        final serverOutput = StringBuffer();
+        final webServerStartedPattern = RegExp(
+          r'Webserver listening on http://app\.managed\.host:(\d+)',
+        );
+        int? webPort;
+        startProjectProcess = await startProcessAndWaitForKeywords(
+          'dart',
+          ['bin/main.dart', '--mode=test'],
+          workingDirectory: project.serverDir,
+          keywords: ['Webserver listening on'],
+          onOutput: (output) {
+            serverOutput.write(output);
+            final match = webServerStartedPattern.firstMatch(
+              serverOutput.toString(),
+            );
+            if (match != null) webPort = int.parse(match.group(1)!);
+          },
+        );
+        expect(
+          webPort,
+          isNotNull,
+          reason: 'Could not determine the web server port.',
+        );
+        final capturedWebPort = webPort!;
+
+        client = HttpClient()
+          ..connectionFactory = (uri, proxyHost, proxyPort) async {
+            return Socket.startConnect(
+              InternetAddress.loopbackIPv6,
+              capturedWebPort,
+            );
+          };
+      });
+
+      tearDownAll(() {
+        client?.close(force: true);
+        startProjectProcess?.kill();
+      });
+
+      test(
+        'when requesting the root config asset, '
+        'then the dynamic app config overrides the injected asset',
+        () async {
+          final request = await client!.getUrl(
+            Uri.http(
+              'app.managed.host',
+              '/assets/assets/config.json',
+            ),
+          );
+          final response = await request.close();
+          final responseBody = await utf8.decoder.bind(response).join();
+          final appConfig = jsonDecode(responseBody) as Map<String, dynamic>;
+          final apiUrl = Uri.parse(appConfig['apiUrl'] as String);
+
+          expect(response.statusCode, HttpStatus.ok);
+          expect(apiUrl.scheme, 'https');
+          expect(apiUrl.host, 'api.managed.host');
+          expect(apiUrl.port, 443);
+          expect(responseBody, isNot(contains('invalid.url')));
         },
       );
     },

--- a/util/prepare_windows_standard_user_test
+++ b/util/prepare_windows_standard_user_test
@@ -21,8 +21,11 @@ MSYS2_ARG_CONV_EXCL='*' net.exe user \
 
 runner_temp_msys="$(cygpath -u "$RUNNER_TEMP")"
 test_work_msys="$runner_temp_msys/standard-user-test"
-test_work_win="$(cygpath -m "$test_work_msys")"
-test_log_win="$(cygpath -m "$test_work_msys/output.log")"
+test_work_win="$(cygpath -w "$test_work_msys")"
+# This value is consumed by native cmd.exe (IF EXIST and TYPE), not by Git
+# Bash. Keep native backslashes here so reading the log does not depend on
+# CMD's inconsistent handling of forward slashes in file names.
+test_log_win="$(cygpath -w "$test_work_msys/output.log")"
 test_path_win="$(cygpath -mp "$PATH")"
 
 grant_test_user_write_access() {
@@ -70,8 +73,8 @@ fi
 # the tool and CI variables the test commands require; copying the complete
 # runner environment would also expose unrelated credentials.
 test_environment_commands="set \"PATH=$test_path_win\"
-set \"PUB_CACHE=$(cygpath -m "$PUB_CACHE")\"
-set \"RUNNER_TEMP=$(cygpath -m "$RUNNER_TEMP")\"
+set \"PUB_CACHE=$(cygpath -w "$PUB_CACHE")\"
+set \"RUNNER_TEMP=$(cygpath -w "$RUNNER_TEMP")\"
 set \"SHARD_INDEX=${SHARD_INDEX:-}\"
 set \"TOTAL_SHARDS=${TOTAL_SHARDS:-}\""
 
@@ -93,16 +96,23 @@ append_test_environment_variable() {
   test_environment_commands+=$'\n'"set \"$name=$value\""
 }
 
+append_test_path_environment_variable() {
+  local name="$1"
+  local value="${!name:-}"
+  [[ -n "$value" ]] || return 0
+  test_environment_commands+=$'\n'"set \"$name=$(cygpath -w "$value")\""
+}
+
 append_test_environment_variable CI
-append_test_environment_variable DART_HOME
-append_test_environment_variable FLUTTER_ROOT
 append_test_environment_variable GITHUB_ACTIONS
-append_test_environment_variable GITHUB_WORKSPACE
-append_test_environment_variable SERVERPOD_PG_CACHE_DIR
-append_test_environment_variable SERVERPOD_CLI_EXE
-append_test_environment_variable SERVERPOD_REAL_DART
-append_test_environment_variable SERVERPOD_RETRY_RUNNER
 append_test_environment_variable SERVERPOD_SILENCE_LIFECYCLE_MESSAGES
+append_test_path_environment_variable DART_HOME
+append_test_path_environment_variable FLUTTER_ROOT
+append_test_path_environment_variable GITHUB_WORKSPACE
+append_test_path_environment_variable SERVERPOD_PG_CACHE_DIR
+append_test_path_environment_variable SERVERPOD_CLI_EXE
+append_test_path_environment_variable SERVERPOD_REAL_DART
+append_test_path_environment_variable SERVERPOD_RETRY_RUNNER
 
 flutter_preflight_commands=''
 if [[ -n "${FLUTTER_ROOT:-}" ]]; then


### PR DESCRIPTION
Previously, projects created with Flutter web app only enabled served `assets/assets/config.json` under `/app` which causes dynamically injected config to fail. This config is now served under root.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None