### PR TITLE
chore: Comment-out the shared secrets on the template

### DIFF
--- a/templates/serverpod_templates/projectname_server_upgrade/config/passwords.yaml
+++ b/templates/serverpod_templates/projectname_server_upgrade/config/passwords.yaml
@@ -10,8 +10,10 @@
 # place.
 
 # Save passwords used across all configurations here.
-shared:
-  mySharedPassword: 'my password'
+# shared:
+#   # Example custom secret. Uncomment and rename to store a value shared
+#   # across all run modes. Access via `pod.getPassword('mySharedPassword')`.
+#   mySharedPassword: 'my password'
 
 # These are passwords used when running the server locally in development mode
 development:
@@ -30,6 +32,10 @@ development:
   emailSecretHashPepper: 'EMAIL_SECRET_HASH_PEPPER_DEVELOPMENT'
   jwtHmacSha512PrivateKey: 'JWT_HMAC_SHA512_PRIVATE_KEY_DEVELOPMENT'
   jwtRefreshTokenHashPepper: 'JWT_REFRESH_TOKEN_HASH_PEPPER_DEVELOPMENT'
+  # Random value to be used as a pepper for the server-side sessions hash.
+  # Only required if using `ServerSideSessionsConfigFromPasswords()` as token
+  # manager on `tokenManagerBuilders` in lib/server.dart. Safe to remove from
+  # the run modes that won't use it.
   # serverSideSessionKeyHashPepper: 'SERVER_SIDE_SESSION_KEY_HASH_PEPPER_DEVELOPMENT'
   # {{/auth}}
 

--- a/tests/bootstrap_project/test_perform_create/auth_test.dart
+++ b/tests/bootstrap_project/test_perform_create/auth_test.dart
@@ -113,6 +113,22 @@ void main() {
       );
 
       test(
+        'then the server passwords config has the shared section commented out',
+        () async {
+          final file = File(
+            p.join(project.serverDir, 'config', 'passwords.yaml'),
+          );
+          final content = await file.readAsString();
+          expect(content, contains('# shared:'));
+          expect(content, isNot(RegExp(r'^shared:', multiLine: true)));
+          expect(
+            content,
+            isNot(RegExp(r'^  mySharedPassword:', multiLine: true)),
+          );
+        },
+      );
+
+      test(
         'then the server pubspec.yaml contains serverpod_auth_idp_server dependency',
         () async {
           final serverPubspec = File(p.join(project.serverDir, 'pubspec.yaml'));


### PR DESCRIPTION
Prevent automatic generation of the shared secrets section that would lead to unnecessary secrets on deployed projects.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.