### PR TITLE
feat: Allow using `serial` on regular `int` columns

### DIFF
--- a/packages/serverpod_database/lib/src/adapters/postgres/postgres_default_value.dart
+++ b/packages/serverpod_database/lib/src/adapters/postgres/postgres_default_value.dart
@@ -3,13 +3,8 @@ import '../../../serverpod_database.dart';
 /// Extension methods for [ColumnType] to convert default values to PostgreSQL.
 extension PostgresColumnTypeDefault on ColumnType {
   /// Converts abstract default values to PostgreSQL column default SQL.
-  String? getPgColumnDefault(dynamic defaultValue, String tableName) {
+  String? getPgColumnDefault(dynamic defaultValue) {
     if (defaultValue == null) return null;
-
-    if ((this == ColumnType.integer || this == ColumnType.bigint) &&
-        defaultValue == defaultIntSerial) {
-      return "nextval('${tableName}_id_seq'::regclass)";
-    }
 
     switch (this) {
       case ColumnType.timestampWithoutTimeZone:

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions.dart
@@ -107,7 +107,7 @@ const _databaseModelReservedFieldNames = [
 
 /// We reserve 7 characters to enable deterministic generation of the following
 /// suffixes:
-/// - "_id_seq" suffix for the default value for serial fields stored in the
+/// - "_id_seq" suffix for the default value for serial id fields stored in the
 /// server generated table definition.
 /// - "_fk_{index}" suffix for foreign key constraints.
 const _reservedTableSuffixChars = 7;

--- a/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions/default.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/validation/restrictions/default.dart
@@ -275,6 +275,22 @@ class DefaultValueRestriction extends ValueRestriction {
       return errors;
     }
 
+    if (value == defaultIntSerial) {
+      if (key == Keyword.defaultPersistKey) {
+        return errors;
+      }
+
+      errors.add(
+        SourceSpanSeverityException(
+          'The default value "$defaultIntSerial" can not be set using the '
+          '"$key" keyword. Use the "${Keyword.defaultPersistKey}" keyword '
+          'instead.',
+          span,
+        ),
+      );
+      return errors;
+    }
+
     int? parsedValue = int.tryParse(value);
     if (parsedValue == null) {
       errors.add(

--- a/tools/serverpod_cli/lib/src/database/create_definition.dart
+++ b/tools/serverpod_cli/lib/src/database/create_definition.dart
@@ -32,8 +32,11 @@ DatabaseDefinition createDatabaseDefinitionFromModels(
                   columnType: ColumnType.values.byName(
                     column.type.databaseTypeEnum,
                   ),
-                  // The id column is not null, since it is auto generated.
-                  isNullable: column.name != 'id' && column.type.nullable,
+                  // Serial and id columns are not null, since they are auto generated.
+                  isNullable:
+                      column.defaultPersistValue != defaultIntSerial &&
+                      column.name != 'id' &&
+                      column.type.nullable,
                   dartType: column.type.toString(),
                   columnDefault: _parseColumnDefault(column),
                   vectorDimension: column.type.vectorDimension,

--- a/tools/serverpod_cli/lib/src/database/dialects/postgres.dart
+++ b/tools/serverpod_cli/lib/src/database/dialects/postgres.dart
@@ -264,6 +264,9 @@ extension PostgresColumnDefinitionPgSqlGeneration on ColumnDefinition {
 
     // The id column is special.
     if (isPrimary) {
+      if (isNullable) {
+        throw const FormatException('The id column must be non-nullable');
+      }
       type = '$type PRIMARY KEY';
       nullable = '';
     }
@@ -608,6 +611,14 @@ extension PostgresColumnMigrationPgSqlGenerator on ColumnMigration {
             'ALTER TABLE "$tableName" ALTER COLUMN "$physicalName"'
             ' DROP DEFAULT;\n';
         return out;
+      } else if (newDefault == defaultIntSerial) {
+        // Adding a serial default requires creating a sequence via the serial
+        // pseudo-type on column (re)create. SET DEFAULT cannot express this.
+        throw StateError(
+          'Cannot SET DEFAULT "$defaultIntSerial" on column "$physicalName" '
+          'of table "$tableName". Auto-increment defaults must be applied by '
+          'recreating the column with the serial type.',
+        );
       } else {
         var newDefaultSql = columnDefinition.columnType.getPgColumnDefault(
           newDefault,

--- a/tools/serverpod_cli/lib/src/database/dialects/postgres.dart
+++ b/tools/serverpod_cli/lib/src/database/dialects/postgres.dart
@@ -123,7 +123,7 @@ extension PostgresTableDefinitionPgSqlGeneration on TableDefinition {
 
     var columnsPgSql = <String>[];
     for (var column in columns) {
-      columnsPgSql.add('    ${column.toPgSqlFragment(tableName: name)}');
+      columnsPgSql.add('    ${column.toPgSqlFragment()}');
     }
     out += columnsPgSql.join(',\n');
 
@@ -169,12 +169,10 @@ extension PostgresTableDefinitionPgSqlGeneration on TableDefinition {
 }
 
 extension PostgresColumnDefinitionPgSqlGeneration on ColumnDefinition {
-  /// Whether the column is a primary key of type int serial.
-  bool get isIntSerialIdColumn =>
-      isPrimary &&
+  /// Whether the column uses a serial auto-increment default.
+  bool get isIntSerialColumn =>
       (columnType == ColumnType.integer || columnType == ColumnType.bigint) &&
-      ((columnDefault?.startsWith('nextval') ?? false) ||
-          columnDefault == defaultIntSerial);
+      columnDefault == defaultIntSerial;
 
   /// Whether the column is of a vector type.
   bool get isVectorColumn =>
@@ -190,7 +188,7 @@ extension PostgresColumnDefinitionPgSqlGeneration on ColumnDefinition {
       columnType == ColumnType.geographyPolygon ||
       columnType == ColumnType.geographyGeometryCollection;
 
-  String toPgSqlFragment({String tableName = ''}) {
+  String toPgSqlFragment() {
     String type;
     switch (columnType) {
       case ColumnType.bigint:
@@ -252,24 +250,20 @@ extension PostgresColumnDefinitionPgSqlGeneration on ColumnDefinition {
     }
 
     var nullable = isNullable ? '' : ' NOT NULL';
-    var defaultSql = columnType.getPgColumnDefault(
-      columnDefault,
-      tableName,
-    );
+    var defaultSql = columnType.getPgColumnDefault(columnDefault);
 
     var defaultValue = defaultSql != null ? ' DEFAULT $defaultSql' : '';
 
+    if (isIntSerialColumn) {
+      type = columnType == ColumnType.bigint || isPrimary
+          ? 'bigserial'
+          : 'serial';
+      defaultValue = '';
+      nullable = ' NOT NULL';
+    }
+
     // The id column is special.
     if (isPrimary) {
-      if (isNullable) {
-        throw const FormatException('The id column must be non-nullable');
-      }
-
-      if (isIntSerialIdColumn) {
-        type = 'bigserial';
-        defaultValue = '';
-      }
-
       type = '$type PRIMARY KEY';
       nullable = '';
     }
@@ -554,8 +548,7 @@ extension PostgresTableMigrationPgSqlGenerator on TableMigration {
 
     // Add columns
     for (var addColumn in addColumns) {
-      out +=
-          'ALTER TABLE "$name" ADD COLUMN ${addColumn.toPgSqlFragment(tableName: name)};\n';
+      out += 'ALTER TABLE "$name" ADD COLUMN ${addColumn.toPgSqlFragment()};\n';
     }
 
     // Modify columns
@@ -618,7 +611,6 @@ extension PostgresColumnMigrationPgSqlGenerator on ColumnMigration {
       } else {
         var newDefaultSql = columnDefinition.columnType.getPgColumnDefault(
           newDefault,
-          tableName,
         );
         out +=
             'ALTER TABLE "$tableName" ALTER COLUMN "$physicalName"'

--- a/tools/serverpod_cli/lib/src/database/dialects/sqlite.dart
+++ b/tools/serverpod_cli/lib/src/database/dialects/sqlite.dart
@@ -100,7 +100,7 @@ extension SqliteTableDefinitionSqlGeneration on TableDefinition {
     var definitions = <String>[];
 
     for (var column in columns) {
-      definitions.add('    ${column.toSqlFragment()}');
+      definitions.add('    ${column.toSqlFragment(tableName: tableName)}');
     }
 
     // Inline Foreign Keys
@@ -141,7 +141,7 @@ extension SqliteColumnDefinitionSqlGeneration on ColumnDefinition {
     return isPrimary || isUnique || columnDefault != null;
   }
 
-  String toSqlFragment() {
+  String toSqlFragment({String? tableName}) {
     String type;
     switch (columnType) {
       case ColumnType.bigint:
@@ -174,6 +174,19 @@ extension SqliteColumnDefinitionSqlGeneration on ColumnDefinition {
     var defaultSql = columnType.getSqliteColumnDefault(columnDefault);
 
     var defaultValue = defaultSql != null ? ' DEFAULT ($defaultSql)' : '';
+
+    if (columnDefault == defaultIntSerial && !isPrimary) {
+      final columnLocation = tableName == null
+          ? 'Column "$name"'
+          : 'Column "$name" on table "$tableName"';
+      throw MigrationUnsupportedByDialectException(
+        dialect: DatabaseDialect.sqlite.name,
+        reason:
+            '$columnLocation uses "$defaultIntSerial" as its default value, '
+            'but "${DatabaseDialect.sqlite.name}" only supports auto-increment '
+            'on the "$defaultPrimaryKeyName" column.',
+      );
+    }
 
     // The id column is special.
     if (isPrimary) {
@@ -379,7 +392,9 @@ extension SqliteTableMigrationSqlGeneration on TableMigration {
     for (var addColumn in addColumns) {
       // Note: SQLite ADD COLUMN cannot support PRIMARY KEY or UNIQUE constraints.
       // These will be handled by the table rebuild.
-      out += 'ALTER TABLE "$name" ADD COLUMN ${addColumn.toSqlFragment()};\n';
+      out +=
+          'ALTER TABLE "$name" '
+          'ADD COLUMN ${addColumn.toSqlFragment(tableName: name)};\n';
     }
 
     // Add indexes

--- a/tools/serverpod_cli/lib/src/database/extensions.dart
+++ b/tools/serverpod_cli/lib/src/database/extensions.dart
@@ -43,6 +43,16 @@ extension ColumnComparisons on ColumnDefinition {
       return false;
     }
 
+    // Adding a serial (auto-increment) default requires creating a sequence,
+    // which can only be done by (re)creating the column with the serial
+    // pseudo-type. An in-place "ALTER COLUMN ... SET DEFAULT" would reference a
+    // sequence that is never created, so the column must be dropped and
+    // recreated instead.
+    if (other.columnDefault == db.defaultIntSerial &&
+        columnDefault != db.defaultIntSerial) {
+      return false;
+    }
+
     // Vector dimension changes require dropping and recreating the column.
     if (vectorDimension != other.vectorDimension) {
       return false;

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_model_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_model_test.dart
@@ -100,6 +100,39 @@ void main() {
     );
 
     test(
+      'when the field is of type int and the defaultModel is set to "serial", '
+      'then an error is generated',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+          class: Example
+          table: example
+          fields:
+            intType: int?, defaultModel=serial
+          ''',
+          ).build(),
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(
+          config,
+          models,
+          onErrorsCollector(collector),
+        ).validateAll();
+
+        expect(collector.errors, isNotEmpty);
+
+        var error = collector.errors.first as SourceSpanSeverityException;
+        expect(
+          error.message,
+          'The default value "serial" can not be set using the "defaultModel" '
+          'keyword. Use the "defaultPersist" keyword instead.',
+        );
+      },
+    );
+
+    test(
       'when the field is of type int with an invalid default value "TEN", then an error is generated',
       () {
         var models = [

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_persist_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_persist_test.dart
@@ -72,6 +72,35 @@ void main() {
     );
 
     test(
+      'when the field is of type int and the defaultPersist is set to "serial", '
+      'then the field should have a "default persist" value',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+          class: Example
+          table: example
+          fields:
+            syncVersion: int?, defaultPersist=serial
+          ''',
+          ).build(),
+        ];
+
+        var collector = CodeGenerationCollector();
+        var definitions = StatefulAnalyzer(
+          config,
+          models,
+          onErrorsCollector(collector),
+        ).validateAll();
+
+        expect(collector.errors, isEmpty);
+
+        var definition = definitions.first as ClassDefinition;
+        expect(definition.fields.last.defaultPersistValue, 'serial');
+      },
+    );
+
+    test(
       'when the field is of type int and the defaultPersist is empty, then an error is generated',
       () {
         var models = [

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/default/integer/field_int_default_test.dart
@@ -193,6 +193,39 @@ void main() {
         );
       },
     );
+
+    test(
+      'when the field is of type int and the default is set to "serial", '
+      'then an error is generated',
+      () {
+        var models = [
+          ModelSourceBuilder().withYaml(
+            '''
+          class: Example
+          table: example
+          fields:
+            intType: int?, default=serial
+          ''',
+          ).build(),
+        ];
+
+        var collector = CodeGenerationCollector();
+        StatefulAnalyzer(
+          config,
+          models,
+          onErrorsCollector(collector),
+        ).validateAll();
+
+        expect(collector.errors, isNotEmpty);
+
+        var error = collector.errors.first as SourceSpanSeverityException;
+        expect(
+          error.message,
+          'The default value "serial" can not be set using the "default" '
+          'keyword. Use the "defaultPersist" keyword instead.',
+        );
+      },
+    );
   });
 
   test(

--- a/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
+++ b/tools/serverpod_cli/test/database/create_definition/database_action_definition_test.dart
@@ -262,4 +262,46 @@ void main() {
       });
     },
   );
+
+  group(
+    'Given a class definition with a serial int field when generating a database definition',
+    () {
+      var field = FieldDefinitionBuilder()
+          .withName('syncVersion')
+          .withTypeDefinition('int', true)
+          .withDefaults(defaultPersistValue: defaultIntSerial)
+          .build();
+      var model = ModelClassDefinitionBuilder()
+          .withTableName('example')
+          .withField(field)
+          .build();
+
+      late var databaseDefinition = createDatabaseDefinitionFromModels(
+        [model],
+        'example',
+        [],
+      );
+
+      test('then the serial column is not primary.', () {
+        var serialColumn = databaseDefinition.tables.first.columns.firstWhere(
+          (c) => c.name == 'syncVersion',
+        );
+        expect(serialColumn.isPrimary, isFalse);
+      });
+
+      test('then the serial column has default "serial".', () {
+        var serialColumn = databaseDefinition.tables.first.columns.firstWhere(
+          (c) => c.name == 'syncVersion',
+        );
+        expect(serialColumn.columnDefault, defaultIntSerial);
+      });
+
+      test('then the serial column is not nullable.', () {
+        var serialColumn = databaseDefinition.tables.first.columns.firstWhere(
+          (c) => c.name == 'syncVersion',
+        );
+        expect(serialColumn.isNullable, isFalse);
+      });
+    },
+  );
 }

--- a/tools/serverpod_cli/test/database/extentions/pgsql_code_generation_test.dart
+++ b/tools/serverpod_cli/test/database/extentions/pgsql_code_generation_test.dart
@@ -1,8 +1,7 @@
 import 'package:recase/recase.dart';
 import 'package:serverpod_cli/analyzer.dart';
-import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/database/create_definition.dart';
-import 'package:serverpod_service_client/serverpod_service_client.dart';
+import 'package:serverpod_database/serverpod_database.dart';
 import 'package:test/test.dart';
 
 import '../../test_util/builders/database/column_definition_builder.dart';
@@ -777,6 +776,41 @@ END
       },
     );
   });
+
+  test(
+    'Given a column migration that sets a serial default, '
+    'when generating PostgreSQL SQL, '
+    'then a StateError is thrown instead of emitting SET DEFAULT serial.',
+    () {
+      var columnDefinition = ColumnDefinitionBuilder()
+          .withName('count')
+          .withColumnType(ColumnType.bigint)
+          .withDartType('int?')
+          .build();
+
+      var migration = ColumnMigration(
+        columnName: 'count',
+        addNullable: false,
+        removeNullable: true,
+        changeDefault: true,
+        newDefault: defaultIntSerial,
+      );
+
+      expect(
+        () => migration.toPgSql(
+          tableName: 'example_table',
+          columnDefinition: columnDefinition,
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('Cannot SET DEFAULT "$defaultIntSerial"'),
+          ),
+        ),
+      );
+    },
+  );
 
   group('Given a column migration with a type change', () {
     test(

--- a/tools/serverpod_cli/test/database/migration/default_value_test.dart
+++ b/tools/serverpod_cli/test/database/migration/default_value_test.dart
@@ -466,4 +466,73 @@ void main() {
       );
     },
   );
+
+  group(
+    'Given a source and target definition where an existing int column is changed to a serial auto-increment column',
+    () {
+      var tableName = 'example_table';
+      var columnName = 'count';
+
+      ColumnDefinition countColumn({required bool serial}) => ColumnDefinition(
+        name: columnName,
+        columnType: ColumnType.bigint,
+        isNullable: !serial,
+        columnDefault: serial ? defaultIntSerial : null,
+        dartType: 'int?',
+      );
+
+      DatabaseDefinition definition({required bool serial}) =>
+          DatabaseDefinitionBuilder()
+              .withTable(
+                TableDefinitionBuilder()
+                    .withName(tableName)
+                    .withColumn(countColumn(serial: serial))
+                    .build(),
+              )
+              .build();
+
+      var migration = generateDatabaseMigration(
+        databaseSource: definition(serial: false),
+        databaseTarget: definition(serial: true),
+      );
+
+      test(
+        'then the column is dropped and recreated instead of altered in place.',
+        () {
+          var alterTable = migration.actions.first.alterTable!;
+          expect(alterTable.modifyColumns, isEmpty);
+          expect(alterTable.deleteColumns, contains(columnName));
+          expect(
+            alterTable.addColumns.map((c) => c.name),
+            contains(columnName),
+          );
+        },
+      );
+
+      test('then a destructive warning is generated.', () {
+        expect(
+          migration.warnings.map((w) => w.destructive),
+          contains(true),
+        );
+      });
+
+      test(
+        'then the generated SQL recreates the column using bigserial without '
+        'an explicit sequence.',
+        () {
+          var sql = migration.toPgSql(
+            databaseDefinition: definition(serial: true),
+            installedModules: [],
+            removedModules: [],
+          );
+          expect(
+            sql,
+            contains('ADD COLUMN "$columnName" bigserial NOT NULL'),
+          );
+          expect(sql, isNot(contains('CREATE SEQUENCE')));
+          expect(sql, isNot(contains('nextval')));
+        },
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/database/migration/migration_sql_test.dart
+++ b/tools/serverpod_cli/test/database/migration/migration_sql_test.dart
@@ -1,6 +1,9 @@
 import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_database/serverpod_database.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
 import 'package:test/test.dart';
 
+import '../../test_util/builders/database/column_definition_builder.dart';
 import '../../test_util/builders/database/database_definition_builder.dart';
 import '../../test_util/builders/database/table_definition_builder.dart';
 
@@ -64,6 +67,81 @@ void main() {
       );
 
       expect(sql, contains('"id" INTEGER PRIMARY KEY'));
+    },
+  );
+
+  test(
+    'Given database table definition with a serial int column, '
+    'when generating PostgreSQL SQL, '
+    'then the column uses bigserial without an explicit sequence.',
+    () {
+      const tableName = 'example_table';
+      const columnName = 'syncVersion';
+
+      var serialColumn = ColumnDefinitionBuilder()
+          .withName(columnName)
+          .withColumnType(ColumnType.bigint)
+          .withIsNullable(false)
+          .withColumnDefault(defaultIntSerial)
+          .withDartType('int?')
+          .build();
+
+      var databaseDefinition = DatabaseDefinitionBuilder()
+          .withTable(
+            TableDefinitionBuilder()
+                .withName(tableName)
+                .withColumn(serialColumn)
+                .build(),
+          )
+          .build();
+
+      var sql = databaseDefinition.toPgSql(installedModules: []);
+
+      expect(sql, contains('"syncVersion" bigserial NOT NULL'));
+      expect(sql, isNot(contains('CREATE SEQUENCE')));
+      expect(sql, isNot(contains('nextval')));
+    },
+  );
+
+  test(
+    'Given a SQLite database table definition with a serial int column, '
+    'when generating SQL for SQLite, '
+    'then the unsupported dialect configuration is rejected.',
+    () {
+      var databaseDefinition = DatabaseDefinitionBuilder()
+          .withDefaultModules()
+          .withTable(
+            TableDefinitionBuilder()
+                .withName('example_table')
+                .withColumn(
+                  ColumnDefinitionBuilder()
+                      .withName('syncVersion')
+                      .withColumnType(ColumnType.bigint)
+                      .withIsNullable(false)
+                      .withColumnDefault(defaultIntSerial)
+                      .withDartType('int?')
+                      .build(),
+                )
+                .build(),
+          )
+          .build();
+
+      expect(
+        () => databaseDefinition.toSqliteSql(
+          installedModules: databaseDefinition.installedModules,
+        ),
+        throwsA(
+          isA<MigrationUnsupportedByDialectException>()
+              .having((error) => error.dialect, 'dialect', 'sqlite')
+              .having(
+                (error) => error.reason,
+                'reason',
+                'Column "syncVersion" on table "example_table" uses "serial" '
+                    'as its default value, but "sqlite" only supports '
+                    'auto-increment on the "id" column.',
+              ),
+        ),
+      );
     },
   );
 

--- a/tools/serverpod_cli/test/integration/migrations/create_migration_dialect_rejection_test.dart
+++ b/tools/serverpod_cli/test/integration/migrations/create_migration_dialect_rejection_test.dart
@@ -14,10 +14,9 @@ import '../../test_util/builders/database/index_definition_builder.dart';
 import '../../test_util/builders/database/table_definition_builder.dart';
 import '../../test_util/builders/generator_config_builder.dart';
 
-/// A model can declare an index that only some dialects can express, and it
-/// reaches every dialect the project migrates to. `nulls_distinct: false` is
-/// one such index: PostgreSQL has `NULLS NOT DISTINCT`, SQLite has no
-/// equivalent and the constraint cannot be dropped without widening the index.
+/// A model can declare database behavior that only some dialects can express,
+/// and it reaches every dialect the project migrates to. Examples include a
+/// null-not-distinct index or a non-ID serial column reaching SQLite.
 ///
 /// These tests drive the real action against an on-disk project to lock that
 /// hard dialect rejection returns a single top-level [CreateMigrationFailed],
@@ -64,6 +63,19 @@ indexes:
     fields: name
     unique: true
     nulls_distinct: $nullsDistinct
+''');
+  }
+
+  void writeClientTableModelWithSerial({required bool includeSerial}) {
+    var hostModelsDir = Directory(
+      path.join(serverDirectory.path, 'lib', 'src', 'models'),
+    )..createSync(recursive: true);
+    File(path.join(hostModelsDir.path, 'example.yaml')).writeAsStringSync('''
+class: Example
+table: example
+database: all
+fields:
+  name: String${includeSerial ? '\n  syncVersion: int?, defaultPersist=serial' : ''}
 ''');
   }
 
@@ -228,6 +240,61 @@ fields:
 
       expect(result, isA<CreateMigrationServerClientCreated>());
       expect(result.success, isTrue);
+    },
+  );
+
+  group(
+    'Given a PostgreSQL server and SQLite client migration adding a non-ID serial column,',
+    () {
+      late GeneratorConfig config;
+      late String serverRegistryBeforeRejection;
+      late String clientRegistryBeforeRejection;
+      late List<String> serverVersionsBeforeRejection;
+      late List<String> clientVersionsBeforeRejection;
+
+      setUp(() async {
+        writeClientTableModelWithSerial(includeSerial: false);
+        config = buildConfig();
+        await createMigrationAction(config: config);
+        writeClientTableModelWithSerial(includeSerial: true);
+        serverRegistryBeforeRejection = readServerRegistry();
+        clientRegistryBeforeRejection = readClientRegistry(config);
+        serverVersionsBeforeRejection = listMigrationVersions(
+          serverMigrationsDirectory(),
+        );
+        clientVersionsBeforeRejection = listMigrationVersions(
+          clientMigrationsDirectory(config),
+        );
+      });
+
+      test(
+        'when creating a migration, '
+        'then it rejects the SQLite migration and persists neither side.',
+        () async {
+          var result = await createMigrationAction(config: config);
+
+          expect(result, isA<CreateMigrationFailed>());
+          expect(
+            (result as CreateMigrationFailed).message,
+            'Unable to create migration for the "sqlite" database. The '
+            'following is not supported by this database:\n'
+            '  • Column "syncVersion" on table "example" uses "serial" as its '
+            'default value, but "sqlite" only supports auto-increment on the '
+            '"id" column.',
+          );
+          expect(result.success, isFalse);
+          expect(readServerRegistry(), serverRegistryBeforeRejection);
+          expect(readClientRegistry(config), clientRegistryBeforeRejection);
+          expect(
+            listMigrationVersions(serverMigrationsDirectory()),
+            serverVersionsBeforeRejection,
+          );
+          expect(
+            listMigrationVersions(clientMigrationsDirectory(config)),
+            clientVersionsBeforeRejection,
+          );
+        },
+      );
     },
   );
 


### PR DESCRIPTION
Closes: #5484

While addressing this, I removed the default `nextval(...)` that we used to generate for Postgres in the past only to identify that the column should be written with `bigserial` (we have never used the `nextval(...)` on real SQL code). It is safe to remove because this check would only happen when generating SQL, which comes after the migration that already evaluates the field as `serial` (in case a project migrates directly from 3.2 -> 4.0.0, for example).

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.