### PR TITLE
fix: Include the session key salt in the session key hash

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/session/business/server_side_sessions.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/session/business/server_side_sessions.dart
@@ -75,17 +75,36 @@ class ServerSideSessions {
       return null;
     }
 
-    if (!_sessionKeyHash.validateSessionKeyHash(
+    final keyHashValidation = _sessionKeyHash.validateSessionKeyHash(
       secret: secret,
       hash: Uint8List.sublistView(serverSideSession.sessionKeyHash),
       salt: Uint8List.sublistView(serverSideSession.sessionKeySalt),
-    )) {
+    );
+
+    if (keyHashValidation == SessionKeyHashValidation.invalid) {
       session.log(
         'Provided `secret` did not result in correct session key hash.',
         level: LogLevel.debug,
       );
 
       return null;
+    }
+
+    if (keyHashValidation == SessionKeyHashValidation.validButOutdated) {
+      // Upgrade-on-verify: the secret is genuine but the stored hash predates
+      // the versioned, salt-in-digest scheme. Re-hash with the existing salt and
+      // persist, so the row validates under the current scheme from now on -
+      // this is what keeps the salt fix from signing existing sessions out.
+      final rehashed = _sessionKeyHash.rehashSessionKeyHash(
+        secret: secret,
+        salt: Uint8List.sublistView(serverSideSession.sessionKeySalt),
+      );
+      serverSideSession = await ServerSideSession.db.updateRow(
+        session,
+        serverSideSession.copyWith(
+          sessionKeyHash: ByteData.sublistView(rehashed),
+        ),
+      );
     }
 
     if (serverSideSession.lastUsedAt.isBefore(

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/session/util/session_key_hash.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/session/util/session_key_hash.dart
@@ -7,8 +7,29 @@ import 'package:serverpod_shared/serverpod_shared.dart';
 
 import '../business/server_side_sessions_config.dart';
 
+/// Outcome of validating a presented secret against a stored session key hash.
+enum SessionKeyHashValidation {
+  /// The secret did not match under any supported scheme or pepper.
+  invalid,
+
+  /// The secret matched a hash already stored in the current scheme.
+  valid,
+
+  /// The secret matched, but the stored hash uses a superseded scheme (the
+  /// pre-versioning saltless digest). The caller should re-hash via
+  /// [ServerSideSessionKeyHash.rehashSessionKeyHash] and persist it, upgrading
+  /// the row in place without dropping the session.
+  validButOutdated,
+}
+
 @internal
 final class ServerSideSessionKeyHash {
+  /// Length in bytes of a raw SHA-512 digest.
+  static const int _digestLength = 64;
+
+  /// The scheme written today: `[_saltedVersion] + sha512(secret + salt + pepper)`.
+  static const int _saltedVersion = 1;
+
   final int _sessionKeyHashSaltLength;
   final String _sessionKeyHashPepper;
   final List<String> _fallbackSessionKeyHashPeppers;
@@ -20,66 +41,140 @@ final class ServerSideSessionKeyHash {
        _sessionKeyHashPepper = sessionKeyHashPepper,
        _fallbackSessionKeyHashPeppers = fallbackSessionKeyHashPeppers;
 
-  /// Uses SHA512 to create a hash for a string using the specified pepper.
+  /// Creates a versioned hash for [secret] with a per-session salt and the
+  /// configured pepper.
+  ///
+  /// The stored hash is `[version] + digest`. The leading version byte lets
+  /// [validateSessionKeyHash] pick the right digest formula, and lets future
+  /// scheme changes be told apart from what is already on disk. The returned
+  /// salt has to be stored next to the hash and handed back to
+  /// [validateSessionKeyHash], which cannot verify the hash without it.
   ({Uint8List hash, Uint8List salt}) createSessionKeyHash({
     required final Uint8List secret,
     @protected final Uint8List? salt,
   }) {
-    return _createSessionKeyHash(
+    final actualSalt = salt ?? generateRandomBytes(_sessionKeyHashSaltLength);
+    return (
+      hash: rehashSessionKeyHash(secret: secret, salt: actualSalt),
+      salt: actualSalt,
+    );
+  }
+
+  /// Produces the current-scheme hash for [secret], reusing an already-stored
+  /// [salt].
+  ///
+  /// Used to upgrade a row whose hash used a superseded scheme; the salt does
+  /// not change, so only the hash column needs to be written.
+  Uint8List rehashSessionKeyHash({
+    required final Uint8List secret,
+    required final Uint8List salt,
+  }) {
+    final digest = _saltedDigest(
       secret: secret,
       salt: salt,
       pepper: _sessionKeyHashPepper,
     );
+
+    return Uint8List(1 + digest.length)
+      ..[0] = _saltedVersion
+      ..setRange(1, 1 + digest.length, digest);
   }
 
-  /// Internal method to create a session key hash with a specific pepper.
-  ({Uint8List hash, Uint8List salt}) _createSessionKeyHash({
-    required final Uint8List secret,
-    required final String pepper,
-    final Uint8List? salt,
-  }) {
-    final pepperBytes = utf8.encode(pepper);
-
-    final actualSalt = salt ?? generateRandomBytes(_sessionKeyHashSaltLength);
-
-    final hash = Uint8List.fromList(sha512.convert(secret + pepperBytes).bytes);
-
-    return (hash: hash, salt: actualSalt);
-  }
-
-  /// Validates the session key hash
-  bool validateSessionKeyHash({
+  /// Validates [secret] against a stored [hash] and its [salt], across the
+  /// primary and fallback peppers.
+  ///
+  /// Dispatches on the stored scheme: a bare 64-byte value is a pre-versioning
+  /// saltless hash and is always superseded; a longer value carries its version
+  /// in the first byte. Returns [SessionKeyHashValidation.validButOutdated] when
+  /// the match came from a superseded scheme, so the caller can upgrade the row.
+  SessionKeyHashValidation validateSessionKeyHash({
     required final Uint8List secret,
     required final Uint8List hash,
     required final Uint8List salt,
   }) {
-    // Try the primary pepper first (most common case)
+    // Pre-versioning rows are the released saltless digest, sha512(secret +
+    // pepper), stored as a bare 64-byte value. A match is genuine but
+    // superseded, so the caller upgrades the row.
+    if (hash.length == _digestLength) {
+      return _matchesAnyPepper(
+            hash,
+            (final pepper) =>
+                _legacySaltlessDigest(secret: secret, pepper: pepper),
+          )
+          ? SessionKeyHashValidation.validButOutdated
+          : SessionKeyHashValidation.invalid;
+    }
+
+    // Anything that is neither a bare digest nor a version byte followed by
+    // one is corrupt or truncated. Fail closed rather than indexing into it.
+    if (hash.length != 1 + _digestLength) {
+      return SessionKeyHashValidation.invalid;
+    }
+
+    // Versioned rows carry their scheme in the first byte.
+    switch (hash[0]) {
+      case _saltedVersion:
+        final storedDigest = Uint8List.sublistView(hash, 1);
+        return _matchesAnyPepper(
+              storedDigest,
+              (final pepper) =>
+                  _saltedDigest(secret: secret, salt: salt, pepper: pepper),
+            )
+            ? SessionKeyHashValidation.valid
+            : SessionKeyHashValidation.invalid;
+      default:
+        // A newer scheme written by a build ahead of this one. Fail closed.
+        return SessionKeyHashValidation.invalid;
+    }
+  }
+
+  bool _matchesAnyPepper(
+    final Uint8List expectedDigest,
+    final Uint8List Function(String pepper) computeDigest,
+  ) {
     if (uint8ListAreEqual(
-      hash,
-      _createSessionKeyHash(
-        secret: secret,
-        salt: salt,
-        pepper: _sessionKeyHashPepper,
-      ).hash,
+      expectedDigest,
+      computeDigest(_sessionKeyHashPepper),
     )) {
       return true;
     }
-
-    // Try fallback peppers if primary didn't match
     for (final fallbackPepper in _fallbackSessionKeyHashPeppers) {
-      if (uint8ListAreEqual(
-        hash,
-        _createSessionKeyHash(
-          secret: secret,
-          salt: salt,
-          pepper: fallbackPepper,
-        ).hash,
-      )) {
+      if (uint8ListAreEqual(expectedDigest, computeDigest(fallbackPepper))) {
         return true;
       }
     }
-
     return false;
+  }
+
+  /// The current digest, with the salt folded in.
+  ///
+  /// The salt has to be part of the digest, not merely stored beside it.
+  /// Without it every session sharing a secret shares a hash, and one
+  /// precomputation is good against every row at once. Both lengths are fixed
+  /// by configuration, so the concatenation is unambiguous.
+  Uint8List _saltedDigest({
+    required final Uint8List secret,
+    required final Uint8List salt,
+    required final String pepper,
+  }) {
+    return Uint8List.fromList(
+      sha512.convert(secret + salt + utf8.encode(pepper)).bytes,
+    );
+  }
+
+  /// The pre-fix digest that never mixed the salt in.
+  ///
+  /// Validation-only: a hash is never written with this formula again. It exists
+  /// so sessions issued before the fix keep working until they are re-hashed on
+  /// next use. It can be removed after a deprecation window, at which point any
+  /// remaining pre-fix sessions simply require a fresh sign-in.
+  Uint8List _legacySaltlessDigest({
+    required final Uint8List secret,
+    required final String pepper,
+  }) {
+    return Uint8List.fromList(
+      sha512.convert(secret + utf8.encode(pepper)).bytes,
+    );
   }
 
   factory ServerSideSessionKeyHash.fromConfig(

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/session/integration/server_side_sessions_authentication_handler_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/session/integration/server_side_sessions_authentication_handler_test.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:clock/clock.dart';
+import 'package:crypto/crypto.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart';
 import 'package:serverpod_auth_core_server/src/session/business/server_side_sessions_token.dart';
@@ -488,4 +490,120 @@ void main() {
       );
     },
   );
+
+  withServerpod('Given a session stored under the pre-fix saltless hash,', (
+    final sessionBuilder,
+    final endpoints,
+  ) {
+    late Session session;
+    late UuidValue sessionId;
+    late String sessionToken;
+    late ByteData originalSalt;
+
+    // The secret the client presents. The pre-fix digest is
+    // sha512(secret + pepper), with the stored salt never mixed in.
+    final secret = Uint8List.fromList(List.generate(32, (final i) => i + 7));
+
+    setUp(() async {
+      session = sessionBuilder.build();
+
+      final authUserId = (await serverSideSessions.authUsers.create(
+        session,
+      )).id;
+
+      originalSalt = ByteData.sublistView(
+        Uint8List.fromList(List.generate(16, (final i) => 255 - i)),
+      );
+      final legacyHash = ByteData.sublistView(
+        Uint8List.fromList(
+          sha512.convert(secret + utf8.encode('test-pepper')).bytes,
+        ),
+      );
+
+      final row = await ServerSideSession.db.insertRow(
+        session,
+        ServerSideSession(
+          authUserId: authUserId,
+          createdAt: clock.now(),
+          lastUsedAt: clock.now(),
+          scopeNames: {},
+          sessionKeyHash: legacyHash,
+          sessionKeySalt: originalSalt,
+          method: 'test',
+        ),
+      );
+      sessionId = row.id!;
+      sessionToken = buildServerSideSessionToken(
+        serverSideSessionId: sessionId,
+        secret: secret,
+      );
+    });
+
+    group('when it authenticates,', () {
+      late AuthenticationInfo? authInfo;
+      late ServerSideSession after;
+
+      setUp(() async {
+        final before = (await ServerSideSession.db.findById(
+          session,
+          sessionId,
+        ))!;
+        expect(
+          before.sessionKeyHash.lengthInBytes,
+          64,
+          reason: 'Precondition: a bare saltless digest, no version byte.',
+        );
+
+        authInfo = await serverSideSessions.authenticationHandler(
+          session,
+          sessionToken,
+        );
+
+        after = (await ServerSideSession.db.findById(session, sessionId))!;
+      });
+
+      test('then it succeeds.', () {
+        expect(
+          authInfo,
+          isNotNull,
+          reason:
+              'A pre-fix session must keep working - the fix is non-breaking.',
+        );
+      });
+
+      test(
+        'then the stored hash is upgraded in place to the versioned salted '
+        'scheme.',
+        () {
+          expect(
+            after.sessionKeyHash.lengthInBytes,
+            65,
+            reason: 'The row is re-hashed under the versioned scheme on use.',
+          );
+          expect(
+            after.sessionKeyHash.getUint8(0),
+            1,
+            reason: 'The current scheme version.',
+          );
+        },
+      );
+
+      test('then the upgrade reuses the stored salt.', () {
+        expect(
+          Uint8List.sublistView(after.sessionKeySalt),
+          Uint8List.sublistView(originalSalt),
+        );
+      });
+
+      test('then it still authenticates after the upgrade.', () async {
+        expect(
+          await serverSideSessions.authenticationHandler(
+            session,
+            sessionToken,
+          ),
+          isNotNull,
+        );
+      });
+    });
+  });
 }

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/session/util/session_key_hash_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/session/util/session_key_hash_test.dart
@@ -1,5 +1,7 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:crypto/crypto.dart';
 import 'package:serverpod_auth_core_server/src/session/util/session_key_hash.dart';
 import 'package:test/test.dart';
 
@@ -15,6 +17,10 @@ import 'package:test/test.dart';
 /// CSPRNG output by default, so nothing is currently at risk - the point of a
 /// per-session salt is to keep a shortened or lower-entropy secret from being
 /// attacked across every row at once, and that layer is simply absent.
+///
+/// The fix folds the salt into the digest and tags each hash with a leading
+/// version byte, so sessions issued under the old, saltless scheme keep working
+/// and are re-hashed in place on next use rather than being invalidated.
 void main() {
   group('Given a session key hash util', () {
     final sessionKeyHash = ServerSideSessionKeyHash(
@@ -59,7 +65,7 @@ void main() {
             hash: stored.hash,
             salt: other.salt,
           ),
-          isFalse,
+          SessionKeyHashValidation.invalid,
           reason:
               'A hash bound to one salt must not validate under another, or '
               'the salt is not part of what is being verified.',
@@ -78,7 +84,7 @@ void main() {
             hash: stored.hash,
             salt: stored.salt,
           ),
-          isTrue,
+          SessionKeyHashValidation.valid,
         );
       },
     );
@@ -98,9 +104,177 @@ void main() {
             hash: stored.hash,
             salt: stored.salt,
           ),
-          isFalse,
+          SessionKeyHashValidation.invalid,
         );
       },
     );
   });
+
+  group(
+    'Given a session key hash stored under the pre-fix saltless scheme,',
+    () {
+      final sessionKeyHash = ServerSideSessionKeyHash(
+        sessionKeyHashSaltLength: 16,
+        sessionKeyHashPepper: 'test-pepper',
+        fallbackSessionKeyHashPeppers: const [],
+      );
+
+      final secret = Uint8List.fromList(List.generate(32, (final i) => i));
+
+      // Any stored salt: the pre-fix digest never mixed it in.
+      final salt = Uint8List.fromList(List.generate(16, (final i) => 255 - i));
+
+      final legacyHash = _legacySaltlessHash(secret, 'test-pepper');
+
+      test(
+        'when it is validated with the right secret, '
+        'then it is accepted as outdated so the caller upgrades it.',
+        () {
+          expect(
+            legacyHash,
+            hasLength(64),
+            reason: 'Precondition: a bare digest with no version byte.',
+          );
+
+          expect(
+            sessionKeyHash.validateSessionKeyHash(
+              secret: secret,
+              hash: legacyHash,
+              salt: salt,
+            ),
+            SessionKeyHashValidation.validButOutdated,
+          );
+        },
+      );
+
+      test(
+        'when it is validated with the wrong secret, then it is rejected.',
+        () {
+          final otherSecret = Uint8List.fromList(
+            List.generate(32, (final i) => i + 1),
+          );
+
+          expect(
+            sessionKeyHash.validateSessionKeyHash(
+              secret: otherSecret,
+              hash: legacyHash,
+              salt: salt,
+            ),
+            SessionKeyHashValidation.invalid,
+          );
+        },
+      );
+
+      group('when it is re-hashed,', () {
+        late Uint8List upgraded;
+
+        setUp(() {
+          upgraded = sessionKeyHash.rehashSessionKeyHash(
+            secret: secret,
+            salt: salt,
+          );
+        });
+
+        test('then the result is versioned.', () {
+          expect(
+            upgraded,
+            hasLength(65),
+            reason: 'A one-byte version tag followed by the 64-byte digest.',
+          );
+          expect(
+            upgraded.first,
+            1,
+            reason: 'The current scheme version.',
+          );
+        });
+
+        test('then it validates as current under the same salt.', () {
+          expect(
+            sessionKeyHash.validateSessionKeyHash(
+              secret: secret,
+              hash: upgraded,
+              salt: salt,
+            ),
+            SessionKeyHashValidation.valid,
+            reason: 'The upgraded row must validate under the current scheme.',
+          );
+        });
+      });
+
+      test(
+        'when its pepper has since been rotated to a fallback, '
+        'then it still validates as outdated.',
+        () {
+          final rotated = ServerSideSessionKeyHash(
+            sessionKeyHashSaltLength: 16,
+            sessionKeyHashPepper: 'new-pepper',
+            fallbackSessionKeyHashPeppers: const ['test-pepper'],
+          );
+
+          expect(
+            rotated.validateSessionKeyHash(
+              secret: secret,
+              hash: legacyHash,
+              salt: salt,
+            ),
+            SessionKeyHashValidation.validButOutdated,
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a stored hash of a length no scheme produces,',
+    () {
+      final sessionKeyHash = ServerSideSessionKeyHash(
+        sessionKeyHashSaltLength: 16,
+        sessionKeyHashPepper: 'test-pepper',
+        fallbackSessionKeyHashPeppers: const [],
+      );
+
+      final secret = Uint8List.fromList(List.generate(32, (final i) => i));
+      final salt = Uint8List.fromList(List.generate(16, (final i) => 255 - i));
+
+      // An empty hash reached `hash[0]` and threw a RangeError, turning a
+      // corrupt row into a server error rather than a failed authentication.
+      for (final (label, hash) in [
+        ('an empty hash', Uint8List(0)),
+        ('a truncated hash', Uint8List(32)),
+        ('a hash longer than the versioned scheme', Uint8List(128)),
+      ]) {
+        test(
+          'when $label is validated, '
+          'then it is rejected rather than throwing.',
+          () {
+            expect(
+              () => sessionKeyHash.validateSessionKeyHash(
+                secret: secret,
+                hash: hash,
+                salt: salt,
+              ),
+              returnsNormally,
+              reason: 'A corrupt row must not throw out of validation.',
+            );
+
+            expect(
+              sessionKeyHash.validateSessionKeyHash(
+                secret: secret,
+                hash: hash,
+                salt: salt,
+              ),
+              SessionKeyHashValidation.invalid,
+            );
+          },
+        );
+      }
+    },
+  );
+}
+
+/// The pre-fix digest: `sha512(secret + pepper)`, with the salt never mixed in.
+Uint8List _legacySaltlessHash(final Uint8List secret, final String pepper) {
+  return Uint8List.fromList(
+    sha512.convert(secret + utf8.encode(pepper)).bytes,
+  );
 }

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/session/util/session_key_hash_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/session/util/session_key_hash_test.dart
@@ -1,0 +1,106 @@
+import 'dart:typed_data';
+
+import 'package:serverpod_auth_core_server/src/session/util/session_key_hash.dart';
+import 'package:test/test.dart';
+
+/// `ServerSideSession.sessionKeySalt` is documented as "the salt used for
+/// computing the [sessionKeyHash]", and `sessionKeyHashSaltLength` as the
+/// length of "the salt used for the session key hash". A salt is generated per
+/// session, stored alongside the hash, read back, and handed to
+/// `validateSessionKeyHash` - but it never reaches the digest, which covers
+/// only the secret and the pepper.
+///
+/// The consequence is that two sessions sharing a secret share a hash, and a
+/// hash validates against any salt at all. Session key secrets are 32 bytes of
+/// CSPRNG output by default, so nothing is currently at risk - the point of a
+/// per-session salt is to keep a shortened or lower-entropy secret from being
+/// attacked across every row at once, and that layer is simply absent.
+void main() {
+  group('Given a session key hash util', () {
+    final sessionKeyHash = ServerSideSessionKeyHash(
+      sessionKeyHashSaltLength: 16,
+      sessionKeyHashPepper: 'test-pepper',
+      fallbackSessionKeyHashPeppers: const [],
+    );
+
+    final secret = Uint8List.fromList(List.generate(32, (final i) => i));
+
+    test(
+      'when the same secret is hashed twice, then the two hashes differ.',
+      () {
+        final first = sessionKeyHash.createSessionKeyHash(secret: secret);
+        final second = sessionKeyHash.createSessionKeyHash(secret: secret);
+
+        expect(
+          first.salt,
+          isNot(orderedEquals(second.salt)),
+          reason: 'Precondition: each hash must get its own random salt.',
+        );
+
+        expect(
+          first.hash,
+          isNot(orderedEquals(second.hash)),
+          reason:
+              'Two sessions holding the same secret must not share a hash, or '
+              'the stored salt is not reaching the digest.',
+        );
+      },
+    );
+
+    test(
+      'when a hash is validated against a different salt, then it is rejected.',
+      () {
+        final stored = sessionKeyHash.createSessionKeyHash(secret: secret);
+        final other = sessionKeyHash.createSessionKeyHash(secret: secret);
+
+        expect(
+          sessionKeyHash.validateSessionKeyHash(
+            secret: secret,
+            hash: stored.hash,
+            salt: other.salt,
+          ),
+          isFalse,
+          reason:
+              'A hash bound to one salt must not validate under another, or '
+              'the salt is not part of what is being verified.',
+        );
+      },
+    );
+
+    test(
+      'when a hash is validated against its own salt, then it is accepted.',
+      () {
+        final stored = sessionKeyHash.createSessionKeyHash(secret: secret);
+
+        expect(
+          sessionKeyHash.validateSessionKeyHash(
+            secret: secret,
+            hash: stored.hash,
+            salt: stored.salt,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'when a hash is validated against a different secret, '
+      'then it is rejected.',
+      () {
+        final stored = sessionKeyHash.createSessionKeyHash(secret: secret);
+        final otherSecret = Uint8List.fromList(
+          List.generate(32, (final i) => i + 1),
+        );
+
+        expect(
+          sessionKeyHash.validateSessionKeyHash(
+            secret: otherSecret,
+            hash: stored.hash,
+            salt: stored.salt,
+          ),
+          isFalse,
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
The per-session salt was generated, stored, and handed to validation, but never entered the digest, which covered only `secret + pepper`. The salt is now part of the digest.

Session key secrets are 32-byte CSPRNG output. The salt is defense-in-depth, but not security critical by itself.

The change is non-breaking. Hashes now carry a leading version byte (`[1] + sha512(secret + salt + pepper)`). Pre-fix rows (bare 64-byte saltless digest) still validate and are re-hashed in place on next use with their already stored salt. No user is signed out.