### PR TITLE
refactor(cli): Remove the hardcoded id reference in relations

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/lib/src/protocol/client.dart
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/lib/src/protocol/client.dart
@@ -76,7 +76,7 @@ class EndpointLegacyEmail extends _i1.EndpointRef {
     },
   );
 
-  /// Stub — registration is not supported via legacy endpoints.
+  /// Stub - registration is not supported via legacy endpoints.
   _i2.Future<bool> createAccountRequest(
     String userName,
     String email,
@@ -91,7 +91,7 @@ class EndpointLegacyEmail extends _i1.EndpointRef {
     },
   );
 
-  /// Stub — account creation is not supported via legacy endpoints.
+  /// Stub - account creation is not supported via legacy endpoints.
   _i2.Future<_i3.LegacyUserInfo?> createAccount(
     String email,
     String verificationCode,
@@ -104,7 +104,7 @@ class EndpointLegacyEmail extends _i1.EndpointRef {
     },
   );
 
-  /// Stub — password change is not supported via legacy endpoints.
+  /// Stub - password change is not supported via legacy endpoints.
   _i2.Future<bool> changePassword(
     String oldPassword,
     String newPassword,
@@ -117,7 +117,7 @@ class EndpointLegacyEmail extends _i1.EndpointRef {
     },
   );
 
-  /// Stub — password reset initiation is not supported via legacy endpoints.
+  /// Stub - password reset initiation is not supported via legacy endpoints.
   _i2.Future<bool> initiatePasswordReset(String email) =>
       caller.callServerEndpoint<bool>(
         'serverpod_auth_bridge.legacyEmail',
@@ -125,7 +125,7 @@ class EndpointLegacyEmail extends _i1.EndpointRef {
         {'email': email},
       );
 
-  /// Stub — password reset is not supported via legacy endpoints.
+  /// Stub - password reset is not supported via legacy endpoints.
   _i2.Future<bool> resetPassword(
     String verificationCode,
     String password,

--- a/tests/serverpod_test_shared_module/serverpod_test_shared_module_client/lib/src/protocol/protocol.dart
+++ b/tests/serverpod_test_shared_module/serverpod_test_shared_module_client/lib/src/protocol/protocol.dart
@@ -12,9 +12,9 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:serverpod_database/serverpod_database.dart' as _i1;
+import 'package:serverpod_client/serverpod_client.dart' as _i2;
 import 'package:serverpod_test_shared_module_shared/serverpod_test_shared_module_shared.dart'
-    as _i2;
-import 'package:serverpod_client/serverpod_client.dart' as _i3;
+    as _i3;
 export 'package:serverpod_test_shared_module_shared/serverpod_test_shared_module_shared.dart'
     hide Protocol;
 export 'client.dart';
@@ -26,21 +26,21 @@ class Protocol extends _i1.DatabaseSerializationManager {
 
   static final Protocol _instance = Protocol._();
 
-  final Set<_i3.SerializationManager> _hostProtocols = {};
+  final Set<_i2.SerializationManager> _hostProtocols = {};
 
   static List<_i1.TableDefinition> get targetTableDefinitions => [
-    ..._i2.Protocol() is _i1.DatabaseSerializationManager
-        ? (_i2.Protocol() as _i1.DatabaseSerializationManager)
+    ..._i3.Protocol() is _i1.DatabaseSerializationManager
+        ? (_i3.Protocol() as _i1.DatabaseSerializationManager)
               .getTargetTableDefinitions()
         : [],
   ];
 
   void registerHostProtocol(
     String projectName,
-    _i3.SerializationManager protocol,
+    _i2.SerializationManager protocol,
   ) {
     _hostProtocols.add(protocol);
-    _i2.Protocol().registerHostProtocol(projectName, protocol);
+    _i3.Protocol().registerHostProtocol(projectName, protocol);
   }
 
   static String? getClassNameFromObjectJson(dynamic data) {
@@ -74,8 +74,8 @@ class Protocol extends _i1.DatabaseSerializationManager {
     }
 
     try {
-      return _i2.Protocol().deserialize<T>(data, t);
-    } on _i3.DeserializationTypeNotFoundException catch (_) {}
+      return _i3.Protocol().deserialize<T>(data, t);
+    } on _i2.DeserializationTypeNotFoundException catch (_) {}
     return super.deserialize<T>(data, t);
   }
 
@@ -97,7 +97,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
       );
     }
 
-    className = _i2.Protocol().getClassNameForObject(data);
+    className = _i3.Protocol().getClassNameForObject(data);
     if (className != null) return className;
     return null;
   }
@@ -109,7 +109,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
       return super.deserializeByClassName(data);
     }
     try {
-      return _i2.Protocol().deserializeByClassName(data);
+      return _i3.Protocol().deserializeByClassName(data);
     } on FormatException catch (_) {}
     return super.deserializeByClassName(data);
   }
@@ -132,8 +132,8 @@ class Protocol extends _i1.DatabaseSerializationManager {
         'data': object,
       };
       return forProtocol
-          ? _i3.SerializationManager.toEncodableForProtocol(wrapped)
-          : _i3.SerializationManager.toEncodable(wrapped);
+          ? _i2.SerializationManager.toEncodableForProtocol(wrapped)
+          : _i2.SerializationManager.toEncodable(wrapped);
     }
     return super.dynamicFieldToJson(object, forProtocol: forProtocol);
   }
@@ -176,7 +176,7 @@ class Protocol extends _i1.DatabaseSerializationManager {
   @override
   _i1.Table? getTableForType(Type t) {
     {
-      var protocol = _i2.Protocol();
+      var protocol = _i3.Protocol();
       var table = protocol is _i1.DatabaseSerializationManager
           ? (protocol as _i1.DatabaseSerializationManager).getTableForType(t)
           : null;

--- a/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
@@ -412,6 +412,12 @@ class SerializableModelFieldDefinition {
   /// Whether this field should have a unique index auto-generated for it.
   bool get shouldCreateUniqueIndex => uniquePerFieldNames != null;
 
+  /// Whether this field is the primary key of the table it belongs to.
+  ///
+  /// This is resolved before validation runs, so it can be relied on when
+  /// validating relations.
+  final bool isPrimaryKey;
+
   /// Create a new [SerializableModelFieldDefinition].
   SerializableModelFieldDefinition({
     required this.name,
@@ -427,6 +433,7 @@ class SerializableModelFieldDefinition {
     String? columnNameOverride,
     String? jsonKeyOverride,
     this.uniquePerFieldNames,
+    this.isPrimaryKey = false,
   }) : _columnNameOverride = columnNameOverride,
        _jsonKeyOverride = jsonKeyOverride;
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/definitions.dart
@@ -736,9 +736,13 @@ sealed class RelationDefinition {
 class UnresolvedListRelationDefinition extends RelationDefinition {
   final bool nullableRelation;
 
+  /// References the field in the current object that the foreign key points to.
+  final String referenceFieldName;
+
   UnresolvedListRelationDefinition({
     String? name,
     required this.nullableRelation,
+    this.referenceFieldName = defaultPrimaryKeyName,
   }) : super(name, false);
 }
 
@@ -847,6 +851,9 @@ class UnresolvedObjectRelationDefinition extends RelationDefinition {
   /// Only used for implicit relations, toggles if the relation id is nullable.
   final bool nullableRelation;
 
+  /// References the field in the parent table that the foreign key points to.
+  final String referenceFieldName;
+
   UnresolvedObjectRelationDefinition({
     String? name,
     required this.fieldName,
@@ -854,6 +861,7 @@ class UnresolvedObjectRelationDefinition extends RelationDefinition {
     required this.onUpdate,
     required bool isForeignKeyOrigin,
     this.nullableRelation = false,
+    this.referenceFieldName = defaultPrimaryKeyName,
   }) : super(name, isForeignKeyOrigin);
 }
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
@@ -128,6 +128,7 @@ class ModelDependencyResolver {
         shouldPersist: true,
         documentation: maybeIdField?.documentation ?? defaultIdFieldDoc,
         isRequired: false, // ID fields are typically optional
+        isPrimaryKey: true,
       ),
     );
   }

--- a/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/entity_dependency_resolver.dart
@@ -258,6 +258,7 @@ class ModelDependencyResolver {
     SerializableModelFieldDefinition foreignField,
   ) {
     String? foreignFieldName;
+    String? referenceFieldName;
 
     SerializableModelFieldDefinition? foreignContainerField;
 
@@ -267,14 +268,16 @@ class ModelDependencyResolver {
     var foreignRelation = foreignField.relation;
     if (foreignRelation is UnresolvedObjectRelationDefinition) {
       foreignFieldName = foreignRelation.fieldName;
+      referenceFieldName = foreignRelation.referenceFieldName;
       foreignContainerField = foreignField;
     } else if (foreignRelation is ForeignRelationDefinition) {
       foreignFieldName = foreignField.name;
+      referenceFieldName = foreignRelation.foreignFieldName;
       foreignRelation.foreignContainerField = fieldDefinition;
       foreignContainerField = foreignRelation.containerField;
     }
 
-    if (foreignFieldName == null) return;
+    if (foreignFieldName == null || referenceFieldName == null) return;
 
     fieldDefinition.relation = ObjectRelationDefinition(
       name: relation.name,
@@ -282,7 +285,7 @@ class ModelDependencyResolver {
           ? classDefinition.idField.type
           : referenceClass.idField.type,
       parentTable: tableName,
-      fieldName: defaultPrimaryKeyName,
+      fieldName: referenceFieldName,
       foreignFieldName: foreignFieldName,
       foreignContainerField: foreignContainerField,
       isForeignKeyOrigin: relation.isForeignKeyOrigin,
@@ -319,7 +322,7 @@ class ModelDependencyResolver {
       relation: ForeignRelationDefinition(
         name: relation.name,
         parentTable: tableName,
-        foreignFieldName: defaultPrimaryKeyName,
+        foreignFieldName: relation.referenceFieldName,
         containerField: fieldDefinition,
         foreignContainerField: foreignContainerField,
         onUpdate: relation.onUpdate,
@@ -341,7 +344,7 @@ class ModelDependencyResolver {
       parentTable: tableName,
       parentTableIdType: classDefinition.idField.type,
       fieldName: foreignRelationField.name,
-      foreignFieldName: defaultPrimaryKeyName,
+      foreignFieldName: relation.referenceFieldName,
       foreignContainerField: foreignContainerField,
       isForeignKeyOrigin: true,
       nullableRelation: relation.nullableRelation,
@@ -381,7 +384,7 @@ class ModelDependencyResolver {
     field.relation = ForeignRelationDefinition(
       name: relation.name,
       parentTable: tableName,
-      foreignFieldName: defaultPrimaryKeyName,
+      foreignFieldName: relation.referenceFieldName,
       containerField: fieldDefinition,
       foreignContainerField: foreignContainerField,
       onUpdate: relation.onUpdate,
@@ -392,7 +395,7 @@ class ModelDependencyResolver {
       parentTable: tableName,
       parentTableIdType: classDefinition.idField.type,
       fieldName: relationFieldName,
-      foreignFieldName: defaultPrimaryKeyName,
+      foreignFieldName: relation.referenceFieldName,
       foreignContainerField: foreignContainerField,
       isForeignKeyOrigin: true,
       nullableRelation: field.type.nullable,
@@ -483,7 +486,7 @@ class ModelDependencyResolver {
         relation: ForeignRelationDefinition(
           name: autoRelationName,
           parentTable: tableName,
-          foreignFieldName: defaultPrimaryKeyName,
+          foreignFieldName: relation.referenceFieldName,
           containerField: null, // Will never be set on implicit list relations.
           foreignContainerField: fieldDefinition,
         ),
@@ -497,7 +500,7 @@ class ModelDependencyResolver {
       fieldDefinition.relation = ListRelationDefinition(
         name: autoRelationName,
         foreignKeyOwnerIdType: classDefinition.idField.type,
-        fieldName: defaultPrimaryKeyName,
+        fieldName: relation.referenceFieldName,
         foreignFieldName: foreignFieldName,
         foreignContainerField:
             null, // Will never be set on implicit list relations.
@@ -519,14 +522,17 @@ class ModelDependencyResolver {
       var foreignField = foreignFields.first;
 
       String? foreignFieldName;
+      String? referenceFieldName;
 
       var foreignRelation = foreignField.relation;
       if (foreignRelation is ForeignRelationDefinition) {
         foreignFieldName = foreignField.name;
+        referenceFieldName = foreignRelation.foreignFieldName;
       } else if (foreignRelation is UnresolvedObjectRelationDefinition) {
         foreignFieldName =
             foreignRelation.fieldName ??
             _createImplicitForeignIdFieldName(foreignField.name);
+        referenceFieldName = foreignRelation.referenceFieldName;
       }
 
       SerializableModelFieldDefinition? foreignContainerField;
@@ -537,7 +543,7 @@ class ModelDependencyResolver {
         foreignContainerField = foreignField;
       }
 
-      if (foreignFieldName == null) return;
+      if (foreignFieldName == null || referenceFieldName == null) return;
 
       // The nullability of the relation is always determined by the foreign
       // key field, never by the object field. If the foreign class is not yet
@@ -557,7 +563,7 @@ class ModelDependencyResolver {
       fieldDefinition.relation = ListRelationDefinition(
         name: relation.name,
         foreignKeyOwnerIdType: referenceClass.idField.type,
-        fieldName: defaultPrimaryKeyName,
+        fieldName: referenceFieldName,
         foreignFieldName: foreignFieldName,
         foreignContainerField: foreignContainerField,
         nullableRelation: nullableRelation,

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_parser/model_parser.dart
@@ -462,16 +462,19 @@ class ModelParser {
 
     var optionalRelation = _isOptionalRelation(node);
 
+    var referenceFieldName = defaultPrimaryKeyName;
+
     if (typeResult.isListType) {
       return UnresolvedListRelationDefinition(
         name: relationName,
         nullableRelation: optionalRelation,
+        referenceFieldName: referenceFieldName,
       );
     } else if (typeResult.isIdType && parentTable != null) {
       return ForeignRelationDefinition(
         name: relationName,
         parentTable: parentTable,
-        foreignFieldName: defaultPrimaryKeyName,
+        foreignFieldName: referenceFieldName,
         onUpdate: onUpdate,
         onDelete: onDelete,
       );
@@ -483,6 +486,7 @@ class ModelParser {
         onDelete: onDelete,
         isForeignKeyOrigin: relationFieldName != null,
         nullableRelation: optionalRelation,
+        referenceFieldName: referenceFieldName,
       );
     } else {
       return null;

--- a/tools/serverpod_cli/lib/src/database/create_definition.dart
+++ b/tools/serverpod_cli/lib/src/database/create_definition.dart
@@ -122,7 +122,9 @@ List<ForeignKeyDefinition> _createForeignKeys(
         columns: [field.columnName],
         referenceTable: relation.parentTable,
         referenceTableSchema: 'public',
-        referenceColumns: ['id'],
+        // TODO(#1147): Map the reference field to its column name. The two only
+        // coincide today because the primary key has no column name override.
+        referenceColumns: [relation.foreignFieldName],
         onDelete: relation.onDelete,
         onUpdate: relation.onUpdate,
       ),

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_primary_key_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/field/field_primary_key_test.dart
@@ -1,0 +1,239 @@
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:test/test.dart';
+
+import '../../../../../test_util/builders/generator_config_builder.dart';
+import '../../../../../test_util/builders/model_source_builder.dart';
+
+void main() {
+  var config = GeneratorConfigBuilder().build();
+
+  group('Given a class with a table defined,', () {
+    var models = [
+      ModelSourceBuilder().withYaml(
+        '''
+        class: Example
+        table: example
+        fields:
+          name: String
+        ''',
+      ).build(),
+    ];
+
+    var collector = CodeGenerationCollector();
+    var definitions = StatefulAnalyzer(
+      config,
+      models,
+      onErrorsCollector(collector),
+    ).validateAll();
+
+    test('then no errors are collected.', () {
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors but some were generated.',
+      );
+    });
+
+    test('then the id field is marked as the primary key.', () {
+      var definition = definitions.first as ClassDefinition;
+
+      expect(definition.findField('id')?.isPrimaryKey, isTrue);
+    });
+
+    test('then other fields are not marked as the primary key.', () {
+      var definition = definitions.first as ClassDefinition;
+
+      expect(definition.findField('name')?.isPrimaryKey, isFalse);
+    });
+  });
+
+  test(
+    'Given a class with a UuidValue id field '
+    'then the id field is marked as the primary key.',
+    () {
+      var models = [
+        ModelSourceBuilder().withYaml(
+          '''
+          class: Example
+          table: example
+          fields:
+            id: UuidValue?, defaultPersist=random
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var definitions = StatefulAnalyzer(
+        config,
+        models,
+        onErrorsCollector(collector),
+      ).validateAll();
+
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors but some were generated.',
+      );
+
+      var definition = definitions.first as ClassDefinition;
+
+      expect(definition.findField('id')?.isPrimaryKey, isTrue);
+    },
+  );
+
+  test(
+    'Given a class that extends a class with a table defined '
+    'then the inherited id field is marked as the primary key.',
+    () {
+      var models = [
+        ModelSourceBuilder().withFileName('parent').withYaml(
+          '''
+          class: Parent
+          table: parent
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('child').withYaml(
+          '''
+          class: Child
+          extends: Parent
+          fields:
+            nickname: String
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var definitions = StatefulAnalyzer(
+        config,
+        models,
+        onErrorsCollector(collector),
+      ).validateAll();
+
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors but some were generated.',
+      );
+
+      var definition = definitions.last as ClassDefinition;
+
+      var idField = definition.fieldsIncludingInherited.firstWhere(
+        (field) => field.name == 'id',
+      );
+
+      expect(idField.isPrimaryKey, isTrue);
+    },
+  );
+
+  test(
+    'Given a class without a table defined '
+    'then no field is marked as the primary key.',
+    () {
+      var models = [
+        ModelSourceBuilder().withYaml(
+          '''
+          class: Example
+          fields:
+            name: String
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var definitions = StatefulAnalyzer(
+        config,
+        models,
+        onErrorsCollector(collector),
+      ).validateAll();
+
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors but some were generated.',
+      );
+
+      var definition = definitions.first as ClassDefinition;
+
+      expect(definition.fields.any((field) => field.isPrimaryKey), isFalse);
+    },
+  );
+
+  test(
+    'Given a class without a table defined that declares an id field '
+    'then the id field is not marked as the primary key.',
+    () {
+      var models = [
+        ModelSourceBuilder().withYaml(
+          '''
+          class: Example
+          fields:
+            id: int?
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var definitions = StatefulAnalyzer(
+        config,
+        models,
+        onErrorsCollector(collector),
+      ).validateAll();
+
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors but some were generated.',
+      );
+
+      var definition = definitions.first as ClassDefinition;
+
+      expect(definition.findField('id')?.isPrimaryKey, isFalse);
+    },
+  );
+
+  test(
+    'Given a class with an object relation '
+    'then the implicit foreign key field is not marked as the primary key.',
+    () {
+      var models = [
+        ModelSourceBuilder().withFileName('company').withYaml(
+          '''
+          class: Company
+          table: company
+          fields:
+            name: String
+          ''',
+        ).build(),
+        ModelSourceBuilder().withFileName('employee').withYaml(
+          '''
+          class: Employee
+          table: employee
+          fields:
+            company: Company?, relation
+          ''',
+        ).build(),
+      ];
+
+      var collector = CodeGenerationCollector();
+      var definitions = StatefulAnalyzer(
+        config,
+        models,
+        onErrorsCollector(collector),
+      ).validateAll();
+
+      expect(
+        collector.errors,
+        isEmpty,
+        reason: 'Expected no errors but some were generated.',
+      );
+
+      var definition = definitions.last as ClassDefinition;
+
+      expect(definition.findField('companyId')?.isPrimaryKey, isFalse);
+    },
+  );
+}


### PR DESCRIPTION
# Changes

This is a pure refactor that makes the `reference=` keyword from #1147 implementable. It ships no user-visible feature, and generated output is unchanged.

Relations used to assume the foreign key always points at the `id` column. The relation resolver wrote the `id` constant into every resolved relation at eight call sites, and `create_definition.dart` wrote a literal `['id']` into every foreign key without ever reading `foreignFieldName`. Adding a configurable reference field on top of that would have meant touching all of it in the same PR as the feature, so I split it out to keep the feature diff small and to isolate the risk of silently changing existing users' generated code.

The unresolved relation definitions now carry the reference field, defaulting to the primary key, and `_parseRelation` threads it into every relation it builds. From there it flows to the resolved relations and to the foreign key definitions. The parser has no way to read a non-default value yet, so every call site still resolves to `id`.

One thing I deliberately did not fix: `referenceColumns` wants column names, while the value now threaded into it is a field name. Today that is harmless and unreachable rather than merely unlikely, because `_resolveIdField` rebuilds the id field without a column name override, so the only field a relation can reference always has `columnName == name`. It only becomes a real bug once `reference=` can name an arbitrary field, which can carry `column=`.

Fixing it properly is also not a one-liner: `_createForeignKeys` only sees the child class, so it would need the full model list plumbed in, a table-to-class lookup, and a fallback for when that lookup misses. It does miss in practice, since foreign keys can target module tables that are not part of the generating package's own models. That is worth doing deliberately in the follow-up, so it is marked with a `TODO` against this issue rather than rushed in here.

I also added a primary key flag to `SerializableModelFieldDefinition`. There was no representation of a primary key in the analyzer's model layer beyond the literal field name `id`, and the follow-up needs to ask that question during validation. It is set where the id field is already synthesised, which runs before validation.

Towards #1147.
