### PR TITLE
fix: Clears orphaned server-scope operations when serverpod start res…

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -1369,6 +1369,9 @@ Future<void> _runTuiBackend({
         // so a degraded->running transition lights up the action buttons.
         holder.state.serverReady = true;
         holder.state.serverStartable = false;
+        // The previous process (if any) is gone, so none of its open scopes
+        // (e.g. a stream endpoint) can still emit their `scope_end`.
+        clearOrphanedServerScopes(holder);
         holder.markDirty();
         final vmService = server.vmService;
         if (vmService == null) return;

--- a/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/event_handler.dart
@@ -10,6 +10,14 @@ import 'tab_model.dart';
 
 int _actionCounter = 0;
 
+/// IDs of [TrackedOperation]s currently open because of a `scope_start`
+/// server log event, as opposed to a CLI-driven action started by
+/// [runTrackedAction]. Tracked separately because [TrackedOperation] (from
+/// the external `serverpod_tui` package) carries no origin of its own, and
+/// [clearOrphanedServerScopes] must only finalize the former: CLI actions
+/// already self-complete through their own future.
+final Set<String> _serverScopeIds = {};
+
 /// Dispatches a structured server log event to the TUI state.
 void handleServerLogEvent(TuiAppStateHolder holder, Event event) {
   if (event.extensionKind != 'ext.serverpod.log') return;
@@ -40,9 +48,11 @@ void handleServerLogEvent(TuiAppStateHolder holder, Event event) {
         id: id,
         label: label,
       );
+      _serverScopeIds.add(id);
 
     case 'scope_end':
       final id = data['id'] as String? ?? '';
+      _serverScopeIds.remove(id);
       final op = state.activeOperations.remove(id);
       if (op != null) {
         op.stopwatch.stop();
@@ -58,6 +68,35 @@ void handleServerLogEvent(TuiAppStateHolder holder, Event event) {
         );
       }
   }
+  holder.markDirty();
+}
+
+/// Finalizes every operation still open from a `scope_start` server log
+/// event, e.g. a stream endpoint whose connection was still open.
+///
+/// A hard-killed pod (a hot restart) never emits the matching `scope_end`
+/// for scopes that were open at the time, so without this those entries
+/// would stay pinned in [TuiState.activeOperations] forever, growing the
+/// TUI's stream/operation counter on every restart. Call this once the new
+/// server process has taken over - at that point no in-flight scope from
+/// the old process can possibly still complete normally.
+void clearOrphanedServerScopes(TuiAppStateHolder holder) {
+  if (_serverScopeIds.isEmpty) return;
+
+  final state = holder.state;
+  for (final id in _serverScopeIds) {
+    final op = state.activeOperations.remove(id);
+    if (op == null) continue;
+    op.stopwatch.stop();
+    state.logHistory.add(
+      CompletedOperation(
+        label: op.label,
+        success: false,
+        duration: op.stopwatch.elapsed,
+      ),
+    );
+  }
+  _serverScopeIds.clear();
   holder.markDirty();
 }
 

--- a/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
@@ -317,6 +317,71 @@ void main() {
     });
   });
 
+  group('Given clearOrphanedServerScopes', () {
+    test('when a scope is still open then it is finalized as failed', () {
+      handleServerLogEvent(
+        holder,
+        _logEvent({
+          'type': 'scope_start',
+          'id': 'scope_stream',
+          'label': 'GET /api/stream',
+        }),
+      );
+
+      clearOrphanedServerScopes(holder);
+
+      expect(state.activeOperations, isEmpty);
+      expect(state.logHistory, hasLength(1));
+      final op = state.logHistory.first as CompletedOperation;
+      expect(op.label, 'GET /api/stream');
+      expect(op.success, isFalse);
+    });
+
+    test('when no scopes are open then it does nothing', () {
+      clearOrphanedServerScopes(holder);
+
+      expect(state.activeOperations, isEmpty);
+      expect(state.logHistory, isEmpty);
+    });
+
+    test('when a scope already completed then it is not finalized twice', () {
+      handleServerLogEvent(
+        holder,
+        _logEvent({
+          'type': 'scope_start',
+          'id': 'scope_done',
+          'label': 'GET /api/data',
+        }),
+      );
+      handleServerLogEvent(
+        holder,
+        _logEvent({
+          'type': 'scope_end',
+          'id': 'scope_done',
+          'success': true,
+        }),
+      );
+
+      clearOrphanedServerScopes(holder);
+
+      expect(state.logHistory, hasLength(1));
+    });
+
+    test('when a CLI action is in flight then it is left untouched', () {
+      state.serverReady = true;
+      final completer = Completer<void>();
+      runTrackedAction(holder, 'Restarting server', () => completer.future);
+
+      clearOrphanedServerScopes(holder);
+
+      expect(state.activeOperations, hasLength(1));
+      expect(state.activeOperations.values.first.label, 'Restarting server');
+      expect(state.actionBusy, isTrue);
+
+      completer.complete();
+    });
+  });
+
   group('Given a non-serverpod extension event', () {
     test('when dispatched then ignores it', () {
       final event = Event(


### PR DESCRIPTION
Fixes the TUI's stream/operation counter permanently growing after a hot restart.

`WatchSession.forceRestart()` hard-kills the pod process to restart it, so any
scope that was still open at that moment (e.g. a live stream endpoint) never
gets its matching `scope_end` event - the process that would have sent it is
gone. Those entries stayed pinned in the TUI's `activeOperations` forever,
so the displayed stream/operation count only ever grew across restarts,
eventually crowding out the log.

This adds `clearOrphanedServerScopes`, called from `onServerStart` - which
already fires on every server boot, including a restart - to finalize any
operation still tracked from the previous process (as a failed completion,
matching the existing convention for `scope_end`) before the new process's
event listener attaches. CLI-driven actions (e.g. "Restarting server"
itself) are tracked separately and are untouched by this.

Fixes #5540

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

## Breaking changes

None.
