### PR TITLE
fix: Make the login rate limit bound guesses per user

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/endpoints/legacy_email_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/lib/src/endpoints/legacy_email_endpoint.dart
@@ -18,21 +18,13 @@ class LegacyEmailEndpoint extends Endpoint {
     final String email,
     final String password,
   ) async {
-    await AuthBackwardsCompatibility.importLegacyPasswordIfNeeded(
-      session,
-      email: email,
-      password: password,
-    );
-
     final UuidValue authUserId;
     try {
-      authUserId = await AuthServices.instance.emailIdp.utils.authentication
-          .authenticate(
-            session,
-            email: email,
-            password: password,
-            transaction: null,
-          );
+      authUserId = await _authenticateWithLegacyFallback(
+        session,
+        email: email,
+        password: password,
+      );
     } on EmailAccountNotFoundException {
       return LegacyAuthenticationResponse(
         success: false,
@@ -112,7 +104,47 @@ class LegacyEmailEndpoint extends Endpoint {
     );
   }
 
-  /// Stub — registration is not supported via legacy endpoints.
+  /// Authenticates against the new email IdP, falling back to the password
+  /// held in the legacy system for an account migrated without one.
+  ///
+  /// The fallback runs only after [EmailIdpAuthenticationUtil.authenticate] has
+  /// rejected the credentials, which means the rate limiter has already
+  /// accepted and recorded the attempt. Consulting the legacy password first,
+  /// as this endpoint used to, verified it against the stored legacy hash on
+  /// every request - including for an account that was already locked out - so
+  /// the limit bounded how often the caller learned the outcome rather than
+  /// how many guesses they got to make.
+  Future<UuidValue> _authenticateWithLegacyFallback(
+    final Session session, {
+    required final String email,
+    required final String password,
+  }) async {
+    final authentication = AuthServices.instance.emailIdp.utils.authentication;
+
+    try {
+      return await authentication.authenticate(
+        session,
+        email: email,
+        password: password,
+        transaction: null,
+      );
+    } on EmailAuthenticationInvalidCredentialsException {
+      await AuthBackwardsCompatibility.importLegacyPasswordIfNeeded(
+        session,
+        email: email,
+        password: password,
+      );
+
+      return authentication.authenticate(
+        session,
+        email: email,
+        password: password,
+        transaction: null,
+      );
+    }
+  }
+
+  /// Stub - registration is not supported via legacy endpoints.
   Future<bool> createAccountRequest(
     final Session session,
     final String userName,
@@ -122,7 +154,7 @@ class LegacyEmailEndpoint extends Endpoint {
     return false;
   }
 
-  /// Stub — account creation is not supported via legacy endpoints.
+  /// Stub - account creation is not supported via legacy endpoints.
   Future<LegacyUserInfo?> createAccount(
     final Session session,
     final String email,
@@ -131,7 +163,7 @@ class LegacyEmailEndpoint extends Endpoint {
     return null;
   }
 
-  /// Stub — password change is not supported via legacy endpoints.
+  /// Stub - password change is not supported via legacy endpoints.
   Future<bool> changePassword(
     final Session session,
     final String oldPassword,
@@ -140,7 +172,7 @@ class LegacyEmailEndpoint extends Endpoint {
     return false;
   }
 
-  /// Stub — password reset initiation is not supported via legacy endpoints.
+  /// Stub - password reset initiation is not supported via legacy endpoints.
   Future<bool> initiatePasswordReset(
     final Session session,
     final String email,
@@ -148,7 +180,7 @@ class LegacyEmailEndpoint extends Endpoint {
     return false;
   }
 
-  /// Stub — password reset is not supported via legacy endpoints.
+  /// Stub - password reset is not supported via legacy endpoints.
   Future<bool> resetPassword(
     final Session session,
     final String verificationCode,

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/test/integration/backwards_compatibility_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/test/integration/backwards_compatibility_test.dart
@@ -1,5 +1,9 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_bridge_server/serverpod_auth_bridge_server.dart';
+import 'package:serverpod_auth_bridge_server/src/generated/protocol.dart';
 import 'package:serverpod_auth_idp_server/core.dart';
 import 'package:serverpod_auth_idp_server/providers/email.dart';
 import 'package:test/test.dart';
@@ -50,4 +54,136 @@ void main() {
       },
     );
   });
+
+  withServerpod(
+    'Given a migrated account whose password only exists in the legacy system,',
+    rollbackDatabase: RollbackDatabase.disabled,
+    (final sessionBuilder, final endpoints) {
+      late Session session;
+      late UuidValue emailAccountId;
+
+      const email = 'migrated@serverpod.dev';
+      const password = 'Foobar123!';
+      const failedLoginRateLimit = RateLimit(
+        maxAttempts: 2,
+        timeframe: Duration(hours: 1),
+      );
+
+      setUp(() async {
+        session = sessionBuilder.build();
+        AuthServices.set(
+          identityProviderBuilders: [
+            const EmailIdpConfig(
+              secretHashPepper: 'test',
+              failedLoginRateLimit: failedLoginRateLimit,
+            ),
+          ],
+          tokenManagerBuilders: [tokenManagerConfig],
+        );
+
+        final authUser = await const AuthUsers().create(session);
+        emailAccountId = await AuthServices.instance.emailIdp.admin
+            .createEmailAuthentication(
+              session,
+              authUserId: authUser.id,
+              email: email,
+              password: null,
+            );
+
+        await AuthBackwardsCompatibility.storeLegacyPassword(
+          session,
+          emailAccountId: emailAccountId,
+          passwordHash: _legacyPasswordHash(password: password, email: email),
+        );
+      });
+
+      tearDown(() async {
+        AuthServices.set(
+          identityProviderBuilders: [],
+          tokenManagerBuilders: [tokenManagerConfig],
+        );
+
+        // Rollbacks are disabled here, so each test has to leave the database
+        // as it found it. Deleting the user cascades to its email account, and
+        // that in turn to the legacy password hanging off it.
+        await AuthUser.db.deleteWhere(
+          session,
+          where: (final _) => Constant.bool(true),
+        );
+        await RateLimitedRequestAttempt.db.deleteWhere(
+          session,
+          where: (final _) => Constant.bool(true),
+        );
+      });
+
+      group('when the failed login rate limit is already exhausted,', () {
+        late LegacyAuthenticationResponse response;
+
+        setUp(() async {
+          for (
+            var attempt = 0;
+            attempt <= failedLoginRateLimit.maxAttempts;
+            attempt++
+          ) {
+            await endpoints.legacyEmail.authenticate(
+              sessionBuilder,
+              email,
+              'wrong-password-$attempt',
+            );
+          }
+
+          response = await endpoints.legacyEmail.authenticate(
+            sessionBuilder,
+            email,
+            password,
+          );
+        });
+
+        test('then a correct password is refused as a locked out guess.', () {
+          expect(
+            response.failReason,
+            LegacyAuthenticationFailReason.tooManyFailedAttempts,
+          );
+        });
+
+        test(
+          'then a correct password is not verified against the legacy hash.',
+          () async {
+            // A correct guess consumes the legacy row: the import verifies it,
+            // installs the password on the `EmailAccount` and deletes it.
+            // Finding the row gone is therefore proof that the hash was
+            // verified while the account was locked out - which is the guess
+            // the rate limit was supposed to refuse.
+            final legacyPassword = await LegacyEmailPassword.db.findFirstRow(
+              session,
+              where: (final t) => t.emailAccountId.equals(emailAccountId),
+            );
+
+            expect(
+              legacyPassword,
+              isNotNull,
+              reason:
+                  'The legacy password was verified and imported even though '
+                  'the account was rate limited, so the limit does not bound '
+                  'how many guesses an attacker gets.',
+            );
+          },
+        );
+      });
+    },
+  );
+}
+
+/// Builds a `serverpod_auth` era password hash, as
+/// `LegacyEmailPassword.hash` would hold for an account migrated from it.
+///
+/// Mirrors the plain `legacy` hash type: `sha256(password + salt)`, with the
+/// email appended to the salt because `extraSaltyHash` defaults to true.
+String _legacyPasswordHash({
+  required final String password,
+  required final String email,
+}) {
+  const legacySalt = 'serverpod password salt';
+
+  return sha256.convert(utf8.encode('$password$legacySalt:$email')).toString();
 }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/rate_limited_request_attempt/rate_limited_request_attempt_util.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/rate_limited_request_attempt/rate_limited_request_attempt_util.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:clock/clock.dart';
 import 'package:serverpod/serverpod.dart';
 
@@ -95,6 +97,10 @@ class DatabaseRateLimitedRequestAttemptUtil<T>
     final rateLimitExceeded = await session.db.transaction((
       final transaction,
     ) async {
+      // Taken before the savepoint, so that rolling the savepoint back on a
+      // rate limited attempt does not release it early.
+      await _lockNonce(session, nonce: nonce, transaction: transaction);
+
       final savePoint = await transaction.createSavepoint();
       await recordAttempt(
         session,
@@ -126,6 +132,54 @@ class DatabaseRateLimitedRequestAttemptUtil<T>
     }
 
     return rateLimitExceeded;
+  }
+
+  /// Serialises concurrent [hasTooManyAttempts] checks for the same [nonce].
+  ///
+  /// Recording the attempt and counting the attempts are two statements, and
+  /// two PostgreSQL transactions running them at once cannot see each other's
+  /// uncommitted insert. Without a lock both would read the same count and both
+  /// would be let through, so a burst of parallel requests would spend the
+  /// budget once between them instead of once each.
+  ///
+  /// A transaction scoped advisory lock keyed on the nonce makes the pair
+  /// atomic against other checks for the same nonce while leaving different
+  /// nonces free to run in parallel. It is released when the transaction ends.
+  ///
+  /// No-op on SQLite, which permits only one write transaction at a time and
+  /// therefore already serialises these checks - the same reasoning that makes
+  /// `lockRows` a no-op on that adapter.
+  Future<void> _lockNonce(
+    final Session session, {
+    required final T nonce,
+    required final Transaction transaction,
+  }) async {
+    if (session.db.dialect != DatabaseDialect.postgres) return;
+
+    await session.db.unsafeQuery(
+      'SELECT pg_advisory_xact_lock(@key)',
+      parameters: QueryParameters.named({'key': _lockKey(nonce)}),
+      transaction: transaction,
+    );
+  }
+
+  /// A stable 64 bit key for [nonce] within this limiter's domain and source.
+  ///
+  /// FNV-1a. A collision would only make two unrelated nonces wait on each
+  /// other, never let an attempt through, so the hash carries no security
+  /// weight.
+  int _lockKey(final T nonce) {
+    const offsetBasis = 0xcbf29ce484222325;
+    const prime = 0x100000001b3;
+
+    var hash = offsetBasis;
+    for (final unit in utf8.encode(
+      '${config.domain}:${config.source}:${config.nonceToString(nonce)}',
+    )) {
+      hash = (hash ^ unit) * prime;
+    }
+
+    return hash;
   }
 
   @override

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/email/business/utils/email_idp_authentication_util.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/email/business/utils/email_idp_authentication_util.dart
@@ -15,7 +15,6 @@ import '../email_idp_server_exceptions.dart';
 class EmailIdpAuthenticationUtil {
   final Argon2HashUtil _hashUtil;
   final DatabaseRateLimitedRequestAttemptUtil<String> _rateLimitUtil;
-  final int _maxAttempts;
 
   /// Creates a new instance of [EmailIdpAuthenticationUtil].
   EmailIdpAuthenticationUtil({
@@ -29,8 +28,7 @@ class EmailIdpAuthenticationUtil {
            maxAttempts: failedLoginRateLimit.maxAttempts,
            timeframe: failedLoginRateLimit.timeframe,
          ),
-       ),
-       _maxAttempts = failedLoginRateLimit.maxAttempts;
+       );
 
   /// Returns the [AuthUser]'s ID upon successful email/password verification.
   ///
@@ -42,8 +40,9 @@ class EmailIdpAuthenticationUtil {
   /// - [EmailAuthenticationTooManyAttemptsException] if the user has made
   ///   too many failed attempts.
   ///
-  /// In case of invalid credentials, the failed attempt will be logged to
-  /// the database outside of the [transaction] and can not be rolled back.
+  /// The attempt is logged to the database outside of the [transaction] and
+  /// can not be rolled back. A successful authentication clears the log for
+  /// [email], so the count only ever accumulates over failures.
   Future<UuidValue> authenticate(
     final Session session, {
     required String email,
@@ -52,12 +51,12 @@ class EmailIdpAuthenticationUtil {
   }) async {
     email = email.normalizedEmail;
 
-    final attemptCount = await _rateLimitUtil.countAttempts(
-      session,
-      nonce: email,
-      transaction: transaction,
-    );
-    if (attemptCount >= _maxAttempts) {
+    // Records the attempt and reads the count as one atomic step. Counting
+    // first and recording the failure afterwards left the account lookup and
+    // the Argon2 verification inside the window, so requests sent together all
+    // read the same pre-attempt count and the budget bounded a batch rather
+    // than a time window.
+    if (await _rateLimitUtil.hasTooManyAttempts(session, nonce: email)) {
       throw EmailAuthenticationTooManyAttemptsException();
     }
 
@@ -68,10 +67,6 @@ class EmailIdpAuthenticationUtil {
     );
 
     if (account == null) {
-      await _rateLimitUtil.recordAttempt(
-        session,
-        nonce: email,
-      );
       throw EmailAccountNotFoundException();
     }
 
@@ -79,12 +74,17 @@ class EmailIdpAuthenticationUtil {
       secret: password,
       hashString: account.passwordHash,
     )) {
-      await _rateLimitUtil.recordAttempt(
-        session,
-        nonce: email,
-      );
       throw EmailAuthenticationInvalidCredentialsException();
     }
+
+    // The attempt had to be counted before the outcome was known. Clearing on
+    // success keeps this a limit on *failed* logins, so someone who mistypes a
+    // few times and then gets it right is not left locked out.
+    await _rateLimitUtil.deleteAttempts(
+      session,
+      nonce: email,
+      olderThan: Duration.zero,
+    );
 
     return account.authUserId;
   }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/email/email_idp_admin_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/email/email_idp_admin_test.dart
@@ -9,6 +9,7 @@ import 'test_utils/email_idp_test_fixture.dart';
 void main() {
   withServerpod(
     'Given an existing auth user',
+    rollbackDatabase: RollbackDatabase.disabled,
     (final sessionBuilder, final endpoints) {
       late Session session;
       late EmailIdpTestFixture fixture;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/email/utils/email_idp_account_creation_util/create_email_authentication_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/email/utils/email_idp_account_creation_util/create_email_authentication_test.dart
@@ -8,6 +8,7 @@ import '../../test_utils/email_idp_test_fixture.dart';
 void main() {
   withServerpod(
     'Given auth user',
+    rollbackDatabase: RollbackDatabase.disabled,
     (final sessionBuilder, final endpoints) {
       late Session session;
       late EmailIdpTestFixture fixture;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/email/utils/email_idp_authentication_utils_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/email/utils/email_idp_authentication_utils_test.dart
@@ -122,6 +122,82 @@ void main() {
   );
 
   withServerpod(
+    'Given an existing email account and a failed login rate limit',
+    rollbackDatabase: RollbackDatabase.disabled,
+    (final sessionBuilder, final endpoints) {
+      late Session session;
+      late EmailIdpTestFixture fixture;
+      late EmailIdpAuthenticationUtil authenticationUtil;
+      const email = 'parallel@serverpod.dev';
+      const password = 'Foobar123!';
+      const failedLoginRateLimit = RateLimit(
+        maxAttempts: 3,
+        timeframe: Duration(hours: 1),
+      );
+
+      setUp(() async {
+        session = sessionBuilder.build();
+        fixture = EmailIdpTestFixture(
+          config: const EmailIdpConfig(
+            secretHashPepper: 'test-pepper',
+            failedLoginRateLimit: failedLoginRateLimit,
+          ),
+        );
+
+        final authUser = await fixture.authUsers.create(session);
+        await fixture.createEmailAccount(
+          session,
+          authUserId: authUser.id,
+          email: email,
+          password: EmailAccountPassword.fromString(password),
+        );
+
+        authenticationUtil = fixture.authenticationUtil;
+      });
+
+      tearDown(() async {
+        await fixture.tearDown(session);
+      });
+
+      test(
+        'when more wrong-password logins are issued in parallel than the limit allows, '
+        'then no more than the limit are given a password comparison.',
+        () async {
+          const parallelAttempts = 12;
+
+          final passwordWasCompared = await Future.wait(
+            List.generate(parallelAttempts, (final _) async {
+              try {
+                await authenticationUtil.authenticate(
+                  session,
+                  email: email,
+                  password: '$password-incorrect',
+                  transaction: null,
+                );
+                return true;
+              } on EmailAuthenticationInvalidCredentialsException {
+                // Reaching this means the stored hash was verified against the
+                // supplied password - one guess spent.
+                return true;
+              } on EmailAuthenticationTooManyAttemptsException {
+                return false;
+              }
+            }),
+          );
+
+          expect(
+            passwordWasCompared.where((final compared) => compared).length,
+            lessThanOrEqualTo(failedLoginRateLimit.maxAttempts),
+            reason:
+                'Guesses sent in parallel must consume the same budget as '
+                'guesses sent one at a time.',
+          );
+        },
+      );
+    },
+  );
+
+  withServerpod(
     'Given non-existing email account',
     rollbackDatabase: RollbackDatabase.disabled,
     (final sessionBuilder, final endpoints) {

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/email/utils/email_idp_password_reset_util/set_password_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/email/utils/email_idp_password_reset_util/set_password_test.dart
@@ -8,6 +8,7 @@ import '../../test_utils/email_idp_test_fixture.dart';
 void main() {
   withServerpod(
     'Given email account',
+    rollbackDatabase: RollbackDatabase.disabled,
     (final sessionBuilder, final endpoints) {
       late Session session;
       late UuidValue authUserId;


### PR DESCRIPTION
The per-user failed-login budget capped how often a caller learned the outcome, not how many guesses they got.

- Parallel guesses for one account all read the attempt count before any recorded (record and count were separate steps, and uncommitted inserts are invisible across transactions).
- `LegacyEmailEndpoint` verified the password against the legacy hash before the rate-limited call, even for a locked-out account.

Now `authenticate` gates on `hasTooManyAttempts` (record + count in one step, cleared on success), that is serialised by a transaction-scoped advisory lock on the nonce.

The legacy import runs only after credentials are rejected. Also covers password reset, anonymous login, and secret-challenge flows.

This is not critical. It weakens online brute-force protection, but guessing still needs valid credentials against Argon2 hashes. 
