### PR TITLE
feat: Allow overriding the default cache header for `FlutterRoute` from env vars

### DIFF
--- a/packages/serverpod/lib/src/web_server/routes/flutter_route.dart
+++ b/packages/serverpod/lib/src/web_server/routes/flutter_route.dart
@@ -4,6 +4,9 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 import 'package:serverpod/serverpod.dart';
 
+const _flutterCacheControlEnvironmentVariable =
+    'SERVERPOD_WEB_SERVER_FLUTTER_CACHE_CONTROL';
+
 /// Route for serving Flutter web applications.
 ///
 /// Combines static file serving with automatic fallback to index.html for
@@ -21,9 +24,9 @@ import 'package:serverpod/serverpod.dart';
 ///
 /// ## About Caching
 ///
-/// By default, all files are served with `private, no-cache` headers so the
-/// browser always revalidates with the server via ETag. This is the only safe
-/// default because:
+/// Unless `SERVERPOD_WEB_SERVER_FLUTTER_CACHE_CONTROL` is set, all files are
+/// served with `private, no-cache` headers so the browser always revalidates
+/// with the server via ETag. This is the only safe built-in default because:
 ///
 /// - Flutter's service worker is deprecated and will be removed
 ///   (see [flutter#156910](https://github.com/flutter/flutter/issues/156910)).
@@ -52,9 +55,10 @@ class FlutterRoute extends Route {
 
   /// Cache control factory for static files.
   ///
-  /// Defaults to `private, no-cache` for all files (ETag revalidation on
-  /// every request). Override this when using [cacheBustingConfig] to serve
-  /// cache-busted assets with aggressive caching headers.
+  /// Defaults to the value of `SERVERPOD_WEB_SERVER_FLUTTER_CACHE_CONTROL`, or
+  /// `private, no-cache` when the environment variable is not set. Override
+  /// this when using [cacheBustingConfig] to serve cache-busted assets with
+  /// aggressive caching headers.
   final CacheControlFactory cacheControlFactory;
 
   /// Optional cache busting configuration for static files.
@@ -80,6 +84,9 @@ class FlutterRoute extends Route {
   /// The [host] parameter restricts this route to a specific virtual host
   /// (defaults to `null`, matching any host).
   ///
+  /// An explicit [cacheControlFactory] takes precedence over the value of the
+  /// `SERVERPOD_WEB_SERVER_FLUTTER_CACHE_CONTROL` environment variable.
+  ///
   /// Set [enableWasmHeaders] to `false` when serving a non-WASM Flutter web
   /// build that should not use cross-origin isolation.
   FlutterRoute(
@@ -91,8 +98,17 @@ class FlutterRoute extends Route {
     super.host,
   }) : indexFile = indexFile ?? File(path.join(directory.path, 'index.html')),
        cacheControlFactory =
-           cacheControlFactory ?? StaticRoute.privateNoCache(),
+           cacheControlFactory ?? _cacheControlFactoryFromEnvironment(),
        super(methods: {Method.get, Method.head});
+
+  static CacheControlFactory _cacheControlFactoryFromEnvironment() {
+    final cacheControl =
+        Platform.environment[_flutterCacheControlEnvironmentVariable];
+    if (cacheControl == null) return StaticRoute.privateNoCache();
+
+    final parsedCacheControl = CacheControlHeader.parse([cacheControl]);
+    return (_, _) => parsedCacheControl;
+  }
 
   @override
   void injectIn(RelicRouter router) {

--- a/tests/serverpod_test_server/test_integration/web_server/flutter_route_test.dart
+++ b/tests/serverpod_test_server/test_integration/web_server/flutter_route_test.dart
@@ -219,6 +219,115 @@ void main() {
     });
   });
 
+  const _environmentCacheControlTestName =
+      'Given a Flutter cache control environment variable and no Dart factory, '
+      'when a Flutter asset is requested, '
+      'then the environment cache control is applied.';
+  test(_environmentCacheControlTestName, () async {
+    if (await _rerunWithCacheControlEnvironment(
+      testName: _environmentCacheControlTestName,
+      value: 'public, max-age=60, s-maxage=86400',
+    )) {
+      return;
+    }
+
+    final pod = IntegrationTestServer.create(
+      config: ServerpodConfig(
+        apiServer: ServerConfig(
+          port: 0,
+          publicHost: 'localhost',
+          publicPort: 0,
+          publicScheme: 'http',
+        ),
+        webServer: ServerConfig(
+          port: 0,
+          publicHost: 'localhost',
+          publicPort: 0,
+          publicScheme: 'http',
+        ),
+      ),
+    );
+    pod.webServer.addRoute(FlutterRoute(webDir));
+
+    await pod.start();
+    addTearDown(() async {
+      await pod.shutdown(exitProcess: false);
+    });
+
+    final response = await client.get(
+      Uri.parse('${pod.webUrl}main.dart.js'),
+    );
+
+    expect(response.statusCode, 200);
+    expect(response.headers['cache-control'], contains('public'));
+    expect(response.headers['cache-control'], contains('max-age=60'));
+    expect(response.headers['cache-control'], contains('s-maxage=86400'));
+  });
+
+  const _dartCacheControlTestName =
+      'Given a Flutter cache control environment variable and a Dart factory, '
+      'when a Flutter asset is requested, '
+      'then the Dart cache control takes precedence.';
+  test(_dartCacheControlTestName, () async {
+    if (await _rerunWithCacheControlEnvironment(
+      testName: _dartCacheControlTestName,
+      value: 'max-age=not-a-number',
+    )) {
+      return;
+    }
+
+    final pod = IntegrationTestServer.create(
+      config: ServerpodConfig(
+        apiServer: ServerConfig(
+          port: 0,
+          publicHost: 'localhost',
+          publicPort: 0,
+          publicScheme: 'http',
+        ),
+        webServer: ServerConfig(
+          port: 0,
+          publicHost: 'localhost',
+          publicPort: 0,
+          publicScheme: 'http',
+        ),
+      ),
+    );
+    pod.webServer.addRoute(
+      FlutterRoute(
+        webDir,
+        cacheControlFactory: StaticRoute.noStore(),
+      ),
+    );
+
+    await pod.start();
+    addTearDown(() async {
+      await pod.shutdown(exitProcess: false);
+    });
+
+    final response = await client.get(
+      Uri.parse('${pod.webUrl}main.dart.js'),
+    );
+
+    expect(response.statusCode, 200);
+    expect(response.headers['cache-control'], contains('no-store'));
+    expect(response.headers['cache-control'], isNot(contains('public')));
+  });
+
+  const _invalidEnvironmentCacheControlTestName =
+      'Given an invalid Flutter cache control environment variable and no Dart factory, '
+      'when FlutterRoute is created, '
+      'then a FormatException is thrown.';
+  test(_invalidEnvironmentCacheControlTestName, () async {
+    if (await _rerunWithCacheControlEnvironment(
+      testName: _invalidEnvironmentCacheControlTestName,
+      value: 'invalid-directive',
+    )) {
+      return;
+    }
+
+    expect(() => FlutterRoute(webDir), throwsFormatException);
+  });
+
   group('Given a FlutterRoute with default caching', () {
     late Serverpod pod;
 
@@ -335,4 +444,35 @@ void main() {
       },
     );
   });
+}
+
+Future<bool> _rerunWithCacheControlEnvironment({
+  required String testName,
+  required String value,
+}) async {
+  const cacheControlEnvVarName = 'SERVERPOD_WEB_SERVER_FLUTTER_CACHE_CONTROL';
+
+  if (Platform.environment[cacheControlEnvVarName] == value) {
+    return false;
+  }
+
+  final result = await Process.run(
+    Platform.resolvedExecutable,
+    [
+      'test',
+      '--plain-name',
+      testName,
+      'test_integration/web_server/flutter_route_test.dart',
+    ],
+    workingDirectory: Directory.current.path,
+    environment: {cacheControlEnvVarName: value},
+  );
+
+  expect(
+    result.exitCode,
+    0,
+    reason:
+        'Nested test failed.\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}',
+  );
+  return true;
 }


### PR DESCRIPTION
Closes: #5527

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.