### PR TITLE
fix: Allows relaxing Cross-Origin-Opener-Policy on FlutterRoute for p…

### DIFF
--- a/packages/serverpod/lib/src/web_server/middleware/wasm_headers_middleware.dart
+++ b/packages/serverpod/lib/src/web_server/middleware/wasm_headers_middleware.dart
@@ -4,7 +4,7 @@ import 'package:serverpod/serverpod.dart';
 ///
 /// Adds the following headers required for SharedArrayBuffer and WASM
 /// multi-threading:
-/// - `Cross-Origin-Opener-Policy: same-origin`
+/// - `Cross-Origin-Opener-Policy` (defaults to `same-origin`)
 /// - `Cross-Origin-Embedder-Policy: require-corp`
 ///
 /// These headers enable Flutter web apps to use WebAssembly multi-threading
@@ -27,14 +27,36 @@ import 'package:serverpod/serverpod.dart';
 /// pod.webServer.addMiddleware(WasmHeadersMiddleware(), '/app');
 /// ```
 ///
+/// ## Cross-Origin-Opener-Policy and popup-based sign-in flows
+///
+/// The default `same-origin` policy achieves full cross-origin isolation,
+/// which is required for `SharedArrayBuffer`/WASM multi-threading, but it
+/// also prevents `window.postMessage`-based popup flows (such as
+/// "Sign in with Google") from communicating back with the opening window.
+///
+/// If your app needs those popup-based flows, set
+/// [crossOriginOpenerPolicy] to
+/// [CrossOriginOpenerPolicyHeader.sameOriginAllowPopups]. This keeps
+/// `SharedArrayBuffer` and other cross-origin-isolation-only APIs disabled,
+/// so only do this if your app does not rely on WASM multi-threading.
+///
 /// ## How It Works
 ///
 /// The middleware intercepts all Response objects and adds COOP/COEP headers.
 /// Other Result types (Hijack, WebSocketUpgrade) pass through unchanged.
 /// Existing headers are preserved.
 class WasmHeadersMiddleware extends MiddlewareObject {
+  /// The `Cross-Origin-Opener-Policy` header value to add to responses.
+  ///
+  /// Defaults to [CrossOriginOpenerPolicyHeader.sameOrigin], which is
+  /// required for full cross-origin isolation (`SharedArrayBuffer`/WASM
+  /// multi-threading) but blocks popup-based sign-in flows.
+  final CrossOriginOpenerPolicyHeader crossOriginOpenerPolicy;
+
   /// Creates a new WasmHeadersMiddleware
-  const WasmHeadersMiddleware();
+  const WasmHeadersMiddleware({
+    this.crossOriginOpenerPolicy = CrossOriginOpenerPolicyHeader.sameOrigin,
+  });
 
   @override
   Handler call(Handler next) {
@@ -45,8 +67,7 @@ class WasmHeadersMiddleware extends MiddlewareObject {
       if (result is Response) {
         return result.copyWith(
           headers: result.headers.transform((mh) {
-            mh.crossOriginOpenerPolicy =
-                CrossOriginOpenerPolicyHeader.sameOrigin;
+            mh.crossOriginOpenerPolicy = crossOriginOpenerPolicy;
             mh.crossOriginEmbedderPolicy =
                 CrossOriginEmbedderPolicyHeader.requireCorp;
           }),

--- a/packages/serverpod/lib/src/web_server/routes/flutter_route.dart
+++ b/packages/serverpod/lib/src/web_server/routes/flutter_route.dart
@@ -75,6 +75,17 @@ class FlutterRoute extends Route {
   /// not need cross-origin isolation. Defaults to `true`.
   final bool enableWasmHeaders;
 
+  /// The `Cross-Origin-Opener-Policy` header value to add when
+  /// [enableWasmHeaders] is `true`.
+  ///
+  /// Defaults to [CrossOriginOpenerPolicyHeader.sameOrigin], which is
+  /// required for `SharedArrayBuffer`/WASM multi-threading but blocks
+  /// popup-based sign-in flows (e.g. "Sign in with Google"). Set this to
+  /// [CrossOriginOpenerPolicyHeader.sameOriginAllowPopups] if your app needs
+  /// those flows and does not rely on WASM multi-threading. See
+  /// [WasmHeadersMiddleware] for details.
+  final CrossOriginOpenerPolicyHeader crossOriginOpenerPolicy;
+
   /// Creates a new FlutterRoute.
   ///
   /// The [directory] parameter specifies the root directory containing Flutter
@@ -88,13 +99,16 @@ class FlutterRoute extends Route {
   /// `SERVERPOD_WEB_SERVER_FLUTTER_CACHE_CONTROL` environment variable.
   ///
   /// Set [enableWasmHeaders] to `false` when serving a non-WASM Flutter web
-  /// build that should not use cross-origin isolation.
+  /// build that should not use cross-origin isolation. Use
+  /// [crossOriginOpenerPolicy] to relax cross-origin isolation while keeping
+  /// the WASM headers, e.g. to support popup-based sign-in flows.
   FlutterRoute(
     this.directory, {
     File? indexFile,
     CacheControlFactory? cacheControlFactory,
     this.cacheBustingConfig,
     this.enableWasmHeaders = true,
+    this.crossOriginOpenerPolicy = CrossOriginOpenerPolicyHeader.sameOrigin,
     super.host,
   }) : indexFile = indexFile ?? File(path.join(directory.path, 'index.html')),
        cacheControlFactory =
@@ -115,7 +129,12 @@ class FlutterRoute extends Route {
     final subRouter = Router<Handler>();
 
     if (enableWasmHeaders) {
-      subRouter.use('/', const WasmHeadersMiddleware().call);
+      subRouter.use(
+        '/',
+        WasmHeadersMiddleware(
+          crossOriginOpenerPolicy: crossOriginOpenerPolicy,
+        ).call,
+      );
     }
 
     subRouter.use(

--- a/tests/serverpod_test_server/test_integration/web_server/flutter_route_test.dart
+++ b/tests/serverpod_test_server/test_integration/web_server/flutter_route_test.dart
@@ -144,6 +144,50 @@ void main() {
     },
   );
 
+  group(
+    'Given a web server with FlutterRoute configured with '
+    'sameOriginAllowPopups COOP policy',
+    () {
+      late Serverpod pod;
+
+      setUp(() async {
+        pod = IntegrationTestServer.create();
+
+        pod.webServer.addRoute(
+          FlutterRoute(
+            webDir,
+            crossOriginOpenerPolicy:
+                CrossOriginOpenerPolicyHeader.sameOriginAllowPopups,
+          ),
+        );
+
+        await pod.startWithDatabase();
+      });
+
+      tearDown(() async {
+        await pod.shutdown(exitProcess: false);
+      });
+
+      test(
+        'when requesting file then the configured COOP policy is used',
+        () async {
+          final response = await client.get(
+            Uri.parse('${pod.webUrl}main.dart.js'),
+          );
+          expect(response.statusCode, 200);
+          expect(
+            response.headers['cross-origin-opener-policy'],
+            'same-origin-allow-popups',
+          );
+          expect(
+            response.headers['cross-origin-embedder-policy'],
+            'require-corp',
+          );
+        },
+      );
+    },
+  );
+
   group('Given a FlutterRoute with custom index file', () {
     late Serverpod pod;
     late File customIndex;

--- a/tests/serverpod_test_server/test_integration/web_server/wasm_headers_middleware_test.dart
+++ b/tests/serverpod_test_server/test_integration/web_server/wasm_headers_middleware_test.dart
@@ -59,6 +59,47 @@ void main() {
     );
   });
 
+  group('Given wasmHeadersMiddleware with sameOriginAllowPopups policy', () {
+    late Serverpod pod;
+
+    setUp(() async {
+      pod = IntegrationTestServer.create();
+
+      pod.webServer.addMiddleware(
+        const WasmHeadersMiddleware(
+          crossOriginOpenerPolicy:
+              CrossOriginOpenerPolicyHeader.sameOriginAllowPopups,
+        ),
+        '/test',
+      );
+      pod.webServer.addRoute(_TestRoute('test response'), '/test/route');
+
+      await pod.startWithDatabase();
+    });
+
+    tearDown(() async {
+      await pod.shutdown(exitProcess: false);
+    });
+
+    test(
+      'when Response is returned then the configured COOP policy is used',
+      () async {
+        final response = await client.get(
+          Uri.parse('${pod.webUrl}test/route'),
+        );
+        expect(response.statusCode, 200);
+        expect(
+          response.headers['cross-origin-opener-policy'],
+          'same-origin-allow-popups',
+        );
+        expect(
+          response.headers['cross-origin-embedder-policy'],
+          'require-corp',
+        );
+      },
+    );
+  });
+
   group('Given wasmHeadersMiddleware applied to multiple routes', () {
     late Serverpod pod;
 


### PR DESCRIPTION
Adds a `crossOriginOpenerPolicy` parameter to `WasmHeadersMiddleware` and
`FlutterRoute`, defaulting to today's `same-origin` (no behavior change).

The middleware's hardcoded `Cross-Origin-Opener-Policy: same-origin` is
required for `SharedArrayBuffer`/WASM multi-threading, but it also blocks
`window.postMessage`-based popup sign-in flows (e.g. "Sign in with Google")
from talking back to the opening window. Apps that need those flows and
don't rely on WASM multi-threading can now opt into
`CrossOriginOpenerPolicyHeader.sameOriginAllowPopups` instead of writing a
custom middleware.

Fixes #5076

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

## Breaking changes

None. The default COOP policy is unchanged.
