### PR TITLE
fix: Join start TUI borders and dividers with T-junction characters

### DIFF
--- a/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
+++ b/templates/pubspecs/tools/serverpod_cli/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   logging: ^1.2.0
   lsp_server: ^0.4.0
   meta: ^1.15.0
-  nocterm: ^0.8.0
+  nocterm: ^0.9.0
   package_config: ^2.1.0
   path: ^1.8.3
   pub_api_client: '>=2.4.0 <4.0.0'
@@ -65,7 +65,7 @@ dependencies:
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_service_client: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION
-  serverpod_tui: ^0.10.0
+  serverpod_tui: ^0.12.0
   skills: ^0.3.1
   source_span: ^1.10.0
   stream_channel: ^2.1.1

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -112,10 +112,7 @@ class MainScreen extends StatelessComponent {
                                 children: [
                                   Expanded(
                                     child: state.useSideBySideLayout
-                                        ? _buildSideBySideLayout(
-                                            st,
-                                            constraints,
-                                          )
+                                        ? _buildSideBySideLayout(st)
                                         : _buildMergedColumn(st),
                                   ),
                                   if (state.activeOperations.isNotEmpty)
@@ -130,7 +127,11 @@ class MainScreen extends StatelessComponent {
                                     ),
                                   if (state.alert case final alert?) ...[
                                     const SizedBox(height: 1),
-                                    Divider(color: st.subtleDivider),
+                                    Divider(
+                                      color: st.subtleDivider,
+                                      indent: -1,
+                                      endIndent: -1,
+                                    ),
                                     Padding(
                                       padding: const EdgeInsets.symmetric(
                                         horizontal: 1,
@@ -173,41 +174,59 @@ class MainScreen extends StatelessComponent {
     );
   }
 
-  Component _buildSideBySideLayout(
-    ServerpodThemeData st,
-    BoxConstraints constraints,
-  ) {
+  Component _buildSideBySideLayout(ServerpodThemeData st) {
     final tabAreas = state.tabs.areas;
-    final tabAreasCount = tabAreas.length;
-    final dividerPositionFactor = (1 / tabAreasCount) * 0.99;
 
-    // Stack is used here to position the dividers correctly,
-    // removing small gaps between the area panes and dividers.
+    // The dividers reach one cell into the surrounding border rows and merge
+    // with them (┬/┴). When operations or an alert render below the panes,
+    // the bottom end stops at the pane edge instead - the row below is
+    // content, not the border.
+    final reachesBottomBorder =
+        state.activeOperations.isEmpty && state.alert == null;
+
+    // The dividers paint in an underlay so every pane paints after them:
+    // blending only joins what is already in the buffer, so rules and tab
+    // underlines reaching into a divider from either side need it painted
+    // first. Both layers are built by the same loop so their flex geometry
+    // stays in lockstep - the pane layer reserves each divider's column with
+    // an equal-width spacer.
+    final dividerLayer = <Component>[];
+    final paneLayer = <Component>[];
+    for (var i = 0; i < tabAreas.length; i++) {
+      if (i > 0) {
+        dividerLayer.add(
+          VerticalDivider(
+            color: st.subtleDivider,
+            width: 1,
+            thickness: 1,
+            indent: -1,
+            endIndent: reachesBottomBorder ? -1 : 0,
+          ),
+        );
+        paneLayer.add(const SizedBox(width: 1));
+      }
+      dividerLayer.add(
+        Expanded(flex: tabAreas[i].flex, child: const SizedBox.shrink()),
+      );
+      paneLayer.add(
+        Expanded(
+          flex: tabAreas[i].flex,
+          child: _buildAreaPane(st, tabAreas[i], i),
+        ),
+      );
+    }
+
     return Stack(
+      fit: StackFit.expand,
       children: [
         Row(
           crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            for (var i = 0; i < tabAreasCount; i++)
-              Expanded(
-                flex: tabAreas[i].flex,
-                child: _buildAreaPane(st, tabAreas[i], i),
-              ),
-          ],
+          children: dividerLayer,
         ),
-        if (tabAreasCount > 1)
-          for (var i = 1; i <= tabAreasCount - 1; i++)
-            Positioned(
-              left: constraints.maxWidth * dividerPositionFactor * i,
-              child: SizedBox(
-                height: constraints.maxHeight,
-                child: VerticalDivider(
-                  color: st.subtleDivider,
-                  width: 1,
-                  thickness: 1,
-                ),
-              ),
-            ),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: paneLayer,
+        ),
       ],
     );
   }
@@ -244,7 +263,7 @@ class MainScreen extends StatelessComponent {
                   ),
                 ),
               ),
-              const Divider(),
+              const Divider(indent: -1, endIndent: -1),
               Expanded(
                 child: Scrollbar(
                   controller: appPanelScrollController,
@@ -564,7 +583,7 @@ class MainScreen extends StatelessComponent {
             },
           ),
         ),
-        Divider(color: st.subtleDivider),
+        Divider(color: st.subtleDivider, indent: -1, endIndent: -1),
       ],
     );
   }
@@ -610,7 +629,7 @@ class MainScreen extends StatelessComponent {
             ),
           ),
         ),
-        Divider(color: st.subtleDivider),
+        Divider(color: st.subtleDivider, indent: -1, endIndent: -1),
         Expanded(
           child: _buildRawOutputView(state.rawLines, rawScrollController),
         ),

--- a/tools/serverpod_cli/pubspec.yaml
+++ b/tools/serverpod_cli/pubspec.yaml
@@ -51,7 +51,7 @@ dependencies:
   logging: ^1.2.0
   lsp_server: ^0.4.0
   meta: ^1.15.0
-  nocterm: ^0.8.0
+  nocterm: ^0.9.0
   package_config: ^2.1.0
   path: ^1.8.3
   pub_api_client: '>=2.4.0 <4.0.0'
@@ -66,7 +66,7 @@ dependencies:
   serverpod_serialization: 4.0.0-beta.2
   serverpod_service_client: 4.0.0-beta.2
   serverpod_shared: 4.0.0-beta.2
-  serverpod_tui: ^0.10.0
+  serverpod_tui: ^0.12.0
   skills: ^0.3.1
   source_span: ^1.10.0
   stream_channel: ^2.1.1

--- a/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
@@ -161,6 +161,54 @@ void main() {
         expect(label.first.y, lessThan(logLine.first.y));
       });
 
+      test('then the pane divider tees into the outer border', () {
+        final ts = tester.terminalState;
+
+        // The border rows are where the outer box's corners sit.
+        final topBorderRow = ts.findText('╭').first.y;
+        final bottomBorderRow = ts.findText('╰').first.y;
+
+        // The divider between the panes merges with the border rows instead
+        // of leaving gaps.
+        final tee = ts.findText('┬');
+        expect(tee.isNotEmpty, isTrue);
+        expect(tee.first.y, topBorderRow);
+        final bottomTee = ts.findText('┴');
+        expect(bottomTee.isNotEmpty, isTrue);
+        expect(bottomTee.first.y, bottomBorderRow);
+        expect(tee.first.x, bottomTee.first.x);
+      });
+
+      test('then the tab bar underline crosses the pane divider', () {
+        final ts = tester.terminalState;
+
+        // The pane divider column is where the top border tees.
+        final dividerX = ts.findText('┬').first.x;
+        // Both panes' tab bars share the underline row.
+        final underlineRow = ts.findText(_tabBarRule).first.y;
+
+        // The dividers paint in an underlay before the panes, so the
+        // underline joins the pane divider from both sides, forming a
+        // cross instead of stopping short on the left.
+        expect(ts.getTextAt(dividerX, underlineRow, length: 1), '┿');
+        // The underline's outer ends merge into the box border sides.
+        expect(ts.getTextAt(0, underlineRow, length: 1), '┝');
+        expect(ts.getTextAt(199, underlineRow, length: 1), '┥');
+      });
+
+      test('then the app status rule tees into the pane edges', () {
+        final ts = tester.terminalState;
+
+        // The focused app tab renders a status rule under its breadcrumb;
+        // its left end joins the pane divider and its right end joins the
+        // outer border.
+        final left = ts.findText('├');
+        final right = ts.findText('┤');
+        expect(left.isNotEmpty, isTrue);
+        expect(right.isNotEmpty, isTrue);
+        expect(left.first.y, right.first.y);
+      });
+
       test(
         'when an app tab is clicked then it is selected and the view updates',
         () async {
@@ -184,6 +232,20 @@ void main() {
 
     setUp(() async {
       tester = await _pumpAppsLayout(const Size(100, 24));
+    });
+
+    test('then the app status rule tees into the outer border', () {
+      final ts = tester.terminalState;
+
+      // In the merged layout the status rule spans the full content width,
+      // joining the outer border on both sides.
+      final left = ts.findText('├');
+      final right = ts.findText('┤');
+      expect(left.isNotEmpty, isTrue);
+      expect(right.isNotEmpty, isTrue);
+      expect(left.first.y, right.first.y);
+      expect(left.first.x, 0);
+      expect(right.first.x, 99);
     });
 
     test('then one merged tab bar lists every tab', () {
@@ -249,6 +311,28 @@ void main() {
     test('then the title reads "Relaunch app"', () {
       // Selecting the focused running app relaunches it.
       expect(tester.terminalState.containsText('Relaunch app'), isTrue);
+    });
+
+    test('then the panel border tees into the outer border', () {
+      final ts = tester.terminalState;
+
+      final topBorderRow = ts.findText('╭').first.y;
+      final bottomBorderRow = ts.findText('╰').first.y;
+      // The panel is 30 columns wide plus its border, anchored to the right
+      // edge (119), so its left border sits at column 88.
+      const panelLeft = 88;
+
+      // The panel's corners land on the outer border and merge into tees
+      // instead of overwriting it.
+      expect(ts.getTextAt(panelLeft, topBorderRow, length: 1), '┬');
+      expect(ts.getTextAt(panelLeft, bottomBorderRow, length: 1), '┴');
+      // The rule under the panel title joins the panel's own borders.
+      final headerRule = ts.findText('├').first;
+      expect(headerRule.x, panelLeft);
+      expect(ts.getTextAt(119, headerRule.y, length: 1), '┤');
+      // The outer box's corners stay rounded.
+      expect(ts.getTextAt(0, topBorderRow, length: 1), '╭');
+      expect(ts.getTextAt(119, topBorderRow, length: 1), '╮');
     });
   });
 


### PR DESCRIPTION
The `serverpod` start TUI drew its borders, pane dividers, and rules independently, leaving visible gaps where lines met. With `nocterm` 0.9.0's box-line blending and `serverpod_tui` 0.12.0's border-matched tab bar underline, the TUI now joins them with junction characters: the pane divider tees into the outer border (┬/┴), the tab bar underline runs border-to-border and crosses the divider (┝/┿/┥), and the status, alert, and raw-log rules tee into the edges (├/┤).

Bumps `nocterm` to ^0.9.0 and `serverpod_tui` to ^0.12.0.

Fixes #5424 
### Before
<img width="1280" height="691" alt="start-before" src="https://github.com/user-attachments/assets/796ed471-19fa-4593-a8ba-02213278041b" />

### After
<img width="1380" height="745" alt="start-after-rebased" src="https://github.com/user-attachments/assets/63182fd6-d868-41a9-95e1-d0705ca0938b" />

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None