### PR TITLE
fix: Generate detach/detachRow for named list relations without order dependence

### DIFF
--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/many_to_many/course.dart
@@ -264,10 +264,6 @@ class CourseUuidRepository {
 
   final attachRow = const CourseUuidAttachRowRepository._();
 
-  final detach = const CourseUuidDetachRepository._();
-
-  final detachRow = const CourseUuidDetachRowRepository._();
-
   /// Returns a list of [CourseUuid]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -714,60 +710,6 @@ class CourseUuidAttachRowRepository {
     }
 
     var $enrollmentInt = enrollmentInt.copyWith(courseId: courseUuid.id);
-    await session.db.updateRow<_i2.EnrollmentInt>(
-      $enrollmentInt,
-      columns: [_i2.EnrollmentInt.t.courseId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CourseUuidDetachRepository {
-  const CourseUuidDetachRepository._();
-
-  /// Detaches the relation between this [CourseUuid] and the given [EnrollmentInt]
-  /// by setting the [EnrollmentInt]'s foreign key `courseId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> enrollments(
-    _i1.DatabaseSession session,
-    List<_i2.EnrollmentInt> enrollmentInt, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (enrollmentInt.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('enrollmentInt.id');
-    }
-
-    var $enrollmentInt = enrollmentInt
-        .map((e) => e.copyWith(courseId: null))
-        .toList();
-    await session.db.update<_i2.EnrollmentInt>(
-      $enrollmentInt,
-      columns: [_i2.EnrollmentInt.t.courseId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CourseUuidDetachRowRepository {
-  const CourseUuidDetachRowRepository._();
-
-  /// Detaches the relation between this [CourseUuid] and the given [EnrollmentInt]
-  /// by setting the [EnrollmentInt]'s foreign key `courseId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> enrollments(
-    _i1.DatabaseSession session,
-    _i2.EnrollmentInt enrollmentInt, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (enrollmentInt.id == null) {
-      throw ArgumentError.notNull('enrollmentInt.id');
-    }
-
-    var $enrollmentInt = enrollmentInt.copyWith(courseId: null);
     await session.db.updateRow<_i2.EnrollmentInt>(
       $enrollmentInt,
       columns: [_i2.EnrollmentInt.t.courseId],

--- a/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
@@ -258,10 +258,6 @@ class CustomerIntRepository {
 
   final attachRow = const CustomerIntAttachRowRepository._();
 
-  final detach = const CustomerIntDetachRepository._();
-
-  final detachRow = const CustomerIntDetachRowRepository._();
-
   /// Returns a list of [CustomerInt]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -708,60 +704,6 @@ class CustomerIntAttachRowRepository {
     }
 
     var $orderUuid = orderUuid.copyWith(customerId: customerInt.id);
-    await session.db.updateRow<_i2.OrderUuid>(
-      $orderUuid,
-      columns: [_i2.OrderUuid.t.customerId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CustomerIntDetachRepository {
-  const CustomerIntDetachRepository._();
-
-  /// Detaches the relation between this [CustomerInt] and the given [OrderUuid]
-  /// by setting the [OrderUuid]'s foreign key `customerId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> orders(
-    _i1.DatabaseSession session,
-    List<_i2.OrderUuid> orderUuid, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (orderUuid.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
-
-    var $orderUuid = orderUuid
-        .map((e) => e.copyWith(customerId: null))
-        .toList();
-    await session.db.update<_i2.OrderUuid>(
-      $orderUuid,
-      columns: [_i2.OrderUuid.t.customerId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CustomerIntDetachRowRepository {
-  const CustomerIntDetachRowRepository._();
-
-  /// Detaches the relation between this [CustomerInt] and the given [OrderUuid]
-  /// by setting the [OrderUuid]'s foreign key `customerId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> orders(
-    _i1.DatabaseSession session,
-    _i2.OrderUuid orderUuid, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (orderUuid.id == null) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
-
-    var $orderUuid = orderUuid.copyWith(customerId: null);
     await session.db.updateRow<_i2.OrderUuid>(
       $orderUuid,
       columns: [_i2.OrderUuid.t.customerId],

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -259,10 +259,6 @@ class CourseRepository {
 
   final attachRow = const CourseAttachRowRepository._();
 
-  final detach = const CourseDetachRepository._();
-
-  final detachRow = const CourseDetachRowRepository._();
-
   /// Returns a list of [Course]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -709,60 +705,6 @@ class CourseAttachRowRepository {
     }
 
     var $enrollment = enrollment.copyWith(courseId: course.id);
-    await session.db.updateRow<_i2.Enrollment>(
-      $enrollment,
-      columns: [_i2.Enrollment.t.courseId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CourseDetachRepository {
-  const CourseDetachRepository._();
-
-  /// Detaches the relation between this [Course] and the given [Enrollment]
-  /// by setting the [Enrollment]'s foreign key `courseId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> enrollments(
-    _i1.DatabaseSession session,
-    List<_i2.Enrollment> enrollment, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (enrollment.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('enrollment.id');
-    }
-
-    var $enrollment = enrollment
-        .map((e) => e.copyWith(courseId: null))
-        .toList();
-    await session.db.update<_i2.Enrollment>(
-      $enrollment,
-      columns: [_i2.Enrollment.t.courseId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CourseDetachRowRepository {
-  const CourseDetachRowRepository._();
-
-  /// Detaches the relation between this [Course] and the given [Enrollment]
-  /// by setting the [Enrollment]'s foreign key `courseId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> enrollments(
-    _i1.DatabaseSession session,
-    _i2.Enrollment enrollment, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (enrollment.id == null) {
-      throw ArgumentError.notNull('enrollment.id');
-    }
-
-    var $enrollment = enrollment.copyWith(courseId: null);
     await session.db.updateRow<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],

--- a/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -258,10 +258,6 @@ class CustomerRepository {
 
   final attachRow = const CustomerAttachRowRepository._();
 
-  final detach = const CustomerDetachRepository._();
-
-  final detachRow = const CustomerDetachRowRepository._();
-
   /// Returns a list of [Customer]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -706,58 +702,6 @@ class CustomerAttachRowRepository {
     }
 
     var $order = order.copyWith(customerId: customer.id);
-    await session.db.updateRow<_i2.Order>(
-      $order,
-      columns: [_i2.Order.t.customerId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CustomerDetachRepository {
-  const CustomerDetachRepository._();
-
-  /// Detaches the relation between this [Customer] and the given [Order]
-  /// by setting the [Order]'s foreign key `customerId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> orders(
-    _i1.DatabaseSession session,
-    List<_i2.Order> order, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (order.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('order.id');
-    }
-
-    var $order = order.map((e) => e.copyWith(customerId: null)).toList();
-    await session.db.update<_i2.Order>(
-      $order,
-      columns: [_i2.Order.t.customerId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CustomerDetachRowRepository {
-  const CustomerDetachRowRepository._();
-
-  /// Detaches the relation between this [Customer] and the given [Order]
-  /// by setting the [Order]'s foreign key `customerId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> orders(
-    _i1.DatabaseSession session,
-    _i2.Order order, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (order.id == null) {
-      throw ArgumentError.notNull('order.id');
-    }
-
-    var $order = order.copyWith(customerId: null);
     await session.db.updateRow<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/many_to_many/course.dart
@@ -260,10 +260,6 @@ class CourseRepository {
 
   final attachRow = const CourseAttachRowRepository._();
 
-  final detach = const CourseDetachRepository._();
-
-  final detachRow = const CourseDetachRowRepository._();
-
   /// Returns a list of [Course]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -710,60 +706,6 @@ class CourseAttachRowRepository {
     }
 
     var $enrollment = enrollment.copyWith(courseId: course.id);
-    await session.db.updateRow<_i3.Enrollment>(
-      $enrollment,
-      columns: [_i3.Enrollment.t.courseId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CourseDetachRepository {
-  const CourseDetachRepository._();
-
-  /// Detaches the relation between this [Course] and the given [Enrollment]
-  /// by setting the [Enrollment]'s foreign key `courseId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> enrollments(
-    _i1.DatabaseSession session,
-    List<_i3.Enrollment> enrollment, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (enrollment.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('enrollment.id');
-    }
-
-    var $enrollment = enrollment
-        .map((e) => e.copyWith(courseId: null))
-        .toList();
-    await session.db.update<_i3.Enrollment>(
-      $enrollment,
-      columns: [_i3.Enrollment.t.courseId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CourseDetachRowRepository {
-  const CourseDetachRowRepository._();
-
-  /// Detaches the relation between this [Course] and the given [Enrollment]
-  /// by setting the [Enrollment]'s foreign key `courseId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> enrollments(
-    _i1.DatabaseSession session,
-    _i3.Enrollment enrollment, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (enrollment.id == null) {
-      throw ArgumentError.notNull('enrollment.id');
-    }
-
-    var $enrollment = enrollment.copyWith(courseId: null);
     await session.db.updateRow<_i3.Enrollment>(
       $enrollment,
       columns: [_i3.Enrollment.t.courseId],

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/models_with_relations/one_to_many/customer.dart
@@ -259,10 +259,6 @@ class CustomerRepository {
 
   final attachRow = const CustomerAttachRowRepository._();
 
-  final detach = const CustomerDetachRepository._();
-
-  final detachRow = const CustomerDetachRowRepository._();
-
   /// Returns a list of [Customer]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -707,58 +703,6 @@ class CustomerAttachRowRepository {
     }
 
     var $order = order.copyWith(customerId: customer.id);
-    await session.db.updateRow<_i3.Order>(
-      $order,
-      columns: [_i3.Order.t.customerId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CustomerDetachRepository {
-  const CustomerDetachRepository._();
-
-  /// Detaches the relation between this [Customer] and the given [Order]
-  /// by setting the [Order]'s foreign key `customerId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> orders(
-    _i1.DatabaseSession session,
-    List<_i3.Order> order, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (order.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('order.id');
-    }
-
-    var $order = order.map((e) => e.copyWith(customerId: null)).toList();
-    await session.db.update<_i3.Order>(
-      $order,
-      columns: [_i3.Order.t.customerId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CustomerDetachRowRepository {
-  const CustomerDetachRowRepository._();
-
-  /// Detaches the relation between this [Customer] and the given [Order]
-  /// by setting the [Order]'s foreign key `customerId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> orders(
-    _i1.DatabaseSession session,
-    _i3.Order order, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (order.id == null) {
-      throw ArgumentError.notNull('order.id');
-    }
-
-    var $order = order.copyWith(customerId: null);
     await session.db.updateRow<_i3.Order>(
       $order,
       columns: [_i3.Order.t.customerId],

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/course.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/many_to_many/course.dart
@@ -265,10 +265,6 @@ class CourseUuidRepository {
 
   final attachRow = const CourseUuidAttachRowRepository._();
 
-  final detach = const CourseUuidDetachRepository._();
-
-  final detachRow = const CourseUuidDetachRowRepository._();
-
   /// Returns a list of [CourseUuid]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -715,60 +711,6 @@ class CourseUuidAttachRowRepository {
     }
 
     var $enrollmentInt = enrollmentInt.copyWith(courseId: courseUuid.id);
-    await session.db.updateRow<_i2.EnrollmentInt>(
-      $enrollmentInt,
-      columns: [_i2.EnrollmentInt.t.courseId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CourseUuidDetachRepository {
-  const CourseUuidDetachRepository._();
-
-  /// Detaches the relation between this [CourseUuid] and the given [EnrollmentInt]
-  /// by setting the [EnrollmentInt]'s foreign key `courseId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> enrollments(
-    _i1.DatabaseSession session,
-    List<_i2.EnrollmentInt> enrollmentInt, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (enrollmentInt.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('enrollmentInt.id');
-    }
-
-    var $enrollmentInt = enrollmentInt
-        .map((e) => e.copyWith(courseId: null))
-        .toList();
-    await session.db.update<_i2.EnrollmentInt>(
-      $enrollmentInt,
-      columns: [_i2.EnrollmentInt.t.courseId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CourseUuidDetachRowRepository {
-  const CourseUuidDetachRowRepository._();
-
-  /// Detaches the relation between this [CourseUuid] and the given [EnrollmentInt]
-  /// by setting the [EnrollmentInt]'s foreign key `courseId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> enrollments(
-    _i1.DatabaseSession session,
-    _i2.EnrollmentInt enrollmentInt, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (enrollmentInt.id == null) {
-      throw ArgumentError.notNull('enrollmentInt.id');
-    }
-
-    var $enrollmentInt = enrollmentInt.copyWith(courseId: null);
     await session.db.updateRow<_i2.EnrollmentInt>(
       $enrollmentInt,
       columns: [_i2.EnrollmentInt.t.courseId],

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/changed_id_type/one_to_many/customer.dart
@@ -259,10 +259,6 @@ class CustomerIntRepository {
 
   final attachRow = const CustomerIntAttachRowRepository._();
 
-  final detach = const CustomerIntDetachRepository._();
-
-  final detachRow = const CustomerIntDetachRowRepository._();
-
   /// Returns a list of [CustomerInt]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -709,60 +705,6 @@ class CustomerIntAttachRowRepository {
     }
 
     var $orderUuid = orderUuid.copyWith(customerId: customerInt.id);
-    await session.db.updateRow<_i2.OrderUuid>(
-      $orderUuid,
-      columns: [_i2.OrderUuid.t.customerId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CustomerIntDetachRepository {
-  const CustomerIntDetachRepository._();
-
-  /// Detaches the relation between this [CustomerInt] and the given [OrderUuid]
-  /// by setting the [OrderUuid]'s foreign key `customerId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> orders(
-    _i1.DatabaseSession session,
-    List<_i2.OrderUuid> orderUuid, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (orderUuid.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
-
-    var $orderUuid = orderUuid
-        .map((e) => e.copyWith(customerId: null))
-        .toList();
-    await session.db.update<_i2.OrderUuid>(
-      $orderUuid,
-      columns: [_i2.OrderUuid.t.customerId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CustomerIntDetachRowRepository {
-  const CustomerIntDetachRowRepository._();
-
-  /// Detaches the relation between this [CustomerInt] and the given [OrderUuid]
-  /// by setting the [OrderUuid]'s foreign key `customerId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> orders(
-    _i1.DatabaseSession session,
-    _i2.OrderUuid orderUuid, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (orderUuid.id == null) {
-      throw ArgumentError.notNull('orderUuid.id');
-    }
-
-    var $orderUuid = orderUuid.copyWith(customerId: null);
     await session.db.updateRow<_i2.OrderUuid>(
       $orderUuid,
       columns: [_i2.OrderUuid.t.customerId],

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/course.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/many_to_many/course.dart
@@ -260,10 +260,6 @@ class CourseRepository {
 
   final attachRow = const CourseAttachRowRepository._();
 
-  final detach = const CourseDetachRepository._();
-
-  final detachRow = const CourseDetachRowRepository._();
-
   /// Returns a list of [Course]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -710,60 +706,6 @@ class CourseAttachRowRepository {
     }
 
     var $enrollment = enrollment.copyWith(courseId: course.id);
-    await session.db.updateRow<_i2.Enrollment>(
-      $enrollment,
-      columns: [_i2.Enrollment.t.courseId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CourseDetachRepository {
-  const CourseDetachRepository._();
-
-  /// Detaches the relation between this [Course] and the given [Enrollment]
-  /// by setting the [Enrollment]'s foreign key `courseId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> enrollments(
-    _i1.DatabaseSession session,
-    List<_i2.Enrollment> enrollment, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (enrollment.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('enrollment.id');
-    }
-
-    var $enrollment = enrollment
-        .map((e) => e.copyWith(courseId: null))
-        .toList();
-    await session.db.update<_i2.Enrollment>(
-      $enrollment,
-      columns: [_i2.Enrollment.t.courseId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CourseDetachRowRepository {
-  const CourseDetachRowRepository._();
-
-  /// Detaches the relation between this [Course] and the given [Enrollment]
-  /// by setting the [Enrollment]'s foreign key `courseId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> enrollments(
-    _i1.DatabaseSession session,
-    _i2.Enrollment enrollment, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (enrollment.id == null) {
-      throw ArgumentError.notNull('enrollment.id');
-    }
-
-    var $enrollment = enrollment.copyWith(courseId: null);
     await session.db.updateRow<_i2.Enrollment>(
       $enrollment,
       columns: [_i2.Enrollment.t.courseId],

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/models_with_relations/one_to_many/customer.dart
@@ -259,10 +259,6 @@ class CustomerRepository {
 
   final attachRow = const CustomerAttachRowRepository._();
 
-  final detach = const CustomerDetachRepository._();
-
-  final detachRow = const CustomerDetachRowRepository._();
-
   /// Returns a list of [Customer]s matching the given query parameters.
   ///
   /// Use [where] to specify which items to include in the return value.
@@ -707,58 +703,6 @@ class CustomerAttachRowRepository {
     }
 
     var $order = order.copyWith(customerId: customer.id);
-    await session.db.updateRow<_i2.Order>(
-      $order,
-      columns: [_i2.Order.t.customerId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CustomerDetachRepository {
-  const CustomerDetachRepository._();
-
-  /// Detaches the relation between this [Customer] and the given [Order]
-  /// by setting the [Order]'s foreign key `customerId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> orders(
-    _i1.DatabaseSession session,
-    List<_i2.Order> order, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (order.any((e) => e.id == null)) {
-      throw ArgumentError.notNull('order.id');
-    }
-
-    var $order = order.map((e) => e.copyWith(customerId: null)).toList();
-    await session.db.update<_i2.Order>(
-      $order,
-      columns: [_i2.Order.t.customerId],
-      transaction: transaction,
-    );
-  }
-}
-
-class CustomerDetachRowRepository {
-  const CustomerDetachRowRepository._();
-
-  /// Detaches the relation between this [Customer] and the given [Order]
-  /// by setting the [Order]'s foreign key `customerId` to `null`.
-  ///
-  /// This removes the association between the two models without deleting
-  /// the related record.
-  Future<void> orders(
-    _i1.DatabaseSession session,
-    _i2.Order order, {
-    _i1.Transaction? transaction,
-  }) async {
-    if (order.id == null) {
-      throw ArgumentError.notNull('order.id');
-    }
-
-    var $order = order.copyWith(customerId: null);
     await session.db.updateRow<_i2.Order>(
       $order,
       columns: [_i2.Order.t.customerId],

--- a/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
@@ -540,13 +540,28 @@ class ModelDependencyResolver {
 
       if (foreignFieldName == null) return;
 
+      // The nullability of the relation is always determined by the foreign
+      // key field, never by the object field. If the foreign class is not yet
+      // resolved, the matched field is the object field and the foreign key
+      // field may not exist yet; in that case the nullability comes from the
+      // explicitly declared foreign key field, or the `optional` keyword when
+      // the foreign key field is implicit.
+      bool nullableRelation;
+      if (foreignRelation is UnresolvedObjectRelationDefinition) {
+        nullableRelation =
+            referenceClass.findField(foreignFieldName)?.type.nullable ??
+            foreignRelation.nullableRelation;
+      } else {
+        nullableRelation = foreignField.type.nullable;
+      }
+
       fieldDefinition.relation = ListRelationDefinition(
         name: relation.name,
         foreignKeyOwnerIdType: referenceClass.idField.type,
         fieldName: defaultPrimaryKeyName,
         foreignFieldName: foreignFieldName,
         foreignContainerField: foreignContainerField,
-        nullableRelation: foreignFields.first.type.nullable,
+        nullableRelation: nullableRelation,
       );
     }
   }

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_list_nullability_resolution_order_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/relation/relation_list_nullability_resolution_order_test.dart
@@ -1,0 +1,170 @@
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:test/test.dart';
+
+import '../../../../../test_util/builders/generator_config_builder.dart';
+import '../../../../../test_util/builders/model_source_builder.dart';
+
+/// The nullability of a named list relation must be determined by the foreign
+/// key field on the foreign class, independently of the order in which the
+/// model files are analyzed.
+void main() {
+  var config = GeneratorConfigBuilder().build();
+
+  var companyYaml = '''
+        class: Company
+        table: company
+        fields:
+          employees: List<Employee>?, relation(name=company_employees)
+        ''';
+
+  ListRelationDefinition resolveListRelation(
+    List<({String fileName, String yaml})> orderedModels,
+  ) {
+    var models = orderedModels
+        .map(
+          (model) => ModelSourceBuilder()
+              .withFileName(model.fileName)
+              .withYaml(model.yaml)
+              .build(),
+        )
+        .toList();
+
+    var collector = CodeGenerationCollector();
+    var analyzer = StatefulAnalyzer(
+      config,
+      models,
+      onErrorsCollector(collector),
+    );
+    var definitions = analyzer.validateAll();
+
+    expect(collector.errors, isEmpty);
+
+    var company = definitions.whereType<ClassDefinition>().firstWhere(
+      (definition) => definition.className == 'Company',
+    );
+
+    return company.findField('employees')!.relation as ListRelationDefinition;
+  }
+
+  group('Given a named one to many relation with a required foreign key', () {
+    var employeeYaml = '''
+        class: Employee
+        table: employee
+        fields:
+          company: Company?, relation(name=company_employees)
+        ''';
+
+    test('when the foreign class is analyzed before the list owner '
+        'then the nullableRelation is set to false.', () {
+      var relation = resolveListRelation([
+        (fileName: 'employee', yaml: employeeYaml),
+        (fileName: 'company', yaml: companyYaml),
+      ]);
+
+      expect(relation.nullableRelation, isFalse);
+    });
+
+    test('when the list owner is analyzed before the foreign class '
+        'then the nullableRelation is set to false.', () {
+      var relation = resolveListRelation([
+        (fileName: 'company', yaml: companyYaml),
+        (fileName: 'employee', yaml: employeeYaml),
+      ]);
+
+      expect(relation.nullableRelation, isFalse);
+    });
+  });
+
+  group('Given a named one to many relation with an optional foreign key', () {
+    var employeeYaml = '''
+        class: Employee
+        table: employee
+        fields:
+          company: Company?, relation(name=company_employees, optional)
+        ''';
+
+    test('when the foreign class is analyzed before the list owner '
+        'then the nullableRelation is set to true.', () {
+      var relation = resolveListRelation([
+        (fileName: 'employee', yaml: employeeYaml),
+        (fileName: 'company', yaml: companyYaml),
+      ]);
+
+      expect(relation.nullableRelation, isTrue);
+    });
+
+    test('when the list owner is analyzed before the foreign class '
+        'then the nullableRelation is set to true.', () {
+      var relation = resolveListRelation([
+        (fileName: 'company', yaml: companyYaml),
+        (fileName: 'employee', yaml: employeeYaml),
+      ]);
+
+      expect(relation.nullableRelation, isTrue);
+    });
+  });
+
+  group('Given a named one to many relation with an explicit nullable '
+      'foreign key field', () {
+    var employeeYaml = '''
+        class: Employee
+        table: employee
+        fields:
+          companyId: int?
+          company: Company?, relation(name=company_employees, field=companyId)
+        ''';
+
+    test('when the foreign class is analyzed before the list owner '
+        'then the nullableRelation is set to true.', () {
+      var relation = resolveListRelation([
+        (fileName: 'employee', yaml: employeeYaml),
+        (fileName: 'company', yaml: companyYaml),
+      ]);
+
+      expect(relation.nullableRelation, isTrue);
+    });
+
+    test('when the list owner is analyzed before the foreign class '
+        'then the nullableRelation is set to true.', () {
+      var relation = resolveListRelation([
+        (fileName: 'company', yaml: companyYaml),
+        (fileName: 'employee', yaml: employeeYaml),
+      ]);
+
+      expect(relation.nullableRelation, isTrue);
+    });
+  });
+
+  group('Given a named one to many relation with an explicit non-nullable '
+      'foreign key field', () {
+    var employeeYaml = '''
+        class: Employee
+        table: employee
+        fields:
+          companyId: int
+          company: Company?, relation(name=company_employees, field=companyId)
+        ''';
+
+    test('when the foreign class is analyzed before the list owner '
+        'then the nullableRelation is set to false.', () {
+      var relation = resolveListRelation([
+        (fileName: 'employee', yaml: employeeYaml),
+        (fileName: 'company', yaml: companyYaml),
+      ]);
+
+      expect(relation.nullableRelation, isFalse);
+    });
+
+    test('when the list owner is analyzed before the foreign class '
+        'then the nullableRelation is set to false.', () {
+      var relation = resolveListRelation([
+        (fileName: 'company', yaml: companyYaml),
+        (fileName: 'employee', yaml: employeeYaml),
+      ]);
+
+      expect(relation.nullableRelation, isFalse);
+    });
+  });
+}

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/database_repository_class_list_relation_additions_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/database_repository_class_list_relation_additions_test.dart
@@ -1,0 +1,250 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/src/generator/dart/client_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/builders/generator_config_builder.dart';
+import '../../../test_util/builders/model_class_definition_builder.dart';
+import '../../../test_util/compilation_unit_helpers.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartClientCodeGenerator();
+
+void main() {
+  var testClassName = 'Example';
+  var testClassFileName = 'example';
+  var expectedFilePath = path.join(
+    '..',
+    'example_project_client',
+    'lib',
+    'src',
+    'protocol',
+    '$testClassFileName.dart',
+  );
+
+  group(
+    'Given a class with a client database table and explicit nullable list relation field, '
+    'when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withClassName(testClassName)
+            .withFileName(testClassFileName)
+            .withTableName('example_table')
+            .withDatabase(ModelDatabaseDefinition.client)
+            .withListRelationField(
+              'people',
+              'Person',
+              'organizationId',
+              nullableRelation: true,
+            )
+            .build(),
+      ];
+
+      var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      var compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      var repositoryClass = CompilationUnitHelpers.tryFindClassDeclaration(
+        compilationUnit,
+        name: '${testClassName}Repository',
+      );
+
+      group(
+        'then the class name ${testClassName}Repository',
+        () {
+          test('has a final detach field', () {
+            var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+              repositoryClass!,
+              name: 'detach',
+            );
+
+            expect(
+              field?.toSource(),
+              'final detach = const ${testClassName}DetachRepository._();',
+              reason: 'Missing static instance field.',
+            );
+          });
+
+          test('has a final detachRow field', () {
+            var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+              repositoryClass!,
+              name: 'detachRow',
+            );
+
+            expect(
+              field?.toSource(),
+              'final detachRow = const ${testClassName}DetachRowRepository._();',
+              reason: 'Missing static instance field.',
+            );
+          });
+        },
+        skip: repositoryClass == null,
+      );
+
+      test(
+        'then a class named ${testClassName}DetachRepository is generated',
+        () {
+          expect(
+            CompilationUnitHelpers.hasClassDeclaration(
+              compilationUnit,
+              name: '${testClassName}DetachRepository',
+            ),
+            isTrue,
+            reason:
+                'Expected the class ${testClassName}DetachRepository to be generated.',
+          );
+        },
+      );
+
+      test(
+        'then a class named ${testClassName}DetachRowRepository is generated',
+        () {
+          expect(
+            CompilationUnitHelpers.hasClassDeclaration(
+              compilationUnit,
+              name: '${testClassName}DetachRowRepository',
+            ),
+            isTrue,
+            reason:
+                'Expected the class ${testClassName}DetachRowRepository to be generated.',
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a class with a client database table and explicit non-nullable list relation field, '
+    'when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withClassName(testClassName)
+            .withFileName(testClassFileName)
+            .withTableName('example_table')
+            .withDatabase(ModelDatabaseDefinition.client)
+            .withListRelationField(
+              'people',
+              'Person',
+              'organizationId',
+              nullableRelation: false,
+            )
+            .build(),
+      ];
+
+      var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      var compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      var repositoryClass = CompilationUnitHelpers.tryFindClassDeclaration(
+        compilationUnit,
+        name: '${testClassName}Repository',
+      );
+
+      group(
+        'then the class name ${testClassName}Repository',
+        () {
+          test('has a final attach field', () {
+            var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+              repositoryClass!,
+              name: 'attach',
+            );
+
+            expect(
+              field?.toSource(),
+              'final attach = const ${testClassName}AttachRepository._();',
+              reason: 'Missing static instance field.',
+            );
+          });
+
+          test('has NO detachRow field', () {
+            var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+              repositoryClass!,
+              name: 'detachRow',
+            );
+
+            expect(
+              field,
+              isNull,
+              reason:
+                  'The field detachRow was found but was expected to not exist.',
+            );
+          });
+
+          test('has NO detach field', () {
+            var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+              repositoryClass!,
+              name: 'detach',
+            );
+
+            expect(
+              field,
+              isNull,
+              reason:
+                  'The field detach was found but was expected to not exist.',
+            );
+          });
+        },
+        skip: repositoryClass == null,
+      );
+
+      test(
+        'then a class named ${testClassName}AttachRepository is generated',
+        () {
+          expect(
+            CompilationUnitHelpers.hasClassDeclaration(
+              compilationUnit,
+              name: '${testClassName}AttachRepository',
+            ),
+            isTrue,
+            reason:
+                'Expected the class ${testClassName}AttachRepository to be generated.',
+          );
+        },
+      );
+
+      test(
+        'then a class named ${testClassName}DetachRepository is NOT generated',
+        () {
+          expect(
+            CompilationUnitHelpers.hasClassDeclaration(
+              compilationUnit,
+              name: '${testClassName}DetachRepository',
+            ),
+            isFalse,
+            reason:
+                'The class ${testClassName}DetachRepository was found but was expected to not exist.',
+          );
+        },
+      );
+
+      test(
+        'then a class named ${testClassName}DetachRowRepository is NOT generated',
+        () {
+          expect(
+            CompilationUnitHelpers.hasClassDeclaration(
+              compilationUnit,
+              name: '${testClassName}DetachRowRepository',
+            ),
+            isFalse,
+            reason:
+                'The class ${testClassName}DetachRowRepository was found but was expected to not exist.',
+          );
+        },
+      );
+    },
+  );
+}

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/database_repository_detach_resolution_order_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/database_repository_detach_resolution_order_test.dart
@@ -1,0 +1,255 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/generator/dart/client_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/builders/generator_config_builder.dart';
+import '../../../test_util/builders/model_source_builder.dart';
+import '../../../test_util/compilation_unit_helpers.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartClientCodeGenerator();
+
+/// The generation of `detach`/`detachRow` for named list relations must not
+/// depend on the order in which the model files are analyzed, and must only
+/// happen when the foreign key field is nullable.
+void main() {
+  const companyYaml = '''
+        class: Company
+        table: company
+        database: all
+        fields:
+          employees: List<Employee>?, relation(name=company_employees)
+        ''';
+
+  CompilationUnit generateCompanyCode(
+    List<({String fileName, String yaml})> orderedModels,
+  ) {
+    var modelSources = orderedModels
+        .map(
+          (model) => ModelSourceBuilder()
+              .withFileName(model.fileName)
+              .withYaml(model.yaml)
+              .build(),
+        )
+        .toList();
+
+    var collector = CodeGenerationCollector();
+    var analyzer = StatefulAnalyzer(
+      config,
+      modelSources,
+      onErrorsCollector(collector),
+    );
+    var models = analyzer.validateAll();
+
+    expect(
+      collector.errors,
+      isEmpty,
+      reason: 'Expected the models to be analyzed without errors.',
+    );
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var companyFilePath = codeMap.keys
+        .where((filePath) => filePath.endsWith('company.dart'))
+        .firstOrNull;
+
+    expect(
+      companyFilePath,
+      isNotNull,
+      reason: 'Expected the code for the list owner to be generated.',
+    );
+
+    return parseString(content: codeMap[companyFilePath]!).unit;
+  }
+
+  group('Given a named one to many relation with a required foreign key', () {
+    const requiredForeignKeyEmployeeYaml = '''
+        class: Employee
+        table: employee
+        database: all
+        fields:
+          company: Company?, relation(name=company_employees)
+        ''';
+
+    group('when the foreign class is analyzed before the list owner', () {
+      late CompilationUnit compilationUnit;
+
+      setUp(() {
+        compilationUnit = generateCompanyCode([
+          (fileName: 'employee', yaml: requiredForeignKeyEmployeeYaml),
+          (fileName: 'company', yaml: companyYaml),
+        ]);
+      });
+
+      test('then a class named CompanyAttachRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyAttachRepository',
+          ),
+          isTrue,
+          reason: 'Expected the class CompanyAttachRepository to be generated.',
+        );
+      });
+
+      test('then a class named CompanyDetachRepository is NOT generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRepository',
+          ),
+          isFalse,
+          reason:
+              'The class CompanyDetachRepository was found but was expected '
+              'to not exist.',
+        );
+      });
+
+      test('then a class named CompanyDetachRowRepository is NOT generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRowRepository',
+          ),
+          isFalse,
+          reason:
+              'The class CompanyDetachRowRepository was found but was expected '
+              'to not exist.',
+        );
+      });
+    });
+
+    group('when the list owner is analyzed before the foreign class', () {
+      late CompilationUnit compilationUnit;
+
+      setUp(() {
+        compilationUnit = generateCompanyCode([
+          (fileName: 'company', yaml: companyYaml),
+          (fileName: 'employee', yaml: requiredForeignKeyEmployeeYaml),
+        ]);
+      });
+
+      test('then a class named CompanyAttachRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyAttachRepository',
+          ),
+          isTrue,
+          reason: 'Expected the class CompanyAttachRepository to be generated.',
+        );
+      });
+
+      test('then a class named CompanyDetachRepository is NOT generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRepository',
+          ),
+          isFalse,
+          reason:
+              'The class CompanyDetachRepository was found but was expected '
+              'to not exist.',
+        );
+      });
+
+      test('then a class named CompanyDetachRowRepository is NOT generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRowRepository',
+          ),
+          isFalse,
+          reason:
+              'The class CompanyDetachRowRepository was found but was expected '
+              'to not exist.',
+        );
+      });
+    });
+  });
+
+  group('Given a named one to many relation with an optional foreign key', () {
+    const optionalForeignKeyEmployeeYaml = '''
+        class: Employee
+        table: employee
+        database: all
+        fields:
+          company: Company?, relation(name=company_employees, optional)
+        ''';
+
+    group('when the foreign class is analyzed before the list owner', () {
+      late CompilationUnit compilationUnit;
+
+      setUp(() {
+        compilationUnit = generateCompanyCode([
+          (fileName: 'employee', yaml: optionalForeignKeyEmployeeYaml),
+          (fileName: 'company', yaml: companyYaml),
+        ]);
+      });
+
+      test('then a class named CompanyDetachRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRepository',
+          ),
+          isTrue,
+          reason: 'Expected the class CompanyDetachRepository to be generated.',
+        );
+      });
+
+      test('then a class named CompanyDetachRowRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRowRepository',
+          ),
+          isTrue,
+          reason:
+              'Expected the class CompanyDetachRowRepository to be generated.',
+        );
+      });
+    });
+
+    group('when the list owner is analyzed before the foreign class', () {
+      late CompilationUnit compilationUnit;
+
+      setUp(() {
+        compilationUnit = generateCompanyCode([
+          (fileName: 'company', yaml: companyYaml),
+          (fileName: 'employee', yaml: optionalForeignKeyEmployeeYaml),
+        ]);
+      });
+
+      test('then a class named CompanyDetachRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRepository',
+          ),
+          isTrue,
+          reason: 'Expected the class CompanyDetachRepository to be generated.',
+        );
+      });
+
+      test('then a class named CompanyDetachRowRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRowRepository',
+          ),
+          isTrue,
+          reason:
+              'Expected the class CompanyDetachRowRepository to be generated.',
+        );
+      });
+    });
+  });
+}

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_list_relation_additions_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_class_list_relation_additions_test.dart
@@ -560,4 +560,130 @@ void main() {
       });
     },
   );
+
+  group(
+    'Given a class with table name and explicit non-nullable list relation field, '
+    'when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withClassName(testClassName)
+            .withFileName(testClassFileName)
+            .withTableName('example_table')
+            .withListRelationField(
+              'people',
+              'Person',
+              'organizationId',
+              nullableRelation: false,
+            )
+            .build(),
+      ];
+
+      var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      var compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      var repositoryClass = CompilationUnitHelpers.tryFindClassDeclaration(
+        compilationUnit,
+        name: '${testClassName}Repository',
+      );
+
+      group(
+        'then the class name ${testClassName}Repository',
+        () {
+          test('has a final attach field', () {
+            var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+              repositoryClass!,
+              name: 'attach',
+            );
+
+            expect(
+              field?.toSource(),
+              'final attach = const ${testClassName}AttachRepository._();',
+              reason: 'Missing final attach field.',
+            );
+          });
+
+          test('has no detachRow field', () {
+            var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+              repositoryClass!,
+              name: 'detachRow',
+            );
+
+            expect(
+              field,
+              isNull,
+              reason:
+                  'The field detachRow was found but was expected to not exist.',
+            );
+          });
+
+          test('has no detach field', () {
+            var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+              repositoryClass!,
+              name: 'detach',
+            );
+
+            expect(
+              field,
+              isNull,
+              reason:
+                  'The field detach was found but was expected to not exist.',
+            );
+          });
+        },
+        skip: repositoryClass == null,
+      );
+
+      test(
+        'then a class named ${testClassName}AttachRepository is generated',
+        () {
+          expect(
+            CompilationUnitHelpers.hasClassDeclaration(
+              compilationUnit,
+              name: '${testClassName}AttachRepository',
+            ),
+            isTrue,
+            reason:
+                'Expected the class ${testClassName}AttachRepository to be generated.',
+          );
+        },
+      );
+
+      test(
+        'then a class named ${testClassName}DetachRepository is not generated',
+        () {
+          expect(
+            CompilationUnitHelpers.hasClassDeclaration(
+              compilationUnit,
+              name: '${testClassName}DetachRepository',
+            ),
+            isFalse,
+            reason:
+                'The class ${testClassName}DetachRepository was found but was expected to not exist.',
+          );
+        },
+      );
+
+      test(
+        'then a class named ${testClassName}DetachRowRepository is not generated',
+        () {
+          expect(
+            CompilationUnitHelpers.hasClassDeclaration(
+              compilationUnit,
+              name: '${testClassName}DetachRowRepository',
+            ),
+            isFalse,
+            reason:
+                'The class ${testClassName}DetachRowRepository was found but was expected to not exist.',
+          );
+        },
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_detach_resolution_order_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/database_repository_detach_resolution_order_test.dart
@@ -1,0 +1,252 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/builders/generator_config_builder.dart';
+import '../../../test_util/builders/model_source_builder.dart';
+import '../../../test_util/compilation_unit_helpers.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+/// The generation of `detach`/`detachRow` for named list relations must not
+/// depend on the order in which the model files are analyzed, and must only
+/// happen when the foreign key field is nullable.
+void main() {
+  const companyYaml = '''
+        class: Company
+        table: company
+        fields:
+          employees: List<Employee>?, relation(name=company_employees)
+        ''';
+
+  CompilationUnit generateCompanyCode(
+    List<({String fileName, String yaml})> orderedModels,
+  ) {
+    var modelSources = orderedModels
+        .map(
+          (model) => ModelSourceBuilder()
+              .withFileName(model.fileName)
+              .withYaml(model.yaml)
+              .build(),
+        )
+        .toList();
+
+    var collector = CodeGenerationCollector();
+    var analyzer = StatefulAnalyzer(
+      config,
+      modelSources,
+      onErrorsCollector(collector),
+    );
+    var models = analyzer.validateAll();
+
+    expect(
+      collector.errors,
+      isEmpty,
+      reason: 'Expected the models to be analyzed without errors.',
+    );
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var companyFilePath = codeMap.keys
+        .where((filePath) => filePath.endsWith('company.dart'))
+        .firstOrNull;
+
+    expect(
+      companyFilePath,
+      isNotNull,
+      reason: 'Expected the code for the list owner to be generated.',
+    );
+
+    return parseString(content: codeMap[companyFilePath]!).unit;
+  }
+
+  group('Given a named one to many relation with a required foreign key', () {
+    const requiredForeignKeyEmployeeYaml = '''
+        class: Employee
+        table: employee
+        fields:
+          company: Company?, relation(name=company_employees)
+        ''';
+
+    group('when the foreign class is analyzed before the list owner', () {
+      late CompilationUnit compilationUnit;
+
+      setUp(() {
+        compilationUnit = generateCompanyCode([
+          (fileName: 'employee', yaml: requiredForeignKeyEmployeeYaml),
+          (fileName: 'company', yaml: companyYaml),
+        ]);
+      });
+
+      test('then a class named CompanyAttachRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyAttachRepository',
+          ),
+          isTrue,
+          reason: 'Expected the class CompanyAttachRepository to be generated.',
+        );
+      });
+
+      test('then a class named CompanyDetachRepository is NOT generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRepository',
+          ),
+          isFalse,
+          reason:
+              'The class CompanyDetachRepository was found but was expected '
+              'to not exist.',
+        );
+      });
+
+      test('then a class named CompanyDetachRowRepository is NOT generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRowRepository',
+          ),
+          isFalse,
+          reason:
+              'The class CompanyDetachRowRepository was found but was expected '
+              'to not exist.',
+        );
+      });
+    });
+
+    group('when the list owner is analyzed before the foreign class', () {
+      late CompilationUnit compilationUnit;
+
+      setUp(() {
+        compilationUnit = generateCompanyCode([
+          (fileName: 'company', yaml: companyYaml),
+          (fileName: 'employee', yaml: requiredForeignKeyEmployeeYaml),
+        ]);
+      });
+
+      test('then a class named CompanyAttachRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyAttachRepository',
+          ),
+          isTrue,
+          reason: 'Expected the class CompanyAttachRepository to be generated.',
+        );
+      });
+
+      test('then a class named CompanyDetachRepository is NOT generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRepository',
+          ),
+          isFalse,
+          reason:
+              'The class CompanyDetachRepository was found but was expected '
+              'to not exist.',
+        );
+      });
+
+      test('then a class named CompanyDetachRowRepository is NOT generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRowRepository',
+          ),
+          isFalse,
+          reason:
+              'The class CompanyDetachRowRepository was found but was expected '
+              'to not exist.',
+        );
+      });
+    });
+  });
+
+  group('Given a named one to many relation with an optional foreign key', () {
+    const optionalForeignKeyEmployeeYaml = '''
+        class: Employee
+        table: employee
+        fields:
+          company: Company?, relation(name=company_employees, optional)
+        ''';
+
+    group('when the foreign class is analyzed before the list owner', () {
+      late CompilationUnit compilationUnit;
+
+      setUp(() {
+        compilationUnit = generateCompanyCode([
+          (fileName: 'employee', yaml: optionalForeignKeyEmployeeYaml),
+          (fileName: 'company', yaml: companyYaml),
+        ]);
+      });
+
+      test('then a class named CompanyDetachRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRepository',
+          ),
+          isTrue,
+          reason: 'Expected the class CompanyDetachRepository to be generated.',
+        );
+      });
+
+      test('then a class named CompanyDetachRowRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRowRepository',
+          ),
+          isTrue,
+          reason:
+              'Expected the class CompanyDetachRowRepository to be generated.',
+        );
+      });
+    });
+
+    group('when the list owner is analyzed before the foreign class', () {
+      late CompilationUnit compilationUnit;
+
+      setUp(() {
+        compilationUnit = generateCompanyCode([
+          (fileName: 'company', yaml: companyYaml),
+          (fileName: 'employee', yaml: optionalForeignKeyEmployeeYaml),
+        ]);
+      });
+
+      test('then a class named CompanyDetachRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRepository',
+          ),
+          isTrue,
+          reason: 'Expected the class CompanyDetachRepository to be generated.',
+        );
+      });
+
+      test('then a class named CompanyDetachRowRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRowRepository',
+          ),
+          isTrue,
+          reason:
+              'Expected the class CompanyDetachRowRepository to be generated.',
+        );
+      });
+    });
+  });
+}

--- a/tools/serverpod_cli/test/generator/dart/shared_code_generator/database_repository_class_list_relation_additions_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/shared_code_generator/database_repository_class_list_relation_additions_test.dart
@@ -578,4 +578,132 @@ void main() {
       });
     },
   );
+
+  group(
+    'Given a class with table name and explicit non-nullable list relation field, '
+    'when generating code',
+    () {
+      var models = [
+        ModelClassDefinitionBuilder()
+            .withClassName(testClassName)
+            .withFileName(testClassFileName)
+            .withTableName('example_table')
+            .withDatabase(ModelDatabaseDefinition.all)
+            .withSharedPackageName(sharedPackageName)
+            .withListRelationField(
+              'people',
+              'Person',
+              'organizationId',
+              nullableRelation: false,
+            )
+            .build(),
+      ];
+
+      var codeMap = generator.generateSerializableModelsCode(
+        models: models,
+        config: config,
+      );
+
+      var compilationUnit = parseString(
+        content: codeMap[expectedFilePath]!,
+      ).unit;
+
+      var repositoryClass = CompilationUnitHelpers.tryFindClassDeclaration(
+        compilationUnit,
+        name: '${testClassName}Repository',
+      );
+
+      group(
+        'then the class name ${testClassName}Repository',
+        () {
+          test('has a final attach field', () {
+            var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+              repositoryClass!,
+              name: 'attach',
+            );
+
+            expect(
+              field?.toSource(),
+              'final attach = const ${testClassName}AttachRepository._();',
+              reason: 'Missing static instance field.',
+            );
+          });
+
+          test('has NO detachRow field', () {
+            var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+              repositoryClass!,
+              name: 'detachRow',
+            );
+
+            expect(
+              field,
+              isNull,
+              reason:
+                  'The field detachRow was found but was expected to not exist.',
+            );
+          });
+
+          test('has NO detach field', () {
+            var field = CompilationUnitHelpers.tryFindFieldDeclaration(
+              repositoryClass!,
+              name: 'detach',
+            );
+
+            expect(
+              field,
+              isNull,
+              reason:
+                  'The field detach was found but was expected to not exist.',
+            );
+          });
+        },
+        skip: repositoryClass == null,
+      );
+
+      test(
+        'then a class named ${testClassName}AttachRepository is generated',
+        () {
+          expect(
+            CompilationUnitHelpers.hasClassDeclaration(
+              compilationUnit,
+              name: '${testClassName}AttachRepository',
+            ),
+            isTrue,
+            reason:
+                'Expected the class ${testClassName}AttachRepository to be generated.',
+          );
+        },
+      );
+
+      test(
+        'then a class named ${testClassName}DetachRepository is NOT generated',
+        () {
+          expect(
+            CompilationUnitHelpers.hasClassDeclaration(
+              compilationUnit,
+              name: '${testClassName}DetachRepository',
+            ),
+            isFalse,
+            reason:
+                'The class ${testClassName}DetachRepository was found but was expected to not exist.',
+          );
+        },
+      );
+
+      test(
+        'then a class named ${testClassName}DetachRowRepository is NOT generated',
+        () {
+          expect(
+            CompilationUnitHelpers.hasClassDeclaration(
+              compilationUnit,
+              name: '${testClassName}DetachRowRepository',
+            ),
+            isFalse,
+            reason:
+                'The class ${testClassName}DetachRowRepository was found but was expected to not exist.',
+          );
+        },
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/generator/dart/shared_code_generator/database_repository_detach_resolution_order_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/shared_code_generator/database_repository_detach_resolution_order_test.dart
@@ -1,0 +1,266 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/generator/dart/shared_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/builders/generator_config_builder.dart';
+import '../../../test_util/builders/model_source_builder.dart';
+import '../../../test_util/compilation_unit_helpers.dart';
+
+const sharedPackageName = 'shared_pkg';
+const projectName = 'example_project';
+const serverPathParts = ['server_root'];
+final config = GeneratorConfigBuilder()
+    .withName(projectName)
+    .withServerPackageDirectoryPathParts(serverPathParts)
+    .withSharedModelsSourcePathsParts({
+      sharedPackageName: ['packages', 'shared'],
+    })
+    .withModules([])
+    .build();
+const generator = DartSharedCodeGenerator();
+
+/// The generation of `detach`/`detachRow` for named list relations must not
+/// depend on the order in which the model files are analyzed, and must only
+/// happen when the foreign key field is nullable.
+void main() {
+  const companyYaml = '''
+class: Company
+table: company
+database: all
+fields:
+  employees: List<Employee>?, relation(name=company_employees)
+''';
+
+  CompilationUnit generateCompanyCode(
+    List<({String fileName, String yaml})> orderedModels,
+  ) {
+    var modelSources = orderedModels
+        .map(
+          (model) => ModelSourceBuilder()
+              .withIsSharedModel(true)
+              .withModuleAlias(sharedPackageName)
+              .withFileName(model.fileName)
+              .withYaml(model.yaml)
+              .build(),
+        )
+        .toList();
+
+    var collector = CodeGenerationCollector();
+    var analyzer = StatefulAnalyzer(
+      config,
+      modelSources,
+      onErrorsCollector(collector),
+    );
+    var models = analyzer.validateAll();
+
+    expect(
+      collector.errors,
+      isEmpty,
+      reason: 'Expected the models to be analyzed without errors.',
+    );
+
+    var codeMap = generator.generateSerializableModelsCode(
+      models: models,
+      config: config,
+    );
+
+    var companyFilePath = codeMap.keys
+        .where((filePath) => filePath.endsWith('company.dart'))
+        .firstOrNull;
+
+    expect(
+      companyFilePath,
+      isNotNull,
+      reason: 'Expected the code for the list owner to be generated.',
+    );
+
+    return parseString(content: codeMap[companyFilePath]!).unit;
+  }
+
+  group('Given a named one to many relation with a required foreign key', () {
+    const requiredForeignKeyEmployeeYaml = '''
+class: Employee
+table: employee
+database: all
+fields:
+  company: Company?, relation(name=company_employees)
+''';
+
+    group('when the foreign class is analyzed before the list owner', () {
+      late CompilationUnit compilationUnit;
+
+      setUp(() {
+        compilationUnit = generateCompanyCode([
+          (fileName: 'employee', yaml: requiredForeignKeyEmployeeYaml),
+          (fileName: 'company', yaml: companyYaml),
+        ]);
+      });
+
+      test('then a class named CompanyAttachRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyAttachRepository',
+          ),
+          isTrue,
+          reason: 'Expected the class CompanyAttachRepository to be generated.',
+        );
+      });
+
+      test('then a class named CompanyDetachRepository is NOT generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRepository',
+          ),
+          isFalse,
+          reason:
+              'The class CompanyDetachRepository was found but was expected '
+              'to not exist.',
+        );
+      });
+
+      test('then a class named CompanyDetachRowRepository is NOT generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRowRepository',
+          ),
+          isFalse,
+          reason:
+              'The class CompanyDetachRowRepository was found but was expected '
+              'to not exist.',
+        );
+      });
+    });
+
+    group('when the list owner is analyzed before the foreign class', () {
+      late CompilationUnit compilationUnit;
+
+      setUp(() {
+        compilationUnit = generateCompanyCode([
+          (fileName: 'company', yaml: companyYaml),
+          (fileName: 'employee', yaml: requiredForeignKeyEmployeeYaml),
+        ]);
+      });
+
+      test('then a class named CompanyAttachRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyAttachRepository',
+          ),
+          isTrue,
+          reason: 'Expected the class CompanyAttachRepository to be generated.',
+        );
+      });
+
+      test('then a class named CompanyDetachRepository is NOT generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRepository',
+          ),
+          isFalse,
+          reason:
+              'The class CompanyDetachRepository was found but was expected '
+              'to not exist.',
+        );
+      });
+
+      test('then a class named CompanyDetachRowRepository is NOT generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRowRepository',
+          ),
+          isFalse,
+          reason:
+              'The class CompanyDetachRowRepository was found but was expected '
+              'to not exist.',
+        );
+      });
+    });
+  });
+
+  group('Given a named one to many relation with an optional foreign key', () {
+    const optionalForeignKeyEmployeeYaml = '''
+class: Employee
+table: employee
+database: all
+fields:
+  company: Company?, relation(name=company_employees, optional)
+''';
+
+    group('when the foreign class is analyzed before the list owner', () {
+      late CompilationUnit compilationUnit;
+
+      setUp(() {
+        compilationUnit = generateCompanyCode([
+          (fileName: 'employee', yaml: optionalForeignKeyEmployeeYaml),
+          (fileName: 'company', yaml: companyYaml),
+        ]);
+      });
+
+      test('then a class named CompanyDetachRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRepository',
+          ),
+          isTrue,
+          reason: 'Expected the class CompanyDetachRepository to be generated.',
+        );
+      });
+
+      test('then a class named CompanyDetachRowRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRowRepository',
+          ),
+          isTrue,
+          reason:
+              'Expected the class CompanyDetachRowRepository to be generated.',
+        );
+      });
+    });
+
+    group('when the list owner is analyzed before the foreign class', () {
+      late CompilationUnit compilationUnit;
+
+      setUp(() {
+        compilationUnit = generateCompanyCode([
+          (fileName: 'company', yaml: companyYaml),
+          (fileName: 'employee', yaml: optionalForeignKeyEmployeeYaml),
+        ]);
+      });
+
+      test('then a class named CompanyDetachRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRepository',
+          ),
+          isTrue,
+          reason: 'Expected the class CompanyDetachRepository to be generated.',
+        );
+      });
+
+      test('then a class named CompanyDetachRowRepository is generated', () {
+        expect(
+          CompilationUnitHelpers.hasClassDeclaration(
+            compilationUnit,
+            name: 'CompanyDetachRowRepository',
+          ),
+          isTrue,
+          reason:
+              'Expected the class CompanyDetachRowRepository to be generated.',
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
`detach/detachRow` methods were previously conditionally generated depending on the order by which models are analyzed.

- **Child class analyzed first**: its object field's relation has already been resolved into an ObjectRelationDefinition which carries no name so the name-based match finds the injected FK id field instead. Its type nullability correctly reflects the optional keyword for a required FK.

- **Owner analyzed first**: the FK field doesn't exist yet, so the match finds the child's UnresolvedObjectRelationDefinition object field, and nullability is taken from the object field's Dart type, which is essentially always nullable.

The models that had generated `detach/detachRow` methods were silently broken as they called `copyWith` and passed `null` for a non-nullable field which doesn't drop the relation.

The fix is to derive nullability from the foreign key regardless of the order by which models are analyzed.

Fixes #4868 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None