### PR TITLE
fix: Make shared-package logs visible in the CLI

### DIFF
--- a/packages/serverpod_database/lib/src/migrations/migration_manager.dart
+++ b/packages/serverpod_database/lib/src/migrations/migration_manager.dart
@@ -285,8 +285,8 @@ class MigrationManager {
           transaction: transaction,
         );
         migrationsApplied.add(code.version);
-      } catch (e) {
-        log.error('Failed to apply migration ${code.version}.', error: e);
+      } catch (_) {
+        log.error('Failed to apply migration ${code.version}.');
         rethrow;
       }
     }

--- a/packages/serverpod_database/test/client_database_session_test.dart
+++ b/packages/serverpod_database/test/client_database_session_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:serverpod_database/serverpod_database.dart';
+import 'package:serverpod_shared/log.dart' as shared;
+import 'package:serverpod_shared/log_io.dart' show TestLogWriter;
 import 'package:test/test.dart';
 
 void main() {
@@ -89,6 +91,47 @@ void main() {
         "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'example';",
       );
       expect(createdTables, hasLength(1));
+    },
+  );
+
+  test(
+    'Given a client migration that fails, '
+    'when applying the migration, '
+    'then its context is logged without duplicating the thrown error.',
+    () async {
+      session = await ClientDatabaseSession.open(
+        databasePath,
+        _TestSerializationManager(),
+        runMigrations: false,
+      );
+      final writer = TestLogWriter();
+      shared.logWriter.add(writer);
+      addTearDown(() => shared.logWriter.remove(writer));
+
+      final manager = MigrationManager.fromMigrations(
+        migrations: const [
+          MigrationVersionSql(
+            version: '20240101000000000',
+            moduleName: 'test',
+            migrationSql: 'INVALID SQL',
+            definitionSql: 'INVALID SQL',
+          ),
+        ],
+        moduleName: 'test',
+      );
+
+      await expectLater(
+        manager.migrateToLatest(session),
+        throwsA(isA<DatabaseQueryException>()),
+      );
+      await shared.log.flush();
+
+      expect(writer.entries, hasLength(1));
+      expect(
+        writer.entries.single.message,
+        'Failed to apply migration 20240101000000000.',
+      );
+      expect(writer.entries.single.error, isNull);
     },
   );
 }

--- a/tools/serverpod_cli/lib/src/util/serverpod_cli_logger.dart
+++ b/tools/serverpod_cli/lib/src/util/serverpod_cli_logger.dart
@@ -4,6 +4,7 @@ import 'package:cli_tools/cli_tools.dart' as cli;
 import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_logging_cli/serverpod_logging_cli.dart';
+import 'package:serverpod_shared/log.dart' as shared;
 import 'package:serverpod_shared/log_io.dart';
 
 // ---------------------------------------------------------------------------
@@ -37,6 +38,7 @@ void initializeLogger() {
       ),
     ),
   );
+  _attachGlobalLogBridge();
 }
 
 /// Replaces the logger singleton with the given [logger].
@@ -48,6 +50,7 @@ void initializeLoggerWith(cli.Logger logger) {
     logger.logLevel = previous.logLevel;
   }
   _logger = logger;
+  _attachGlobalLogBridge();
 }
 
 /// Singleton accessor for logger.
@@ -129,6 +132,7 @@ abstract class _SeveritySpanHelpers {
 
 /// Shuts down and closes the logger, releasing any isolate resources.
 Future<void> closeLogger() async {
+  await _detachGlobalLogBridge();
   final logger = _logger;
   _logger = null;
   if (logger == null) return;
@@ -136,4 +140,102 @@ Future<void> closeLogger() async {
   if (logger is ServerpodCliLogger) {
     await logger.close();
   }
+}
+
+// ---------------------------------------------------------------------------
+// Global log bridge
+// ---------------------------------------------------------------------------
+
+/// Forwards records written to the global [shared.log] - the logger that
+/// packages shared with the server, such as `serverpod_database`, write to - to
+/// the CLI logger singleton.
+///
+/// The global [shared.logWriter] chain starts out empty and entry points are
+/// expected to populate it. The server does so through `ServerpodLogSetup`;
+/// the CLI never did, so every record a shared package emitted was silently
+/// dropped for the whole CLI process.
+///
+/// Forwarding to the singleton rather than registering the singleton's own
+/// writer on the chain keeps a single output path: whichever logger is
+/// installed - stdout, the TUI, an isolate port forwarder, a test logger -
+/// receives the record, and its log level and `--quiet` handling apply to it
+/// unchanged.
+class _GlobalLogBridge extends LogWriter {
+  @override
+  Future<void> log(LogEntry entry) async {
+    // Read the singleton directly rather than through `log`, which would
+    // resurrect a logger that `closeLogger` has just torn down.
+    final logger = _logger;
+    if (logger == null) return;
+
+    // cli.Logger has no error argument, and the record is dropped rather than
+    // rendered if it is not folded into the message.
+    final message = entry.error == null
+        ? entry.message
+        : '${entry.message}\n${entry.error}';
+    final metadataType = entry.metadata?[logTypeKey];
+    final type = metadataType is cli.LogType
+        ? metadataType
+        : cli.TextLogType.normal;
+
+    switch (entry.level) {
+      case LogLevel.debug:
+        logger.debug(message, type: type);
+      case LogLevel.info:
+        logger.info(message, type: type);
+      case LogLevel.warning:
+        logger.warning(message, type: type);
+      case LogLevel.error:
+      case LogLevel.fatal:
+        logger.error(message, stackTrace: entry.stackTrace, type: type);
+    }
+  }
+
+  /// Scopes are progress reporting, which the CLI drives through
+  /// [cli.Logger.progress] on its own logger. Entries logged inside a scope
+  /// still reach [log], only the scope's own start and end are not rendered.
+  @override
+  Future<void> openScope(LogScope scope) async {}
+
+  @override
+  Future<void> closeScope(
+    LogScope scope, {
+    required bool success,
+    required Duration duration,
+    Object? error,
+    StackTrace? stackTrace,
+  }) async {}
+}
+
+final _globalLogBridge = _GlobalLogBridge();
+bool _globalLogBridgeAttached = false;
+LogLevel? _globalLogLevelBeforeBridge;
+
+/// Registers [_globalLogBridge] on the global writer chain. Idempotent, so
+/// swapping the logger singleton does not stack up bridges.
+void _attachGlobalLogBridge() {
+  if (_globalLogBridgeAttached) return;
+  _globalLogBridgeAttached = true;
+
+  // Severity filtering belongs to the CLI logger, which owns the verbosity
+  // flags. Opening the global filter all the way lets `-v` reach the shared
+  // packages instead of their debug records being dropped before the bridge.
+  _globalLogLevelBeforeBridge = shared.log.logLevel;
+  shared.log.logLevel = LogLevel.debug;
+
+  shared.logWriter.add(_globalLogBridge);
+}
+
+/// Undoes [_attachGlobalLogBridge], leaving the globals as they were found.
+Future<void> _detachGlobalLogBridge() async {
+  if (!_globalLogBridgeAttached) return;
+  _globalLogBridgeAttached = false;
+
+  // Records already dispatched are only handed to the writers in the chain at
+  // the time they are written, so drain them before dropping out of it.
+  await shared.log.flush();
+
+  shared.logWriter.remove(_globalLogBridge);
+  shared.log.logLevel = _globalLogLevelBeforeBridge ?? LogLevel.info;
+  _globalLogLevelBeforeBridge = null;
 }

--- a/tools/serverpod_cli/test/util/serverpod_cli_logger_test.dart
+++ b/tools/serverpod_cli/test/util/serverpod_cli_logger_test.dart
@@ -20,14 +20,13 @@ Future<void> _logGlobally(
 void main() {
   late TestLogWriter writer;
 
+  setUp(() {
+    writer = TestLogWriter();
+    initializeLoggerWith(ServerpodCliLogger(writer));
+  });
   tearDown(closeLogger);
 
   group('Given a CLI logger is installed,', () {
-    setUp(() {
-      writer = TestLogWriter();
-      initializeLoggerWith(ServerpodCliLogger(writer));
-    });
-
     test(
       'when a shared package writes a warning to the global log, '
       'then the record reaches the CLI logger.',
@@ -97,9 +96,6 @@ void main() {
     'when a shared package writes a debug record to the global log, '
     'then it is filtered out.',
     () async {
-      writer = TestLogWriter();
-      initializeLoggerWith(ServerpodCliLogger(writer));
-
       await _logGlobally((log) => log.debug('Noisy detail.'));
 
       expect(writer.entries, isEmpty);
@@ -111,8 +107,6 @@ void main() {
     'when a shared package writes a debug record to the global log, '
     'then the record reaches the CLI logger.',
     () async {
-      writer = TestLogWriter();
-      initializeLoggerWith(ServerpodCliLogger(writer));
       log.logLevel = cli.LogLevel.debug;
 
       await _logGlobally((log) => log.debug('Noisy detail.'));
@@ -127,8 +121,6 @@ void main() {
     'when a shared package writes an error to the global log, '
     'then it is suppressed.',
     () async {
-      writer = TestLogWriter();
-      initializeLoggerWith(ServerpodCliLogger(writer));
       log.logLevel = cli.LogLevel.nothing;
 
       await _logGlobally((log) => log.error('Suppress me.'));
@@ -139,8 +131,6 @@ void main() {
 
   group('Given a CLI logger has been closed,', () {
     setUp(() async {
-      writer = TestLogWriter();
-      initializeLoggerWith(ServerpodCliLogger(writer));
       await closeLogger();
     });
 

--- a/tools/serverpod_cli/test/util/serverpod_cli_logger_test.dart
+++ b/tools/serverpod_cli/test/util/serverpod_cli_logger_test.dart
@@ -1,0 +1,166 @@
+import 'package:cli_tools/cli_tools.dart' as cli;
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:serverpod_logging_cli/serverpod_logging_cli.dart';
+import 'package:serverpod_shared/log.dart' as shared;
+// Imported with `show` because the barrel also exposes the global `log`, which
+// would be ambiguous against the CLI logger singleton of the same name.
+import 'package:serverpod_shared/log_io.dart' show LogLevel, TestLogWriter;
+import 'package:test/test.dart';
+
+/// Writes [message] the way a package shared with the server does, and waits
+/// for it to travel through the global chain into the CLI logger.
+Future<void> _logGlobally(
+  void Function(shared.Log log) write,
+) async {
+  write(shared.log);
+  await shared.log.flush();
+  await log.flush();
+}
+
+void main() {
+  late TestLogWriter writer;
+
+  tearDown(closeLogger);
+
+  group('Given a CLI logger is installed,', () {
+    setUp(() {
+      writer = TestLogWriter();
+      initializeLoggerWith(ServerpodCliLogger(writer));
+    });
+
+    test(
+      'when a shared package writes a warning to the global log, '
+      'then the record reaches the CLI logger.',
+      () async {
+        await _logGlobally((log) => log.warning('Removed empty directory.'));
+
+        expect(writer.entries, hasLength(1));
+        expect(writer.entries.single.message, 'Removed empty directory.');
+        expect(writer.entries.single.level, LogLevel.warning);
+      },
+    );
+
+    test(
+      'when a shared package writes an error with an attached error object, '
+      'then the error object is rendered with the message.',
+      () async {
+        var stackTrace = StackTrace.current;
+
+        await _logGlobally(
+          (log) => log.error(
+            'Failed to apply migration 20240101000000000.',
+            error: StateError('relation does not exist'),
+            stackTrace: stackTrace,
+          ),
+        );
+
+        expect(writer.entries, hasLength(1));
+        var entry = writer.entries.single;
+        expect(entry.level, LogLevel.error);
+        expect(entry.message, contains('20240101000000000'));
+        expect(entry.message, contains('relation does not exist'));
+        expect(entry.stackTrace, stackTrace);
+      },
+    );
+
+    test(
+      'when the CLI and a shared package each write a record, '
+      'then each record is delivered once.',
+      () async {
+        log.warning('CLI warning.');
+        await _logGlobally((log) => log.warning('Shared warning.'));
+
+        expect(
+          writer.entries.map((entry) => entry.message),
+          ['CLI warning.', 'Shared warning.'],
+        );
+      },
+    );
+
+    test(
+      'when the logger singleton is replaced, '
+      'then a global record is delivered once, to the current logger.',
+      () async {
+        var replacement = TestLogWriter();
+        initializeLoggerWith(ServerpodCliLogger(replacement));
+
+        await _logGlobally((log) => log.warning('Only once.'));
+
+        expect(writer.entries, isEmpty);
+        expect(replacement.entries, hasLength(1));
+      },
+    );
+  });
+
+  test(
+    'Given a CLI logger with the default log level, '
+    'when a shared package writes a debug record to the global log, '
+    'then it is filtered out.',
+    () async {
+      writer = TestLogWriter();
+      initializeLoggerWith(ServerpodCliLogger(writer));
+
+      await _logGlobally((log) => log.debug('Noisy detail.'));
+
+      expect(writer.entries, isEmpty);
+    },
+  );
+
+  test(
+    'Given a CLI logger with verbose logging, '
+    'when a shared package writes a debug record to the global log, '
+    'then the record reaches the CLI logger.',
+    () async {
+      writer = TestLogWriter();
+      initializeLoggerWith(ServerpodCliLogger(writer));
+      log.logLevel = cli.LogLevel.debug;
+
+      await _logGlobally((log) => log.debug('Noisy detail.'));
+
+      expect(writer.entries, hasLength(1));
+      expect(writer.entries.single.level, LogLevel.debug);
+    },
+  );
+
+  test(
+    'Given a CLI logger with quiet logging, '
+    'when a shared package writes an error to the global log, '
+    'then it is suppressed.',
+    () async {
+      writer = TestLogWriter();
+      initializeLoggerWith(ServerpodCliLogger(writer));
+      log.logLevel = cli.LogLevel.nothing;
+
+      await _logGlobally((log) => log.error('Suppress me.'));
+
+      expect(writer.entries, isEmpty);
+    },
+  );
+
+  group('Given a CLI logger has been closed,', () {
+    setUp(() async {
+      writer = TestLogWriter();
+      initializeLoggerWith(ServerpodCliLogger(writer));
+      await closeLogger();
+    });
+
+    test(
+      'when a shared package writes to the global log, '
+      'then the record is dropped.',
+      () async {
+        shared.log.warning('Nobody is listening.');
+        await shared.log.flush();
+
+        expect(writer.entries, isEmpty);
+      },
+    );
+
+    test(
+      'when observing the global log level, '
+      'then the previous level is restored.',
+      () {
+        expect(shared.log.logLevel, LogLevel.info);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Fixes: #5561

Log records emitted by packages shared with the server (`serverpod_database` above all) were silently discarded whenever that code ran under `serverpod_cli`. Nothing was misreported but the messages simply never appeared.

**What changes for users**

- `serverpod migrate` now names the migration that failed. Previously the exception was reported but the version was lost.
- `serverpod create-migration` now reports pruned empty migration directories — the warning added in #5044, which had never been visible in the scenario it was written for.
- The module-name mismatch warning (#4754) and the "database does not match the target database" report, with its `serverpod generate` hint, now reach the terminal.
- Failures report the exception once, not twice.
- These records honor `-v` and `--quiet` like the CLI's own output, and land in whichever surface is active — plain terminal, the `serverpod start` TUI, or the language server's silent mode.

**No duplicated logging.** The pod runs in its own process with its own log chain, so a record is produced in exactly one place and rendered exactly once. Nothing the CLI relays from a running pod passes back through the new path, and no existing log destination gained a second copy. Verified across the CLI process, the pod process, and the test processes that capture log output.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.