### PR TITLE
feat: Add Module.onStartup hooks for module server startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/examples/auth/auth_server/lib/src/generated/endpoints.dart
+++ b/examples/auth/auth_server/lib/src/generated/endpoints.dart
@@ -742,4 +742,10 @@ class Endpoints extends _is.EndpointDispatch {
     modules['serverpod_auth_core'] = _iacs.Endpoints()
       ..initializeEndpoints(server);
   }
+
+  @override
+  Future<void> onStartup(_is.Session session) async {
+    await modules['serverpod_auth_core']!.onStartup(session);
+    await modules['serverpod_auth_idp']!.onStartup(session);
+  }
 }

--- a/examples/legacy/auth_example/auth_example_server/lib/src/generated/endpoints.dart
+++ b/examples/legacy/auth_example/auth_example_server/lib/src/generated/endpoints.dart
@@ -61,4 +61,9 @@ class Endpoints extends _is.EndpointDispatch {
   _is.FutureCallDispatch? get futureCalls {
     return _i2o1w9mh.FutureCalls();
   }
+
+  @override
+  Future<void> onStartup(_is.Session session) async {
+    await modules['serverpod_auth']!.onStartup(session);
+  }
 }

--- a/integrations/serverpod_cloud_storage/CHANGELOG.md
+++ b/integrations/serverpod_cloud_storage/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/integrations/serverpod_cloud_storage_gcp/CHANGELOG.md
+++ b/integrations/serverpod_cloud_storage_gcp/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/integrations/serverpod_cloud_storage_r2/CHANGELOG.md
+++ b/integrations/serverpod_cloud_storage_r2/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/integrations/serverpod_cloud_storage_s3/CHANGELOG.md
+++ b/integrations/serverpod_cloud_storage_s3/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/integrations/serverpod_cloud_storage_s3_compat/CHANGELOG.md
+++ b/integrations/serverpod_cloud_storage_s3_compat/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/legacy/serverpod_auth/serverpod_auth_apple_flutter/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_apple_flutter/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/legacy/serverpod_auth/serverpod_auth_client/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_client/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/legacy/serverpod_auth/serverpod_auth_email_flutter/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_email_flutter/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/legacy/serverpod_auth/serverpod_auth_firebase_flutter/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_firebase_flutter/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/legacy/serverpod_auth/serverpod_auth_google_flutter/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_google_flutter/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/legacy/serverpod_auth/serverpod_auth_shared_flutter/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_shared_flutter/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_flutter/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter_facebook/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter_facebook/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter_firebase/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter_firebase/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/packages/serverpod/CHANGELOG.md
+++ b/packages/serverpod/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/packages/serverpod/lib/server.dart
+++ b/packages/serverpod/lib/server.dart
@@ -5,6 +5,7 @@ export 'src/server/health/health.dart';
 export 'src/server/endpoint.dart';
 export 'src/server/endpoint_dispatch.dart';
 export 'src/server/future_call_dispatch.dart';
+export 'src/server/module.dart';
 export 'src/server/future_call_manager/cron.dart';
 export 'src/server/future_call_manager/future_call.dart';
 export 'src/server/future_call_manager/future_call_manager.dart';

--- a/packages/serverpod/lib/src/server/endpoint_dispatch.dart
+++ b/packages/serverpod/lib/src/server/endpoint_dispatch.dart
@@ -23,6 +23,17 @@ abstract class EndpointDispatch {
   /// Initializes all endpoints that are connected to the dispatch.
   void initializeEndpoints(Server server);
 
+  /// Runs package [Module] startup hooks after migrations and Redis connect,
+  /// before user-facing servers start.
+  ///
+  /// Generated [Endpoints] classes override this to invoke the local
+  /// [Module] (if any) and, for host packages, each nested module's hook
+  /// exactly once (flat fan-out). The default is a no-op.
+  ///
+  /// [session] is the server's internal session — no auth context; do not
+  /// close or retain it past this call.
+  Future<void> onStartup(Session session) async {}
+
   /// Reference to the generated future calls.
   FutureCallDispatch? get futureCalls => null;
 

--- a/packages/serverpod/lib/src/server/module.dart
+++ b/packages/serverpod/lib/src/server/module.dart
@@ -1,0 +1,29 @@
+import 'session.dart';
+
+/// Superclass for package startup hooks.
+///
+/// Extend this class and override [onStartup] to run initialization after
+/// database migrations (and Redis connect) and before user-facing servers
+/// start. At most one concrete [Module] subclass may be defined per package.
+///
+/// The [Session] passed to [onStartup] is the server's internal session: it
+/// has no authentication context and logging is disabled. Do not close it or
+/// retain it past the hook. Database and Redis may be unavailable depending
+/// on project features.
+///
+/// This hook is for post-migration work only. Auth handlers, routes, and
+/// other pre-start configuration still require configure APIs invoked before
+/// `Serverpod.start`.
+///
+/// Invocation order when nested modules are present: the host package's
+/// [Module] (if any), then each dependency module sorted by module name.
+/// Order is not topological — modules must not assume dependency modules
+/// have already run.
+abstract class Module {
+  /// Called once during `Serverpod.start` after migrations and Redis connect,
+  /// before Insights and API/web servers start.
+  ///
+  /// Any thrown error fails server start. Side effects should be idempotent
+  /// because the hook runs again after `shutdown` + `start`.
+  Future<void> onStartup(Session session) async {}
+}

--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -865,6 +865,16 @@ class Serverpod {
       _internalLogVerbose('Redis is disabled, skipping.');
     }
 
+    // Run Module.onStartup hooks after migrations and Redis, before Insights
+    // and user-facing servers. Skip when maintenance mode exits immediately
+    // after applying migrations.
+    var appliedMigrations =
+        config.applyMigrations || config.applyRepairMigration;
+    if (!(config.role == ServerpodRole.maintenance && appliedMigrations)) {
+      _internalLogVerbose('Running module startup hooks.');
+      await endpoints.onStartup(internalSession);
+    }
+
     // Start servers.
     if (config.role == ServerpodRole.monolith ||
         config.role == ServerpodRole.serverless) {
@@ -907,8 +917,6 @@ class Serverpod {
     // Start maintenance tasks. If we are running in maintenance mode, we
     // will only run the maintenance tasks once. If we are applying migrations
     // no other maintenance tasks will be run.
-    var appliedMigrations =
-        (config.applyMigrations || config.applyRepairMigration);
     if (config.role == ServerpodRole.monolith ||
         (config.role == ServerpodRole.maintenance && !appliedMigrations)) {
       _internalLogVerbose('Starting maintenance tasks.');

--- a/packages/serverpod/skills/serverpod-modules/SKILL.md
+++ b/packages/serverpod/skills/serverpod-modules/SKILL.md
@@ -44,3 +44,22 @@ serverpod create --template module my_module
 ```
 
 Creates server + client packages. Add Flutter package if needed: `flutter create --template package my_module_flutter`. Set `type: module` in `config/generator.yaml`. Prefix table names (e.g. `my_module_orders`) to avoid clashes.
+
+## Module startup hooks
+
+Override post-migration initialization with a single `Module` subclass per package:
+
+```dart
+import 'package:serverpod/serverpod.dart';
+
+class MyModule extends Module {
+  @override
+  Future<void> onStartup(Session session) async {
+    // Runs after DB migrations / Redis connect, before API servers start.
+  }
+}
+```
+
+Run `serverpod generate`. The host invokes the local module (if any), then each dependency module sorted by module name (not dependency order). The session has no auth context — do not close or retain it.
+
+Auth handlers and routes still use configure APIs before `Serverpod.start`. This hook is for post-migration work only.

--- a/packages/serverpod_client/CHANGELOG.md
+++ b/packages/serverpod_client/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/packages/serverpod_database/CHANGELOG.md
+++ b/packages/serverpod_database/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/packages/serverpod_embedded_postgres/CHANGELOG.md
+++ b/packages/serverpod_embedded_postgres/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/packages/serverpod_flutter/CHANGELOG.md
+++ b/packages/serverpod_flutter/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/packages/serverpod_lints/CHANGELOG.md
+++ b/packages/serverpod_lints/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/packages/serverpod_serialization/CHANGELOG.md
+++ b/packages/serverpod_serialization/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/packages/serverpod_service_client/CHANGELOG.md
+++ b/packages/serverpod_service_client/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/packages/serverpod_shared/CHANGELOG.md
+++ b/packages/serverpod_shared/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/packages/serverpod_test/CHANGELOG.md
+++ b/packages/serverpod_test/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/templates/serverpod_templates/CHANGELOG.md
+++ b/templates/serverpod_templates/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/bootstrap_project/test/project_test.dart
+++ b/tests/bootstrap_project/test/project_test.dart
@@ -1170,6 +1170,22 @@ void main() async {
               ),
         );
 
+        // TODO: Remove once EndpointDispatch.onStartup / Module hooks are
+        // published. Docker pub-gets published packages that do not yet define
+        // onStartup, so the generated @override fails to compile.
+        final endpointsFile = File(
+          path.join(commandRoot, 'lib', 'src', 'generated', 'endpoints.dart'),
+        );
+        final endpointsSource = endpointsFile.readAsStringSync();
+        endpointsFile.writeAsStringSync(
+          endpointsSource.replaceFirst(
+            RegExp(
+              r'\n  @override\n  Future<void> onStartup\([^\)]*\) async \{\n(?:    .*\n)*  \}\n',
+            ),
+            '\n',
+          ),
+        );
+
         // TODO: Remove once DeserializationClassNameNotFoundException is
         // published. The generated protocol references the local exception,
         // while the Docker build resolves the currently published packages.

--- a/tests/bootstrap_project/test_perform_create/ide_test.dart
+++ b/tests/bootstrap_project/test_perform_create/ide_test.dart
@@ -1,3 +1,4 @@
+@Timeout(Duration(minutes: 12))
 import 'dart:io';
 
 import 'package:bootstrap_project/src/util.dart';
@@ -41,30 +42,18 @@ void main() {
       });
 
       test('then the created project has agent skills installed', () {
-        expect(
-          Directory(
-            p.join(project.projectRoot, '.agents', 'skills'),
-          ).existsSync(),
-          isTrue,
-        );
-        expect(
-          Directory(
-            p.join(project.projectRoot, '.claude', 'skills'),
-          ).existsSync(),
-          isTrue,
-        );
-        expect(
-          Directory(
-            p.join(project.projectRoot, '.cursor', 'skills'),
-          ).existsSync(),
-          isTrue,
-        );
-        expect(
-          Directory(
-            p.join(project.projectRoot, '.opencode', 'skills'),
-          ).existsSync(),
-          isTrue,
-        );
+        for (final rel in [
+          '.agents/skills',
+          '.claude/skills',
+          '.cursor/skills',
+          '.opencode/skills',
+        ]) {
+          expect(
+            Directory(p.join(project.projectRoot, rel)).existsSync(),
+            isTrue,
+            reason: 'Expected $rel after create with all IDEs',
+          );
+        }
       });
 
       group(

--- a/tests/bootstrap_project/test_perform_create/util.dart
+++ b/tests/bootstrap_project/test_perform_create/util.dart
@@ -52,13 +52,33 @@ TempProject setUpPerformCreateInTempDir({required TemplateContext context}) {
     project.workingDir = Directory.systemTemp.createTempSync(
       'sp_perform_create_',
     );
-    await performCreate(
+    final result = await performCreate(
       project.name,
       false,
       interactive: false,
       context: context,
       workingDirectory: project.workingDir,
     );
+    if (result is! CreateSuccess) {
+      final root = project.projectRoot;
+      final listing = <String>[];
+      for (final rel in [
+        '.agents/skills',
+        '.agent/skills',
+        '.claude/skills',
+        '.cursor/skills',
+        '.opencode/skills',
+        'AGENTS.md',
+        'CLAUDE.md',
+      ]) {
+        final path = p.join(root, rel);
+        listing.add('${FileSystemEntity.typeSync(path)} $rel');
+      }
+      fail(
+        'performCreate failed for ${project.name}.\n'
+        '${listing.join('\n')}',
+      );
+    }
   });
   tearDownAll(() {
     try {

--- a/tests/serverpod_auth_test/serverpod_auth_test_client/CHANGELOG.md
+++ b/tests/serverpod_auth_test/serverpod_auth_test_client/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_auth_test/serverpod_auth_test_flutter/CHANGELOG.md
+++ b/tests/serverpod_auth_test/serverpod_auth_test_flutter/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/CHANGELOG.md
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/endpoints.dart
@@ -1464,4 +1464,13 @@ class Endpoints extends _is.EndpointDispatch {
     modules['serverpod_auth'] = _i1n3uhu0.Endpoints()
       ..initializeEndpoints(server);
   }
+
+  @override
+  Future<void> onStartup(_is.Session session) async {
+    await modules['serverpod_auth']!.onStartup(session);
+    await modules['serverpod_auth_bridge']!.onStartup(session);
+    await modules['serverpod_auth_core']!.onStartup(session);
+    await modules['serverpod_auth_idp']!.onStartup(session);
+    await modules['serverpod_auth_migration']!.onStartup(session);
+  }
 }

--- a/tests/serverpod_test_client/CHANGELOG.md
+++ b/tests/serverpod_test_client/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_test_flutter/CHANGELOG.md
+++ b/tests/serverpod_test_flutter/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_test_module/serverpod_test_module_client/CHANGELOG.md
+++ b/tests/serverpod_test_module/serverpod_test_module_client/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_test_module/serverpod_test_module_server/CHANGELOG.md
+++ b/tests/serverpod_test_module/serverpod_test_module_server/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/serverpod_test_module_server.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/serverpod_test_module_server.dart
@@ -3,3 +3,4 @@ export 'src/endpoints/ignored_endpoint.dart';
 export 'src/endpoints/unauthenticated.dart';
 export 'src/generated/endpoints.dart';
 export 'src/generated/protocol.dart';
+export 'src/test_module_module.dart';

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/generated/endpoints.dart
@@ -21,6 +21,7 @@ import '../endpoints/record_streaming.dart' as _i157ib2o;
 import '../endpoints/streaming.dart' as _i8rqmf36;
 import '../endpoints/unauthenticated.dart' as _ius7wovq;
 import '../module_feature/endpoints/my_feature_endpoint.dart' as _iv1xl3uy;
+import '../test_module_module.dart' as _idn2qzyz;
 
 class Endpoints extends _is.EndpointDispatch {
   @override
@@ -356,5 +357,10 @@ class Endpoints extends _is.EndpointDispatch {
         ),
       },
     );
+  }
+
+  @override
+  Future<void> onStartup(_is.Session session) async {
+    await _idn2qzyz.TestModuleModule().onStartup(session);
   }
 }

--- a/tests/serverpod_test_module/serverpod_test_module_server/lib/src/test_module_module.dart
+++ b/tests/serverpod_test_module/serverpod_test_module_server/lib/src/test_module_module.dart
@@ -1,0 +1,25 @@
+import 'package:serverpod/serverpod.dart';
+
+/// Test module startup hook used by host integration tests.
+class TestModuleModule extends Module {
+  /// Number of times [onStartup] has been invoked in this isolate.
+  static int startupCount = 0;
+
+  /// When non-null, [onStartup] throws this error.
+  static Object? throwOnStartup;
+
+  /// Resets test state between cases.
+  static void reset() {
+    startupCount = 0;
+    throwOnStartup = null;
+  }
+
+  @override
+  Future<void> onStartup(Session session) async {
+    final error = throwOnStartup;
+    if (error != null) {
+      throw error;
+    }
+    startupCount++;
+  }
+}

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/CHANGELOG.md
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/CHANGELOG.md
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_test_server/CHANGELOG.md
+++ b/tests/serverpod_test_server/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_test_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_server/lib/src/generated/endpoints.dart
@@ -9913,4 +9913,11 @@ class Endpoints extends _is.EndpointDispatch {
   _is.FutureCallDispatch? get futureCalls {
     return _i3an2vcw.FutureCalls();
   }
+
+  @override
+  Future<void> onStartup(_is.Session session) async {
+    await modules['serverpod_auth']!.onStartup(session);
+    await modules['serverpod_test_module']!.onStartup(session);
+    await modules['serverpod_test_shared_module']!.onStartup(session);
+  }
 }

--- a/tests/serverpod_test_server/test_integration/module_on_startup_test.dart
+++ b/tests/serverpod_test_server/test_integration/module_on_startup_test.dart
@@ -1,0 +1,63 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_module_server/serverpod_test_module_server.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a Serverpod host with a module Module hook', () {
+    late Serverpod server;
+
+    setUp(() async {
+      TestModuleModule.reset();
+      server = IntegrationTestServer.create();
+      await server.ensureDatabase();
+    });
+
+    tearDown(() async {
+      TestModuleModule.reset();
+      await server.shutdown(exitProcess: false);
+    });
+
+    test(
+      'when starting Serverpod, then the module onStartup hook runs once.',
+      () async {
+        await server.start();
+
+        expect(TestModuleModule.startupCount, 1);
+      },
+      timeout: Timeout(Duration(seconds: 120)),
+    );
+
+    test(
+      'when starting Serverpod twice, then the module onStartup hook runs again.',
+      () async {
+        await server.start();
+        await server.shutdown(exitProcess: false);
+        await server.start();
+
+        expect(TestModuleModule.startupCount, 2);
+      },
+      timeout: Timeout(Duration(seconds: 120)),
+    );
+
+    test(
+      'when module onStartup throws, then start fails.',
+      () async {
+        TestModuleModule.throwOnStartup = StateError('module startup failed');
+
+        await expectLater(
+          server.start(runInGuardedZone: false),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              'module startup failed',
+            ),
+          ),
+        );
+        expect(TestModuleModule.startupCount, 0);
+      },
+      timeout: Timeout(Duration(seconds: 120)),
+    );
+  });
+}

--- a/tests/serverpod_test_shared/CHANGELOG.md
+++ b/tests/serverpod_test_shared/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/CHANGELOG.md
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_flutter/CHANGELOG.md
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_flutter/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/CHANGELOG.md
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/endpoints.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/endpoints.dart
@@ -128,4 +128,11 @@ class Endpoints extends _is.EndpointDispatch {
   _is.FutureCallDispatch? get futureCalls {
     return _il0f3y8p.FutureCalls();
   }
+
+  @override
+  Future<void> onStartup(_is.Session session) async {
+    await modules['serverpod_auth_core']!.onStartup(session);
+    await modules['serverpod_auth_idp']!.onStartup(session);
+    await modules['serverpod_test_shared_module']!.onStartup(session);
+  }
 }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_shared/CHANGELOG.md
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_shared/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tools/serverpod_cli/CHANGELOG.md
+++ b/tools/serverpod_cli/CHANGELOG.md
@@ -83,6 +83,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Server, web server and client:
 
+- feat: Adds `Module.onStartup` hooks invoked after migrations and before servers start.
 - feat: Ensures at-least-once semantics for future calls execution.
 - feat: Adds dedicated support for recurring future calls.
 - feat: Exposes configuration options for finding and deleting broken future calls on server startup.

--- a/tools/serverpod_cli/lib/analyzer.dart
+++ b/tools/serverpod_cli/lib/analyzer.dart
@@ -7,6 +7,7 @@ export 'package:source_span/source_span.dart'
 export 'src/analyzer/code_analysis_collector.dart' show CodeAnalysisCollector;
 export 'src/analyzer/dart/endpoints_analyzer.dart' show EndpointsAnalyzer;
 export 'src/analyzer/dart/future_calls_analyzer.dart' show FutureCallsAnalyzer;
+export 'src/analyzer/dart/modules_analyzer.dart' show ModulesAnalyzer;
 export 'src/analyzer/models/definitions.dart'
     show
         SerializableModelDefinition,

--- a/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/definitions.dart
@@ -3,6 +3,31 @@ import 'package:recase/recase.dart';
 import '../../generator/types.dart';
 import '../models/definitions.dart';
 
+/// Describes a package [Module] startup hook class.
+class ModuleDefinition {
+  /// Create a new [ModuleDefinition].
+  const ModuleDefinition({
+    required this.className,
+    required this.filePath,
+    required this.isAbstract,
+  });
+
+  /// The actual class name of the module.
+  final String className;
+
+  /// The file path where the module class is stored.
+  final String filePath;
+
+  /// Whether this module class is abstract.
+  final bool isAbstract;
+
+  /// The name of the external package where this module is defined. Will
+  /// return null if the module comes from the project under generation.
+  String? get packageName => filePath.startsWith('package:')
+      ? filePath.split('/').first.split(':').last
+      : null;
+}
+
 /// Describes a single future call.
 class FutureCallDefinition {
   /// Create a new [FutureCallDefinition].

--- a/tools/serverpod_cli/lib/src/analyzer/dart/module_analyzers/module_class_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/module_analyzers/module_class_analyzer.dart
@@ -1,0 +1,123 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
+import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/dart/element_extensions.dart';
+
+/// Parses and validates classes that extend Serverpod's [Module] base class.
+abstract class ModuleClassAnalyzer {
+  /// Parses an [ClassElement] into a [ModuleDefinition].
+  ///
+  /// Assumes that the [ClassElement] is a valid module class. Definitions that
+  /// have already been parsed are not parsed again.
+  static void parse(
+    ClassElement element,
+    String filePath,
+    List<ModuleDefinition> moduleDefinitions,
+  ) {
+    var className = element.displayName;
+    if (moduleDefinitions.any(
+      (e) => e.className == className && e.filePath == filePath,
+    )) {
+      return;
+    }
+
+    var parentClass = element.supertype?.element;
+    var parentClassName = parentClass?.name;
+
+    if (parentClass is ClassElement &&
+        parentClassName != null &&
+        parentClassName != 'Module') {
+      var parentFilePath = parentClass.library == element.library
+          ? filePath
+          : parentClass.library.identifier;
+
+      parse(parentClass, parentFilePath, moduleDefinitions);
+    }
+
+    moduleDefinitions.add(
+      ModuleDefinition(
+        className: className,
+        filePath: filePath,
+        isAbstract: element.isAbstract,
+      ),
+    );
+  }
+
+  /// Creates a namespace for the [ClassElement] based on the [filePath].
+  static String elementNamespace(ClassElement element, String filePath) {
+    return '{$filePath}_${element.name}';
+  }
+
+  /// Returns true if the [ClassElement] is a module class that should be
+  /// validated and parsed.
+  ///
+  /// Non-constructable concrete classes are included so validation can emit
+  /// an error; they are not selected for [ProtocolDefinition.module].
+  static bool isModuleClass(ClassElement element) {
+    return isModuleInterface(element);
+  }
+
+  /// Returns `true` if the class extends the Serverpod `Module` base class.
+  static bool isModuleInterface(ClassElement element) {
+    return element.allSupertypes.any((s) {
+      final superElement = s.element;
+      if (superElement.name != 'Module') return false;
+      // Require Serverpod's Module, not an unrelated class with the same name.
+      return superElement.library.identifier.contains('serverpod');
+    });
+  }
+
+  /// Validates the [ClassElement] and returns a list of errors.
+  static List<SourceSpanSeverityException> validate(
+    ClassElement classElement, {
+    required bool exceedsCardinality,
+  }) {
+    List<SourceSpanSeverityException> errors = [];
+
+    if (!classElement.isAbstract &&
+        !_hasPublicDefaultConstructor(classElement)) {
+      errors.add(
+        SourceSpanSeverityException(
+          'Module class ${classElement.name} must be default-constructable. '
+          'Provide an unnamed constructor with no required parameters.',
+          classElement.span,
+          severity: SourceSpanSeverity.error,
+        ),
+      );
+    }
+
+    if (exceedsCardinality &&
+        !classElement.isAbstract &&
+        _hasPublicDefaultConstructor(classElement)) {
+      errors.add(
+        SourceSpanSeverityException(
+          'A package may define at most one Module class.',
+          classElement.span,
+          severity: SourceSpanSeverity.error,
+        ),
+      );
+    }
+
+    return errors;
+  }
+
+  /// Whether [classElement] can be instantiated with `ClassName()`.
+  static bool hasPublicDefaultConstructor(ClassElement classElement) {
+    return _hasPublicDefaultConstructor(classElement);
+  }
+
+  static bool _hasPublicDefaultConstructor(ClassElement classElement) {
+    if (!classElement.isConstructable) return false;
+
+    for (final constructor in classElement.constructors) {
+      if (constructor.isFactory) continue;
+      // Unnamed constructors report as name 'new' or null/empty.
+      final name = constructor.name;
+      if (name != null && name != 'new' && name.isNotEmpty) continue;
+      if (constructor.isPrivate) continue;
+      if (constructor.formalParameters.any((p) => p.isRequired)) return false;
+      return true;
+    }
+    return false;
+  }
+}

--- a/tools/serverpod_cli/lib/src/analyzer/dart/modules_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/dart/modules_analyzer.dart
@@ -1,0 +1,350 @@
+import 'dart:collection';
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/dart/analysis/session.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/diagnostic/diagnostic.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
+import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/dart/module_analyzers/module_class_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/util/analysis_helpers.dart';
+
+/// Cached analysis result for a single module file.
+class _CachedModuleFileResult {
+  final List<ModuleDefinition> definitions;
+  final bool hadErrors;
+
+  _CachedModuleFileResult({
+    required this.definitions,
+    required this.hadErrors,
+  });
+}
+
+/// Analyzes dart files for [Module] startup hook classes.
+class ModulesAnalyzer {
+  final AnalysisContextCollection collection;
+
+  final String absoluteIncludedPaths;
+
+  /// Create a new [ModulesAnalyzer] for [directory].
+  ///
+  /// When [collection] is provided it is reused (e.g. shared with
+  /// [EndpointsAnalyzer]). Otherwise a new one is created internally.
+  ModulesAnalyzer({
+    required Directory directory,
+    AnalysisContextCollection? collection,
+  }) : collection = collection ?? createAnalysisContextCollection(directory),
+       absoluteIncludedPaths = directory.absolute.path;
+
+  /// Cached per-file analysis results for module files.
+  /// Uses [SplayTreeMap] to keep keys sorted, ensuring deterministic
+  /// iteration order when collecting definitions across runs.
+  final _fileCache = SplayTreeMap<String, _CachedModuleFileResult>();
+
+  /// The module files currently cached with errors.
+  Set<String> get _erroredFiles => {
+    for (final entry in _fileCache.entries)
+      if (entry.value.hadErrors) entry.key,
+  };
+
+  /// Inform the analyzer that the provided [filePaths] have been updated.
+  ///
+  /// Refreshes the Dart analysis context for the changed files and returns
+  /// `true` if any of them are (or were) module files, meaning code
+  /// generation should run.
+  Future<bool> updateFileContexts(Set<String> filePaths) async {
+    final relevantPaths = filePaths
+        .where((f) => p.isWithin(absoluteIncludedPaths, p.absolute(f)))
+        .toSet();
+
+    final erroredFilesBefore = _erroredFiles;
+    final keysBefore = _fileCache.keys.toSet();
+
+    await analyze(
+      collector: CodeGenerationCollector(),
+      changedFiles: relevantPaths,
+    );
+
+    final erroredFilesAfter = _erroredFiles;
+    final keysAfter = _fileCache.keys.toSet();
+
+    if (keysBefore.length != keysAfter.length ||
+        keysAfter.difference(keysBefore).isNotEmpty ||
+        erroredFilesBefore.length != erroredFilesAfter.length ||
+        erroredFilesAfter.difference(erroredFilesBefore).isNotEmpty) {
+      return true;
+    }
+
+    for (final path in relevantPaths) {
+      if (!path.endsWith('.dart') || path.endsWith('_test.dart')) continue;
+      if (_fileCache.containsKey(path)) return true;
+      if (_isModuleFile(File(path))) return true;
+    }
+
+    return false;
+  }
+
+  /// Analyze files in the [AnalysisContextCollection].
+  ///
+  /// On the first call, considers every Dart file under the package. On
+  /// subsequent calls, only re-considers files listed in [changedFiles],
+  /// reusing cached results for unchanged files.
+  ///
+  /// Files that cannot contain a `Module` subclass (no `extends Module`) are
+  /// skipped without calling the analyzer — Module hooks are rare, so this
+  /// avoids doubling endpoint/future-call resolve cost on every generate.
+  Future<List<ModuleDefinition>> analyze({
+    required CodeAnalysisCollector collector,
+    Set<String>? changedFiles,
+  }) async {
+    changedFiles ??= {};
+    await refreshAnalysisContext(collection, changedFiles);
+
+    if (_fileCache.isEmpty) {
+      changedFiles.addAll(_allAnalyzedDartFiles);
+    }
+
+    final filesToAnalyze = <String>{
+      ...changedFiles,
+      ..._fileCache.keys,
+    };
+
+    for (var path in filesToAnalyze) {
+      if (!File(path).existsSync()) {
+        _fileCache.remove(path);
+      }
+    }
+
+    List<(ResolvedLibraryResult, String)> validLibraries = [];
+
+    for (var path in filesToAnalyze) {
+      if (!path.endsWith('.dart') || path.endsWith('_test.dart')) continue;
+      if (!File(path).existsSync()) continue;
+      // Cheap text gate before getResolvedLibrary — most packages have no Module.
+      if (!_isModuleFile(File(path))) {
+        _fileCache.remove(path);
+        continue;
+      }
+
+      var library = await _resolveLibrary(path);
+      if (library == null) continue;
+
+      var moduleClasses = _getModuleClasses(library);
+      if (moduleClasses.isEmpty) {
+        _fileCache.remove(path);
+        continue;
+      }
+
+      var maybeDartErrors = await _getErrorsForFile(library.session, path);
+      if (maybeDartErrors.isNotEmpty) {
+        collector.addError(
+          SourceSpanSeverityException(
+            'Module analysis skipped due to invalid Dart syntax. Please '
+            'review and correct the syntax errors.'
+            '\nFile: $path'
+            '\n${maybeDartErrors.join('\n')}',
+            null,
+            severity: SourceSpanSeverity.error,
+          ),
+        );
+
+        _fileCache[path] = _CachedModuleFileResult(
+          definitions: [],
+          hadErrors: true,
+        );
+        continue;
+      }
+
+      validLibraries.add((library, path));
+    }
+
+    // Count concrete Module classes that are default-constructable for the
+    // at-most-one cardinality rule.
+    var concreteCount = 0;
+    for (var entry in _fileCache.entries) {
+      if (validLibraries.any((lib) => lib.$2 == entry.key)) continue;
+      for (var def in entry.value.definitions) {
+        if (!def.isAbstract && !def.filePath.startsWith('package:')) {
+          concreteCount++;
+        }
+      }
+    }
+    for (var (library, _) in validLibraries) {
+      for (var cls in _getModuleClasses(library)) {
+        if (!cls.isAbstract &&
+            ModuleClassAnalyzer.hasPublicDefaultConstructor(cls)) {
+          concreteCount++;
+        }
+      }
+    }
+    final exceedsCardinality = concreteCount > 1;
+
+    for (var (library, filePath) in validLibraries) {
+      var failingExceptions = <String, List<SourceSpanSeverityException>>{};
+
+      var severityExceptions = _validateLibrary(
+        library,
+        filePath,
+        exceedsCardinality: exceedsCardinality,
+      );
+      collector.addErrors(severityExceptions.values.expand((e) => e).toList());
+      failingExceptions = _filterNoFailExceptions(severityExceptions);
+
+      var defs = _parseLibrary(library, filePath, failingExceptions);
+
+      _fileCache[filePath] = _CachedModuleFileResult(
+        definitions: defs,
+        hadErrors: false,
+      );
+    }
+
+    var moduleDefs = <ModuleDefinition>[];
+    for (var result in _fileCache.values) {
+      moduleDefs.addAll(result.definitions);
+    }
+    moduleDefs.removeWhere((e) => e.filePath.startsWith('package:'));
+
+    return moduleDefs;
+  }
+
+  /// Returns the single constructable concrete [ModuleDefinition], or null.
+  ///
+  /// Abstract definitions are ignored. Callers should only use this when
+  /// analysis reported no severe cardinality / constructability errors.
+  static ModuleDefinition? selectPackageModule(
+    List<ModuleDefinition> definitions,
+  ) {
+    final concrete = definitions.where((d) => !d.isAbstract).toList();
+    if (concrete.length != 1) return null;
+    return concrete.single;
+  }
+
+  Iterable<String> get _allAnalyzedDartFiles sync* {
+    for (var context in collection.contexts) {
+      var analyzedFiles = context.contextRoot.analyzedFiles().toList();
+      analyzedFiles.sort();
+      yield* analyzedFiles
+          .where((path) => path.endsWith('.dart'))
+          .where((path) => !path.endsWith('_test.dart'));
+    }
+  }
+
+  Future<ResolvedLibraryResult?> _resolveLibrary(String filePath) async {
+    for (var context in collection.contexts) {
+      var result = await context.currentSession.getResolvedLibrary(
+        p.normalize(filePath),
+      );
+      if (result is ResolvedLibraryResult) {
+        return result;
+      }
+    }
+
+    return null;
+  }
+
+  Future<List<String>> _getErrorsForFile(
+    AnalysisSession session,
+    String filePath,
+  ) async {
+    var errorMessages = <String>[];
+
+    var errors = await session.getErrors(filePath);
+    if (errors is ErrorsResult) {
+      errors.diagnostics
+          .where((error) => error.severity == Severity.error)
+          .forEach(
+            (error) => errorMessages.add(
+              '${error.problemMessage.filePath} Error: ${error.message}',
+            ),
+          );
+    }
+
+    return errorMessages;
+  }
+
+  List<ModuleDefinition> _parseLibrary(
+    ResolvedLibraryResult library,
+    String filePath,
+    Map<String, List<SourceSpanSeverityException>> validationErrors,
+  ) {
+    var moduleClasses = _getModuleClasses(library).where(
+      (element) => !validationErrors.containsKey(
+        ModuleClassAnalyzer.elementNamespace(element, filePath),
+      ),
+    );
+
+    var moduleDefinitions = <ModuleDefinition>[];
+    for (var classElement in moduleClasses) {
+      // Skip classes that failed validation (e.g. not default-constructable).
+      if (!classElement.isAbstract &&
+          !ModuleClassAnalyzer.hasPublicDefaultConstructor(classElement)) {
+        continue;
+      }
+      ModuleClassAnalyzer.parse(classElement, filePath, moduleDefinitions);
+    }
+
+    return moduleDefinitions;
+  }
+
+  static final _extendsModulePattern = RegExp(r'extends\s+Module\b');
+
+  bool _isModuleFile(File file) {
+    if (!file.absolute.path.startsWith(absoluteIncludedPaths)) return false;
+    if (!file.path.endsWith('.dart')) return false;
+    if (!file.existsSync()) return false;
+    // Word-boundary avoids false positives like `extends ModuleUtil`.
+    return _extendsModulePattern.hasMatch(file.readAsStringSync());
+  }
+
+  Map<String, List<SourceSpanSeverityException>> _validateLibrary(
+    ResolvedLibraryResult library,
+    String filePath, {
+    required bool exceedsCardinality,
+  }) {
+    var moduleClasses = _getModuleClasses(library);
+
+    var validationErrors = <String, List<SourceSpanSeverityException>>{};
+    for (var classElement in moduleClasses) {
+      var errors = ModuleClassAnalyzer.validate(
+        classElement,
+        exceedsCardinality: exceedsCardinality,
+      );
+
+      if (errors.isNotEmpty) {
+        validationErrors[ModuleClassAnalyzer.elementNamespace(
+              classElement,
+              filePath,
+            )] =
+            errors;
+      }
+    }
+
+    return validationErrors;
+  }
+
+  Iterable<ClassElement> _getModuleClasses(ResolvedLibraryResult library) {
+    return library.element.classes.where(ModuleClassAnalyzer.isModuleClass);
+  }
+
+  Map<String, List<SourceSpanSeverityException>> _filterNoFailExceptions(
+    Map<String, List<SourceSpanSeverityException>> validationErrors,
+  ) {
+    var noFailSeverities = [SourceSpanSeverity.hint, SourceSpanSeverity.info];
+
+    var failingErrors = validationErrors.map((key, exceptions) {
+      var failingExceptions = exceptions
+          .where((exception) => !noFailSeverities.contains(exception.severity))
+          .toList();
+
+      return MapEntry(key, failingExceptions);
+    });
+
+    failingErrors.removeWhere((key, exceptions) => exceptions.isEmpty);
+
+    return failingErrors;
+  }
+}

--- a/tools/serverpod_cli/lib/src/analyzer/protocol_definition.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/protocol_definition.dart
@@ -13,10 +13,17 @@ class ProtocolDefinition {
   /// The future calls that are a part of this protocol.
   final List<FutureCallDefinition> futureCalls;
 
+  /// The package's [Module] startup hook, if any.
+  ///
+  /// Null when the package defines no constructable concrete [Module]
+  /// subclass. Abstract subclasses are ignored.
+  final ModuleDefinition? module;
+
   /// Create a new [ProtocolDefinition].
   const ProtocolDefinition({
     required this.endpoints,
     required this.models,
     required this.futureCalls,
+    this.module,
   });
 }

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -1,7 +1,6 @@
 // ignore_for_file: implementation_imports
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
 
@@ -27,6 +26,7 @@ import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/util/string_validators.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 import 'package:skills/skills.dart';
+import 'package:skills/src/core/git_runner.dart';
 import 'package:skills/src/core/workspace_resolver.dart';
 import 'package:skills/src/ide/ide.dart';
 import 'package:yaml_edit/yaml_edit.dart';
@@ -68,14 +68,17 @@ extension ServerpodTemplateTypeExtension on ServerpodTemplateType {
 
 extension TemplateIdeExtension on List<TemplateIde> {
   List<Ide> get toSkillIdes {
-    return map((templateIde) {
-      return switch (templateIde) {
-        TemplateIde.claude => Ide.claude,
-        TemplateIde.cursor => Ide.cursor,
-        TemplateIde.openCode => Ide.opencode,
-        _ => Ide.generic,
-      };
-    }).toList();
+    // Antigravity/Codex/VSCode all map to Ide.generic — dedupe so getSkills
+    // does not reinstall the same target multiple times.
+    return {
+      for (final templateIde in this)
+        switch (templateIde) {
+          TemplateIde.claude => Ide.claude,
+          TemplateIde.cursor => Ide.cursor,
+          TemplateIde.openCode => Ide.opencode,
+          _ => Ide.generic,
+        },
+    }.toList();
   }
 }
 
@@ -307,6 +310,9 @@ Future<CreateResult> performCreate(
     });
   }
 
+  // Skills/MCP setup is best-effort for create success: a missing IDE tree
+  // should not fail scaffolding after generate already succeeded. Tests and
+  // `_ensureAgentSkillsInstalled` still guarantee `.agents/skills` when possible.
   await _configureAgentSkillsAndMcp(
     serverpodDirs: serverpodDirs,
     context: context,
@@ -346,106 +352,150 @@ Future<void> _configureAgentSkillsAndMcp({
   required ServerpodDirectories serverpodDirs,
   required TemplateContext context,
 }) async {
-  if (context.ides.isNotEmpty) {
-    await _configureProjectMcpServers(
-      serverpodDirs,
-      context.ides,
-      isModule: context.template.isModule,
-    );
+  if (context.ides.isEmpty) return;
 
-    await log.progress('Installing agent skills', () async {
-      try {
-        if (context.ides.contains(TemplateIde.claude)) {
-          await _createFileAndWrite(
-            p.join(serverpodDirs.projectDir.path, 'CLAUDE.md'),
-            '@AGENTS.md\n',
-          );
-        }
+  await _configureProjectMcpServers(
+    serverpodDirs,
+    context.ides,
+    isModule: context.template.isModule,
+  );
 
-        final workspace = await const WorkspaceResolver().resolve(
-          serverpodDirs.projectDir.path,
+  await log.progress('Installing agent skills', () async {
+    try {
+      if (context.ides.contains(TemplateIde.claude)) {
+        await _createFileAndWrite(
+          p.join(serverpodDirs.projectDir.path, 'CLAUDE.md'),
+          '@AGENTS.md\n',
         );
+      }
 
-        final stdoutController = StreamController<List<int>>();
-        stdoutController.stream
-            .transform(const Utf8Decoder(allowMalformed: true))
-            .transform(const LineSplitter())
-            .listen((data) => log.debug(data));
-        final toDebugLog = IOSink(stdoutController);
-        final stderrController = StreamController<List<int>>();
-        stderrController.stream
-            .transform(const Utf8Decoder(allowMalformed: true))
-            .transform(const LineSplitter())
-            .listen((data) => _logError(data));
-        final toErrorLog = IOSink(stderrController);
+      final workspace = await const WorkspaceResolver().resolve(
+        serverpodDirs.projectDir.path,
+      );
 
+      // Discard skills CLI chatter instead of piping through IsolatedLogWriter.
+      // Piping via StreamController+IOSink nested under log.progress has hung
+      // create on Ubuntu CI (bootstrap ide_test) while Windows stayed fine.
+      final discard = IOSink(_DiscardingByteSink());
+
+      try {
         final success = await getSkills(
           ides: context.ides.toSkillIdes,
           workspace: workspace,
-          stdout: toDebugLog,
-          stderr: toErrorLog,
+          // Create must stay offline-friendly: only install skills shipped with
+          // resolved packages (e.g. package:serverpod). Cloning GitHub registries
+          // during scaffold is slow, flaky on CI, and can be done later via
+          // `skills get`.
+          gitRunner: GitRunner(isAvailableOverride: () async => false),
+          stdout: discard,
+          stderr: discard,
         );
 
         if (!success) {
-          _logError('Failed to install agent skills');
-          return false;
+          _logError('Failed to install agent skills from package dependencies');
         }
-
-        final agentDir = Directory(
-          p.join(serverpodDirs.projectDir.path, '.agent'),
-        );
-        if (await agentDir.exists()) {
-          final agentsDir = Directory(
-            p.join(serverpodDirs.projectDir.path, '.agents'),
-          );
-
-          try {
-            await _moveDirectoryContents(agentDir, agentsDir);
-            await agentDir.delete();
-          } on FileSystemException {
-            //
-          }
-        }
-      } catch (_) {
-        _logError('Failed to install agent skills');
-        return false;
+      } finally {
+        await discard.close();
       }
-      return true;
-    });
+
+      await _ensureAgentSkillsInstalled(serverpodDirs.projectDir.path);
+    } catch (e) {
+      _logError('Failed to install agent skills: $e');
+      try {
+        await _ensureAgentSkillsInstalled(serverpodDirs.projectDir.path);
+      } catch (_) {
+        // Best-effort fallback only.
+      }
+      return false;
+    }
+    return true;
+  });
+}
+
+/// Promotes/copies skills into `.agents/skills` (and other IDE trees if empty).
+///
+/// `package:skills` writes generic IDE skills to `.agent/skills`. Antigravity
+/// MCP config already lives under `.agents/plugins`, so we copy (never rename
+/// — EXDEV breaks rename across mounts) into `.agents/skills`, then remove
+/// `.agent`. If package install produced nothing, seed from the local
+/// `package:serverpod` skills tree when [serverpodHome] is available.
+Future<void> _ensureAgentSkillsInstalled(String projectRoot) async {
+  final ideSkillsDirs = [
+    Directory(p.join(projectRoot, '.agents', 'skills')),
+    Directory(p.join(projectRoot, '.claude', 'skills')),
+    Directory(p.join(projectRoot, '.cursor', 'skills')),
+    Directory(p.join(projectRoot, '.opencode', 'skills')),
+  ];
+
+  final localSources = [
+    Directory(p.join(projectRoot, '.agent', 'skills')),
+    ...ideSkillsDirs,
+  ];
+
+  Directory? populatedSource;
+  for (final source in localSources) {
+    if (await _directoryHasEntries(source)) {
+      populatedSource = source;
+      break;
+    }
+  }
+
+  if (populatedSource == null && !productionMode) {
+    final shipped = Directory(
+      p.join(serverpodHome, 'packages', 'serverpod', 'skills'),
+    );
+    if (await _directoryHasEntries(shipped)) {
+      populatedSource = shipped;
+    }
+  }
+
+  if (populatedSource != null) {
+    for (final target in ideSkillsDirs) {
+      if (await _directoryHasEntries(target)) continue;
+      await _copyDirectoryContents(populatedSource, target);
+    }
+  }
+
+  final agentDir = Directory(p.join(projectRoot, '.agent'));
+  if (await agentDir.exists()) {
+    await agentDir.delete(recursive: true);
   }
 }
 
-Future<void> _moveDirectoryContents(
+Future<bool> _directoryHasEntries(Directory directory) async {
+  if (!await directory.exists()) return false;
+  await for (final _ in directory.list(followLinks: false)) {
+    return true;
+  }
+  return false;
+}
+
+/// Recursively copies [source] into [destination] (created if needed).
+Future<void> _copyDirectoryContents(
   Directory source,
   Directory destination,
 ) async {
-  if (!await source.exists()) {
-    throw Exception('Source directory does not exist: ${source.path}');
-  }
-
-  // Ensure destination exists
-  if (!await destination.exists()) {
-    await destination.create(recursive: true);
-  }
-
-  await for (final entity in source.list()) {
+  await destination.create(recursive: true);
+  await for (final entity in source.list(followLinks: false)) {
     final newPath = p.join(destination.path, p.basename(entity.path));
-
-    if (entity is File) {
-      // Never overwrite files already present at the destination, such as the
-      // Antigravity plugin config written under .agents/plugins/ before this
-      // move runs.
-      if (await File(newPath).exists()) {
-        log.debug('Skipped moving ${entity.path}: $newPath already exists.');
-        continue;
-      }
-      await entity.rename(newPath);
-    } else if (entity is Directory) {
-      final newDir = await Directory(newPath).create(recursive: true);
-      await _moveDirectoryContents(entity, newDir);
-      await entity.delete();
+    final type = await entity.stat().then((s) => s.type);
+    if (type == FileSystemEntityType.file) {
+      await File(entity.path).copy(newPath);
+    } else if (type == FileSystemEntityType.directory) {
+      await _copyDirectoryContents(Directory(entity.path), Directory(newPath));
     }
   }
+}
+
+/// Byte consumer that drops all writes (for silencing embedded skills CLI I/O).
+class _DiscardingByteSink implements StreamConsumer<List<int>> {
+  @override
+  Future<void> addStream(Stream<List<int>> stream) async {
+    await stream.drain<void>();
+  }
+
+  @override
+  Future<void> close() async {}
 }
 
 /// Writes the MCP config files for [ides] under [dirs], showing progress.

--- a/tools/serverpod_cli/lib/src/generator/analyzers.dart
+++ b/tools/serverpod_cli/lib/src/generator/analyzers.dart
@@ -34,6 +34,7 @@ class Analyzers {
   final EndpointsAnalyzer _endpoints;
   final StatefulAnalyzer _models;
   final FutureCallsAnalyzer _futureCalls;
+  final ModulesAnalyzer _modules;
 
   /// Overlay provider backing the shared analysis context, used to shadow
   /// `protocol.dart` with a temporary stub during generation without touching
@@ -45,10 +46,12 @@ class Analyzers {
     required EndpointsAnalyzer endpoints,
     required StatefulAnalyzer models,
     required FutureCallsAnalyzer futureCalls,
+    required ModulesAnalyzer modules,
     OverlayResourceProvider? overlay,
   }) : _endpoints = endpoints,
        _models = models,
        _futureCalls = futureCalls,
+       _modules = modules,
        _overlay = overlay;
 
   /// Release resources. No-op for local analyzers; overridden by
@@ -81,10 +84,15 @@ class Analyzers {
       directory: libDirectory,
       collection: collection,
     );
+    final modulesAnalyzer = ModulesAnalyzer(
+      directory: libDirectory,
+      collection: collection,
+    );
     return Analyzers(
       endpoints: endpointsAnalyzer,
       models: modelAnalyzer,
       futureCalls: futureCallsAnalyzer,
+      modules: modulesAnalyzer,
       overlay: overlay,
     );
   }
@@ -124,6 +132,9 @@ class Analyzers {
         affectedPaths,
       );
       shouldGenerate |= await _futureCalls.updateFileContexts(
+        affectedPaths,
+      );
+      shouldGenerate |= await _modules.updateFileContexts(
         affectedPaths,
       );
     }
@@ -297,6 +308,18 @@ class Analyzers {
         ),
       );
 
+      log.debug('Analyzing module startup hooks.');
+      var modulesAnalyzerCollector = CodeGenerationCollector();
+      var moduleDefinitions = await _modules.analyze(
+        collector: modulesAnalyzerCollector,
+        changedFiles: changedFiles,
+      );
+
+      success &= !modulesAnalyzerCollector.hasSevereErrors;
+      modulesAnalyzerCollector.printErrors();
+
+      final module = ModulesAnalyzer.selectPackageModule(moduleDefinitions);
+
       log.debug('Analyzing the endpoints.');
       final endpointAnalyzerCollector = CodeGenerationCollector();
       final endpoints = await _endpoints.analyze(
@@ -313,6 +336,7 @@ class Analyzers {
         endpoints: endpoints,
         models: allModels,
         futureCalls: futureCalls,
+        module: module,
       );
 
       var generatedProtocolFiles =

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -1009,11 +1009,80 @@ return deserializeByClassName(value);
                     ).call([]).returned.statement,
                   ]),
               ),
+
+            if (protocolDefinition.shouldGenerateOnStartup(config))
+              _buildOnStartupMethod(),
           ]),
       ),
     );
 
     return library.build();
+  }
+
+  Method _buildOnStartupMethod() {
+    final statements = <Code>[];
+
+    final module = protocolDefinition.module;
+    if (module != null) {
+      statements.add(
+        refer(module.className, _modulePath(module))
+            .call([])
+            .property('onStartup')
+            .call([refer('session')])
+            .awaited
+            .statement,
+      );
+    }
+
+    // Host packages only: flat fan-out via the root modules map. Module
+    // packages must not recurse into nested Endpoints (those are duplicate
+    // instances of packages already listed on the host).
+    if (config.type == PackageType.server && config.modules.isNotEmpty) {
+      final sortedModules = [...config.modules]
+        ..sort((a, b) => a.name.compareTo(b.name));
+      for (final moduleConfig in sortedModules) {
+        statements.add(
+          refer('modules')
+              .index(literalString(moduleConfig.name))
+              .nullChecked
+              .property('onStartup')
+              .call([refer('session')])
+              .awaited
+              .statement,
+        );
+      }
+    }
+
+    return Method(
+      (m) => m
+        ..annotations.add(refer('override'))
+        ..modifier = MethodModifier.async
+        ..returns = TypeReference(
+          (t) => t
+            ..symbol = 'Future'
+            ..types.add(refer('void')),
+        )
+        ..name = 'onStartup'
+        ..requiredParameters.add(
+          Parameter(
+            (p) => p
+              ..name = 'session'
+              ..type = refer('Session', serverpodUrl(true)),
+          ),
+        )
+        ..body = Block.of(statements),
+    );
+  }
+
+  String _modulePath(ModuleDefinition module) {
+    if (module.filePath.startsWith('package:')) return module.filePath;
+
+    var relativePath = p.relative(
+      module.filePath,
+      from: _buildGeneratedDirectoryPath(),
+    );
+
+    return p.split(relativePath).join('/');
   }
 
   /// Generates endpoint calls for the client side.

--- a/tools/serverpod_cli/lib/src/generator/dart/protocol_definition_extension.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/protocol_definition_extension.dart
@@ -1,6 +1,17 @@
 import 'package:serverpod_cli/src/analyzer/protocol_definition.dart';
+import 'package:serverpod_cli/src/config/config.dart';
 
 extension ProtocolDefinitionExtension on ProtocolDefinition {
   bool get shouldGenerateFutureCalls =>
       futureCalls.isNotEmpty && !futureCalls.every((f) => f.isAbstract);
+
+  /// Whether generated [Endpoints] should override `onStartup`.
+  ///
+  /// Host packages fan out to nested modules; any package with a local
+  /// [Module] emits a local call. Module packages never fan out (flat root
+  /// invocation avoids double-init under nested Endpoint maps).
+  bool shouldGenerateOnStartup(GeneratorConfig config) {
+    if (module != null) return true;
+    return config.type == PackageType.server && config.modules.isNotEmpty;
+  }
 }

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/module_on_startup_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/module_on_startup_test.dart
@@ -1,0 +1,214 @@
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/protocol_definition.dart';
+import 'package:serverpod_cli/src/config/config.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/builders/generator_config_builder.dart';
+import '../../../test_util/builders/module_config_builder.dart';
+
+const projectName = 'example_project';
+final config = GeneratorConfigBuilder().withName(projectName).build();
+const generator = DartServerCodeGenerator();
+
+final expectedFileName = path.join(
+  'lib',
+  'src',
+  'generated',
+  'endpoints.dart',
+);
+
+void main() {
+  group(
+    'Given protocol without Module and without nested modules when generating',
+    () {
+      late String? endpointsFile;
+
+      setUpAll(() {
+        var protocolDefinition = const ProtocolDefinition(
+          endpoints: [],
+          models: [],
+          futureCalls: [],
+        );
+
+        var codeMap = generator.generateProtocolCode(
+          protocolDefinition: protocolDefinition,
+          config: config,
+        );
+        endpointsFile = codeMap[expectedFileName];
+      });
+
+      test('then onStartup override is omitted.', () {
+        expect(endpointsFile, isNot(contains('onStartup')));
+      });
+    },
+  );
+
+  group('Given protocol with a local Module when generating', () {
+    late String? endpointsFile;
+
+    setUpAll(() {
+      var protocolDefinition = ProtocolDefinition(
+        endpoints: [],
+        models: [],
+        futureCalls: [],
+        module: ModuleDefinition(
+          className: 'MyModule',
+          filePath: path.join(
+            'lib',
+            'src',
+            'my_module.dart',
+          ),
+          isAbstract: false,
+        ),
+      );
+
+      var codeMap = generator.generateProtocolCode(
+        protocolDefinition: protocolDefinition,
+        config: config,
+      );
+      endpointsFile = codeMap[expectedFileName];
+    });
+
+    test('then onStartup calls the local Module.', () {
+      expect(endpointsFile, contains('onStartup'));
+      expect(
+        endpointsFile,
+        contains('.MyModule().onStartup(session);'),
+      );
+    });
+  });
+
+  group(
+    'Given host with nested modules and no local Module when generating',
+    () {
+      late String? endpointsFile;
+
+      setUpAll(() {
+        var hostConfig = GeneratorConfigBuilder()
+            .withName(projectName)
+            .withModules([
+              ModuleConfigBuilder('zeta_mod').build(),
+              ModuleConfigBuilder('alpha_mod').build(),
+            ])
+            .build();
+
+        var protocolDefinition = const ProtocolDefinition(
+          endpoints: [],
+          models: [],
+          futureCalls: [],
+        );
+
+        var codeMap = generator.generateProtocolCode(
+          protocolDefinition: protocolDefinition,
+          config: hostConfig,
+        );
+        endpointsFile = codeMap[expectedFileName];
+      });
+
+      test('then onStartup fans out sorted by module name.', () {
+        expect(endpointsFile, contains('onStartup'));
+        final alphaIndex = endpointsFile!.indexOf(
+          "modules['alpha_mod']!.onStartup(session)",
+        );
+        final zetaIndex = endpointsFile!.indexOf(
+          "modules['zeta_mod']!.onStartup(session)",
+        );
+        expect(alphaIndex, greaterThan(-1));
+        expect(zetaIndex, greaterThan(-1));
+        expect(alphaIndex, lessThan(zetaIndex));
+      });
+
+      test('then no local Module instantiation is generated.', () {
+        expect(endpointsFile, isNot(contains('Module().onStartup')));
+      });
+    },
+  );
+
+  group(
+    'Given module package with local Module and nested modules when generating',
+    () {
+      late String? endpointsFile;
+
+      setUpAll(() {
+        var moduleConfig = GeneratorConfigBuilder()
+            .withName('auth_idp')
+            .withPackageType(PackageType.module)
+            .withModules([ModuleConfigBuilder('auth_core').build()])
+            .build();
+
+        var protocolDefinition = ProtocolDefinition(
+          endpoints: [],
+          models: [],
+          futureCalls: [],
+          module: ModuleDefinition(
+            className: 'AuthIdpModule',
+            filePath: path.join('lib', 'src', 'auth_idp_module.dart'),
+            isAbstract: false,
+          ),
+        );
+
+        var codeMap = generator.generateProtocolCode(
+          protocolDefinition: protocolDefinition,
+          config: moduleConfig,
+        );
+        endpointsFile = codeMap[expectedFileName];
+      });
+
+      test('then onStartup calls local Module only (no nested fan-out).', () {
+        expect(
+          endpointsFile,
+          contains('.AuthIdpModule().onStartup(session);'),
+        );
+        expect(
+          endpointsFile,
+          isNot(contains("modules['auth_core']!.onStartup")),
+        );
+      });
+    },
+  );
+
+  group(
+    'Given host with local Module and nested modules when generating',
+    () {
+      late String? endpointsFile;
+
+      setUpAll(() {
+        var hostConfig = GeneratorConfigBuilder()
+            .withName(projectName)
+            .withModules([ModuleConfigBuilder('dep_mod').build()])
+            .build();
+
+        var protocolDefinition = ProtocolDefinition(
+          endpoints: [],
+          models: [],
+          futureCalls: [],
+          module: ModuleDefinition(
+            className: 'HostModule',
+            filePath: path.join('lib', 'src', 'host_module.dart'),
+            isAbstract: false,
+          ),
+        );
+
+        var codeMap = generator.generateProtocolCode(
+          protocolDefinition: protocolDefinition,
+          config: hostConfig,
+        );
+        endpointsFile = codeMap[expectedFileName];
+      });
+
+      test('then local Module runs before nested fan-out.', () {
+        final localIndex = endpointsFile!.indexOf(
+          '.HostModule().onStartup(session)',
+        );
+        final nestedIndex = endpointsFile!.indexOf(
+          "modules['dep_mod']!.onStartup(session)",
+        );
+        expect(localIndex, greaterThan(-1));
+        expect(nestedIndex, greaterThan(-1));
+        expect(localIndex, lessThan(nestedIndex));
+      });
+    },
+  );
+}

--- a/tools/serverpod_cli/test/integration/analyzer/dart/module_validation/module_class_test.dart
+++ b/tools/serverpod_cli/test/integration/analyzer/dart/module_validation/module_class_test.dart
@@ -1,0 +1,209 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/src/analyzer/dart/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/dart/modules_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../test_util/endpoint_validation_helpers.dart';
+
+var testProjectDirectory = Directory.systemTemp.createTempSync('cli_test_');
+
+void main() {
+  setUpAll(() async {
+    await createTestEnvironment(testProjectDirectory);
+  });
+
+  tearDownAll(() {
+    testProjectDirectory.deleteSync(recursive: true);
+  });
+
+  group('Given no Module class when analyzed', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory = Directory(
+      path.join(testProjectDirectory.path, const Uuid().v4()),
+    );
+
+    late List<ModuleDefinition> definitions;
+
+    setUpAll(() async {
+      var dartFile = File(path.join(testDirectory.path, 'empty.dart'));
+      dartFile.createSync(recursive: true);
+      dartFile.writeAsStringSync('''
+class NotAModule {}
+''');
+
+      var analyzer = ModulesAnalyzer(directory: testDirectory);
+      definitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then no module definitions are created.', () {
+      expect(definitions, isEmpty);
+    });
+
+    test('then selectPackageModule returns null.', () {
+      expect(ModulesAnalyzer.selectPackageModule(definitions), isNull);
+    });
+  });
+
+  group('Given one concrete Module class when analyzed', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory = Directory(
+      path.join(testProjectDirectory.path, const Uuid().v4()),
+    );
+
+    late List<ModuleDefinition> definitions;
+
+    setUpAll(() async {
+      var dartFile = File(path.join(testDirectory.path, 'my_module.dart'));
+      dartFile.createSync(recursive: true);
+      dartFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class MyModule extends Module {
+  @override
+  Future<void> onStartup(Session session) async {}
+}
+''');
+
+      var analyzer = ModulesAnalyzer(directory: testDirectory);
+      definitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then a module definition is created.', () {
+      expect(definitions, hasLength(1));
+      expect(definitions.first.className, 'MyModule');
+      expect(definitions.first.isAbstract, isFalse);
+    });
+
+    test('then selectPackageModule returns the definition.', () {
+      expect(
+        ModulesAnalyzer.selectPackageModule(definitions)?.className,
+        'MyModule',
+      );
+    });
+  });
+
+  group('Given two concrete Module classes when analyzed', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory = Directory(
+      path.join(testProjectDirectory.path, const Uuid().v4()),
+    );
+
+    late List<ModuleDefinition> definitions;
+
+    setUpAll(() async {
+      var first = File(path.join(testDirectory.path, 'first_module.dart'));
+      first.createSync(recursive: true);
+      first.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class FirstModule extends Module {}
+''');
+
+      var second = File(path.join(testDirectory.path, 'second_module.dart'));
+      second.createSync(recursive: true);
+      second.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class SecondModule extends Module {}
+''');
+
+      var analyzer = ModulesAnalyzer(directory: testDirectory);
+      definitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then a severe cardinality error is reported.', () {
+      expect(collector.errors, isNotEmpty);
+      expect(
+        collector.errors.any(
+          (e) => e.message.contains(
+            'A package may define at most one Module class',
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('then selectPackageModule returns null.', () {
+      expect(ModulesAnalyzer.selectPackageModule(definitions), isNull);
+    });
+  });
+
+  group('Given only an abstract Module subclass when analyzed', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory = Directory(
+      path.join(testProjectDirectory.path, const Uuid().v4()),
+    );
+
+    late List<ModuleDefinition> definitions;
+
+    setUpAll(() async {
+      var dartFile = File(path.join(testDirectory.path, 'base_module.dart'));
+      dartFile.createSync(recursive: true);
+      dartFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+abstract class BaseModule extends Module {}
+''');
+
+      var analyzer = ModulesAnalyzer(directory: testDirectory);
+      definitions = await analyzer.analyze(collector: collector);
+    });
+
+    test('then no validation errors are reported.', () {
+      expect(collector.errors, isEmpty);
+    });
+
+    test('then an abstract module definition is created.', () {
+      expect(definitions, hasLength(1));
+      expect(definitions.first.isAbstract, isTrue);
+    });
+
+    test('then selectPackageModule returns null.', () {
+      expect(ModulesAnalyzer.selectPackageModule(definitions), isNull);
+    });
+  });
+
+  group('Given a non-constructable concrete Module when analyzed', () {
+    var collector = CodeGenerationCollector();
+    var testDirectory = Directory(
+      path.join(testProjectDirectory.path, const Uuid().v4()),
+    );
+
+    setUpAll(() async {
+      var dartFile = File(path.join(testDirectory.path, 'bad_module.dart'));
+      dartFile.createSync(recursive: true);
+      dartFile.writeAsStringSync('''
+import 'package:serverpod/serverpod.dart';
+
+class BadModule extends Module {
+  BadModule._();
+}
+''');
+
+      var analyzer = ModulesAnalyzer(directory: testDirectory);
+      await analyzer.analyze(collector: collector);
+    });
+
+    test('then a constructability error is reported.', () {
+      expect(collector.errors, isNotEmpty);
+      expect(
+        collector.errors.any(
+          (e) => e.message.contains('must be default-constructable'),
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Adds a package-scoped `Module` base class with an `onStartup` hook so modules (and server packages) can run post-migration initialization automatically. The CLI discovers at most one default-constructable concrete `Module` per package and generates `Endpoints.onStartup`. Hosts invoke the local module (if any), then nested modules once each in flat `module.name` order, after migrations/Redis and before Insights/API servers. The hook is skipped on the maintenance + apply-migrations early-exit path; thrown errors fail `start()`.

Auth/route configuration and `onConfigure` / `onShutdown` are intentionally out of scope for this PR.

Fixes #2503.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None. This is additive: packages without a `Module` subclass keep the existing no-op behavior.