### PR TITLE
refactor: Remove AuthenticationKeyManager client parameter

### DIFF
--- a/examples/auth/auth_client/lib/src/protocol/client.dart
+++ b/examples/auth/auth_client/lib/src/protocol/client.dart
@@ -572,10 +572,6 @@ class Client extends _i2.ServerpodClientShared {
   Client(
     String host, {
     dynamic securityContext,
-    @Deprecated(
-      'Use authKeyProvider instead. This will be removed in future releases.',
-    )
-    super.authenticationKeyManager,
     Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
     Function(

--- a/examples/legacy/auth_example/auth_example_client/lib/src/protocol/client.dart
+++ b/examples/legacy/auth_example/auth_example_client/lib/src/protocol/client.dart
@@ -42,10 +42,6 @@ class Client extends _i1.ServerpodClientShared {
   Client(
     String host, {
     dynamic securityContext,
-    @Deprecated(
-      'Use authKeyProvider instead. This will be removed in future releases.',
-    )
-    super.authenticationKeyManager,
     Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
     Function(

--- a/examples/legacy/auth_example/auth_example_flutter/lib/src/serverpod_client.dart
+++ b/examples/legacy/auth_example/auth_example_flutter/lib/src/serverpod_client.dart
@@ -11,11 +11,9 @@ Future<void> initializeServerpodClient() async {
   // The client is set up to connect to a Serverpod running on a local server on
   // the default port. You will need to modify this to connect to staging or
   // production servers.
-  client = Client(
-    'http://localhost:8080/',
-    // ignore: deprecated_member_use
-    authenticationKeyManager: FlutterAuthenticationKeyManager(),
-  )..connectivityMonitor = FlutterConnectivityMonitor();
+  client = Client('http://localhost:8080/')
+    ..authKeyProvider = FlutterAuthenticationKeyManager()
+    ..connectivityMonitor = FlutterConnectivityMonitor();
 
   // The session manager keeps track of the signed-in state of the user. You
   // can query it to see if the user is currently signed in and get information

--- a/examples/middleware/middleware_client/lib/src/protocol/client.dart
+++ b/examples/middleware/middleware_client/lib/src/protocol/client.dart
@@ -38,10 +38,6 @@ class Client extends _i1.ServerpodClientShared {
   Client(
     String host, {
     dynamic securityContext,
-    @Deprecated(
-      'Use authKeyProvider instead. This will be removed in future releases.',
-    )
-    super.authenticationKeyManager,
     Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
     Function(

--- a/modules/legacy/serverpod_auth/serverpod_auth_shared_flutter/lib/src/session_manager.dart
+++ b/modules/legacy/serverpod_auth/serverpod_auth_shared_flutter/lib/src/session_manager.dart
@@ -32,15 +32,12 @@ class SessionManager with ChangeNotifier {
     Storage? storage,
   }) : _storage = storage ?? SharedPreferenceStorage() {
     _instance = this;
+    final authKeyProvider = caller.client.authKeyProvider;
     assert(
-      // ignore: deprecated_member_use
-      caller.client.authenticationKeyManager != null,
-      'The client needs an associated key manager',
+      authKeyProvider is FlutterAuthenticationKeyManager,
+      'The client needs a FlutterAuthenticationKeyManager auth key provider',
     );
-    keyManager =
-        // ignore: deprecated_member_use
-        caller.client.authenticationKeyManager!
-            as FlutterAuthenticationKeyManager;
+    keyManager = authKeyProvider as FlutterAuthenticationKeyManager;
   }
 
   /// Returns a singleton instance of the session manager

--- a/packages/serverpod_client/lib/src/serverpod_client_shared.dart
+++ b/packages/serverpod_client/lib/src/serverpod_client_shared.dart
@@ -93,20 +93,6 @@ abstract class ServerpodClientShared extends EndpointCaller {
   /// The [SerializationManager] used to serialize objects sent to the server.
   final SerializationManager serializationManager;
 
-  /// Optional [AuthenticationKeyManager] if the client needs to sign the user in.
-  @Deprecated(
-    'Use authKeyProvider instead. This will be removed in future releases.',
-  )
-  AuthenticationKeyManager? get authenticationKeyManager {
-    final provider = authKeyProvider;
-    if (provider == null) return null;
-    if (provider is AuthenticationKeyManager) return provider;
-    throw StateError(
-      'The authKeyProvider is not an AuthenticationKeyManager. '
-      'Use authKeyProvider directly instead of authenticationKeyManager.',
-    );
-  }
-
   /// Looks up module callers by their name. Overridden by generated code.
   Map<String, ModuleEndpointCaller> get moduleLookup;
 
@@ -160,10 +146,6 @@ abstract class ServerpodClientShared extends EndpointCaller {
     String host,
     this.serializationManager, {
     dynamic securityContext,
-    @Deprecated(
-      'Use authKeyProvider instead. This will be removed in future releases.',
-    )
-    AuthenticationKeyManager? authenticationKeyManager,
     required Duration? streamingConnectionTimeout,
     required Duration? connectionTimeout,
     this.onFailedCall,
@@ -187,10 +169,6 @@ abstract class ServerpodClientShared extends EndpointCaller {
     disconnectStreamsOnLostInternetConnection ??= false;
     _disconnectMethodStreamsOnLostInternetConnection =
         disconnectStreamsOnLostInternetConnection;
-
-    // Use authKeyProvider if provided, otherwise fall back to deprecated
-    // authenticationKeyManager for backwards compatibility.
-    authKeyProvider ??= authenticationKeyManager;
   }
 
   /// Closes all open connections to the server.

--- a/packages/serverpod_service_client/lib/src/protocol/client.dart
+++ b/packages/serverpod_service_client/lib/src/protocol/client.dart
@@ -246,10 +246,6 @@ class Client extends _i1.ServerpodClientShared {
   Client(
     String host, {
     dynamic securityContext,
-    @Deprecated(
-      'Use authKeyProvider instead. This will be removed in future releases.',
-    )
-    super.authenticationKeyManager,
     Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
     Function(

--- a/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_client/lib/src/protocol/client.dart
@@ -929,10 +929,6 @@ class Client extends _i2.ServerpodClientShared {
   Client(
     String host, {
     dynamic securityContext,
-    @Deprecated(
-      'Use authKeyProvider instead. This will be removed in future releases.',
-    )
-    super.authenticationKeyManager,
     Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
     Function(

--- a/tests/serverpod_auth_test/serverpod_auth_test_flutter/test/session_manager_migration_test.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_flutter/test/session_manager_migration_test.dart
@@ -38,11 +38,8 @@ void main() {
         storage: legacyStorage,
       );
 
-      final legacySessionClient = Client(
-        'http://localhost:8080/',
-        // ignore: deprecated_member_use
-        authenticationKeyManager: keyManager,
-      );
+      final legacySessionClient = Client('http://localhost:8080/')
+        ..authKeyProvider = keyManager;
 
       final legacySessionManager = legacy_auth_flutter.SessionManager(
         caller: legacySessionClient.modules.auth,

--- a/tests/serverpod_test_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_client/lib/src/protocol/client.dart
@@ -4408,10 +4408,6 @@ class Client extends _i1.ServerpodClientShared {
   Client(
     String host, {
     dynamic securityContext,
-    @Deprecated(
-      'Use authKeyProvider instead. This will be removed in future releases.',
-    )
-    super.authenticationKeyManager,
     Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
     Function(

--- a/tests/serverpod_test_flutter/test_integration/auth_session_manager_signout_test.dart
+++ b/tests/serverpod_test_flutter/test_integration/auth_session_manager_signout_test.dart
@@ -27,26 +27,20 @@ void main() {
     late SessionManager secondarySessionManager;
 
     setUp(() async {
-      primaryClient = Client(
-        serverUrl,
-        // ignore: deprecated_member_use
-        authenticationKeyManager: FlutterAuthenticationKeyManager(
+      primaryClient = Client(serverUrl)
+        ..authKeyProvider = FlutterAuthenticationKeyManager(
           storage: MockStorage(),
-        ),
-      );
+        );
       primarySessionManager = SessionManager(
         caller: primaryClient.modules.auth,
         storage: MockStorage(),
       );
       await primarySessionManager.initialize();
 
-      secondaryClient = Client(
-        serverUrl,
-        // ignore: deprecated_member_use
-        authenticationKeyManager: FlutterAuthenticationKeyManager(
+      secondaryClient = Client(serverUrl)
+        ..authKeyProvider = FlutterAuthenticationKeyManager(
           storage: MockStorage(),
-        ),
-      );
+        );
       secondarySessionManager = SessionManager(
         caller: secondaryClient.modules.auth,
         storage: MockStorage(),

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/lib/src/protocol/client.dart
@@ -36,10 +36,6 @@ class Client extends _i1.ServerpodClientShared {
   Client(
     String host, {
     dynamic securityContext,
-    @Deprecated(
-      'Use authKeyProvider instead. This will be removed in future releases.',
-    )
-    super.authenticationKeyManager,
     Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
     Function(

--- a/tests/serverpod_test_server/lib/test_util/service_client.dart
+++ b/tests/serverpod_test_server/lib/test_util/service_client.dart
@@ -10,11 +10,8 @@ import 'package:serverpod_test_server/test_util/test_service_key_manager.dart';
 final _serviceServerUrl =
     Platform.environment['SERVERPOD_TEST_SERVICE_URL'] ?? serviceServerUrl;
 
-var serviceClient = Client(
-  _serviceServerUrl,
-  // ignore: deprecated_member_use
-  authenticationKeyManager: TestServiceKeyManager(
+var serviceClient = Client(_serviceServerUrl)
+  ..authKeyProvider = TestServiceKeyManager(
     '0',
     'super_SECRET_password',
-  ),
-);
+  );

--- a/tests/serverpod_test_server/test_e2e/auth_key_backwards_compatibility_test.dart
+++ b/tests/serverpod_test_server/test_e2e/auth_key_backwards_compatibility_test.dart
@@ -12,15 +12,13 @@ void main() {
     'Given a simulated legacy client with old authorization conventions, ',
     () {
       late Client client;
+      late TestAuthKeyManager authKeyProvider;
       late String authKey;
 
       setUpAll(() async {
         // prepare a proper authentication key
-        client = Client(
-          serverUrl,
-          // ignore: deprecated_member_use
-          authenticationKeyManager: TestAuthKeyManager(),
-        );
+        authKeyProvider = TestAuthKeyManager();
+        client = Client(serverUrl)..authKeyProvider = authKeyProvider;
         var response = await client.authentication.authenticate(
           'test@foo.bar',
           'password',
@@ -30,8 +28,7 @@ void main() {
       });
 
       tearDownAll(() async {
-        // ignore: deprecated_member_use
-        await client.authenticationKeyManager?.remove();
+        await authKeyProvider.remove();
         await client.authentication.removeAllUsers();
         await client.authentication.signOut();
         assert(

--- a/tests/serverpod_test_server/test_e2e/auth_module_test.dart
+++ b/tests/serverpod_test_server/test_e2e/auth_module_test.dart
@@ -5,11 +5,8 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var client = Client(
-    serverUrl,
-    // ignore: deprecated_member_use
-    authenticationKeyManager: TestAuthKeyManager(),
-  );
+  var authKeyProvider = TestAuthKeyManager();
+  var client = Client(serverUrl)..authKeyProvider = authKeyProvider;
 
   setUp(() {});
 
@@ -62,8 +59,7 @@ void main() {
         'password',
       );
       if (response.success) {
-        // ignore: deprecated_member_use
-        await client.authenticationKeyManager!.put(
+        await authKeyProvider.put(
           '${response.keyId}:${response.key}',
         );
       }
@@ -126,8 +122,7 @@ void main() {
         'password',
       );
       assert(response.success, 'Failed to authenticate user');
-      // ignore: deprecated_member_use
-      await client.authenticationKeyManager?.put(
+      await authKeyProvider.put(
         '${response.keyId}:${response.key}',
       );
       assert(
@@ -137,8 +132,7 @@ void main() {
     });
 
     tearDown(() async {
-      // ignore: deprecated_member_use
-      await client.authenticationKeyManager?.remove();
+      await authKeyProvider.remove();
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(
@@ -171,8 +165,7 @@ void main() {
         [Scope.admin.name!],
       );
       assert(response.success, 'Failed to authenticate user');
-      // ignore: deprecated_member_use
-      await client.authenticationKeyManager?.put(
+      await authKeyProvider.put(
         '${response.keyId}:${response.key}',
       );
       assert(
@@ -182,8 +175,7 @@ void main() {
     });
 
     tearDown(() async {
-      // ignore: deprecated_member_use
-      await client.authenticationKeyManager?.remove();
+      await authKeyProvider.remove();
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(
@@ -207,8 +199,7 @@ void main() {
         'password',
       );
       assert(response.success, 'Failed to authenticate user');
-      // ignore: deprecated_member_use
-      await client.authenticationKeyManager?.put(
+      await authKeyProvider.put(
         '${response.keyId}:${response.key}',
       );
       assert(
@@ -218,8 +209,7 @@ void main() {
     });
 
     tearDown(() async {
-      // ignore: deprecated_member_use
-      await client.authenticationKeyManager?.remove();
+      await authKeyProvider.remove();
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(

--- a/tests/serverpod_test_server/test_e2e/client_protocol_test.dart
+++ b/tests/serverpod_test_server/test_e2e/client_protocol_test.dart
@@ -6,11 +6,7 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var client = Client(
-    serverUrl,
-    // ignore: deprecated_member_use
-    authenticationKeyManager: TestAuthKeyManager(),
-  );
+  var client = Client(serverUrl)..authKeyProvider = TestAuthKeyManager();
 
   test(
     'when calling method with positional arg then echoes the value',

--- a/tests/serverpod_test_server/test_e2e/definition_in_feature_directory_test.dart
+++ b/tests/serverpod_test_server/test_e2e/definition_in_feature_directory_test.dart
@@ -5,11 +5,7 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var client = Client(
-    serverUrl,
-    // ignore: deprecated_member_use
-    authenticationKeyManager: TestAuthKeyManager(),
-  );
+  var client = Client(serverUrl)..authKeyProvider = TestAuthKeyManager();
 
   group(
     'Given an endpoint that is defined outside of the endpoint directory',

--- a/tests/serverpod_test_server/test_e2e/email_authentication_provider_test.dart
+++ b/tests/serverpod_test_server/test_e2e/email_authentication_provider_test.dart
@@ -4,11 +4,8 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var client = Client(
-    serverUrl,
-    // ignore: deprecated_member_use
-    authenticationKeyManager: TestAuthKeyManager(),
-  );
+  var authKeyProvider = TestAuthKeyManager();
+  var client = Client(serverUrl)..authKeyProvider = authKeyProvider;
   // ".bar" is the only valid top level domain for test email addresses
   const email = 'test@serverpod.bar';
   const password = 'password';
@@ -155,8 +152,7 @@ void main() {
         );
         assert(authResponse.success, 'Failed to authenticate user');
         assert(authResponse.key != null, 'Failed to retrieve auth key');
-        // ignore: deprecated_member_use
-        await client.authenticationKeyManager?.put(
+        await authKeyProvider.put(
           '${authResponse.keyId}:${authResponse.key}',
         );
 
@@ -167,8 +163,7 @@ void main() {
       },
     );
 
-    // ignore: deprecated_member_use
-    tearDown(() async => await client.authenticationKeyManager?.remove());
+    tearDown(() async => await authKeyProvider.remove());
 
     test(
       'when changing password then user can authenticate with new password',

--- a/tests/serverpod_test_server/test_e2e/endpoint_login_hierarchy_test.dart
+++ b/tests/serverpod_test_server/test_e2e/endpoint_login_hierarchy_test.dart
@@ -5,11 +5,8 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var client = Client(
-    serverUrl,
-    // ignore: deprecated_member_use
-    authenticationKeyManager: TestAuthKeyManager(),
-  );
+  var authKeyProvider = TestAuthKeyManager();
+  var client = Client(serverUrl)..authKeyProvider = authKeyProvider;
 
   setUp(() async {
     await client.authentication.removeAllUsers();
@@ -18,8 +15,7 @@ void main() {
   });
 
   tearDown(() async {
-    // ignore: deprecated_member_use
-    await client.authenticationKeyManager?.remove();
+    await authKeyProvider.remove();
     await client.authentication.removeAllUsers();
     await client.authentication.signOut();
     assert(
@@ -56,8 +52,7 @@ void main() {
             'test@foo.bar',
             'password',
           );
-          // ignore: deprecated_member_use
-          await client.authenticationKeyManager!.put(
+          await authKeyProvider.put(
             '${loginResponse.keyId}:${loginResponse.key}',
           );
 
@@ -97,8 +92,7 @@ void main() {
             'test@foo.bar',
             'password',
           );
-          // ignore: deprecated_member_use
-          await client.authenticationKeyManager!.put(
+          await authKeyProvider.put(
             '${loginResponse.keyId}:${loginResponse.key}',
           );
 
@@ -121,8 +115,7 @@ void main() {
             'password',
             [Scope.admin.name!],
           );
-          // ignore: deprecated_member_use
-          await client.authenticationKeyManager!.put(
+          await authKeyProvider.put(
             '${loginResponse.keyId}:${loginResponse.key}',
           );
 
@@ -162,8 +155,7 @@ void main() {
             'test@foo.bar',
             'password',
           );
-          // ignore: deprecated_member_use
-          await client.authenticationKeyManager!.put(
+          await authKeyProvider.put(
             '${loginResponse.keyId}:${loginResponse.key}',
           );
 
@@ -186,8 +178,7 @@ void main() {
             'password',
             [Scope.admin.name!],
           );
-          // ignore: deprecated_member_use
-          await client.authenticationKeyManager!.put(
+          await authKeyProvider.put(
             '${loginResponse.keyId}:${loginResponse.key}',
           );
 

--- a/tests/serverpod_test_server/test_e2e/method_streaming/authenticated_streaming_method_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/authenticated_streaming_method_test.dart
@@ -9,11 +9,8 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var client = Client(
-    serverUrl,
-    // ignore: deprecated_member_use
-    authenticationKeyManager: TestAuthKeyManager(),
-  );
+  var authKeyProvider = TestAuthKeyManager();
+  var client = Client(serverUrl)..authKeyProvider = authKeyProvider;
 
   test(
     'Given an unauthenticated user when calling an authenticated streaming method then client exception with forbidden HTTP status code is thrown.',
@@ -48,8 +45,7 @@ void main() {
         'password',
       );
       assert(response.success, 'Failed to authenticate user');
-      // ignore: deprecated_member_use
-      await client.authenticationKeyManager?.put(
+      await authKeyProvider.put(
         '${response.keyId}:${response.key}',
       );
       assert(
@@ -59,8 +55,7 @@ void main() {
     });
 
     tearDown(() async {
-      // ignore: deprecated_member_use
-      await client.authenticationKeyManager?.remove();
+      await authKeyProvider.remove();
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(
@@ -104,8 +99,7 @@ void main() {
         [Scope.admin.name!],
       );
       assert(response.success, 'Failed to authenticate user');
-      // ignore: deprecated_member_use
-      await client.authenticationKeyManager?.put(
+      await authKeyProvider.put(
         '${response.keyId}:${response.key}',
       );
       assert(
@@ -115,8 +109,7 @@ void main() {
     });
 
     tearDown(() async {
-      // ignore: deprecated_member_use
-      await client.authenticationKeyManager?.remove();
+      await authKeyProvider.remove();
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(
@@ -157,8 +150,7 @@ void main() {
       );
       assert(response.success, 'Failed to authenticate user');
       userId = response.userInfo!.id!;
-      // ignore: deprecated_member_use
-      await client.authenticationKeyManager?.put(
+      await authKeyProvider.put(
         '${response.keyId}:${response.key}',
       );
       assert(
@@ -168,8 +160,7 @@ void main() {
     });
 
     tearDown(() async {
-      // ignore: deprecated_member_use
-      await client.authenticationKeyManager?.remove();
+      await authKeyProvider.remove();
       await client.authentication.removeAllUsers();
       await client.authentication.signOut();
       assert(

--- a/tests/serverpod_test_server/test_e2e/method_streaming/close_connection_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/close_connection_test.dart
@@ -6,11 +6,7 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var client = Client(
-    serverUrl,
-    // ignore: deprecated_member_use
-    authenticationKeyManager: TestAuthKeyManager(),
-  );
+  var client = Client(serverUrl)..authKeyProvider = TestAuthKeyManager();
 
   tearDown(
     () async => await client.closeStreamingMethodConnections(exception: null),

--- a/tests/serverpod_test_server/test_e2e/method_streaming/connectivity_monitor_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/connectivity_monitor_test.dart
@@ -18,10 +18,8 @@ void main() {
       var testConnectivityMonitor = TestConnectivityMonitor();
       var client = Client(
         serverUrl,
-        // ignore: deprecated_member_use
-        authenticationKeyManager: TestAuthKeyManager(),
         disconnectStreamsOnLostInternetConnection: true,
-      );
+      )..authKeyProvider = TestAuthKeyManager();
 
       client.connectivityMonitor = testConnectivityMonitor;
       test(
@@ -59,10 +57,8 @@ void main() {
       var testConnectivityMonitor = TestConnectivityMonitor();
       var client = Client(
         serverUrl,
-        // ignore: deprecated_member_use
-        authenticationKeyManager: TestAuthKeyManager(),
         disconnectStreamsOnLostInternetConnection: false,
-      );
+      )..authKeyProvider = TestAuthKeyManager();
       client.connectivityMonitor = testConnectivityMonitor;
 
       tearDown(() => client.closeStreamingMethodConnections(exception: null));

--- a/tests/serverpod_test_server/test_e2e/method_streaming/input_parameter_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/input_parameter_test.dart
@@ -7,11 +7,7 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var client = Client(
-    serverUrl,
-    // ignore: deprecated_member_use
-    authenticationKeyManager: TestAuthKeyManager(),
-  );
+  var client = Client(serverUrl)..authKeyProvider = TestAuthKeyManager();
 
   test(
     'Given an integer stream when calling a streaming method that echoes input stream then values are returned from the server.',

--- a/tests/serverpod_test_server/test_e2e/method_streaming/multiple_streaming_methods_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/multiple_streaming_methods_test.dart
@@ -7,11 +7,7 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var client = Client(
-    serverUrl,
-    // ignore: deprecated_member_use
-    authenticationKeyManager: TestAuthKeyManager(),
-  );
+  var client = Client(serverUrl)..authKeyProvider = TestAuthKeyManager();
 
   test(
     'Given multiple streaming method connections when one is finished then the open method stream can still transmit messages.',

--- a/tests/serverpod_test_server/test_e2e/method_streaming/out_future_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/out_future_test.dart
@@ -8,11 +8,7 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var client = Client(
-    serverUrl,
-    // ignore: deprecated_member_use
-    authenticationKeyManager: TestAuthKeyManager(),
-  );
+  var client = Client(serverUrl)..authKeyProvider = TestAuthKeyManager();
 
   test(
     'Given a streaming method that returns first value from stream, when calling the method, then the first value is received.',

--- a/tests/serverpod_test_server/test_e2e/method_streaming/out_stream_test.dart
+++ b/tests/serverpod_test_server/test_e2e/method_streaming/out_stream_test.dart
@@ -5,11 +5,7 @@ import 'package:serverpod_test_server/test_util/test_key_manager.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var client = Client(
-    serverUrl,
-    // ignore: deprecated_member_use
-    authenticationKeyManager: TestAuthKeyManager(),
-  );
+  var client = Client(serverUrl)..authKeyProvider = TestAuthKeyManager();
 
   test(
     'Given a streaming method that returns a stream of integers, when calling the method, then the expected integers are received.',

--- a/tests/serverpod_test_server/test_e2e/service_protocol_test.dart
+++ b/tests/serverpod_test_server/test_e2e/service_protocol_test.dart
@@ -7,14 +7,11 @@ import 'package:test/test.dart';
 
 void main() {
   var client = Client(serverUrl);
-  var serviceClient = service.Client(
-    serviceServerUrl,
-    // ignore: deprecated_member_use
-    authenticationKeyManager: TestServiceKeyManager(
+  var serviceClient = service.Client(serviceServerUrl)
+    ..authKeyProvider = TestServiceKeyManager(
       '0',
       'super_SECRET_password',
-    ),
-  );
+    );
 
   group('Health metrics', () {
     test('Fetch health metrics', () async {

--- a/tests/serverpod_test_server/test_e2e/signout/auth_status_signout_test.dart
+++ b/tests/serverpod_test_server/test_e2e/signout/auth_status_signout_test.dart
@@ -9,16 +9,9 @@ void main() {
     late Client secondaryClient;
 
     setUp(() async {
-      primaryClient = Client(
-        serverUrl,
-        // ignore: deprecated_member_use
-        authenticationKeyManager: TestAuthKeyManager(),
-      );
-      secondaryClient = Client(
-        serverUrl,
-        // ignore: deprecated_member_use
-        authenticationKeyManager: TestAuthKeyManager(),
-      );
+      primaryClient = Client(serverUrl)..authKeyProvider = TestAuthKeyManager();
+      secondaryClient = Client(serverUrl)
+        ..authKeyProvider = TestAuthKeyManager();
 
       await _authenticateClient(primaryClient);
       await _authenticateClient(secondaryClient);
@@ -94,8 +87,7 @@ Future<void> _authenticateClient(Client client) async {
     'password',
   );
   expect(response.success, isTrue, reason: 'Authentication failed for client');
-  // ignore: deprecated_member_use
-  await client.authenticationKeyManager?.put(
+  await (client.authKeyProvider as TestAuthKeyManager).put(
     '${response.keyId}:${response.key}',
   );
 }

--- a/tests/serverpod_test_server/test_integration/auth_core/auth_header_test.dart
+++ b/tests/serverpod_test_server/test_integration/auth_core/auth_header_test.dart
@@ -28,11 +28,7 @@ void main() async {
         authenticationHandler: authenticationHandler,
       );
       await server.startWithDatabase();
-      client = Client(
-        server.apiUrl,
-        // ignore: deprecated_member_use
-        authenticationKeyManager: authKeyManager,
-      );
+      client = Client(server.apiUrl)..authKeyProvider = authKeyManager;
     });
 
     tearDown(() async {
@@ -119,11 +115,7 @@ void main() async {
         authenticationHandler: authenticationHandler,
       );
       await server.startWithDatabase();
-      client = Client(
-        server.apiUrl,
-        // ignore: deprecated_member_use
-        authenticationKeyManager: incorrectAuthKeyManager,
-      );
+      client = Client(server.apiUrl)..authKeyProvider = incorrectAuthKeyManager;
     });
 
     tearDown(() async {
@@ -167,11 +159,7 @@ void main() async {
         authenticationHandler: authenticationHandler,
       );
       await server.startWithDatabase();
-      client = Client(
-        server.apiUrl,
-        // ignore: deprecated_member_use
-        authenticationKeyManager: authKeyManager,
-      );
+      client = Client(server.apiUrl)..authKeyProvider = authKeyManager;
     });
 
     tearDown(() async {

--- a/tests/serverpod_test_server/test_integration/session_authentication_test.dart
+++ b/tests/serverpod_test_server/test_integration/session_authentication_test.dart
@@ -46,11 +46,7 @@ void main() {
 
         setUp(() {
           final authKeyManager = TestAuthKeyManager();
-          client = Client(
-            server.apiUrl,
-            // ignore: deprecated_member_use
-            authenticationKeyManager: authKeyManager,
-          );
+          client = Client(server.apiUrl)..authKeyProvider = authKeyManager;
           authKeyManager.put(validTestToken);
         });
 
@@ -97,11 +93,7 @@ void main() {
 
         setUp(() {
           final authKeyManager = TestAuthKeyManager();
-          client = Client(
-            server.apiUrl,
-            // ignore: deprecated_member_use
-            authenticationKeyManager: authKeyManager,
-          );
+          client = Client(server.apiUrl)..authKeyProvider = authKeyManager;
           authKeyManager.put(invalidTestToken);
         });
 
@@ -142,11 +134,7 @@ void main() {
 
         setUp(() {
           final authKeyManager = TestAuthKeyManager();
-          client = Client(
-            server.apiUrl,
-            // ignore: deprecated_member_use
-            authenticationKeyManager: authKeyManager,
-          );
+          client = Client(server.apiUrl)..authKeyProvider = authKeyManager;
           authKeyManager.put(validTestToken);
         });
 
@@ -184,11 +172,7 @@ void main() {
 
         setUp(() {
           final authKeyManager = TestAuthKeyManager();
-          client = Client(
-            server.apiUrl,
-            // ignore: deprecated_member_use
-            authenticationKeyManager: authKeyManager,
-          );
+          client = Client(server.apiUrl)..authKeyProvider = authKeyManager;
           authKeyManager.put(invalidTestToken);
         });
 

--- a/tests/serverpod_test_server/test_integration/test_tools/unauthenticated_annotation_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/unauthenticated_annotation_test.dart
@@ -15,11 +15,7 @@ void main() {
     await server.startWithDatabase();
 
     authKeyManager = TestAuthKeyManager();
-    client = Client(
-      server.apiUrl,
-      // ignore: deprecated_member_use
-      authenticationKeyManager: authKeyManager,
-    );
+    client = Client(server.apiUrl)..authKeyProvider = authKeyManager;
 
     await client.authentication.removeAllUsers();
 

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/reconnect_to_server_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/reconnect_to_server_test.dart
@@ -17,11 +17,7 @@ void main() {
     server = IntegrationTestServer.create(apiPort: stableTestPort());
     await server.startWithDatabase();
 
-    client = c.Client(
-      server.apiUrl,
-      // ignore: deprecated_member_use
-      authenticationKeyManager: TestAuthKeyManager(),
-    );
+    client = c.Client(server.apiUrl)..authKeyProvider = TestAuthKeyManager();
   });
 
   tearDown(() async {

--- a/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
+++ b/tests/serverpod_test_server/test_integration/websockets/method_websockets/method_streams/revoked_authentication_stream_test.dart
@@ -34,11 +34,7 @@ void main() {
     session = await server.createSession();
 
     authKeyManager = TestAuthKeyManager();
-    client = c.Client(
-      server.apiUrl,
-      // ignore: deprecated_member_use
-      authenticationKeyManager: authKeyManager,
-    );
+    client = c.Client(server.apiUrl)..authKeyProvider = authKeyManager;
     expect(
       server.redisController,
       isNotNull,

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/client.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/lib/src/protocol/client.dart
@@ -86,10 +86,6 @@ class Client extends _i1.ServerpodClientShared {
   Client(
     String host, {
     dynamic securityContext,
-    @Deprecated(
-      'Use authKeyProvider instead. This will be removed in future releases.',
-    )
-    super.authenticationKeyManager,
     Duration? streamingConnectionTimeout,
     Duration? connectionTimeout,
     Function(

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/test_util/service_client.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/test_util/service_client.dart
@@ -9,12 +9,9 @@ Client _createServiceClient() {
   MigrationTestUtils.setModuleName('serverpod_test_sqlite');
   MigrationTestUtils.setDatabaseDialect(DatabaseDialect.sqlite);
 
-  return Client(
-    'http://localhost:8081/',
-    // ignore: deprecated_member_use
-    authenticationKeyManager: TestServiceKeyManager(
+  return Client('http://localhost:8081/')
+    ..authKeyProvider = TestServiceKeyManager(
       '0',
       'super_SECRET_password',
-    ),
-  );
+    );
 }

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -1277,20 +1277,6 @@ return deserializeByClassName(value);
                     ),
                     Parameter(
                       (p) => p
-                        ..annotations.add(
-                          refer('Deprecated', 'dart:core').call([
-                            literalString(
-                              'Use authKeyProvider instead. '
-                              'This will be removed in future releases.',
-                            ),
-                          ]),
-                        )
-                        ..name = 'authenticationKeyManager'
-                        ..named = true
-                        ..toSuper = true,
-                    ),
-                    Parameter(
-                      (p) => p
                         ..name = 'streamingConnectionTimeout'
                         ..named = true
                         ..type = TypeReference(

--- a/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/client_code_generator/client_test.dart
@@ -31,6 +31,46 @@ void main() {
   );
 
   group(
+    'Given a protocol definition, '
+    'when generating the client file,',
+    () {
+      late String generatedClient;
+
+      setUpAll(() {
+        var codeMap = generator.generateProtocolCode(
+          protocolDefinition: const ProtocolDefinition(
+            endpoints: [],
+            models: [],
+            futureCalls: [],
+          ),
+          config: config,
+        );
+        generatedClient = codeMap[expectedFileName]!;
+      });
+
+      test(
+        'then its constructor does not expose the authKeyProvider as a parameter.',
+        () {
+          expect(
+            generatedClient,
+            isNot(contains('super.authKeyProvider')),
+          );
+        },
+      );
+
+      test(
+        'then its constructor does not expose the legacy authenticationKeyManager parameter.',
+        () {
+          expect(
+            generatedClient,
+            isNot(contains('authenticationKeyManager')),
+          );
+        },
+      );
+    },
+  );
+
+  group(
     'Given a protocol definition with a method with Stream return value when generating client file',
     () {
       var endpointName = 'testing';


### PR DESCRIPTION
Removes the legacy `authenticationKeyManger` parameter, that is not necessary for the legacy auth to work since the `AuthenticationKeyManager` class implements the `AuthKeyProvider` interface.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

The PR in itself is the breaking change.