### PR TITLE
feat: Add dark theme and polish to the default Flutter app

### DIFF
--- a/templates/serverpod_templates/projectname_flutter/lib/main.dart
+++ b/templates/serverpod_templates/projectname_flutter/lib/main.dart
@@ -33,6 +33,16 @@ void main() async {
   runApp(const MyApp());
 }
 
+/// Builds a theme for the given [brightness].
+ThemeData _buildTheme(Brightness brightness) {
+  return ThemeData(
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: Colors.blue,
+      brightness: brightness,
+    ),
+  );
+}
+
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
@@ -40,7 +50,9 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Serverpod Demo',
-      theme: ThemeData(primarySwatch: Colors.blue),
+      theme: _buildTheme(Brightness.light),
+      darkTheme: _buildTheme(Brightness.dark),
+      themeMode: ThemeMode.system,
       home: const MyHomePage(title: 'Serverpod Example'),
     );
   }
@@ -90,20 +102,19 @@ class MyHomePageState extends State<MyHomePage> {
         padding: const EdgeInsets.all(16),
         child: Column(
           children: [
-            Padding(
-              padding: const EdgeInsets.only(bottom: 16.0),
-              child: TextField(
-                controller: _textEditingController,
-                decoration: const InputDecoration(hintText: 'Enter your name'),
+            TextField(
+              controller: _textEditingController,
+              onSubmitted: (_) => _callHello(),
+              decoration: InputDecoration(
+                hintText: 'Enter your name',
+                border: const OutlineInputBorder(),
+                suffixIcon: IconButton(
+                  onPressed: _callHello,
+                  icon: const Icon(Icons.send),
+                ),
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.only(bottom: 16.0),
-              child: ElevatedButton(
-                onPressed: _callHello,
-                child: const Text('Send to Server'),
-              ),
-            ),
+            const SizedBox(height: 16),
             ResultDisplay(
               resultMessage: _resultMessage,
               errorMessage: _errorMessage,
@@ -125,24 +136,38 @@ class ResultDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
     String text;
     Color backgroundColor;
+    Color foregroundColor;
     if (errorMessage != null) {
-      backgroundColor = Colors.red[300]!;
+      backgroundColor = colors.errorContainer;
+      foregroundColor = colors.onErrorContainer;
       text = errorMessage!;
     } else if (resultMessage != null) {
-      backgroundColor = Colors.green[300]!;
+      backgroundColor = colors.primaryContainer;
+      foregroundColor = colors.onPrimaryContainer;
       text = resultMessage!;
     } else {
-      backgroundColor = Colors.grey[300]!;
+      backgroundColor = colors.surfaceContainerHighest;
+      foregroundColor = colors.onSurfaceVariant;
       text = 'No server response yet.';
     }
 
-    return ConstrainedBox(
-      constraints: const BoxConstraints(minHeight: 50),
-      child: Container(
+    return Container(
+      constraints: const BoxConstraints(minHeight: 60),
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      // Reuses the text field's border so the shape and width always match.
+      decoration: ShapeDecoration(
         color: backgroundColor,
-        child: Center(child: Text(text)),
+        shape: OutlineInputBorder(
+          borderSide: BorderSide(color: foregroundColor),
+        ),
+      ),
+      child: Center(
+        child: Text(text, style: TextStyle(color: foregroundColor)),
       ),
     );
   }

--- a/templates/serverpod_templates/projectname_flutter_upgrade/lib/main.dart
+++ b/templates/serverpod_templates/projectname_flutter_upgrade/lib/main.dart
@@ -46,6 +46,16 @@ void main() async {
   runApp(const MyApp());
 }
 
+/// Builds a theme for the given [brightness].
+ThemeData _buildTheme(Brightness brightness) {
+  return ThemeData(
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: Colors.blue,
+      brightness: brightness,
+    ),
+  );
+}
+
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
@@ -53,7 +63,9 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Serverpod Demo',
-      theme: ThemeData(primarySwatch: Colors.blue),
+      theme: _buildTheme(Brightness.light),
+      darkTheme: _buildTheme(Brightness.dark),
+      themeMode: ThemeMode.system,
       home: const MyHomePage(title: 'Serverpod Example'),
     );
   }

--- a/templates/serverpod_templates/projectname_flutter_upgrade/lib/screens/greetings_screen.dart
+++ b/templates/serverpod_templates/projectname_flutter_upgrade/lib/screens/greetings_screen.dart
@@ -53,12 +53,15 @@ class _GreetingsScreenState extends State<GreetingsScreen> {
           const SizedBox(height: 32),
           TextField(
             controller: _textEditingController,
-            decoration: const InputDecoration(hintText: 'Enter your name'),
-          ),
-          const SizedBox(height: 16),
-          ElevatedButton(
-            onPressed: _callHello,
-            child: const Text('Send to Server'),
+            onSubmitted: (_) => _callHello(),
+            decoration: InputDecoration(
+              hintText: 'Enter your name',
+              border: const OutlineInputBorder(),
+              suffixIcon: IconButton(
+                onPressed: _callHello,
+                icon: const Icon(Icons.send),
+              ),
+            ),
           ),
           const SizedBox(height: 16),
           ResultDisplay(
@@ -81,24 +84,38 @@ class ResultDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
     String text;
     Color backgroundColor;
+    Color foregroundColor;
     if (errorMessage != null) {
-      backgroundColor = Colors.red[300]!;
+      backgroundColor = colors.errorContainer;
+      foregroundColor = colors.onErrorContainer;
       text = errorMessage!;
     } else if (resultMessage != null) {
-      backgroundColor = Colors.green[300]!;
+      backgroundColor = colors.primaryContainer;
+      foregroundColor = colors.onPrimaryContainer;
       text = resultMessage!;
     } else {
-      backgroundColor = Colors.grey[300]!;
+      backgroundColor = colors.surfaceContainerHighest;
+      foregroundColor = colors.onSurfaceVariant;
       text = 'No server response yet.';
     }
 
-    return ConstrainedBox(
-      constraints: const BoxConstraints(minHeight: 50),
-      child: Container(
+    return Container(
+      constraints: const BoxConstraints(minHeight: 60),
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      // Reuses the text field's border so the shape and width always match.
+      decoration: ShapeDecoration(
         color: backgroundColor,
-        child: Center(child: Text(text)),
+        shape: OutlineInputBorder(
+          borderSide: BorderSide(color: foregroundColor),
+        ),
+      ),
+      child: Center(
+        child: Text(text, style: TextStyle(color: foregroundColor)),
       ),
     );
   }

--- a/templates/serverpod_templates/projectname_flutter_upgrade/lib/screens/{{#auth}}sign_in_screen{{!auth}}.dart
+++ b/templates/serverpod_templates/projectname_flutter_upgrade/lib/screens/{{#auth}}sign_in_screen{{!auth}}.dart
@@ -35,6 +35,8 @@ class _SignInScreenState extends State<SignInScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
     return _isSignedIn
         ? widget.child
         : Center(
@@ -43,13 +45,15 @@ class _SignInScreenState extends State<SignInScreen> {
               onAuthenticated: () {
                 context.showSnackBar(
                   message: 'User authenticated.',
-                  backgroundColor: Colors.green,
+                  backgroundColor: colors.primaryContainer,
+                  foregroundColor: colors.onPrimaryContainer,
                 );
               },
               onError: (error) {
                 context.showSnackBar(
                   message: 'Authentication failed: $error',
-                  backgroundColor: Colors.red,
+                  backgroundColor: colors.errorContainer,
+                  foregroundColor: colors.onErrorContainer,
                 );
               },
             ),
@@ -60,11 +64,12 @@ class _SignInScreenState extends State<SignInScreen> {
 extension on BuildContext {
   void showSnackBar({
     required String message,
-    Color? backgroundColor,
+    required Color backgroundColor,
+    required Color foregroundColor,
   }) {
     ScaffoldMessenger.of(this).showSnackBar(
       SnackBar(
-        content: Text(message),
+        content: Text(message, style: TextStyle(color: foregroundColor)),
         backgroundColor: backgroundColor,
         duration: const Duration(seconds: 5),
       ),


### PR DESCRIPTION
The default app from `serverpod create` now follows the system light/dark theme and uses ColorScheme-aware colors, so it looks better and works in App Studio and agent tools. Greeting input uses an outlined field with a send action instead of a separate button.

Based on the proposed changes in https://github.com/serverpod/example/commit/3fbd77b07befa950b7318adff451afdc5607b923.

Fixes #5577.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.