### PR TITLE
fix: Squash the most frequent flaky tests

### DIFF
--- a/packages/serverpod_database/lib/src/adapters/postgres/database_connection.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/database_connection.dart
@@ -866,17 +866,27 @@ class PostgresDatabaseConnection
     );
 
     final connection = await _postgresConnection;
-    return connection.runTx<R>(
-      (ctx) {
-        var transaction = _PostgresTransaction(
-          ctx,
-          session,
-          this,
-        );
-        return transactionFunction(transaction);
-      },
-      settings: pgTransactionSettings,
-    );
+    try {
+      return await connection.runTx<R>(
+        (ctx) {
+          var transaction = _PostgresTransaction(
+            ctx,
+            session,
+            this,
+          );
+          return transactionFunction(transaction);
+        },
+        settings: pgTransactionSettings,
+      );
+    } on pg.ServerException catch (exception, trace) {
+      var serverpodException = _PgDatabaseQueryException.fromServerException(
+        exception,
+      );
+      Error.throwWithStackTrace(serverpodException, trace);
+    } on pg.PgException catch (exception, trace) {
+      var serverpodException = _PgDatabaseQueryException(exception.message);
+      Error.throwWithStackTrace(serverpodException, trace);
+    }
   }
 
   Future<Map<String, Map<Object, List<Map<String, dynamic>>>>>

--- a/tests/serverpod_cli_e2e_test/lib/src/keyword_search_in_stream.dart
+++ b/tests/serverpod_cli_e2e_test/lib/src/keyword_search_in_stream.dart
@@ -31,9 +31,9 @@ class KeywordSearchInStream {
       value = _found;
     }
 
-    _found = null;
-
+    // Coalesce duplicate matches emitted while the stream action settles.
     await Future.delayed(const Duration(milliseconds: 250));
+    _found = null;
     return value;
   }
 

--- a/tests/serverpod_cli_e2e_test/test/keyword_search_in_stream_test.dart
+++ b/tests/serverpod_cli_e2e_test/test/keyword_search_in_stream_test.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+
+import 'package:serverpod_cli_e2e_test/src/keyword_search_in_stream.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'Given a stream search that receives duplicate matches while settling, '
+    'when waiting for the next match, '
+    'then it waits for a new stream event.',
+    () async {
+      final streamSearch = KeywordSearchInStream(
+        keywords: ['complete'],
+        timeout: const Duration(seconds: 2),
+      );
+      addTearDown(streamSearch.cancel);
+
+      streamSearch.onData('complete');
+      final firstMatch = streamSearch.keywordFound;
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      streamSearch.onData('complete');
+      await expectLater(firstMatch, completion(isTrue));
+
+      var nextMatchCompleted = false;
+      final nextMatch = streamSearch.keywordFound.whenComplete(
+        () => nextMatchCompleted = true,
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 350));
+      expect(nextMatchCompleted, isFalse);
+
+      streamSearch.onData('complete');
+      await expectLater(nextMatch, completion(isTrue));
+    },
+  );
+}

--- a/tests/serverpod_test_server/test_integration/future_calls/future_call_claim_test.dart
+++ b/tests/serverpod_test_server/test_integration/future_calls/future_call_claim_test.dart
@@ -21,10 +21,14 @@ class _CounterFutureCall extends FutureCall<SimpleData>
 class _CompleterFutureCall extends FutureCall<SimpleData>
     implements InvokableFutureCall<SimpleData> {
   final Completer<SimpleData?> completer = Completer<SimpleData?>();
+  final Completer<void> invocationStarted = Completer<void>();
   int counter = 0;
 
   @override
   Future<void> invoke(Session session, SimpleData? object) async {
+    if (!invocationStarted.isCompleted) {
+      invocationStarted.complete();
+    }
     await completer.future;
     counter++;
   }
@@ -73,8 +77,7 @@ void main() {
       group('when start is called', () {
         setUp(() async {
           await futureCallManager.start();
-          // Wait for future call execution to be scheduled
-          await Future.delayed(const Duration(milliseconds: 100));
+          await testCall.invocationStarted.future;
         });
 
         tearDown(() async {

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/test/utils/database_path_io.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/test/utils/database_path_io.dart
@@ -10,9 +10,25 @@ Future<String> createTestDatabasePath() async {
 }
 
 /// Removes the temporary directory holding the database at [path].
+///
+/// Retries while Windows releases SQLite handles from stopped worker isolates.
 Future<void> deleteTestDatabase(String path) async {
   var directory = Directory(p.dirname(path));
-  if (directory.existsSync()) {
-    await directory.delete(recursive: true);
+  if (!await directory.exists()) return;
+
+  const maxAttempts = 30;
+  var delay = const Duration(milliseconds: 100);
+  for (var attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      await directory.delete(recursive: true);
+      return;
+    } on PathAccessException {
+      if (attempt == maxAttempts - 1) rethrow;
+      await Future<void>.delayed(delay);
+      delay *= 2;
+      if (delay > const Duration(seconds: 2)) {
+        delay = const Duration(seconds: 2);
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes 4 of the most common flaky tests that we're having after the CI improvements.

### Future-call claim synchronization

The test assumed that a claim existed 100 ms after starting the future-call manager. Since starting the manager only schedules asynchronous scanning, slower CI workers could reach the assertion first. The fixed test waits for the future call to begin invocation, which can only happen after its claim has been inserted.

### PostgreSQL transaction error normalization

Depending on transaction timing, PostgreSQL reported the serialization conflict either during an update or during commit. Update errors passed through the existing query adapter and became `DatabaseQueryException`, while commit errors bypassed that adapter and escaped raw because the transaction boundary performed no error translation. The fix added that translation around `runTx()` (while still preserving SQLSTATE `40001`).

### Windows SQLite cleanup retry

Windows may briefly retain SQLite worker handles after the database session has closed, preventing immediate deletion of the temporary database directory. Cleanup now retries only transient `PathAccessException` failures with bounded backoff and still reports persistent failures.

### Generate-watch completion sequencing

Generate-watch emits an incremental-generation completion followed by a watcher-ready initial-generation completion during startup, and the test treated both as equivalent. Because the stream helper cleared its state before its settling delay, the second marker could remain queued and satisfy the next file-change wait, leaving assertions one generation behind. Clearing the state after the delay coalesces those markers and makes each subsequent wait require a new event.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.