### PR TITLE
fix: Increase Flutter preflight timeout to avoid flakiness on Windows tests

### DIFF
--- a/util/prepare_windows_standard_user_test
+++ b/util/prepare_windows_standard_user_test
@@ -116,11 +116,12 @@ append_test_path_environment_variable SERVERPOD_RETRY_RUNNER
 
 flutter_preflight_commands=''
 if [[ -n "${FLUTTER_ROOT:-}" ]]; then
-  # Fail with a bounded diagnostic instead of allowing a nested Flutter command
-  # to consume the bootstrap test's full timeout while acquiring its SDK lock.
+  # A fresh hosted SDK may need to resolve flutter_tools and build its snapshot
+  # under the test account. Allow that cold start to finish while still bounding
+  # a stale SDK-lock wait well below the bootstrap job's overall timeout.
   flutter_preflight_commands='echo Verifying Flutter under the Windows test account
 set "MSYS2_ARG_CONV_EXCL=*"
-bash -c "timeout 60s cmd.exe /d /c flutter --version"
+bash -c "timeout 180s cmd.exe /d /c flutter --version"
 if errorlevel 1 exit /b %errorlevel%'
 fi
 


### PR DESCRIPTION
Fix the 124 error with "Run call util\run_windows_standard_user_test.cmd run-bootstrap.cmd" on Windows CI.

```console
Run call util\run_windows_standard_user_test.cmd run-bootstrap.cmd
    call util\run_windows_standard_user_test.cmd run-bootstrap.cmd
    shell: C:\Windows\system32\cmd.EXE /D /E:ON /V:OFF /S /C "CALL "{0}""
    env:
      SERVERPOD_SILENCE_LIFECYCLE_MESSAGES: 1
      SERVERPOD_PG_CACHE_DIR: D:\a\serverpod\serverpod/.pg-cache
      PUB_CACHE: D:\a\serverpod\serverpod\.pub-cache
      FLUTTER_ROOT: C:\hostedtoolcache\windows\flutter\stable-3.38.4-x64/flutter
      SERVERPOD_REAL_DART: C:\hostedtoolcache\windows\flutter\stable-3.38.4-x64\flutter\bin\cache\dart-sdk\bin\dart.exe
      SERVERPOD_RETRY_RUNNER: D:\a\serverpod\serverpod\.github\actions\retry\run_with_retry.dart
      SERVERPOD_CLI_EXE: D:\a\serverpod\serverpod/.cli/bin/serverpod_cli.exe
      SERVERPOD_WINDOWS_TEST_USER: serverpod_ci
      SERVERPOD_WINDOWS_TEST_PASSWORD: ***
      SERVERPOD_WINDOWS_TEST_LOG: D:\a\_temp\standard-user-test\output.log
  cmd exited with error code 124.
  Verifying Flutter under the Windows test account
  Building flutter tool...
  Running pub upgrade...
  Resolving dependencies...
  Downloading packages...
  Got dependencies.
  Error: Unable to create dart snapshot for flutter tool.
```

The flake is a Flutter cold-start racing a hard-coded 60-second timeout. The chain is:

1. Every Windows bootstrap shard runs this preflight under the standard account:
    ```bash
    # util/prepare_windows_standard_user_test:117
    bash -c "timeout 60s cmd.exe /d /c flutter --version"
    ```
2. Flutter decides its tool snapshot needs rebuilding. Its launcher runs `pub upgrade`, then invokes Dart to create `flutter_tools.snapshot`.
3. If that cold bootstrap exceeds 60 seconds, `timeout` terminates it and returns 124.
4. Flutter's batch script sees the interrupted Dart process return non-zero and prints the generic:
    ```console
    # ~/fvm/versions/3.38.4/bin/internal/shared.bat:219
    Error: Unable to create dart snapshot for flutter tool.
    ```
5. The standard-user wrapper preserves exit code 124 through PsExec: `util/run_windows_standard_user_test.cmd:25`.

Live CI evidence:

- The [3.38.4 shard 2 failure](https://github.com/serverpod/serverpod/actions/runs/31039278990/job/92419888712) completed dependency resolution and was then killed while creating the snapshot.
- The [3.44.4 shard 10 failure](https://github.com/serverpod/serverpod/actions/runs/31039278990/job/92419889058) reported `Error (143)` during `pub upgrade`; 143 is the conventional `SIGTERM` result, confirming the outer timer interrupted Flutter.
- A successful sibling also printed `Building flutter tool...` and `Running pub upgrade...`, proving that rebuilding is normal here. The failure is simply whether it crosses the threshold.
- The exact same [3.38.4 shard 2 rerun](https://github.com/serverpod/serverpod/actions/runs/31039278990/job/92423430930) passed on another hosted runner without a code change.

That also explains why it moves between shards: this preflight runs before `util/run_tests_bootstrap` selects or starts any shard tests. Whichever fresh Windows VM has slower networking, disk, antivirus scanning, cache restoration, or snapshot compilation
loses the race.

One logging wrinkle: PsExec writes inner output to a file, and the outer wrapper prints it only after the process exits. Therefore the nearly identical GitHub timestamps on the Flutter lines do not represent their actual timing.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.