### PR TITLE
fix: Fix failing to find formatters on Windows

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/dart_formatters.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart_formatters.dart
@@ -91,11 +91,19 @@ Future<DartFormatter> _formatterFor(
 ) async {
   final outputFile = File(p.join(directory, 'protocol.dart')).absolute;
 
-  // Package config discovery starts from the file's parent directory, which
-  // may not exist before the first generation.
+  // Package config discovery needs a path inside an existing directory. The
+  // generated output folder (e.g. lib/src/protocol) may not exist yet on the
+  // first run, so walk up to the nearest existing parent. In a real project
+  // that parent is always within the target package (e.g. lib/src or the
+  // package root); only test teardown races or a missing package can climb
+  // further, in which case language-version lookup falls back below.
   var languageVersionDirectory = outputFile.parent;
-  while (!await languageVersionDirectory.exists()) {
-    languageVersionDirectory = languageVersionDirectory.parent;
+  while (!await _directoryExists(languageVersionDirectory)) {
+    final parent = languageVersionDirectory.parent;
+    if (parent.path == languageVersionDirectory.path) {
+      break;
+    }
+    languageVersionDirectory = parent;
   }
   final languageVersionFile = File(
     p.join(languageVersionDirectory.path, p.basename(outputFile.path)),
@@ -112,4 +120,13 @@ Future<DartFormatter> _formatterFor(
     pageWidth: await configCache.findPageWidth(outputFile),
     trailingCommas: await configCache.findTrailingCommas(outputFile),
   );
+}
+
+Future<bool> _directoryExists(Directory directory) async {
+  try {
+    return await directory.exists();
+  } on PathAccessException {
+    // Windows can deny access while a directory is being deleted.
+    return false;
+  }
 }

--- a/tools/serverpod_cli/test/generator/dart_formatters_test.dart
+++ b/tools/serverpod_cli/test/generator/dart_formatters_test.dart
@@ -150,4 +150,87 @@ formatter:
       expect(formatter.pageWidth, 120);
     },
   );
+
+  test(
+    'Given a client package using Dart 3.12 whose generated protocol directory cannot be checked for existence, '
+    'when its generated-code formatters are resolved, '
+    'then they use the client package language version.',
+    () async {
+      final clientDirectory = Directory(
+        p.join(tempDirectory.path, 'example_client'),
+      );
+      final clientDartToolDirectory = Directory(
+        p.join(clientDirectory.path, '.dart_tool'),
+      );
+      await clientDartToolDirectory.create(recursive: true);
+      await File(
+        p.join(clientDartToolDirectory.path, 'package_config.json'),
+      ).writeAsString('''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "example_client",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "3.12"
+    }
+  ]
+}
+''');
+      final libDirectory = Directory(p.join(clientDirectory.path, 'lib'));
+      await Directory(p.join(libDirectory.path, 'src')).create(recursive: true);
+
+      if (!await _makeUnsearchable(libDirectory)) {
+        markTestSkipped(
+          'Directory.exists() cannot be made to fail on this platform.',
+        );
+        return;
+      }
+      addTearDown(() => Process.run('chmod', ['755', libDirectory.path]));
+
+      final config = GeneratorConfigBuilder()
+          .withServerPackageDirectoryPathParts(p.split(serverDirectory.path))
+          .withRelativeDartClientPackagePathParts(['..', 'example_client'])
+          .build();
+
+      await GeneratedDartFormatters.resolve(config);
+
+      // The language version is only found if the walk up out of the
+      // unreadable output directory stops inside the client package.
+      final formatter = GeneratedDartFormatters.of(
+        p.joinAll([
+          ...config.generatedDartClientModelPathParts,
+          'protocol.dart',
+        ]),
+      );
+
+      expect(formatter.languageVersion, Version(3, 12, 0));
+    },
+  );
+}
+
+/// Makes [directory] unsearchable, so that `Directory.exists()` on the paths
+/// below it fails with a [PathAccessException] instead of returning `false`.
+///
+/// This is how Windows reports a directory that is pending deletion, which the
+/// generated output directory can be when one generation run follows another.
+/// Returns `false`, leaving [directory] untouched, where that cannot be
+/// arranged: on Windows, or when running as a user that bypasses permission
+/// checks.
+///
+/// It is the only reliable way to test the behavior, because a delete-pending
+/// directory is inherently a race condition and can't be reliably reproduced.
+Future<bool> _makeUnsearchable(Directory directory) async {
+  if (Platform.isWindows) return false;
+
+  await Process.run('chmod', ['000', directory.path]);
+  try {
+    await Directory(p.join(directory.path, 'probe')).exists();
+  } on PathAccessException {
+    return true;
+  }
+
+  await Process.run('chmod', ['755', directory.path]);
+  return false;
 }

--- a/tools/serverpod_cli/test/integration/generate/generate_from_scratch_test.dart
+++ b/tools/serverpod_cli/test/integration/generate/generate_from_scratch_test.dart
@@ -6,11 +6,11 @@ import 'package:serverpod_cli/src/commands/generate.dart';
 import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/generator/analyzers.dart';
 import 'package:serverpod_shared/process_io.dart';
-import 'package:serverpod_shared/serverpod_shared.dart';
 import 'package:test/test.dart';
 
 import '../../test_util/builders/generator_config_builder.dart';
 import '../../test_util/endpoint_validation_helpers.dart';
+import '../../test_util/file_system_entity_helpers.dart';
 
 Future<(Directory, Directory)> _buildProject() async {
   final projectDir = Directory.systemTemp.createTempSync('cli_test_');
@@ -31,7 +31,7 @@ void main() {
       late GeneratorConfig config;
       late Analyzers analyzers;
 
-      tearDownAll(() => projectDir.deleteIfExists(recursive: true));
+      tearDownAll(() => projectDir.deleteBestEffort(recursive: true));
 
       setUpAll(() async {
         (projectDir, generatedDir) = await _buildProject();
@@ -83,7 +83,7 @@ class MyFutureCall extends FutureCall {
         () {
           late GenerateResult result;
 
-          tearDown(() => generatedDir.deleteIfExists(recursive: true));
+          tearDown(() => generatedDir.deleteBestEffort(recursive: true));
           setUp(() async {
             result = await analyzers.performGenerate(
               config: config,
@@ -123,7 +123,7 @@ class MyFutureCall extends FutureCall {
       late GeneratorConfig config;
       late Analyzers analyzers;
 
-      tearDownAll(() => projectDir.deleteIfExists(recursive: true));
+      tearDownAll(() => projectDir.deleteBestEffort(recursive: true));
 
       setUpAll(() async {
         (projectDir, generatedDir) = await _buildProject();
@@ -197,7 +197,7 @@ class GreetingEndpoint extends Endpoint {
       group('when generating', () {
         late GenerateResult result;
 
-        tearDown(() => generatedDir.deleteIfExists(recursive: true));
+        tearDown(() => generatedDir.deleteBestEffort(recursive: true));
         setUp(() async {
           result = await analyzers.performGenerate(
             config: config,
@@ -232,10 +232,10 @@ class GreetingEndpoint extends Endpoint {
     late GeneratorConfig config;
     late Analyzers analyzers;
 
-    tearDownAll(() => projectDir.deleteIfExists(recursive: true));
-    tearDown(() {
-      generatedDir.deleteIfExists(recursive: true);
-      generatedClientDir.deleteIfExists(recursive: true);
+    tearDownAll(() => projectDir.deleteBestEffort(recursive: true));
+    tearDown(() async {
+      await generatedDir.deleteBestEffort(recursive: true);
+      await generatedClientDir.deleteBestEffort(recursive: true);
     });
 
     setUpAll(() async {
@@ -368,11 +368,11 @@ class ClientItemEndpoint extends Endpoint {
       late GeneratorConfig config;
       late Analyzers analyzers;
 
-      tearDownAll(() => projectDir.deleteIfExists(recursive: true));
-      tearDown(() {
-        generatedDir.deleteIfExists(recursive: true);
-        generatedClientDir.deleteIfExists(recursive: true);
-        generatedClientMigrationsDir.deleteIfExists(recursive: true);
+      tearDownAll(() => projectDir.deleteBestEffort(recursive: true));
+      tearDown(() async {
+        await generatedDir.deleteBestEffort(recursive: true);
+        await generatedClientDir.deleteBestEffort(recursive: true);
+        await generatedClientMigrationsDir.deleteBestEffort(recursive: true);
       });
 
       setUpAll(() async {
@@ -525,8 +525,8 @@ abstract class Item
       late GeneratorConfig config;
       late Analyzers analyzers;
 
-      tearDownAll(() => projectDir.deleteIfExists(recursive: true));
-      tearDown(() => generatedDir.deleteIfExists(recursive: true));
+      tearDownAll(() => projectDir.deleteBestEffort(recursive: true));
+      tearDown(() => generatedDir.deleteBestEffort(recursive: true));
 
       setUpAll(() async {
         (projectDir, generatedDir) = await _buildProject();
@@ -601,7 +601,7 @@ values:
       late Analyzers analyzers;
       late String modelPath;
 
-      tearDownAll(() => projectDir.deleteIfExists(recursive: true));
+      tearDownAll(() => projectDir.deleteBestEffort(recursive: true));
 
       setUpAll(() async {
         (projectDir, _) = await _buildProject();
@@ -665,7 +665,7 @@ fields:
       late GeneratorConfig config;
       late Analyzers analyzers;
 
-      tearDownAll(() => projectDir.deleteIfExists(recursive: true));
+      tearDownAll(() => projectDir.deleteBestEffort(recursive: true));
 
       setUpAll(() async {
         (projectDir, _) = await _buildProject();
@@ -724,8 +724,8 @@ class ${package == 'test_server' ? 'Server' : 'Client'}SharedModelEndpoint exten
       late GeneratorConfig config;
       late Analyzers analyzers;
 
-      tearDownAll(() => projectDir.deleteIfExists(recursive: true));
-      tearDown(() => generatedSharedDir.deleteIfExists(recursive: true));
+      tearDownAll(() => projectDir.deleteBestEffort(recursive: true));
+      tearDown(() => generatedSharedDir.deleteBestEffort(recursive: true));
 
       setUpAll(() async {
         (projectDir, _) = await _buildProject();


### PR DESCRIPTION
Fixes an issue that was detected on a flaky test, but highlights a real problem with the new formatting on Windows: a directory that is being deleted would cause the formatter to fail when attempting to identify the language version. Now, we search the parent directories for the language version, given that the project folder will always exist.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.