### PR TITLE
feat: Post message central events globally by default with fallback to local delivery

### DIFF
--- a/packages/serverpod/lib/src/server/message_central.dart
+++ b/packages/serverpod/lib/src/server/message_central.dart
@@ -18,6 +18,20 @@ abstract class MessageCentralServerpodChannels {
 typedef MessageCentralListenerCallback =
     void Function(SerializableModel message);
 
+/// Determines how a message posted to the [MessageCentral] is delivered.
+enum MessageScope {
+  /// The message is only delivered within this server instance.
+  local,
+
+  /// The message is delivered across the cluster via Redis. Requires Redis
+  /// to be enabled.
+  global,
+
+  /// The message is delivered across the cluster if Redis is enabled,
+  /// otherwise it is delivered locally within this server instance.
+  auto,
+}
+
 /// The [MessageCentral] handles communication within the server, and between
 /// servers in a cluster. It is especially useful when working with streaming
 /// endpoints. The message central can pass on any serializable to a channel.
@@ -29,40 +43,54 @@ class MessageCentral {
       <Session, Set<MessageCentralListenerCallback>>{};
   final _sessionToCleanupCallbacksLookup = <Session, Set<Function()>>{};
 
-  /// Posts a [message] to a named channel. Optionally a [destinationServerId]
-  /// can be provided, in which case the message is sent only to that specific
-  /// server within the cluster. If no [destinationServerId] is provided, the
-  /// message is passed on to all servers in the cluster.
+  /// Posts a [message] to a named channel. The [scope] determines whether the
+  /// message is delivered locally within this server instance, globally across
+  /// the cluster, or globally with a local fallback if Redis is not enabled
+  /// (the default).
   ///
   /// Returns true if the message was successfully posted.
   ///
-  /// Throws a [StateError] if Redis is not enabled and [global] is set to true.
+  /// Throws a [StateError] if Redis is not enabled and [scope] is
+  /// [MessageScope.global].
   Future<bool> postMessage(
     String channelName,
     SerializableModel message, {
-    bool global = false,
+    MessageScope scope = MessageScope.auto,
   }) async {
-    if (global) {
-      // Send to Redis
-      var data = Serverpod.instance.serializationManager.encodeWithType(
-        message,
-      );
-      var redisController = Serverpod.instance.redisController;
-      if (redisController == null) {
-        throw StateError('Redis needs to be enabled to use this method');
-      }
-
-      return await redisController.publish(channelName, data);
-    } else {
-      // Handle internally in this server instance
-      var channel = _channels[channelName];
-      if (channel == null) return true;
-
-      for (var callback in channel.toList()) {
-        callback(message);
-      }
-      return true;
+    var redisController = Serverpod.instance.redisController;
+    switch (scope) {
+      case MessageScope.local:
+        return _postLocal(channelName, message);
+      case MessageScope.global:
+        if (redisController == null) {
+          throw StateError('Redis needs to be enabled to use this method');
+        }
+        return _postGlobal(redisController, channelName, message);
+      case MessageScope.auto:
+        if (redisController == null) {
+          return _postLocal(channelName, message);
+        }
+        return _postGlobal(redisController, channelName, message);
     }
+  }
+
+  Future<bool> _postGlobal(
+    RedisController redisController,
+    String channelName,
+    SerializableModel message,
+  ) async {
+    var data = Serverpod.instance.serializationManager.encodeWithType(message);
+    return await redisController.publish(channelName, data);
+  }
+
+  bool _postLocal(String channelName, SerializableModel message) {
+    var channel = _channels[channelName];
+    if (channel == null) return true;
+
+    for (var callback in channel.toList()) {
+      callback(message);
+    }
+    return true;
   }
 
   Set<MessageCentralListenerCallback> _getChannel(String channelName) {
@@ -116,7 +144,12 @@ class MessageCentral {
     if (messageObj == null) {
       return;
     }
-    postMessage(channelName, messageObj as SerializableModel, global: false);
+    // Local scope prevents received messages from being republished to Redis.
+    postMessage(
+      channelName,
+      messageObj as SerializableModel,
+      scope: MessageScope.local,
+    );
   }
 
   /// Removes a listener from a named channel.

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -606,22 +606,23 @@ class MessageCentralAccess {
     );
   }
 
-  /// Posts a [message] to a named channel. If [global] is set to true, the
-  /// message will be posted to all servers in the cluster, otherwise it will
-  /// only be posted locally on the current server. Returns true if the message
-  /// was successfully posted.
+  /// Posts a [message] to a named channel. The [scope] determines whether the
+  /// message is delivered locally on the current server, globally to all
+  /// servers in the cluster, or globally with a local fallback if Redis is
+  /// not enabled (the default).
   ///
   /// Returns true if the message was successfully posted.
   ///
-  /// Throws a [StateError] if Redis is not enabled and [global] is set to true.
+  /// Throws a [StateError] if Redis is not enabled and [scope] is
+  /// [MessageScope.global].
   Future<bool> postMessage(
     String channelName,
     SerializableModel message, {
-    bool global = false,
+    MessageScope scope = MessageScope.auto,
   }) => _session.server.messageCentral.postMessage(
     channelName,
     message,
-    global: global,
+    scope: scope,
   );
 
   /// Creates a stream that listens to a specified channel.
@@ -664,21 +665,9 @@ class MessageCentralAccess {
       );
     }
 
-    try {
-      return await _session.server.messageCentral.postMessage(
-        MessageCentralServerpodChannels.revokedAuthentication(userIdentifier),
-        message,
-        global: true,
-      );
-    } on StateError catch (_) {
-      // Throws StateError if Redis is not enabled that is ignored.
-    }
-
-    // If Redis is not enabled, send the message locally.
     return _session.server.messageCentral.postMessage(
       MessageCentralServerpodChannels.revokedAuthentication(userIdentifier),
       message,
-      global: false,
     );
   }
 }

--- a/packages/serverpod/skills/serverpod-server-events/SKILL.md
+++ b/packages/serverpod/skills/serverpod-server-events/SKILL.md
@@ -5,18 +5,19 @@ description: Serverpod message system — postMessage, addListener, createStream
 
 # Serverpod Server Events
 
-Event messaging via `session.messages` on named channels. Messages must be serializable models. Local by default; global (cross-server) with Redis.
+Event messaging via `session.messages` on named channels. Messages must be serializable models. By default (`MessageScope.auto`) messages are delivered across the cluster when Redis is enabled, otherwise locally within the server instance.
 
 ## Sending
 
 ```dart
 await session.messages.postMessage('user_updates', UserUpdate(...));
 
-// Cross-server (requires Redis):
-await session.messages.postMessage('user_updates', message, global: true);
+// Restrict delivery with a scope:
+await session.messages.postMessage('user_updates', message, scope: MessageScope.local);
+await session.messages.postMessage('user_updates', message, scope: MessageScope.global);
 ```
 
-Posting with `global: true` throws if Redis is not enabled. Fall back to local messages only when cross-server delivery is not required.
+`MessageScope.local` delivers synchronously within this server only. `MessageScope.global` requires Redis and throws a `StateError` if it is not enabled. With Redis enabled, delivery is asynchronous and best effort, and listeners receive a deserialized copy of the message rather than the posted instance.
 
 ## Receiving
 

--- a/tests/serverpod_test_server/lib/src/endpoints/redis.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/redis.dart
@@ -46,7 +46,7 @@ class RedisEndpoint extends Endpoint {
     String channel,
     SimpleData data,
   ) async {
-    session.messages.postMessage(channel, data, global: true);
+    session.messages.postMessage(channel, data, scope: MessageScope.global);
   }
 
   Future<int> countSubscribedChannels(Session session) async {

--- a/tests/serverpod_test_server/test_integration/redis_cache_test.dart
+++ b/tests/serverpod_test_server/test_integration/redis_cache_test.dart
@@ -369,7 +369,7 @@ void main() {
       final result = await session.messages.postMessage(
         channelName,
         messageSent,
-        global: true,
+        scope: MessageScope.global,
       );
 
       expect(result, isTrue);
@@ -380,7 +380,7 @@ void main() {
       await session.messages.postMessage(
         channelName,
         messageSent,
-        global: true,
+        scope: MessageScope.global,
       );
 
       var messageReceived = await messageCompleter.future.timeout(
@@ -397,7 +397,7 @@ void main() {
       var published = await session.messages.postMessage(
         channelName,
         messageSent,
-        global: true,
+        scope: MessageScope.global,
       );
 
       expect(published, true);
@@ -428,7 +428,7 @@ void main() {
         await session.messages.postMessage(
           uniqueChannelName,
           messageSent,
-          global: true,
+          scope: MessageScope.global,
         );
 
         var uniqueChannelMessageReceived = await uniqueChannelMessageCompleter
@@ -448,13 +448,29 @@ void main() {
       });
     });
 
+    test('when a message is published with the default auto scope '
+        'then the message is received', () async {
+      await session.messages.postMessage(
+        channelName,
+        messageSent,
+      );
+
+      var messageReceived = await messageCompleter.future.timeout(
+        Duration(seconds: 10),
+        onTimeout: () => null,
+      );
+
+      expect(messageReceived, isNotNull);
+      expect(messageReceived?.num, messageSent.num);
+    });
+
     test('when a global message is published to a channel with no listeners '
         'then the publish is still successful', () async {
       var uniqueChannelName = Uuid().v4();
       var published = await session.messages.postMessage(
         uniqueChannelName,
         messageSent,
-        global: true,
+        scope: MessageScope.global,
       );
 
       expect(published, true);
@@ -482,7 +498,19 @@ void main() {
       var published = await session.messages.postMessage(
         'testChannel',
         SimpleData(num: 1337),
-        global: true,
+        scope: MessageScope.global,
+      );
+
+      expect(published, false);
+    });
+
+    // Auto scope only falls back to local delivery when Redis is not
+    // enabled, not when the connection is down.
+    test('when publishing a message with auto scope '
+        'then the publish fails', () async {
+      var published = await session.messages.postMessage(
+        'testChannel',
+        SimpleData(num: 1337),
       );
 
       expect(published, false);
@@ -519,7 +547,7 @@ void main() {
           () async => await session.messages.postMessage(
             'testChannel',
             SimpleData(num: 1337),
-            global: true,
+            scope: MessageScope.global,
           ),
           throwsA(
             isA<StateError>().having(
@@ -529,6 +557,31 @@ void main() {
             ),
           ),
         );
+      },
+    );
+
+    test(
+      'when publishing a message with auto scope '
+      'then the message is delivered locally',
+      () async {
+        var messageCompleter = Completer<SimpleData>();
+        MessageCentralListenerCallback listener = (message) {
+          messageCompleter.complete(message as SimpleData);
+        };
+        session.messages.addListener('testChannel', listener);
+        addTearDown(
+          () => session.messages.removeListener('testChannel', listener),
+        );
+
+        var published = await session.messages.postMessage(
+          'testChannel',
+          SimpleData(num: 1337),
+        );
+
+        expect(published, isTrue);
+        await expectLater(messageCompleter.future, completes);
+        var messageReceived = await messageCompleter.future;
+        expect(messageReceived.num, 1337);
       },
     );
   });


### PR DESCRIPTION
`postMessage` took a `global` flag that throws if Redis is not enabled.

This PR replaces the flag with a `MessageScope` enum (`local`, `global`, `auto`) and defaults to `auto`, which posts through Redis when it is enabled and otherwise falls back to local delivery. `authenticationRevoked` already implemented this exact fallback manually with a try/catch and now just relies on the default.

The fallback only applies when Redis is not enabled. If Redis is enabled but unreachable, `auto` behaves like `global` and the post fails best effort, same as before. `MessageScope.global` still throws a `StateError` without Redis.

I went with `auto` instead of the `all` name suggested in the issue since it makes more sense to me personally, but happy to change it.

Fixes #2733 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
**serverpod**
- `MessageCentral.postMessage` and `session.messages.postMessage` now take `MessageScope scope = MessageScope.auto` instead of `bool global = false`.
- With Redis enabled, messages posted with the default scope are now delivered asynchronously through Redis, and listeners receive a deserialized copy of the message instead of the posted instance.