### PR TITLE
fix: Resolve generated dart formatters with captured stderr

### DIFF
--- a/tools/serverpod_cli/lib/src/generator/dart_formatters.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart_formatters.dart
@@ -39,26 +39,25 @@ final class GeneratedDartFormatters {
   /// `dart_style` reports problems with a target package's
   /// `analysis_options.yaml` by writing to `stderr` itself, which corrupts the
   /// TUI. Those writes are captured and re-emitted through the logger instead.
+  ///
+  /// Anything written to `stdout` is captured the same way
+  /// but logged as debug output.
   static Future<void> resolve(GeneratorConfig config) async {
     final formatterStderr = _BufferedStdout();
+    final formatterStdout = _BufferedStdout();
 
     await IOOverrides.runZoned(
       () => _resolve(config),
       stderr: () => formatterStderr,
-      stdout: () => formatterStderr,
+      stdout: () => formatterStdout,
     );
 
-    // Output directories in the same package share an `analysis_options.yaml`,
-    // so a problem with it is reported once per directory. Report each distinct
-    // line once, as a single warning, keeping multi-line messages intact.
-    final warnings = <String>{};
-    for (final line in const LineSplitter().convert(formatterStderr.text)) {
-      if (line.trim().isEmpty) continue;
-      warnings.add(line);
+    if (formatterStdout.text.trim().isNotEmpty) {
+      log.debug(formatterStdout.text);
     }
 
-    if (warnings.isNotEmpty) {
-      log.warning(warnings.join('\n'));
+    if (formatterStderr.text.trim().isNotEmpty) {
+      log.warning(formatterStderr.text);
     }
   }
 
@@ -167,11 +166,12 @@ Future<bool> _directoryExists(Directory directory) async {
 
 /// A [Stdout] that buffers everything written to it in memory.
 ///
-/// Installed over `stderr` with [IOOverrides.runZoned] so that direct writes
-/// from within `dart_style` can be routed through the logger. The top-level
-/// `stderr` in `dart:io` resolves [IOOverrides.current] on every access, and
-/// the overrides are zone scoped, so the buffer stays in effect across the
-/// `await`s inside the library.
+/// Installed over `stdout` and `stderr` with [IOOverrides.runZoned] so that
+/// direct writes from within `dart_style` can be routed through the logger
+/// rather than corrupting the TUI. The top-level `stdout` and `stderr` in
+/// `dart:io` resolve [IOOverrides.current] on every access, and the overrides
+/// are zone scoped, so the buffers stay in effect across the `await`s inside
+/// the library.
 class _BufferedStdout implements Stdout {
   final StringBuffer _buffer = StringBuffer();
 

--- a/tools/serverpod_cli/lib/src/generator/dart_formatters.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart_formatters.dart
@@ -58,7 +58,7 @@ final class GeneratedDartFormatters {
     }
 
     if (warnings.isNotEmpty) {
-      log.debug(warnings.join('\n'));
+      log.warning(warnings.join('\n'));
     }
   }
 

--- a/tools/serverpod_cli/lib/src/generator/dart_formatters.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart_formatters.dart
@@ -120,12 +120,17 @@ Future<DartFormatter> _formatterFor(
 ) async {
   final outputFile = File(p.join(directory, 'protocol.dart')).absolute;
 
-  // Package config discovery needs a path inside an existing directory. The
-  // generated output folder (e.g. lib/src/protocol) may not exist yet on the
-  // first run, so walk up to the nearest existing parent. In a real project
-  // that parent is always within the target package (e.g. lib/src or the
-  // package root); only test teardown races or a missing package can climb
-  // further, in which case language-version lookup falls back below.
+  // Package config discovery needs a path inside an existing directory: it
+  // starts at the file's own directory and does not walk up out of one that
+  // is missing. The generated output folder (e.g. lib/src/protocol) may not
+  // exist yet on the first run, so resolve against the nearest existing
+  // parent instead. Only missing directories are skipped, and those can hold
+  // neither a `.dart_tool/` nor an `analysis_options.yaml`, so this finds the
+  // same configuration the output directory itself would once it exists.
+  //
+  // In a real project that parent is always within the target package (e.g.
+  // lib/src or the package root); only test teardown races or a missing
+  // package can climb further, in which case language-version lookup falls back below.
   var languageVersionDirectory = outputFile.parent;
   while (!await _directoryExists(languageVersionDirectory)) {
     final parent = languageVersionDirectory.parent;
@@ -146,8 +151,8 @@ Future<DartFormatter> _formatterFor(
 
   return DartFormatter(
     languageVersion: languageVersion,
-    pageWidth: await configCache.findPageWidth(outputFile),
-    trailingCommas: await configCache.findTrailingCommas(outputFile),
+    pageWidth: await configCache.findPageWidth(languageVersionFile),
+    trailingCommas: await configCache.findTrailingCommas(languageVersionFile),
   );
 }
 

--- a/tools/serverpod_cli/lib/src/generator/dart_formatters.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart_formatters.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_style/dart_style.dart';
@@ -8,6 +9,7 @@ import 'package:dart_style/src/config_cache.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
 /// Formatters for generated Dart, resolved from each output directory's
 /// `analysis_options.yaml`.
@@ -33,7 +35,34 @@ final class GeneratedDartFormatters {
   );
 
   /// Resolves the formatters needed by one generation run.
+  ///
+  /// `dart_style` reports problems with a target package's
+  /// `analysis_options.yaml` by writing to `stderr` itself, which corrupts the
+  /// TUI. Those writes are captured and re-emitted through the logger instead.
   static Future<void> resolve(GeneratorConfig config) async {
+    final formatterStderr = _BufferedStdout();
+
+    await IOOverrides.runZoned(
+      () => _resolve(config),
+      stderr: () => formatterStderr,
+      stdout: () => formatterStderr,
+    );
+
+    // Output directories in the same package share an `analysis_options.yaml`,
+    // so a problem with it is reported once per directory. Report each distinct
+    // line once, as a single warning, keeping multi-line messages intact.
+    final warnings = <String>{};
+    for (final line in const LineSplitter().convert(formatterStderr.text)) {
+      if (line.trim().isEmpty) continue;
+      warnings.add(line);
+    }
+
+    if (warnings.isNotEmpty) {
+      log.debug(warnings.join('\n'));
+    }
+  }
+
+  static Future<void> _resolve(GeneratorConfig config) async {
     final directories = _outputDirectories(config);
     final configCache = ConfigCache();
     final formatters = await Future.wait([
@@ -129,4 +158,76 @@ Future<bool> _directoryExists(Directory directory) async {
     // Windows can deny access while a directory is being deleted.
     return false;
   }
+}
+
+/// A [Stdout] that buffers everything written to it in memory.
+///
+/// Installed over `stderr` with [IOOverrides.runZoned] so that direct writes
+/// from within `dart_style` can be routed through the logger. The top-level
+/// `stderr` in `dart:io` resolves [IOOverrides.current] on every access, and
+/// the overrides are zone scoped, so the buffer stays in effect across the
+/// `await`s inside the library.
+class _BufferedStdout implements Stdout {
+  final StringBuffer _buffer = StringBuffer();
+
+  /// Everything written so far.
+  String get text => _buffer.toString();
+
+  @override
+  Encoding encoding = utf8;
+
+  @override
+  void write(Object? object) => _buffer.write(object);
+
+  @override
+  void writeln([Object? object = '']) => _buffer.writeln(object);
+
+  @override
+  void writeAll(Iterable<Object?> objects, [String separator = '']) =>
+      _buffer.writeAll(objects, separator);
+
+  @override
+  void writeCharCode(int charCode) => _buffer.writeCharCode(charCode);
+
+  @override
+  void add(List<int> data) => _buffer.write(encoding.decode(data));
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) =>
+      _buffer.writeln(error);
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) => stream.forEach(add);
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<void> get done => Future.value();
+
+  @override
+  IOSink get nonBlocking => this;
+
+  // Reported as a non-terminal so that anything checking before emitting ANSI
+  // escapes writes plain text the logger can render.
+  @override
+  bool get hasTerminal => false;
+
+  @override
+  bool get supportsAnsiEscapes => false;
+
+  @override
+  int get terminalColumns => 80;
+
+  @override
+  int get terminalLines => 24;
+
+  // Declaring `noSuchMethod` makes the compiler generate forwarders for any
+  // member a later SDK adds to `Stdout`, so this keeps compiling across SDK
+  // upgrades. Reaching one throws, as it would on any unimplemented member.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/tools/serverpod_cli/test/generator/dart_formatters_test.dart
+++ b/tools/serverpod_cli/test/generator/dart_formatters_test.dart
@@ -195,6 +195,82 @@ formatter:
   );
 
   test(
+    'Given a target package whose analysis options include a package URI, '
+    'when its generated-code formatters are resolved before the output directory exists, '
+    'then they capture the target formatter settings and report no resolution error.',
+    () async {
+      // Stands in for `package:lints`, which the project templates include.
+      final lintsDirectory = Directory(
+        p.join(tempDirectory.path, 'example_lints', 'lib'),
+      );
+      await lintsDirectory.create(recursive: true);
+      await File(
+        p.join(lintsDirectory.path, 'recommended.yaml'),
+      ).writeAsString('''
+linter:
+  rules:
+    - camel_case_types
+''');
+
+      final dartToolDirectory = Directory(
+        p.join(serverDirectory.path, '.dart_tool'),
+      );
+      await dartToolDirectory.create(recursive: true);
+      await File(
+        p.join(dartToolDirectory.path, 'package_config.json'),
+      ).writeAsString('''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "example_server",
+      "rootUri": "../",
+      "packageUri": "lib/",
+      "languageVersion": "3.12"
+    },
+    {
+      "name": "example_lints",
+      "rootUri": "../../example_lints",
+      "packageUri": "lib/",
+      "languageVersion": "3.12"
+    }
+  ]
+}
+''');
+      await File(
+        p.join(serverDirectory.path, 'analysis_options.yaml'),
+      ).writeAsString('''
+include: package:example_lints/recommended.yaml
+
+formatter:
+  page_width: 120
+  trailing_commas: preserve
+''');
+
+      // The generated output directory is deliberately left uncreated: it does
+      // not exist until the first generation run writes to it, and resolving
+      // the include from a directory that does not exist fails.
+      final config = GeneratorConfigBuilder()
+          .withServerPackageDirectoryPathParts(p.split(serverDirectory.path))
+          .build();
+
+      await GeneratedDartFormatters.resolve(config);
+
+      final formatter = GeneratedDartFormatters.of(
+        p.joinAll(config.generatedServerProtocolFilePathParts),
+      );
+
+      expect(formatter.pageWidth, 120);
+      expect(formatter.trailingCommas, TrailingCommas.preserve);
+      expect(
+        logger.debugMessages,
+        isEmpty,
+        reason: 'The include resolves, so dart_style reports no error.',
+      );
+    },
+  );
+
+  test(
     'Given a client package using Dart 3.12 whose generated protocol directory cannot be checked for existence, '
     'when its generated-code formatters are resolved, '
     'then they use the client package language version.',

--- a/tools/serverpod_cli/test/generator/dart_formatters_test.dart
+++ b/tools/serverpod_cli/test/generator/dart_formatters_test.dart
@@ -1,9 +1,12 @@
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:cli_tools/cli_tools.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:serverpod_cli/src/generator/dart_formatters.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:test/test.dart';
 
 import '../test_util/builders/generator_config_builder.dart';
@@ -11,6 +14,7 @@ import '../test_util/builders/generator_config_builder.dart';
 void main() {
   late Directory tempDirectory;
   late Directory serverDirectory;
+  late _DebugCapturingLogger logger;
 
   setUp(() async {
     tempDirectory = await Directory.systemTemp.createTemp(
@@ -21,12 +25,17 @@ void main() {
       p.join(tempDirectory.path, 'example_server'),
     );
     await serverDirectory.create(recursive: true);
+
+    logger = _DebugCapturingLogger();
+    initializeLoggerWith(logger);
   });
 
   tearDown(() async {
     GeneratedDartFormatters.reset();
     await tempDirectory.delete(recursive: true);
   });
+
+  tearDownAll(closeLogger);
 
   test(
     'Given a target package using Dart 3.12, '
@@ -152,6 +161,40 @@ formatter:
   );
 
   test(
+    'Given a target package with an invalid trailing-comma analysis options setting, '
+    'when its generated-code formatters are resolved, '
+    'then the formatter warning is logged instead of written to stderr.',
+    () async {
+      await File(
+        p.join(serverDirectory.path, 'analysis_options.yaml'),
+      ).writeAsString('''
+formatter:
+  trailing_commas: not_a_valid_setting
+''');
+      final config = GeneratorConfigBuilder()
+          .withServerPackageDirectoryPathParts(p.split(serverDirectory.path))
+          .build();
+
+      // Stands in for the real stderr, which the TUI owns.
+      final outerStderr = _RecordingStdout();
+      await IOOverrides.runZoned(
+        () => GeneratedDartFormatters.resolve(config),
+        stderr: () => outerStderr,
+      );
+
+      expect(
+        outerStderr.text,
+        isEmpty,
+        reason: 'dart_style must not write to stderr itself.',
+      );
+      expect(
+        logger.debugMessages.single,
+        contains('Warning: "trailing_commas" option'),
+      );
+    },
+  );
+
+  test(
     'Given a client package using Dart 3.12 whose generated protocol directory cannot be checked for existence, '
     'when its generated-code formatters are resolved, '
     'then they use the client package language version.',
@@ -233,4 +276,64 @@ Future<bool> _makeUnsearchable(Directory directory) async {
 
   await Process.run('chmod', ['755', directory.path]);
   return false;
+}
+
+/// A logger that records the debug messages it is given and prints nothing.
+class _DebugCapturingLogger extends VoidLogger {
+  final List<String> debugMessages = [];
+
+  @override
+  void debug(String message, {bool newParagraph = false, LogType? type}) {
+    debugMessages.add(message);
+  }
+}
+
+/// A [Stdout] that records everything written to it in memory.
+class _RecordingStdout implements Stdout {
+  final StringBuffer _buffer = StringBuffer();
+
+  String get text => _buffer.toString();
+
+  @override
+  Encoding encoding = utf8;
+
+  @override
+  void write(Object? object) => _buffer.write(object);
+
+  @override
+  void writeln([Object? object = '']) => _buffer.writeln(object);
+
+  @override
+  void writeAll(Iterable<Object?> objects, [String separator = '']) =>
+      _buffer.writeAll(objects, separator);
+
+  @override
+  void writeCharCode(int charCode) => _buffer.writeCharCode(charCode);
+
+  @override
+  void add(List<int> data) => _buffer.write(encoding.decode(data));
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) => stream.forEach(add);
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<void> get done => Future.value();
+
+  @override
+  IOSink get nonBlocking => this;
+
+  @override
+  bool get hasTerminal => false;
+
+  @override
+  bool get supportsAnsiEscapes => false;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/tools/serverpod_cli/test/generator/dart_formatters_test.dart
+++ b/tools/serverpod_cli/test/generator/dart_formatters_test.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:cli_tools/cli_tools.dart';
@@ -10,6 +9,7 @@ import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:test/test.dart';
 
 import '../test_util/builders/generator_config_builder.dart';
+import '../test_util/mock_std.dart';
 
 void main() {
   late Directory tempDirectory;
@@ -175,17 +175,24 @@ formatter:
           .withServerPackageDirectoryPathParts(p.split(serverDirectory.path))
           .build();
 
-      // Stands in for the real stderr, which the TUI owns.
-      final outerStderr = _RecordingStdout();
+      // Stand in for the real stdout and stderr, which the TUI owns.
+      final outerStderr = MockStdout();
+      final outerStdout = MockStdout();
       await IOOverrides.runZoned(
         () => GeneratedDartFormatters.resolve(config),
         stderr: () => outerStderr,
+        stdout: () => outerStdout,
       );
 
       expect(
-        outerStderr.text,
+        outerStderr.output,
         isEmpty,
         reason: 'dart_style must not write to stderr itself.',
+      );
+      expect(
+        outerStdout.output,
+        isEmpty,
+        reason: 'dart_style must not write to stdout itself.',
       );
       expect(
         logger.warnings.single,
@@ -362,54 +369,4 @@ class _WarningCapturingLogger extends VoidLogger {
   void warning(String message, {bool newParagraph = false, LogType? type}) {
     warnings.add(message);
   }
-}
-
-/// A [Stdout] that records everything written to it in memory.
-class _RecordingStdout implements Stdout {
-  final StringBuffer _buffer = StringBuffer();
-
-  String get text => _buffer.toString();
-
-  @override
-  Encoding encoding = utf8;
-
-  @override
-  void write(Object? object) => _buffer.write(object);
-
-  @override
-  void writeln([Object? object = '']) => _buffer.writeln(object);
-
-  @override
-  void writeAll(Iterable<Object?> objects, [String separator = '']) =>
-      _buffer.writeAll(objects, separator);
-
-  @override
-  void writeCharCode(int charCode) => _buffer.writeCharCode(charCode);
-
-  @override
-  void add(List<int> data) => _buffer.write(encoding.decode(data));
-
-  @override
-  Future<void> addStream(Stream<List<int>> stream) => stream.forEach(add);
-
-  @override
-  Future<void> flush() async {}
-
-  @override
-  Future<void> close() async {}
-
-  @override
-  Future<void> get done => Future.value();
-
-  @override
-  IOSink get nonBlocking => this;
-
-  @override
-  bool get hasTerminal => false;
-
-  @override
-  bool get supportsAnsiEscapes => false;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/tools/serverpod_cli/test/generator/dart_formatters_test.dart
+++ b/tools/serverpod_cli/test/generator/dart_formatters_test.dart
@@ -14,7 +14,7 @@ import '../test_util/builders/generator_config_builder.dart';
 void main() {
   late Directory tempDirectory;
   late Directory serverDirectory;
-  late _DebugCapturingLogger logger;
+  late _WarningCapturingLogger logger;
 
   setUp(() async {
     tempDirectory = await Directory.systemTemp.createTemp(
@@ -26,7 +26,7 @@ void main() {
     );
     await serverDirectory.create(recursive: true);
 
-    logger = _DebugCapturingLogger();
+    logger = _WarningCapturingLogger();
     initializeLoggerWith(logger);
   });
 
@@ -188,7 +188,7 @@ formatter:
         reason: 'dart_style must not write to stderr itself.',
       );
       expect(
-        logger.debugMessages.single,
+        logger.warnings.single,
         contains('Warning: "trailing_commas" option'),
       );
     },
@@ -263,7 +263,7 @@ formatter:
       expect(formatter.pageWidth, 120);
       expect(formatter.trailingCommas, TrailingCommas.preserve);
       expect(
-        logger.debugMessages,
+        logger.warnings,
         isEmpty,
         reason: 'The include resolves, so dart_style reports no error.',
       );
@@ -355,12 +355,12 @@ Future<bool> _makeUnsearchable(Directory directory) async {
 }
 
 /// A logger that records the debug messages it is given and prints nothing.
-class _DebugCapturingLogger extends VoidLogger {
-  final List<String> debugMessages = [];
+class _WarningCapturingLogger extends VoidLogger {
+  final List<String> warnings = [];
 
   @override
-  void debug(String message, {bool newParagraph = false, LogType? type}) {
-    debugMessages.add(message);
+  void warning(String message, {bool newParagraph = false, LogType? type}) {
+    warnings.add(message);
   }
 }
 


### PR DESCRIPTION
`dart_style` writes warnings to stderr when it [encounters some issues ](https://github.com/dart-lang/dart_style/blob/ce379a15fc8d30b4d955e24589897b183c476722/lib/src/config_cache.dart#L155) with `analysis_options.yaml`. This became more likely to happen with the introduction of `GeneratedDartFormatters`. Specifically the parts that try to resolve `pageWidth` and `trailingCommas` configurations from `analysis_options.yaml`. 

The resolution of formatters is now down in a fresh zone with overriden stderr and stdout (for future-proof safety) to capture the library's warnings and log them as debug messages.

Closes #5576 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None