### PR TITLE
feat: Implement device selection for VS Code launch

### DIFF
--- a/templates/serverpod_templates/vscode/tasks.json
+++ b/templates/serverpod_templates/vscode/tasks.json
@@ -8,11 +8,16 @@
       "args": ["start"],
       "options": {
         "cwd": "${workspaceFolder}/projectname_server",
-        // {{#postgres}}
         "env": {
-          "SERVERPOD_PASSWORD_database": "DB_PASSWORD"
+          // {{#postgres}}
+          "SERVERPOD_PASSWORD_database": "DB_PASSWORD",
+          // {{/postgres}}
+          // Marks a `serverpod start` launched from the IDE, which is the
+          // only kind that honors the Flutter device picked in VS Code. A run
+          // started from a plain terminal carries no marker, so a device file
+          // left behind by a session that was killed cannot retarget it.
+          "SERVERPOD_LAUNCHED_FROM_IDE": "true"
         }
-        // {{/postgres}}
       },
       "isBackground": true,
       "presentation": {

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -53,9 +53,14 @@ class FlutterAppManager {
     required this.serverPackageDirectoryPathParts,
     required this.projectName,
     required this.launchFlutterApp,
+    this.environmentOverrideForTesting,
     this.flutterExecutableForTesting,
     this.argsOverrideForTesting,
   });
+
+  /// Test-only override for process environment.
+  /// Decides whether this run was launched by the IDE - see [ideLaunchEnvVar].
+  final Map<String, String>? environmentOverrideForTesting;
 
   /// Test-only override for the `flutter` executable path.
   final String? flutterExecutableForTesting;
@@ -408,12 +413,17 @@ class FlutterAppManager {
   }
 
   /// Closes every proxy and deletes info files.
+  ///
+  /// Only an IDE launch removes the device info; a plain terminal run leaves
+  /// it alone, since it may belong to a pending IDE launch.
   Future<void> dispose() async {
     await stopAll();
     await _runtimes.values.map((runtime) => runtime.proxy.close()).wait;
-    await File(
-      p.join(serverpodToolDir, ideDeviceInfoFile),
-    ).deleteIfExists();
+    if (_isIdeLaunch) {
+      await File(
+        p.join(serverpodToolDir, ideDeviceInfoFile),
+      ).deleteIfExists();
+    }
   }
 
   _AppRuntime? _runtimeFor(String appId) => _runtimes[appId];
@@ -426,22 +436,40 @@ class FlutterAppManager {
   /// [serverpodToolDir].
   ///
   /// Scoped to one session: the extension writes it as it launches, and
-  /// [dispose] removes it when the session ends, so a later `serverpod start`
-  /// from a plain terminal is never silently retargeted by a device
-  /// picked in an IDE.
+  /// [dispose] removes it when the session ends. Only a run carrying
+  /// [ideLaunchEnvVar] reads it, so a `serverpod start` from a plain terminal
+  /// is never silently retargeted by a device picked in an IDE - including
+  /// when a killed session left the file behind.
   static const ideDeviceInfoFile = 'ide-flutter-device.json';
+
+  /// Environment variable the generated VS Code `serverpod_start` task sets
+  /// to mark a run it launched.
+  ///
+  /// Only such a run reads [ideDeviceInfoFile]. A `serverpod start` from a
+  /// plain terminal carries no marker and ignores the file entirely, so one
+  /// left behind by a session that was killed - which never reaches
+  /// [dispose] - can never retarget an unrelated run.
+  static const ideLaunchEnvVar = 'SERVERPOD_LAUNCHED_FROM_IDE';
+
+  /// Whether this process was launched by the IDE.
+  bool get _isIdeLaunch {
+    final env = environmentOverrideForTesting ?? Platform.environment;
+    return bool.tryParse(env[ideLaunchEnvVar] ?? '') ?? false;
+  }
 
   /// The device id selected in the IDE, or null when it does not apply.
   ///
-  /// Only honored when exactly one app is configured - with several apps the
-  /// selection would ambiguously retarget all of them, so each app must pin
-  /// its own `device` in the pubspec instead. An explicit `device` on the
-  /// single app also wins over the IDE device info.
+  /// Only honored on an IDE launch (see [ideLaunchEnvVar]), and only when
+  /// exactly one app is configured - with several apps the selection would
+  /// ambiguously retarget all of them, so each app must pin its own `device`
+  /// in the pubspec instead. An explicit `device` on the single app also wins
+  /// over the IDE device info.
   /// Read fresh on every spawn so a new IDE selection applies to the next
   /// launch without restarting the session, and so a `device` added to the
   /// server pubspec while running takes over through the config reload.
   @visibleForTesting
   String? ideDevice() {
+    if (!_isIdeLaunch) return null;
     if (_apps.length != 1) return null;
     final file = File(p.join(serverpodToolDir, ideDeviceInfoFile));
     try {

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -252,7 +252,8 @@ class FlutterAppManager {
 
     onEnsureAppTab(runtime.app);
 
-    final device = runtime.app.device ?? flutterDeviceWebServerWithBrowser;
+    final device =
+        runtime.app.device ?? ideDevice() ?? flutterDeviceWebServerWithBrowser;
 
     late final FlutterProcess process;
     process = FlutterProcess(
@@ -410,12 +411,48 @@ class FlutterAppManager {
   Future<void> dispose() async {
     await stopAll();
     await _runtimes.values.map((runtime) => runtime.proxy.close()).wait;
+    await File(
+      p.join(serverpodToolDir, ideDeviceInfoFile),
+    ).deleteIfExists();
   }
 
   _AppRuntime? _runtimeFor(String appId) => _runtimes[appId];
 
   String _infoFileFor(String appId) =>
       p.join(serverpodToolDir, 'flutter-vm-service-info-$appId.json');
+
+  /// The file where the serverpod VS Code extension writes the
+  /// IDE-selected Flutter device to, as `{"deviceId": "<id>"}`, inside
+  /// [serverpodToolDir].
+  ///
+  /// Scoped to one session: the extension writes it as it launches, and
+  /// [dispose] removes it when the session ends, so a later `serverpod start`
+  /// from a plain terminal is never silently retargeted by a device
+  /// picked in an IDE.
+  static const ideDeviceInfoFile = 'ide-flutter-device.json';
+
+  /// The device id selected in the IDE, or null when it does not apply.
+  ///
+  /// Only honored when exactly one app is configured - with several apps the
+  /// selection would ambiguously retarget all of them, so each app must pin
+  /// its own `device` in the pubspec instead. An explicit `device` on the
+  /// single app also wins over the IDE device info.
+  /// Read fresh on every spawn so a new IDE selection applies to the next
+  /// launch without restarting the session, and so a `device` added to the
+  /// server pubspec while running takes over through the config reload.
+  @visibleForTesting
+  String? ideDevice() {
+    if (_apps.length != 1) return null;
+    final file = File(p.join(serverpodToolDir, ideDeviceInfoFile));
+    try {
+      final decoded = jsonDecode(file.readAsStringSync());
+      final deviceId = decoded is Map ? decoded['deviceId'] : null;
+      if (deviceId is String && deviceId.isNotEmpty) return deviceId;
+    } catch (_) {
+      // Missing or malformed info file - fall back to the default device.
+    }
+    return null;
+  }
 
   void _setupDependencyTracker(String appId) {
     final runtime = _runtimeFor(appId);

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -147,6 +147,9 @@ class FlutterProcess {
   /// True between [start] and [stop]/exit.
   bool get isRunning => _process != null;
 
+  /// Target device id this process was created for (`flutter run -d`).
+  String get device => _device;
+
   /// True once [connectToVmService] resolved the upstream VM service.
   bool get isVmServiceConnected => _vmService != null;
 

--- a/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
@@ -5,6 +5,8 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/start/flutter_app_manager.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_log_event.dart';
+import 'package:serverpod_cli/src/commands/start/flutter_process.dart'
+    show flutterDeviceWebServerWithBrowser;
 import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
 import 'package:serverpod_cli/src/config/flutter_app_config.dart';
 import 'package:serverpod_shared/log.dart' show LogLevel;
@@ -54,12 +56,13 @@ class _AppSpec {
     this.id, {
     // `web-server` (no browser) so launches never spawn a real browser and
     // the VM-service connect waits without a timeout, as most manager tests
-    // expect. Pass a desktop device (e.g. `linux`) for non-web scenarios.
+    // expect. Pass a desktop device (e.g. `linux`) for non-web scenarios, or
+    // null to omit the `device` line from the app's pubspec entry.
     this.device = 'web-server',
   });
 
   final String id;
-  final String device;
+  final String? device;
 
   /// Directory (and package) name of the fabricated Flutter app.
   String get dirName => '${id.replaceAll('-', '_')}_flutter';
@@ -122,7 +125,9 @@ class _ManagerFixture {
     for (final spec in apps) {
       appEntries.writeln('    ${spec.id}:');
       appEntries.writeln('      path: ../${spec.dirName}');
-      appEntries.writeln('      device: ${spec.device}');
+      if (spec.device != null) {
+        appEntries.writeln('      device: ${spec.device}');
+      }
     }
     final serverPubspecFile = File(p.join(serverDir.path, 'pubspec.yaml'));
     serverPubspecFile.writeAsStringSync('''
@@ -200,6 +205,19 @@ dependencies:
     sdk: flutter
 ''');
     return dir;
+  }
+
+  void writeIdeDeviceInfo(String content) {
+    File(
+        p.join(
+          serverDir.path,
+          '.dart_tool',
+          'serverpod',
+          FlutterAppManager.ideDeviceInfoFile,
+        ),
+      )
+      ..createSync(recursive: true)
+      ..writeAsStringSync(content);
   }
 
   Future<void> dispose() async {
@@ -732,6 +750,154 @@ serverpod:
           expect(f.manager.dependencyTrackerFor('project'), isNotNull);
         },
       );
+    },
+  );
+
+  test(
+    'Given a FlutterAppManager with a single app configured without a device '
+    'and an IDE device info file, '
+    'when the app is launched, '
+    'then the IDE device info drives the spawn device',
+    () async {
+      final f = await _ManagerFixture.create(
+        apps: const [_AppSpec('project', device: null)],
+        shim: 'never_publishes_uri.dart',
+      );
+
+      addTearDown(() => f.dispose());
+
+      f.writeIdeDeviceInfo('{"deviceId": "linux"}');
+
+      expect(f.manager.ideDevice(), 'linux');
+
+      await f.manager.launch('project');
+      expect(f.manager.processFor('project')!.device, 'linux');
+    },
+  );
+
+  test(
+    'Given a FlutterAppManager with a single app configured with a device '
+    'and an IDE device info file, '
+    'when the app is launched, '
+    'then the configured device is used',
+    () async {
+      final f = await _ManagerFixture.create(
+        apps: const [_AppSpec('project', device: 'web-server')],
+        shim: 'never_publishes_uri.dart',
+      );
+
+      addTearDown(() => f.dispose());
+
+      f.writeIdeDeviceInfo('{"deviceId": "linux"}');
+
+      await f.manager.launch('project');
+      expect(f.manager.processFor('project')!.device, 'web-server');
+    },
+  );
+
+  test(
+    'Given a FlutterAppManager with a single app configured without a device '
+    'and an IDE device info file, '
+    'when a device is added to the pubspec while running, '
+    'then it takes over on the next launch',
+    () async {
+      final f = await _ManagerFixture.create(
+        apps: const [_AppSpec('project', device: null)],
+        shim: 'never_publishes_uri.dart',
+      );
+
+      addTearDown(() => f.dispose());
+
+      f.writeIdeDeviceInfo('{"deviceId": "linux"}');
+
+      await f.manager.launch('project');
+      expect(f.manager.processFor('project')!.device, 'linux');
+
+      f.serverPubspecFile.writeAsStringSync('''
+name: project_server
+serverpod:
+  flutter_apps:
+    project:
+      path: ../project_flutter
+      device: web-server
+''');
+      await f.manager.loadApps();
+      await f.manager.stop('project');
+      await f.manager.launch('project');
+
+      expect(f.manager.processFor('project')!.device, 'web-server');
+    },
+  );
+
+  test(
+    'Given a FlutterAppManager with multiple configured apps '
+    'and an IDE device info file, '
+    'when an app is launched, '
+    'then the IDE device info is ignored',
+    () async {
+      final f = await _ManagerFixture.create(
+        apps: const [
+          _AppSpec('web', device: null),
+          _AppSpec('admin', device: null),
+        ],
+        shim: 'never_publishes_uri.dart',
+      );
+
+      addTearDown(() => f.dispose());
+
+      f.writeIdeDeviceInfo('{"deviceId": "linux"}');
+
+      expect(f.manager.ideDevice(), isNull);
+
+      await f.manager.launch('web');
+      expect(
+        f.manager.processFor('web')!.device,
+        flutterDeviceWebServerWithBrowser,
+      );
+    },
+  );
+
+  test(
+    'Given a FlutterAppManager with a malformed IDE device info file, '
+    'when the IDE device is read, '
+    'then it returns null',
+    () async {
+      final f = await _ManagerFixture.create(
+        apps: const [_AppSpec('project', device: null)],
+      );
+
+      addTearDown(() => f.dispose());
+
+      f.writeIdeDeviceInfo('not json');
+
+      expect(f.manager.ideDevice(), isNull);
+    },
+  );
+
+  test(
+    'Given a FlutterAppManager with an IDE device info file, '
+    'when the manager is disposed, '
+    'then the IDE device info file is removed',
+    () async {
+      final f = await _ManagerFixture.create(
+        apps: const [_AppSpec('project', device: null)],
+      );
+
+      f.writeIdeDeviceInfo('{"deviceId": "linux"}');
+      final infoFile = File(
+        p.join(
+          f.serverDir.path,
+          '.dart_tool',
+          'serverpod',
+          FlutterAppManager.ideDeviceInfoFile,
+        ),
+      );
+      expect(infoFile.existsSync(), isTrue);
+
+      await f.manager.dispose();
+
+      expect(infoFile.existsSync(), isFalse);
+      expect(f.manager.ideDevice(), isNull);
     },
   );
 }

--- a/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
@@ -103,6 +103,7 @@ class _ManagerFixture {
     List<String> shimArgs = const [],
     bool fakeVmService = false,
     bool initialize = true,
+    Map<String, String> environment = const {},
     void Function(FlutterAppConfig app, String stage)? onProgress,
     void Function(FlutterAppConfig app, String? url)? onReady,
     void Function(FlutterAppConfig app)? onStop,
@@ -147,6 +148,7 @@ $appEntries''');
     final manager = FlutterAppManager(
       projectName: 'project',
       launchFlutterApp: false,
+      environmentOverrideForTesting: environment,
       serverPubspecFile: serverPubspecFile,
       serverPackageDirectoryPathParts: p.split(serverDir.path),
       serverpodToolDir: p.join(serverDir.path, '.dart_tool', 'serverpod'),
@@ -207,15 +209,18 @@ dependencies:
     return dir;
   }
 
+  /// The IDE device info file the VS Code extension would write.
+  File get ideDeviceInfoFile => File(
+    p.join(
+      serverDir.path,
+      '.dart_tool',
+      'serverpod',
+      FlutterAppManager.ideDeviceInfoFile,
+    ),
+  );
+
   void writeIdeDeviceInfo(String content) {
-    File(
-        p.join(
-          serverDir.path,
-          '.dart_tool',
-          'serverpod',
-          FlutterAppManager.ideDeviceInfoFile,
-        ),
-      )
+    ideDeviceInfoFile
       ..createSync(recursive: true)
       ..writeAsStringSync(content);
   }
@@ -755,6 +760,7 @@ serverpod:
 
   test(
     'Given a FlutterAppManager with a single app configured without a device '
+    'and SERVERPOD_LAUNCHED_FROM_IDE environment variable is enabled, '
     'and an IDE device info file, '
     'when the app is launched, '
     'then the IDE device info drives the spawn device',
@@ -762,6 +768,7 @@ serverpod:
       final f = await _ManagerFixture.create(
         apps: const [_AppSpec('project', device: null)],
         shim: 'never_publishes_uri.dart',
+        environment: const {'SERVERPOD_LAUNCHED_FROM_IDE': 'true'},
       );
 
       addTearDown(() => f.dispose());
@@ -777,6 +784,7 @@ serverpod:
 
   test(
     'Given a FlutterAppManager with a single app configured with a device '
+    'and SERVERPOD_LAUNCHED_FROM_IDE environment variable is enabled, '
     'and an IDE device info file, '
     'when the app is launched, '
     'then the configured device is used',
@@ -784,6 +792,7 @@ serverpod:
       final f = await _ManagerFixture.create(
         apps: const [_AppSpec('project', device: 'web-server')],
         shim: 'never_publishes_uri.dart',
+        environment: const {'SERVERPOD_LAUNCHED_FROM_IDE': 'true'},
       );
 
       addTearDown(() => f.dispose());
@@ -797,6 +806,7 @@ serverpod:
 
   test(
     'Given a FlutterAppManager with a single app configured without a device '
+    'and SERVERPOD_LAUNCHED_FROM_IDE environment variable is enabled, '
     'and an IDE device info file, '
     'when a device is added to the pubspec while running, '
     'then it takes over on the next launch',
@@ -804,6 +814,7 @@ serverpod:
       final f = await _ManagerFixture.create(
         apps: const [_AppSpec('project', device: null)],
         shim: 'never_publishes_uri.dart',
+        environment: const {'SERVERPOD_LAUNCHED_FROM_IDE': 'true'},
       );
 
       addTearDown(() => f.dispose());
@@ -831,6 +842,7 @@ serverpod:
 
   test(
     'Given a FlutterAppManager with multiple configured apps '
+    'and SERVERPOD_LAUNCHED_FROM_IDE environment variable is enabled, '
     'and an IDE device info file, '
     'when an app is launched, '
     'then the IDE device info is ignored',
@@ -841,6 +853,7 @@ serverpod:
           _AppSpec('admin', device: null),
         ],
         shim: 'never_publishes_uri.dart',
+        environment: const {'SERVERPOD_LAUNCHED_FROM_IDE': 'true'},
       );
 
       addTearDown(() => f.dispose());
@@ -859,11 +872,13 @@ serverpod:
 
   test(
     'Given a FlutterAppManager with a malformed IDE device info file, '
+    'and SERVERPOD_LAUNCHED_FROM_IDE environment variable is enabled, '
     'when the IDE device is read, '
     'then it returns null',
     () async {
       final f = await _ManagerFixture.create(
         apps: const [_AppSpec('project', device: null)],
+        environment: const {'SERVERPOD_LAUNCHED_FROM_IDE': 'true'},
       );
 
       addTearDown(() => f.dispose());
@@ -876,11 +891,13 @@ serverpod:
 
   test(
     'Given a FlutterAppManager with an IDE device info file, '
+    'and SERVERPOD_LAUNCHED_FROM_IDE environment variable is enabled, '
     'when the manager is disposed, '
     'then the IDE device info file is removed',
     () async {
       final f = await _ManagerFixture.create(
         apps: const [_AppSpec('project', device: null)],
+        environment: const {'SERVERPOD_LAUNCHED_FROM_IDE': 'true'},
       );
 
       f.writeIdeDeviceInfo('{"deviceId": "linux"}');
@@ -898,6 +915,110 @@ serverpod:
 
       expect(infoFile.existsSync(), isFalse);
       expect(f.manager.ideDevice(), isNull);
+    },
+  );
+
+  test(
+    'Given a FlutterAppManager with an IDE device info file, '
+    'and SERVERPOD_LAUNCHED_FROM_IDE environment variable is disabled, '
+    'when an app is launched, '
+    'then the IDE device info is ignored and the file is left in place',
+    () async {
+      final f = await _ManagerFixture.create(
+        apps: const [_AppSpec('project', device: null)],
+        shim: 'never_publishes_uri.dart',
+        environment: const {'SERVERPOD_LAUNCHED_FROM_IDE': 'false'},
+      );
+
+      addTearDown(() => f.dispose());
+
+      f.writeIdeDeviceInfo('{"deviceId": "linux"}');
+
+      expect(f.manager.ideDevice(), isNull);
+
+      await f.manager.launch('project');
+      expect(
+        f.manager.processFor('project')!.device,
+        flutterDeviceWebServerWithBrowser,
+      );
+      expect(
+        f.ideDeviceInfoFile.existsSync(),
+        isTrue,
+        reason:
+            'a terminal run must not remove a file that may belong to a '
+            'pending IDE launch',
+      );
+    },
+  );
+
+  test(
+    'Given a FlutterAppManager with an IDE device info file, '
+    'and SERVERPOD_LAUNCHED_FROM_IDE environment variable is not set, '
+    'when an app is launched, '
+    'then the IDE device info is ignored and the file is left in place',
+    () async {
+      final f = await _ManagerFixture.create(
+        apps: const [_AppSpec('project', device: null)],
+        shim: 'never_publishes_uri.dart',
+        environment: const {},
+      );
+
+      addTearDown(() => f.dispose());
+
+      f.writeIdeDeviceInfo('{"deviceId": "linux"}');
+
+      expect(f.manager.ideDevice(), isNull);
+
+      await f.manager.launch('project');
+      expect(
+        f.manager.processFor('project')!.device,
+        flutterDeviceWebServerWithBrowser,
+      );
+      expect(
+        f.ideDeviceInfoFile.existsSync(),
+        isTrue,
+        reason:
+            'a terminal run must not remove a file that may belong to a '
+            'pending IDE launch',
+      );
+    },
+  );
+
+  test(
+    'Given a FlutterAppManager with an IDE device info file, '
+    'and SERVERPOD_LAUNCHED_FROM_IDE environment variable is disabled, '
+    'when the manager is disposed, '
+    'then the IDE device info file is left in place',
+    () async {
+      final f = await _ManagerFixture.create(
+        apps: const [_AppSpec('project', device: null)],
+        environment: const {'SERVERPOD_LAUNCHED_FROM_IDE': 'false'},
+      );
+
+      f.writeIdeDeviceInfo('{"deviceId": "linux"}');
+
+      await f.manager.dispose();
+
+      expect(f.ideDeviceInfoFile.existsSync(), isTrue);
+    },
+  );
+
+  test(
+    'Given a FlutterAppManager with an IDE device info file, '
+    'and SERVERPOD_LAUNCHED_FROM_IDE environment variable is not set, '
+    'when the manager is disposed, '
+    'then the IDE device info file is left in place',
+    () async {
+      final f = await _ManagerFixture.create(
+        apps: const [_AppSpec('project', device: null)],
+        environment: const {},
+      );
+
+      f.writeIdeDeviceInfo('{"deviceId": "linux"}');
+
+      await f.manager.dispose();
+
+      expect(f.ideDeviceInfoFile.existsSync(), isTrue);
     },
   );
 }

--- a/tools/serverpod_vscode_extension/package-lock.json
+++ b/tools/serverpod_vscode_extension/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.3.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "vscode-languageclient": "^9.0.1"
+        "vscode-languageclient": "^9.0.1",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/glob": "^9.0.0",
@@ -7829,6 +7830,21 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -18,7 +18,9 @@
   ],
   "activationEvents": [
     "onLanguage:yaml",
-    "onLanguage:serverpod"
+    "onLanguage:serverpod",
+    "onDebugResolve:dart",
+    "activationEvents:serverpod"
   ],
   "pricing": "Free",
   "homepage": "https://serverpod.dev",
@@ -73,7 +75,8 @@
     "build": "vsce package"
   },
   "dependencies": {
-    "vscode-languageclient": "^9.0.1"
+    "vscode-languageclient": "^9.0.1",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/glob": "^9.0.0",

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -19,8 +19,7 @@
   "activationEvents": [
     "onLanguage:yaml",
     "onLanguage:serverpod",
-    "onDebugResolve:dart",
-    "activationEvents:serverpod"
+    "onDebugResolve:dart"
   ],
   "pricing": "Free",
   "homepage": "https://serverpod.dev",

--- a/tools/serverpod_vscode_extension/src/extension.ts
+++ b/tools/serverpod_vscode_extension/src/extension.ts
@@ -1,5 +1,5 @@
 
-import { ExtensionContext, window } from 'vscode';
+import { debug, ExtensionContext, window } from 'vscode';
 import {
 	LanguageClient,
 	LanguageClientOptions,
@@ -9,10 +9,23 @@ import {
 } from 'vscode-languageclient/node';
 import { execSync } from 'child_process';
 import { satisfies, coerce } from 'semver';
+import { resolveServerpodFlutterAttach } from './flutter_device_selection';
 
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
+	// Device selection for `serverpod start` companion-app attach sessions.
+	// Registered before the CLI version gate so debugging still works when
+	// the language server cannot start. Uses the pre-substitution hook so the
+	// selected device lands on the config before Dart-Code injects its own in
+	// resolveDebugConfigurationWithSubstitutedVariables.
+	context.subscriptions.push(
+		debug.registerDebugConfigurationProvider('dart', {
+			resolveDebugConfiguration: (folder, config) =>
+				resolveServerpodFlutterAttach(config, folder?.uri.fsPath),
+		})
+	);
+
 	let output;
 	try {
 		output = execSync('serverpod version');

--- a/tools/serverpod_vscode_extension/src/flutter_device_selection.ts
+++ b/tools/serverpod_vscode_extension/src/flutter_device_selection.ts
@@ -1,0 +1,267 @@
+import { commands, DebugConfiguration } from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { parse as parseYaml } from 'yaml';
+
+/// File the IDE-selected Flutter device is handed to `serverpod start` in,
+/// inside the server's `.dart_tool/serverpod/` directory.
+///
+/// Scoped to one session: written as VS Code launches, and removed by the CLI
+/// when the session ends, so a later `serverpod start` from a plain terminal
+/// is never silently retargeted by a device picked in an IDE.
+export const ideDeviceInfoFile = 'ide-flutter-device.json';
+
+const flutterAppInfoFilePattern =
+	/[\\/]\.dart_tool[\\/]serverpod[\\/]flutter-vm-service-info-.+\.json$/;
+const serverInfoFilePattern =
+	/[\\/]\.dart_tool[\\/]serverpod[\\/]vm-service-info\.json$/;
+
+/// A launch configuration that causes `serverpod start` to run.
+export interface ServerpodAttachTarget {
+	/// The server package directory owning `.dart_tool/serverpod/`.
+	serverDir: string;
+	/// True for the companion Flutter app attach, false for the server attach.
+	isFlutterApp: boolean;
+}
+
+/// Substitutes `${workspaceFolder}` in [value] with [workspaceFolderPath].
+///
+/// This runs in `resolveDebugConfiguration` - before VS Code's own variable
+/// substitution - so the launch.json template's
+/// `${workspaceFolder}/..._server/...` path must be expanded by hand. Returns
+/// undefined for non-strings or when other, unsupported variables remain.
+export function substituteWorkspaceFolder(
+	value: unknown,
+	workspaceFolderPath: string | undefined,
+): string | undefined {
+	if (typeof value !== 'string') { return undefined; }
+	let result = value;
+	if (result.includes('${workspaceFolder}')) {
+		if (workspaceFolderPath === undefined) { return undefined; }
+		result = result.split('${workspaceFolder}').join(workspaceFolderPath);
+	}
+	return result.includes('${') ? undefined : result;
+}
+
+/// Classifies [vmServiceInfoFile] as one of the two serverpod attach
+/// configurations, or undefined when it is neither.
+///
+/// Both matter here because both carry the `serverpod_start` preLaunchTask:
+/// the generated `<project> (full stack)` compound launches the server config
+/// first, so leaving it unhooked would let `serverpod start` spawn the app
+/// while the device menu is still open.
+export function serverpodAttachTarget(
+	vmServiceInfoFile: unknown,
+): ServerpodAttachTarget | undefined {
+	if (typeof vmServiceInfoFile !== 'string') { return undefined; }
+	// <serverDir>/.dart_tool/serverpod/<info file>
+	const serverDir = path.dirname(
+		path.dirname(path.dirname(vmServiceInfoFile)),
+	);
+	if (flutterAppInfoFilePattern.test(vmServiceInfoFile)) {
+		return { serverDir, isFlutterApp: true };
+	}
+	if (serverInfoFilePattern.test(vmServiceInfoFile)) {
+		return { serverDir, isFlutterApp: false };
+	}
+	return undefined;
+}
+
+/// Whether the server at [serverDir] is eligible for IDE device selection:
+/// exactly one companion Flutter app is configured and it has no explicit
+/// `device:` line. When the pubspec has no `serverpod: flutter_apps:` section
+/// the CLI synthesizes the default sibling `../<project>_flutter` app, which
+/// counts as the one (device-less) app when its package exists.
+export function isEligibleForDeviceSelection(
+	pubspecContent: string,
+	serverDir: string,
+): boolean {
+	let pubspec: unknown;
+	try {
+		pubspec = parseYaml(pubspecContent);
+	} catch {
+		return false;
+	}
+	if (typeof pubspec !== 'object' || pubspec === null) { return false; }
+
+	const serverpodSection = (pubspec as Record<string, unknown>).serverpod;
+	const flutterApps =
+		typeof serverpodSection === 'object' && serverpodSection !== null
+			? (serverpodSection as Record<string, unknown>).flutter_apps
+			: undefined;
+
+	if (flutterApps === undefined || flutterApps === null) {
+		// Synthesized default app: `../<project>_flutter` next to the server
+		// package, where the server package is named `<project>_server`.
+		const serverName = (pubspec as Record<string, unknown>).name;
+		if (typeof serverName !== 'string' || !serverName.endsWith('_server')) {
+			return false;
+		}
+		const projectName = serverName.slice(0, -'_server'.length);
+		const flutterPubspec = path.join(
+			serverDir,
+			'..',
+			`${projectName}_flutter`,
+			'pubspec.yaml',
+		);
+		return fs.existsSync(flutterPubspec);
+	}
+
+	if (typeof flutterApps !== 'object') { return false; }
+	const entries = Object.values(flutterApps as Record<string, unknown>);
+	if (entries.length !== 1) { return false; }
+
+	const app = entries[0];
+	if (typeof app !== 'object' || app === null) { return false; }
+	return (app as Record<string, unknown>).device === undefined;
+}
+
+/// Path of the session device-info file for the server package at [serverDir].
+export function deviceInfoFilePath(serverDir: string): string {
+	return path.join(serverDir, '.dart_tool', 'serverpod', ideDeviceInfoFile);
+}
+
+/// Removes [infoFile] so `serverpod start` uses its own default device.
+export function clearDeviceInfo(infoFile: string): void {
+	try {
+		fs.rmSync(infoFile, { force: true });
+	} catch {
+		// Best-effort; the CLI also removes the file when the session ends.
+	}
+}
+
+function writeDeviceInfo(infoFile: string, deviceId: string): void {
+	try {
+		fs.mkdirSync(path.dirname(infoFile), { recursive: true });
+		fs.writeFileSync(infoFile, JSON.stringify({ deviceId }));
+	} catch {
+		// Best-effort: without the info serverpod falls back to its default
+		// device and the user is prompted again next time.
+	}
+}
+
+/// Outcome of resolving which device the companion app should run on.
+type DeviceSelection =
+	| { kind: 'selected'; deviceId: string }
+	/// The device menu was dismissed; the launch should be aborted.
+	| { kind: 'cancelled' }
+	/// No device could be determined (Dart-Code absent); launch without info.
+	| { kind: 'unavailable' };
+
+/// In-flight selections keyed by server directory, so the two configurations
+/// of the `<project> (full stack)` compound share one device menu instead of
+/// each opening their own.
+const inFlightSelections = new Map<string, Promise<DeviceSelection>>();
+
+async function selectDeviceForServer(
+	serverDir: string,
+): Promise<DeviceSelection> {
+	const infoFile = deviceInfoFilePath(serverDir);
+
+	// Dart-Code's status-bar selection is the source of truth: it always names
+	// a device that currently exists (Dart-Code re-picks when one disappears),
+	// so there is nothing to validate and no prompt to show.
+	let current: unknown;
+	try {
+		current = await commands.executeCommand('flutter.getSelectedDeviceId');
+	} catch {
+		// Dart-Code is not installed or not active; don't block the attach, and
+		// drop any info a previous session left behind.
+		clearDeviceInfo(infoFile);
+		return { kind: 'unavailable' };
+	}
+
+	if (typeof current === 'string' && current.length > 0) {
+		writeDeviceInfo(infoFile, current);
+		return { kind: 'selected', deviceId: current };
+	}
+
+	// No device is selected (none connected, or none supported yet) - ask.
+	let picked: unknown;
+	try {
+		picked = await commands.executeCommand('flutter.selectDevice');
+	} catch {
+		clearDeviceInfo(infoFile);
+		return { kind: 'unavailable' };
+	}
+	const deviceId =
+		typeof picked === 'object' && picked !== null
+			? (picked as Record<string, unknown>).id
+			: undefined;
+	if (typeof deviceId !== 'string' || deviceId.length === 0) {
+		clearDeviceInfo(infoFile);
+		return { kind: 'cancelled' };
+	}
+
+	writeDeviceInfo(infoFile, deviceId);
+	return { kind: 'selected', deviceId };
+}
+
+function selectDeviceOnce(serverDir: string): Promise<DeviceSelection> {
+	const existing = inFlightSelections.get(serverDir);
+	if (existing !== undefined) { return existing; }
+
+	const pending = selectDeviceForServer(serverDir).finally(() => {
+		inFlightSelections.delete(serverDir);
+	});
+	inFlightSelections.set(serverDir, pending);
+	return pending;
+}
+
+/// Hooks the launch of a serverpod attach configuration: when the project is
+/// eligible (one companion app, no pinned device), hands the device currently
+/// selected in VS Code to `serverpod start`, prompting with Dart-Code's device
+/// menu only when nothing is selected.
+///
+/// Meant for `resolveDebugConfiguration`, which VS Code awaits before running
+/// the `serverpod_start` preLaunchTask - that ordering is what lets the device
+/// reach the info file before the app is spawned. It also runs before every
+/// provider's substituted-variables hook, where Dart-Code injects its own
+/// current device as `deviceId`, so setting ours first keeps VS Code's
+/// `flutter attach` on the same device serverpod spawns, and a `deviceId`
+/// already present here is genuinely user-authored.
+///
+/// Returns the configuration, or undefined to abort the session when the
+/// device menu is dismissed.
+export async function resolveServerpodFlutterAttach(
+	config: DebugConfiguration,
+	workspaceFolderPath?: string,
+): Promise<DebugConfiguration | undefined> {
+	if (config.type !== 'dart' || config.request !== 'attach') { return config; }
+	const infoFile = substituteWorkspaceFolder(
+		config.vmServiceInfoFile,
+		workspaceFolderPath,
+	);
+	const target = serverpodAttachTarget(infoFile);
+	if (target === undefined) { return config; }
+	// An explicit deviceId in launch.json is a pin, like `device:` in the
+	// pubspec - don't second-guess it.
+	if (target.isFlutterApp && config.deviceId !== undefined) { return config; }
+
+	let pubspecContent: string;
+	try {
+		pubspecContent = fs.readFileSync(
+			path.join(target.serverDir, 'pubspec.yaml'),
+			'utf8',
+		);
+	} catch {
+		return config;
+	}
+	if (!isEligibleForDeviceSelection(pubspecContent, target.serverDir)) {
+		return config;
+	}
+
+	const selection = await selectDeviceOnce(target.serverDir);
+	switch (selection.kind) {
+		case 'cancelled':
+			return undefined;
+		case 'unavailable':
+			return config;
+		case 'selected':
+			// Only the Flutter attach takes a deviceId; the server session just
+			// needed to wait so its preLaunchTask starts after the choice.
+			return target.isFlutterApp
+				? { ...config, deviceId: selection.deviceId }
+				: config;
+	}
+}

--- a/tools/serverpod_vscode_extension/src/test/flutter_device_selection.test.ts
+++ b/tools/serverpod_vscode_extension/src/test/flutter_device_selection.test.ts
@@ -1,0 +1,381 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as sinon from 'sinon';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    clearDeviceInfo,
+    deviceInfoFilePath,
+    isEligibleForDeviceSelection,
+    resolveServerpodFlutterAttach,
+    serverpodAttachTarget,
+    substituteWorkspaceFolder,
+} from '../flutter_device_selection';
+
+/** Creates a temp server package dir with the given pubspec content. */
+function createServerDir(pubspec: string): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'serverpod_ext_test_'));
+    const serverDir = path.join(root, 'project_server');
+    fs.mkdirSync(serverDir, { recursive: true });
+    fs.writeFileSync(path.join(serverDir, 'pubspec.yaml'), pubspec);
+    return serverDir;
+}
+
+function attachConfig(serverDir: string): vscode.DebugConfiguration {
+    return {
+        name: 'project_flutter',
+        type: 'dart',
+        request: 'attach',
+        vmServiceInfoFile: path.join(
+            serverDir,
+            '.dart_tool',
+            'serverpod',
+            'flutter-vm-service-info-project.json',
+        ),
+    };
+}
+
+/** The generated `<project>_server` attach config, which shares the
+ * `serverpod_start` preLaunchTask with the Flutter one. */
+function serverAttachConfig(serverDir: string): vscode.DebugConfiguration {
+    return {
+        name: 'project_server',
+        type: 'dart',
+        request: 'attach',
+        vmServiceInfoFile: path.join(
+            serverDir,
+            '.dart_tool',
+            'serverpod',
+            'vm-service-info.json',
+        ),
+    };
+}
+
+/** Seeds a device-info file, as a crashed previous session would leave behind. */
+function writeDeviceInfo(serverDir: string, deviceId: string): string {
+    const infoFile = deviceInfoFilePath(serverDir);
+    fs.mkdirSync(path.dirname(infoFile), { recursive: true });
+    fs.writeFileSync(infoFile, JSON.stringify({ deviceId }));
+    return infoFile;
+}
+
+/** The device id currently handed to `serverpod start`, if any. */
+function readDeviceInfo(serverDir: string): string | undefined {
+    try {
+        return JSON.parse(
+            fs.readFileSync(deviceInfoFilePath(serverDir), 'utf8'),
+        ).deviceId;
+    } catch {
+        return undefined;
+    }
+}
+
+const singleAppNoDevice = `
+name: project_server
+serverpod:
+  flutter_apps:
+    project:
+      path: ../project_flutter
+`;
+
+suite('Flutter device selection', () => {
+    teardown(() => {
+        sinon.restore();
+    });
+
+    suite('serverpodAttachTarget', () => {
+        test('Given a per-app info file then it is the Flutter app target.', () => {
+            const p = ['', 'w', 'proj_server', '.dart_tool', 'serverpod', 'flutter-vm-service-info-app.json'].join(path.sep);
+            assert.deepStrictEqual(serverpodAttachTarget(p), {
+                serverDir: ['', 'w', 'proj_server'].join(path.sep),
+                isFlutterApp: true,
+            });
+        });
+
+        test('Given the server info file then it is the server target.', () => {
+            const p = ['', 'w', 'proj_server', '.dart_tool', 'serverpod', 'vm-service-info.json'].join(path.sep);
+            assert.deepStrictEqual(serverpodAttachTarget(p), {
+                serverDir: ['', 'w', 'proj_server'].join(path.sep),
+                isFlutterApp: false,
+            });
+        });
+
+        test('Given an unrelated path then there is no target.', () => {
+            assert.strictEqual(serverpodAttachTarget('/tmp/other/file.json'), undefined);
+        });
+
+        test('Given a non-string then there is no target.', () => {
+            assert.strictEqual(serverpodAttachTarget(undefined), undefined);
+        });
+    });
+
+    suite('isEligibleForDeviceSelection', () => {
+        test('Given one app without a device line then it is eligible.', () => {
+            assert.strictEqual(
+                isEligibleForDeviceSelection(singleAppNoDevice, '/tmp/none'),
+                true,
+            );
+        });
+
+        test('Given one app with a device line then it is not eligible.', () => {
+            const pubspec = `
+name: project_server
+serverpod:
+  flutter_apps:
+    project:
+      path: ../project_flutter
+      device: chrome
+`;
+            assert.strictEqual(isEligibleForDeviceSelection(pubspec, '/tmp/none'), false);
+        });
+
+        test('Given two apps then it is not eligible.', () => {
+            const pubspec = `
+name: project_server
+serverpod:
+  flutter_apps:
+    web:
+      path: ../web_flutter
+    admin:
+      path: ../admin_flutter
+`;
+            assert.strictEqual(isEligibleForDeviceSelection(pubspec, '/tmp/none'), false);
+        });
+
+        test('Given no flutter_apps section and an existing sibling flutter package then the synthesized app is eligible.', () => {
+            const serverDir = createServerDir('name: project_server\n');
+            const flutterDir = path.join(serverDir, '..', 'project_flutter');
+            fs.mkdirSync(flutterDir, { recursive: true });
+            fs.writeFileSync(path.join(flutterDir, 'pubspec.yaml'), 'name: project_flutter\n');
+
+            assert.strictEqual(
+                isEligibleForDeviceSelection('name: project_server\n', serverDir),
+                true,
+            );
+        });
+
+        test('Given no flutter_apps section and no sibling flutter package then it is not eligible.', () => {
+            const serverDir = createServerDir('name: project_server\n');
+            assert.strictEqual(
+                isEligibleForDeviceSelection('name: project_server\n', serverDir),
+                false,
+            );
+        });
+    });
+
+    suite('substituteWorkspaceFolder', () => {
+        test('Given a workspaceFolder variable then it is expanded.', () => {
+            assert.strictEqual(
+                substituteWorkspaceFolder('${workspaceFolder}/a/b.json', '/work/proj'),
+                '/work/proj/a/b.json',
+            );
+        });
+
+        test('Given a workspaceFolder variable without a folder then it fails.', () => {
+            assert.strictEqual(
+                substituteWorkspaceFolder('${workspaceFolder}/a.json', undefined),
+                undefined,
+            );
+        });
+
+        test('Given other variables then it fails rather than mis-resolve.', () => {
+            assert.strictEqual(
+                substituteWorkspaceFolder('${userHome}/a.json', '/work/proj'),
+                undefined,
+            );
+        });
+
+        test('Given a plain path then it is returned as-is.', () => {
+            assert.strictEqual(substituteWorkspaceFolder('/a/b.json', undefined), '/a/b.json');
+        });
+    });
+
+    suite('clearDeviceInfo', () => {
+        test('Given an existing info file then it is removed.', () => {
+            const serverDir = createServerDir(singleAppNoDevice);
+            const infoFile = writeDeviceInfo(serverDir, 'macos');
+
+            clearDeviceInfo(infoFile);
+
+            assert.strictEqual(fs.existsSync(infoFile), false);
+        });
+
+        test('Given a missing info file then it does not throw.', () => {
+            clearDeviceInfo(path.join(os.tmpdir(), 'no-such-serverpod-device-info.json'));
+        });
+    });
+
+    suite('resolveServerpodFlutterAttach', () => {
+        test('Given a non-serverpod attach config then it is passed through untouched.', async () => {
+            const config: vscode.DebugConfiguration = {
+                name: 'other',
+                type: 'dart',
+                request: 'attach',
+                vmServiceInfoFile: '/tmp/some/other/file.json',
+            };
+            const resolved = await resolveServerpodFlutterAttach(config);
+            assert.strictEqual(resolved, config);
+        });
+
+        test('Given a config with a user-pinned deviceId then no device is written.', async () => {
+            const serverDir = createServerDir(singleAppNoDevice);
+            const executeCommand = sinon.stub(vscode.commands, 'executeCommand');
+
+            const config = { ...attachConfig(serverDir), deviceId: 'chrome' };
+            const resolved = await resolveServerpodFlutterAttach(config);
+
+            assert.strictEqual(resolved, config);
+            assert.strictEqual(executeCommand.called, false);
+            assert.strictEqual(readDeviceInfo(serverDir), undefined);
+        });
+
+        test('Given a project with pinned device then no device is written.', async () => {
+            const serverDir = createServerDir(`
+name: project_server
+serverpod:
+  flutter_apps:
+    project:
+      path: ../project_flutter
+      device: chrome
+`);
+            const executeCommand = sinon.stub(vscode.commands, 'executeCommand');
+
+            const config = attachConfig(serverDir);
+            const resolved = await resolveServerpodFlutterAttach(config);
+
+            assert.strictEqual(resolved, config);
+            assert.strictEqual(executeCommand.called, false);
+            assert.strictEqual(readDeviceInfo(serverDir), undefined);
+        });
+
+        test('Given a device is already selected in VS Code then it is used without a menu.', async () => {
+            const serverDir = createServerDir(singleAppNoDevice);
+            const executeCommand = sinon.stub(vscode.commands, 'executeCommand');
+            executeCommand.withArgs('flutter.getSelectedDeviceId').resolves('macos');
+
+            const resolved = await resolveServerpodFlutterAttach(attachConfig(serverDir));
+
+            assert.strictEqual(resolved?.deviceId, 'macos');
+            assert.strictEqual(readDeviceInfo(serverDir), 'macos');
+            assert.strictEqual(executeCommand.calledWith('flutter.selectDevice'), false);
+        });
+
+        test('Given device info left by a crashed session then the current selection replaces it.', async () => {
+            const serverDir = createServerDir(singleAppNoDevice);
+            writeDeviceInfo(serverDir, 'ghost-device');
+            const executeCommand = sinon.stub(vscode.commands, 'executeCommand');
+            executeCommand.withArgs('flutter.getSelectedDeviceId').resolves('macos');
+
+            const resolved = await resolveServerpodFlutterAttach(attachConfig(serverDir));
+
+            assert.strictEqual(resolved?.deviceId, 'macos');
+            assert.strictEqual(readDeviceInfo(serverDir), 'macos');
+        });
+
+        test('Given no device is selected then the menu is shown and its result is written.', async () => {
+            const serverDir = createServerDir(singleAppNoDevice);
+            const executeCommand = sinon.stub(vscode.commands, 'executeCommand');
+            executeCommand.withArgs('flutter.getSelectedDeviceId').resolves(undefined);
+            executeCommand.withArgs('flutter.selectDevice').resolves({ id: 'macos' });
+
+            const resolved = await resolveServerpodFlutterAttach(attachConfig(serverDir));
+
+            assert.strictEqual(executeCommand.calledWith('flutter.selectDevice'), true);
+            assert.strictEqual(resolved?.deviceId, 'macos');
+            assert.strictEqual(readDeviceInfo(serverDir), 'macos');
+        });
+
+        test('Given the menu is dismissed then the attach is aborted and no device is left behind.', async () => {
+            const serverDir = createServerDir(singleAppNoDevice);
+            writeDeviceInfo(serverDir, 'ghost-device');
+            const executeCommand = sinon.stub(vscode.commands, 'executeCommand');
+            executeCommand.withArgs('flutter.getSelectedDeviceId').resolves(undefined);
+            executeCommand.withArgs('flutter.selectDevice').resolves(undefined);
+
+            const resolved = await resolveServerpodFlutterAttach(attachConfig(serverDir));
+
+            assert.strictEqual(resolved, undefined);
+            assert.strictEqual(readDeviceInfo(serverDir), undefined);
+        });
+
+        test('Given Dart-Code is unavailable then the attach proceeds and any stale device info is dropped.', async () => {
+            const serverDir = createServerDir(singleAppNoDevice);
+            writeDeviceInfo(serverDir, 'ghost-device');
+            const executeCommand = sinon.stub(vscode.commands, 'executeCommand');
+            executeCommand
+                .withArgs('flutter.getSelectedDeviceId')
+                .rejects(new Error('command not found'));
+
+            const config = attachConfig(serverDir);
+            const resolved = await resolveServerpodFlutterAttach(config);
+
+            assert.strictEqual(resolved, config);
+            assert.strictEqual(readDeviceInfo(serverDir), undefined);
+        });
+
+        test('Given a workspaceFolder-relative info file then it is resolved against the folder.', async () => {
+            const serverDir = createServerDir(singleAppNoDevice);
+            const workspaceFolder = path.dirname(serverDir);
+            const executeCommand = sinon.stub(vscode.commands, 'executeCommand');
+            executeCommand.withArgs('flutter.getSelectedDeviceId').resolves('macos');
+
+            const config: vscode.DebugConfiguration = {
+                name: 'project_flutter',
+                type: 'dart',
+                request: 'attach',
+                vmServiceInfoFile:
+                    '${workspaceFolder}/project_server/.dart_tool/serverpod/flutter-vm-service-info-project.json',
+            };
+            const resolved = await resolveServerpodFlutterAttach(config, workspaceFolder);
+
+            assert.strictEqual(resolved?.deviceId, 'macos');
+        });
+
+        test('Given the server attach config then it also writes the device and waits.', async () => {
+            const serverDir = createServerDir(singleAppNoDevice);
+            const executeCommand = sinon.stub(vscode.commands, 'executeCommand');
+            executeCommand.withArgs('flutter.getSelectedDeviceId').resolves('macos');
+
+            const resolved = await resolveServerpodFlutterAttach(serverAttachConfig(serverDir));
+
+            assert.strictEqual(readDeviceInfo(serverDir), 'macos');
+            // The server session is not a Flutter one; it only had to wait.
+            assert.strictEqual(resolved?.deviceId, undefined);
+        });
+
+        test('Given a dismissed menu on the server attach config then the launch is aborted.', async () => {
+            const serverDir = createServerDir(singleAppNoDevice);
+            const executeCommand = sinon.stub(vscode.commands, 'executeCommand');
+            executeCommand.withArgs('flutter.getSelectedDeviceId').resolves(undefined);
+            executeCommand.withArgs('flutter.selectDevice').resolves(undefined);
+
+            const resolved = await resolveServerpodFlutterAttach(serverAttachConfig(serverDir));
+
+            assert.strictEqual(resolved, undefined);
+        });
+
+        test('Given both compound configs resolving together then only one device menu is shown.', async () => {
+            const serverDir = createServerDir(singleAppNoDevice);
+            const executeCommand = sinon.stub(vscode.commands, 'executeCommand');
+            executeCommand.withArgs('flutter.getSelectedDeviceId').resolves(undefined);
+            let menuCalls = 0;
+            executeCommand.withArgs('flutter.selectDevice').callsFake(async () => {
+                menuCalls++;
+                // Hold the menu open so the sibling config resolves meanwhile.
+                await new Promise((r) => setTimeout(r, 20));
+                return { id: 'macos' };
+            });
+
+            const [server, flutter] = await Promise.all([
+                resolveServerpodFlutterAttach(serverAttachConfig(serverDir)),
+                resolveServerpodFlutterAttach(attachConfig(serverDir)),
+            ]);
+
+            assert.strictEqual(menuCalls, 1, 'the compound must share one menu');
+            assert.strictEqual(flutter?.deviceId, 'macos');
+            assert.strictEqual(server?.deviceId, undefined);
+            assert.strictEqual(readDeviceInfo(serverDir), 'macos');
+        });
+    });
+});


### PR DESCRIPTION
After the changes to the VS Code launch configurations to attach instead of launch and with the introduction of multiple flutter app support to `serverpod start`, there's been no way for users to pick a device when running from VS Code with F5. The device selection is driven by configuration in the server pubspec and defaults to web-server when not set.

One downside of this default device is that it doesn't support debugging out of the box.

This PR brings back device selection when running from VS Code to retain the IDE's UX and also run on a debuggable target. Device selection prompt is only shown when there is one app configured. This also covers when no app is configured in the server's pubspec but one is synthesized. If a device has already been selected in the IDE, the prompt is not shown again for subsequent launches.

The prompt will not appear when running projects with multiple flutter apps configured. Those still require manual configuration in pubspec for the target devices. 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None