### PR TITLE
fix: Make TermsAndPrivacyText respond to app theming

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/common/widgets/buttons/text_button.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/common/widgets/buttons/text_button.dart
@@ -13,17 +13,22 @@ class HyperlinkTextButton extends StatelessWidget {
   /// Padding around the button.
   final EdgeInsets padding;
 
+  /// Font size of the label. Defaults to the theme's bodyMedium font size.
+  final double? fontSize;
+
   /// Creates a [HyperlinkTextButton] widget.
   const HyperlinkTextButton({
     required this.onPressed,
     required this.label,
     this.padding = EdgeInsets.zero,
+    this.fontSize,
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
-    final fontSize = Theme.of(context).textTheme.bodyMedium?.fontSize ?? 0;
+    final fontSize =
+        this.fontSize ?? Theme.of(context).textTheme.bodyMedium?.fontSize ?? 0;
 
     return SizedBox(
       height: math.max(24, fontSize),

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/email/forms/widgets/terms_and_privacy.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/lib/src/email/forms/widgets/terms_and_privacy.dart
@@ -35,6 +35,8 @@ class TermsAndPrivacyText extends StatelessWidget {
     final texts = context.emailSignInTexts;
     final onTermsAndConditionsPressed = this.onTermsAndConditionsPressed;
     final onPrivacyPolicyPressed = this.onPrivacyPolicyPressed;
+    final textStyle =
+        Theme.of(context).textTheme.bodySmall ?? const TextStyle(fontSize: 12);
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.start,
@@ -45,50 +47,41 @@ class TermsAndPrivacyText extends StatelessWidget {
           onChanged: onCheckboxChanged,
         ),
         Expanded(
-          child: Theme(
-            data: Theme.of(context).copyWith(
-              textTheme: Theme.of(context).textTheme.copyWith(
-                bodyMedium: const TextStyle(
-                  fontSize: 12,
+          child: DefaultTextStyle.merge(
+            style: textStyle,
+            child: Wrap(
+              alignment: WrapAlignment.start,
+              crossAxisAlignment: WrapCrossAlignment.end,
+              spacing: 2,
+              runSpacing: -6,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text(texts.termsIntro),
                 ),
-              ),
-            ),
-            child: DefaultTextStyle(
-              style: const TextStyle(
-                fontSize: 12,
-              ),
-              child: Wrap(
-                alignment: WrapAlignment.start,
-                crossAxisAlignment: WrapCrossAlignment.end,
-                spacing: 2,
-                runSpacing: -6,
-                children: [
+                if (onTermsAndConditionsPressed != null)
+                  HyperlinkTextButton(
+                    onPressed: onTermsAndConditionsPressed,
+                    label: texts.termsAndConditions,
+                    fontSize: textStyle.fontSize,
+                  ),
+                if (onTermsAndConditionsPressed != null &&
+                    onPrivacyPolicyPressed != null)
                   Padding(
                     padding: const EdgeInsets.only(bottom: 4),
-                    child: Text(texts.termsIntro),
+                    child: Text(texts.andText),
                   ),
-                  if (onTermsAndConditionsPressed != null)
-                    HyperlinkTextButton(
-                      onPressed: onTermsAndConditionsPressed,
-                      label: texts.termsAndConditions,
-                    ),
-                  if (onTermsAndConditionsPressed != null &&
-                      onPrivacyPolicyPressed != null)
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 4),
-                      child: Text(texts.andText),
-                    ),
-                  if (onPrivacyPolicyPressed != null)
-                    HyperlinkTextButton(
-                      onPressed: onPrivacyPolicyPressed,
-                      label: texts.privacyPolicy,
-                    ),
-                  const Padding(
-                    padding: EdgeInsets.only(bottom: 4),
-                    child: Text("."),
+                if (onPrivacyPolicyPressed != null)
+                  HyperlinkTextButton(
+                    onPressed: onPrivacyPolicyPressed,
+                    label: texts.privacyPolicy,
+                    fontSize: textStyle.fontSize,
                   ),
-                ],
-              ),
+                const Padding(
+                  padding: EdgeInsets.only(bottom: 4),
+                  child: Text("."),
+                ),
+              ],
             ),
           ),
         ),

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/test/terms_and_privacy_theming_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/test/terms_and_privacy_theming_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:serverpod_auth_idp_flutter/serverpod_auth_idp_flutter.dart';
+import 'package:serverpod_auth_idp_flutter/widgets.dart';
+
+void main() {
+  testWidgets(
+    'Given a theme with a custom body text color, '
+    'when building TermsAndPrivacyText, '
+    'then the plain text runs inherit the themed color.',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            textTheme: ThemeData.light().textTheme.apply(
+              bodyColor: Colors.white,
+              displayColor: Colors.white,
+            ),
+          ),
+          home: Scaffold(
+            body: TermsAndPrivacyText(
+              onTermsAndConditionsPressed: () {},
+              onPrivacyPolicyPressed: () {},
+              onCheckboxChanged: (_) {},
+              isChecked: false,
+            ),
+          ),
+        ),
+      );
+
+      final texts = EmailSignInTexts.defaults;
+      expect(_textStyleOf(tester, texts.termsIntro)?.color, Colors.white);
+      expect(_textStyleOf(tester, texts.andText)?.color, Colors.white);
+    },
+  );
+
+  testWidgets(
+    'Given the default theme, '
+    'when building TermsAndPrivacyText, '
+    'then texts and link labels render at the bodySmall font size.',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TermsAndPrivacyText(
+              onTermsAndConditionsPressed: () {},
+              onPrivacyPolicyPressed: () {},
+              onCheckboxChanged: (_) {},
+              isChecked: false,
+            ),
+          ),
+        ),
+      );
+
+      final texts = EmailSignInTexts.defaults;
+      final context = tester.element(find.byType(TermsAndPrivacyText));
+      final bodySmallSize = Theme.of(context).textTheme.bodySmall?.fontSize;
+      expect(bodySmallSize, isNotNull);
+      expect(
+        _textStyleOf(tester, texts.termsIntro)?.fontSize,
+        bodySmallSize,
+      );
+      expect(
+        _textStyleOf(tester, texts.termsAndConditions)?.fontSize,
+        bodySmallSize,
+      );
+      expect(
+        _textStyleOf(tester, texts.privacyPolicy)?.fontSize,
+        bodySmallSize,
+      );
+    },
+  );
+}
+
+/// Effective style of the [RichText] rendered by the [Text] matching [text].
+TextStyle? _textStyleOf(WidgetTester tester, String text) {
+  final richText = tester.widget<RichText>(
+    find.descendant(of: find.text(text), matching: find.byType(RichText)),
+  );
+  return richText.text.style;
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/test/terms_and_privacy_theming_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/test/terms_and_privacy_theming_test.dart
@@ -28,7 +28,7 @@ void main() {
         ),
       );
 
-      final texts = EmailSignInTexts.defaults;
+      const texts = EmailSignInTexts.defaults;
       expect(_textStyleOf(tester, texts.termsIntro)?.color, Colors.white);
       expect(_textStyleOf(tester, texts.andText)?.color, Colors.white);
     },
@@ -52,7 +52,7 @@ void main() {
         ),
       );
 
-      final texts = EmailSignInTexts.defaults;
+      const texts = EmailSignInTexts.defaults;
       final context = tester.element(find.byType(TermsAndPrivacyText));
       final bodySmallSize = Theme.of(context).textTheme.bodySmall?.fontSize;
       expect(bodySmallSize, isNotNull);


### PR DESCRIPTION
The "I accept" text runs replaced the ambient `DefaultTextStyle` with a bare `TextStyle(fontSize: 12)`, locking them to the default black color. Now merges the theme's `bodySmall` style instead, and `HyperlinkTextButton` takes an optional `fontSize` so the nested Theme override is no longer needed.

Fixes #4780 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None