### PR TITLE
fix: Refuse to rotate a refresh token for a blocked auth user

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/jwt/business/jwt_admin.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/jwt/business/jwt_admin.dart
@@ -163,6 +163,33 @@ class JwtAdmin {
       );
     }
 
+    // Checked only once the caller has proven possession of the refresh token,
+    // so this does not become an oracle for the state of an account whose
+    // token the caller does not hold.
+    //
+    // A rotation re-establishes access for another full refresh token
+    // lifetime, so `blocked` has to be consulted here and not only in
+    // `createTokens` - otherwise blocking a user leaves any session they
+    // already hold running indefinitely. The token is deliberately left in
+    // place rather than deleted, so that lifting the block restores it.
+    //
+    // Read directly rather than through `AuthUsers.get`, which opens a
+    // transaction of its own. Rotations are not serialised, so nesting one
+    // here corrupts the savepoint stack when several run on the same session.
+    final authUser = await AuthUser.db.findById(
+      session,
+      refreshTokenRow.authUserId,
+      transaction: transaction,
+    );
+
+    if (authUser == null) {
+      throw AuthUserNotFoundException();
+    }
+
+    if (authUser.blocked) {
+      throw AuthUserBlockedException();
+    }
+
     final newSecret = _generateRefreshTokenRotatingSecret();
     final newHash = await _refreshTokenSecretHash.createHashFromBytes(
       secret: newSecret,

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/jwt/integration/jwt_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/test/jwt/integration/jwt_test.dart
@@ -653,6 +653,93 @@ void main() {
     );
   });
 
+  // `createTokens` refuses to issue a token pair to a blocked user, but that
+  // only guards the login path. A refresh token issued before the block is
+  // rotated through `rotateRefreshToken`, which never looks the `AuthUser` up,
+  // and `isExpired` measures from `lastUpdatedAt` - so each rotation pushes the
+  // expiry out again. Blocking therefore does not end an existing session: the
+  // user keeps full scoped access for as long as they refresh, by calling an
+  // endpoint that requires no authentication of its own.
+  withServerpod('Given a user that is blocked after having signed in,', (
+    final sessionBuilder,
+    final endpoints,
+  ) {
+    late Session session;
+    late UuidValue authUserId;
+    late String refreshToken;
+
+    setUp(() async {
+      session = sessionBuilder.build();
+
+      final authUser = await jwt.authUsers.create(session);
+      authUserId = authUser.id;
+
+      final authSuccess = await jwt.createTokens(
+        session,
+        authUserId: authUserId,
+        scopes: {},
+        method: 'test',
+      );
+      refreshToken = authSuccess.refreshToken!;
+
+      await jwt.authUsers.update(
+        session,
+        authUserId: authUserId,
+        blocked: true,
+      );
+    });
+
+    test(
+      'when refreshing the access token, '
+      'then an AuthUserBlockedException is thrown.',
+      () async {
+        await expectLater(
+          () => jwt.refreshAccessToken(session, refreshToken: refreshToken),
+          throwsA(isA<AuthUserBlockedException>()),
+        );
+      },
+    );
+
+    test(
+      'when rotating the refresh token through the admin API, '
+      'then an AuthUserBlockedException is thrown.',
+      () async {
+        await expectLater(
+          () => jwt.admin.rotateRefreshToken(
+            session,
+            refreshToken: refreshToken,
+          ),
+          throwsA(isA<AuthUserBlockedException>()),
+        );
+      },
+    );
+
+    test(
+      'when a rejected refresh is followed by lifting the block, '
+      'then the same refresh token is accepted again.',
+      () async {
+        await expectLater(
+          () => jwt.refreshAccessToken(session, refreshToken: refreshToken),
+          throwsA(isA<AuthUserBlockedException>()),
+          reason:
+              'Precondition: the refresh must be rejected here to show that '
+              'a later unblock allows rotation again.',
+        );
+
+        await jwt.authUsers.update(
+          session,
+          authUserId: authUserId,
+          blocked: false,
+        );
+
+        expect(
+          await jwt.refreshAccessToken(session, refreshToken: refreshToken),
+          isNotNull,
+        );
+      },
+    );
+  });
+
   withServerpod('Given a JwtConfig with extraClaimsProvider,', (
     final sessionBuilder,
     final endpoints,


### PR DESCRIPTION
`blocked` was only checked at login (`createTokens`). `rotateRefreshToken` never looked up the user, so blocking a user closed the login path but left every session they already held running. 

Each refresh minted a new access token and, since expiry is measured from `lastUpdatedAt`, extended the refresh token's own expiry. A blocked user kept full scoped access for as long as they kept refreshing.

Now `rotateRefreshToken` now refuses rotation for a blocked user.
- Checked *after* the fixed secret, expiry, and rotating secret are validated, so it can't probe account state without holding the token.
- The token row is left in place. Lifting the block restores the session, and the sliding window keeps running so the token still expires on its own.
