### PR TITLE
feat: Simplified Serverpod initialization

### DIFF
--- a/examples/auth/auth_server/lib/src/generated/serverpod.dart
+++ b/examples/auth/auth_server/lib/src/generated/serverpod.dart
@@ -1,0 +1,60 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'dart:io' as _i2;
+import 'protocol.dart' as _i3;
+import 'endpoints.dart' as _i4;
+export 'package:serverpod/serverpod.dart' hide Serverpod;
+
+/// The Serverpod server for this project.
+///
+/// Pre-configured with the generated Protocol serialization manager and
+/// Endpoints, so a server can be created with just the command line
+/// arguments:
+///
+/// ```dart
+/// final pod = Serverpod(args);
+/// ```
+class Serverpod extends _i1.Serverpod {
+  Serverpod(
+    List<String> args, {
+    _i2.Directory? serverDirectory,
+    _i1.ServerpodConfig? config,
+    _i1.ServerpodConfig Function(_i1.ServerpodConfig)? configOverride,
+    _i1.AuthenticationHandler? authenticationHandler,
+    _i1.HealthCheckHandler? healthCheckHandler,
+    _i1.HealthConfig? healthConfig,
+    _i1.Headers? httpResponseHeaders,
+    _i1.Headers? httpOptionsResponseHeaders,
+    _i1.SecurityContextConfig? securityContextConfig,
+    _i1.ExperimentalFeatures? experimentalFeatures,
+    _i1.RuntimeParametersListBuilder? runtimeParametersBuilder,
+    _i1.DatabaseInterceptor? databaseInterceptor,
+  }) : super(
+         args,
+         _i3.Protocol(),
+         _i4.Endpoints(),
+         serverDirectory: serverDirectory,
+         config: config,
+         configOverride: configOverride,
+         authenticationHandler: authenticationHandler,
+         healthCheckHandler: healthCheckHandler,
+         healthConfig: healthConfig,
+         httpResponseHeaders: httpResponseHeaders,
+         httpOptionsResponseHeaders: httpOptionsResponseHeaders,
+         securityContextConfig: securityContextConfig,
+         experimentalFeatures: experimentalFeatures,
+         runtimeParametersBuilder: runtimeParametersBuilder,
+         databaseInterceptor: databaseInterceptor,
+       );
+}

--- a/examples/legacy/auth_example/auth_example_server/lib/src/generated/serverpod.dart
+++ b/examples/legacy/auth_example/auth_example_server/lib/src/generated/serverpod.dart
@@ -15,6 +15,7 @@ import 'dart:io' as _i2;
 import 'protocol.dart' as _i3;
 import 'endpoints.dart' as _i4;
 export 'package:serverpod/serverpod.dart' hide Serverpod;
+export 'future_calls.dart' show ServerpodFutureCallsGetter;
 
 /// The Serverpod server for this project.
 ///

--- a/examples/legacy/auth_example/auth_example_server/lib/src/generated/serverpod.dart
+++ b/examples/legacy/auth_example/auth_example_server/lib/src/generated/serverpod.dart
@@ -1,0 +1,60 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'dart:io' as _i2;
+import 'protocol.dart' as _i3;
+import 'endpoints.dart' as _i4;
+export 'package:serverpod/serverpod.dart' hide Serverpod;
+
+/// The Serverpod server for this project.
+///
+/// Pre-configured with the generated Protocol serialization manager and
+/// Endpoints, so a server can be created with just the command line
+/// arguments:
+///
+/// ```dart
+/// final pod = Serverpod(args);
+/// ```
+class Serverpod extends _i1.Serverpod {
+  Serverpod(
+    List<String> args, {
+    _i2.Directory? serverDirectory,
+    _i1.ServerpodConfig? config,
+    _i1.ServerpodConfig Function(_i1.ServerpodConfig)? configOverride,
+    _i1.AuthenticationHandler? authenticationHandler,
+    _i1.HealthCheckHandler? healthCheckHandler,
+    _i1.HealthConfig? healthConfig,
+    _i1.Headers? httpResponseHeaders,
+    _i1.Headers? httpOptionsResponseHeaders,
+    _i1.SecurityContextConfig? securityContextConfig,
+    _i1.ExperimentalFeatures? experimentalFeatures,
+    _i1.RuntimeParametersListBuilder? runtimeParametersBuilder,
+    _i1.DatabaseInterceptor? databaseInterceptor,
+  }) : super(
+         args,
+         _i3.Protocol(),
+         _i4.Endpoints(),
+         serverDirectory: serverDirectory,
+         config: config,
+         configOverride: configOverride,
+         authenticationHandler: authenticationHandler,
+         healthCheckHandler: healthCheckHandler,
+         healthConfig: healthConfig,
+         httpResponseHeaders: httpResponseHeaders,
+         httpOptionsResponseHeaders: httpOptionsResponseHeaders,
+         securityContextConfig: securityContextConfig,
+         experimentalFeatures: experimentalFeatures,
+         runtimeParametersBuilder: runtimeParametersBuilder,
+         databaseInterceptor: databaseInterceptor,
+       );
+}

--- a/examples/middleware/middleware_server/lib/src/generated/serverpod.dart
+++ b/examples/middleware/middleware_server/lib/src/generated/serverpod.dart
@@ -1,0 +1,60 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'dart:io' as _i2;
+import 'protocol.dart' as _i3;
+import 'endpoints.dart' as _i4;
+export 'package:serverpod/serverpod.dart' hide Serverpod;
+
+/// The Serverpod server for this project.
+///
+/// Pre-configured with the generated Protocol serialization manager and
+/// Endpoints, so a server can be created with just the command line
+/// arguments:
+///
+/// ```dart
+/// final pod = Serverpod(args);
+/// ```
+class Serverpod extends _i1.Serverpod {
+  Serverpod(
+    List<String> args, {
+    _i2.Directory? serverDirectory,
+    _i1.ServerpodConfig? config,
+    _i1.ServerpodConfig Function(_i1.ServerpodConfig)? configOverride,
+    _i1.AuthenticationHandler? authenticationHandler,
+    _i1.HealthCheckHandler? healthCheckHandler,
+    _i1.HealthConfig? healthConfig,
+    _i1.Headers? httpResponseHeaders,
+    _i1.Headers? httpOptionsResponseHeaders,
+    _i1.SecurityContextConfig? securityContextConfig,
+    _i1.ExperimentalFeatures? experimentalFeatures,
+    _i1.RuntimeParametersListBuilder? runtimeParametersBuilder,
+    _i1.DatabaseInterceptor? databaseInterceptor,
+  }) : super(
+         args,
+         _i3.Protocol(),
+         _i4.Endpoints(),
+         serverDirectory: serverDirectory,
+         config: config,
+         configOverride: configOverride,
+         authenticationHandler: authenticationHandler,
+         healthCheckHandler: healthCheckHandler,
+         healthConfig: healthConfig,
+         httpResponseHeaders: httpResponseHeaders,
+         httpOptionsResponseHeaders: httpOptionsResponseHeaders,
+         securityContextConfig: securityContextConfig,
+         experimentalFeatures: experimentalFeatures,
+         runtimeParametersBuilder: runtimeParametersBuilder,
+         databaseInterceptor: databaseInterceptor,
+       );
+}

--- a/templates/serverpod_templates/projectname_server/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server/lib/server.dart
@@ -1,12 +1,10 @@
-import 'package:serverpod/serverpod.dart';
-
-import 'src/generated/protocol.dart';
-import 'src/generated/endpoints.dart';
+import 'src/generated/serverpod.dart';
 
 /// The starting point of the Serverpod server.
 void run(List<String> args) async {
-  // Initialize Serverpod and connect it with your generated code.
-  final pod = Serverpod(args, Protocol(), Endpoints());
+  // Initialize Serverpod. The generated Serverpod class is already connected
+  // with your project's generated code.
+  final pod = Serverpod(args);
 
   // Start the server.
   await pod.start();

--- a/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
+++ b/templates/serverpod_templates/projectname_server_upgrade/lib/server.dart
@@ -2,7 +2,6 @@
 import 'dart:io';
 // {{/webapp}}
 
-import 'package:serverpod/serverpod.dart';
 // {{#auth}}
 import 'package:serverpod_auth_idp_server/core.dart';
 import 'package:serverpod_auth_idp_server/providers/email.dart';
@@ -11,8 +10,7 @@ import 'package:serverpod_auth_idp_server/providers/email.dart';
 // {{#webserver}}
 import 'src/cache_busting.dart';
 // {{/webserver}}
-import 'src/generated/endpoints.dart';
-import 'src/generated/protocol.dart';
+import 'src/generated/serverpod.dart';
 // {{#webapp}}
 import 'src/web/routes/app_config_route.dart';
 // {{/webapp}}
@@ -22,8 +20,9 @@ import 'src/web/routes/root.dart';
 
 /// The starting point of the Serverpod server.
 void run(List<String> args) async {
-  // Initialize Serverpod and connect it with your generated code.
-  final pod = Serverpod(args, Protocol(), Endpoints());
+  // Initialize Serverpod. The generated Serverpod class is already connected
+  // with your project's generated code.
+  final pod = Serverpod(args);
 
   // {{#auth}}
   // Initialize authentication services for the server.

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/serverpod.dart
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/lib/src/generated/serverpod.dart
@@ -1,0 +1,60 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'dart:io' as _i2;
+import 'protocol.dart' as _i3;
+import 'endpoints.dart' as _i4;
+export 'package:serverpod/serverpod.dart' hide Serverpod;
+
+/// The Serverpod server for this project.
+///
+/// Pre-configured with the generated Protocol serialization manager and
+/// Endpoints, so a server can be created with just the command line
+/// arguments:
+///
+/// ```dart
+/// final pod = Serverpod(args);
+/// ```
+class Serverpod extends _i1.Serverpod {
+  Serverpod(
+    List<String> args, {
+    _i2.Directory? serverDirectory,
+    _i1.ServerpodConfig? config,
+    _i1.ServerpodConfig Function(_i1.ServerpodConfig)? configOverride,
+    _i1.AuthenticationHandler? authenticationHandler,
+    _i1.HealthCheckHandler? healthCheckHandler,
+    _i1.HealthConfig? healthConfig,
+    _i1.Headers? httpResponseHeaders,
+    _i1.Headers? httpOptionsResponseHeaders,
+    _i1.SecurityContextConfig? securityContextConfig,
+    _i1.ExperimentalFeatures? experimentalFeatures,
+    _i1.RuntimeParametersListBuilder? runtimeParametersBuilder,
+    _i1.DatabaseInterceptor? databaseInterceptor,
+  }) : super(
+         args,
+         _i3.Protocol(),
+         _i4.Endpoints(),
+         serverDirectory: serverDirectory,
+         config: config,
+         configOverride: configOverride,
+         authenticationHandler: authenticationHandler,
+         healthCheckHandler: healthCheckHandler,
+         healthConfig: healthConfig,
+         httpResponseHeaders: httpResponseHeaders,
+         httpOptionsResponseHeaders: httpOptionsResponseHeaders,
+         securityContextConfig: securityContextConfig,
+         experimentalFeatures: experimentalFeatures,
+         runtimeParametersBuilder: runtimeParametersBuilder,
+         databaseInterceptor: databaseInterceptor,
+       );
+}

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/generated/serverpod.dart
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/lib/src/generated/serverpod.dart
@@ -1,0 +1,60 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'dart:io' as _i2;
+import 'protocol.dart' as _i3;
+import 'endpoints.dart' as _i4;
+export 'package:serverpod/serverpod.dart' hide Serverpod;
+
+/// The Serverpod server for this project.
+///
+/// Pre-configured with the generated Protocol serialization manager and
+/// Endpoints, so a server can be created with just the command line
+/// arguments:
+///
+/// ```dart
+/// final pod = Serverpod(args);
+/// ```
+class Serverpod extends _i1.Serverpod {
+  Serverpod(
+    List<String> args, {
+    _i2.Directory? serverDirectory,
+    _i1.ServerpodConfig? config,
+    _i1.ServerpodConfig Function(_i1.ServerpodConfig)? configOverride,
+    _i1.AuthenticationHandler? authenticationHandler,
+    _i1.HealthCheckHandler? healthCheckHandler,
+    _i1.HealthConfig? healthConfig,
+    _i1.Headers? httpResponseHeaders,
+    _i1.Headers? httpOptionsResponseHeaders,
+    _i1.SecurityContextConfig? securityContextConfig,
+    _i1.ExperimentalFeatures? experimentalFeatures,
+    _i1.RuntimeParametersListBuilder? runtimeParametersBuilder,
+    _i1.DatabaseInterceptor? databaseInterceptor,
+  }) : super(
+         args,
+         _i3.Protocol(),
+         _i4.Endpoints(),
+         serverDirectory: serverDirectory,
+         config: config,
+         configOverride: configOverride,
+         authenticationHandler: authenticationHandler,
+         healthCheckHandler: healthCheckHandler,
+         healthConfig: healthConfig,
+         httpResponseHeaders: httpResponseHeaders,
+         httpOptionsResponseHeaders: httpOptionsResponseHeaders,
+         securityContextConfig: securityContextConfig,
+         experimentalFeatures: experimentalFeatures,
+         runtimeParametersBuilder: runtimeParametersBuilder,
+         databaseInterceptor: databaseInterceptor,
+       );
+}

--- a/tests/serverpod_test_server/lib/server.dart
+++ b/tests/serverpod_test_server/lib/server.dart
@@ -1,18 +1,15 @@
-import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_server/serverpod_auth_server.dart' as auth;
 import 'package:serverpod_cloud_storage_s3/serverpod_cloud_storage_s3.dart'
     as s3;
 import 'package:serverpod_test_server/src/web/routes/root.dart';
 
-import 'src/generated/endpoints.dart';
-import 'src/generated/protocol.dart';
+import 'src/generated/serverpod.dart';
 
 void run(List<String> args) async {
-  // Create serverpod
+  // Create serverpod using the generated Serverpod class, which comes
+  // pre-configured with the generated Protocol and Endpoints.
   var pod = Serverpod(
     args,
-    Protocol(),
-    Endpoints(),
     authenticationHandler: auth.authenticationHandler,
   );
 

--- a/tests/serverpod_test_server/lib/src/generated/serverpod.dart
+++ b/tests/serverpod_test_server/lib/src/generated/serverpod.dart
@@ -15,6 +15,7 @@ import 'dart:io' as _i2;
 import 'protocol.dart' as _i3;
 import 'endpoints.dart' as _i4;
 export 'package:serverpod/serverpod.dart' hide Serverpod;
+export 'future_calls.dart' show ServerpodFutureCallsGetter;
 
 /// The Serverpod server for this project.
 ///

--- a/tests/serverpod_test_server/lib/src/generated/serverpod.dart
+++ b/tests/serverpod_test_server/lib/src/generated/serverpod.dart
@@ -1,0 +1,60 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'dart:io' as _i2;
+import 'protocol.dart' as _i3;
+import 'endpoints.dart' as _i4;
+export 'package:serverpod/serverpod.dart' hide Serverpod;
+
+/// The Serverpod server for this project.
+///
+/// Pre-configured with the generated Protocol serialization manager and
+/// Endpoints, so a server can be created with just the command line
+/// arguments:
+///
+/// ```dart
+/// final pod = Serverpod(args);
+/// ```
+class Serverpod extends _i1.Serverpod {
+  Serverpod(
+    List<String> args, {
+    _i2.Directory? serverDirectory,
+    _i1.ServerpodConfig? config,
+    _i1.ServerpodConfig Function(_i1.ServerpodConfig)? configOverride,
+    _i1.AuthenticationHandler? authenticationHandler,
+    _i1.HealthCheckHandler? healthCheckHandler,
+    _i1.HealthConfig? healthConfig,
+    _i1.Headers? httpResponseHeaders,
+    _i1.Headers? httpOptionsResponseHeaders,
+    _i1.SecurityContextConfig? securityContextConfig,
+    _i1.ExperimentalFeatures? experimentalFeatures,
+    _i1.RuntimeParametersListBuilder? runtimeParametersBuilder,
+    _i1.DatabaseInterceptor? databaseInterceptor,
+  }) : super(
+         args,
+         _i3.Protocol(),
+         _i4.Endpoints(),
+         serverDirectory: serverDirectory,
+         config: config,
+         configOverride: configOverride,
+         authenticationHandler: authenticationHandler,
+         healthCheckHandler: healthCheckHandler,
+         healthConfig: healthConfig,
+         httpResponseHeaders: httpResponseHeaders,
+         httpOptionsResponseHeaders: httpOptionsResponseHeaders,
+         securityContextConfig: securityContextConfig,
+         experimentalFeatures: experimentalFeatures,
+         runtimeParametersBuilder: runtimeParametersBuilder,
+         databaseInterceptor: databaseInterceptor,
+       );
+}

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/serverpod.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/serverpod.dart
@@ -15,6 +15,7 @@ import 'dart:io' as _i2;
 import 'protocol.dart' as _i3;
 import 'endpoints.dart' as _i4;
 export 'package:serverpod/serverpod.dart' hide Serverpod;
+export 'future_calls.dart' show ServerpodFutureCallsGetter;
 
 /// The Serverpod server for this project.
 ///

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/serverpod.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/lib/src/generated/serverpod.dart
@@ -1,0 +1,60 @@
+/* AUTOMATICALLY GENERATED CODE DO NOT MODIFY */
+/*   To generate run: "serverpod generate"    */
+
+// ignore_for_file: implementation_imports
+// ignore_for_file: library_private_types_in_public_api
+// ignore_for_file: non_constant_identifier_names
+// ignore_for_file: public_member_api_docs
+// ignore_for_file: type_literal_in_constant_pattern
+// ignore_for_file: use_super_parameters
+// ignore_for_file: invalid_use_of_internal_member
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:serverpod/serverpod.dart' as _i1;
+import 'dart:io' as _i2;
+import 'protocol.dart' as _i3;
+import 'endpoints.dart' as _i4;
+export 'package:serverpod/serverpod.dart' hide Serverpod;
+
+/// The Serverpod server for this project.
+///
+/// Pre-configured with the generated Protocol serialization manager and
+/// Endpoints, so a server can be created with just the command line
+/// arguments:
+///
+/// ```dart
+/// final pod = Serverpod(args);
+/// ```
+class Serverpod extends _i1.Serverpod {
+  Serverpod(
+    List<String> args, {
+    _i2.Directory? serverDirectory,
+    _i1.ServerpodConfig? config,
+    _i1.ServerpodConfig Function(_i1.ServerpodConfig)? configOverride,
+    _i1.AuthenticationHandler? authenticationHandler,
+    _i1.HealthCheckHandler? healthCheckHandler,
+    _i1.HealthConfig? healthConfig,
+    _i1.Headers? httpResponseHeaders,
+    _i1.Headers? httpOptionsResponseHeaders,
+    _i1.SecurityContextConfig? securityContextConfig,
+    _i1.ExperimentalFeatures? experimentalFeatures,
+    _i1.RuntimeParametersListBuilder? runtimeParametersBuilder,
+    _i1.DatabaseInterceptor? databaseInterceptor,
+  }) : super(
+         args,
+         _i3.Protocol(),
+         _i4.Endpoints(),
+         serverDirectory: serverDirectory,
+         config: config,
+         configOverride: configOverride,
+         authenticationHandler: authenticationHandler,
+         healthCheckHandler: healthCheckHandler,
+         healthConfig: healthConfig,
+         httpResponseHeaders: httpResponseHeaders,
+         httpOptionsResponseHeaders: httpOptionsResponseHeaders,
+         securityContextConfig: securityContextConfig,
+         experimentalFeatures: experimentalFeatures,
+         runtimeParametersBuilder: runtimeParametersBuilder,
+         databaseInterceptor: databaseInterceptor,
+       );
+}

--- a/tools/serverpod_cli/lib/src/config/config.dart
+++ b/tools/serverpod_cli/lib/src/config/config.dart
@@ -192,6 +192,12 @@ class GeneratorConfig implements ModelLoadConfig {
     'protocol.dart',
   ];
 
+  /// The path parts of the generated serverpod server file.
+  List<String> get generatedServerServerpodFilePathParts => [
+    ...generatedServeModelPathParts,
+    'serverpod.dart',
+  ];
+
   /// The path parts of the generated protocol file.
   List<String> get generatedServerEndpointDescriptionFilePathParts => [
     ...generatedServeModelPathParts,

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/library_generator.dart
@@ -13,6 +13,7 @@ import 'package:serverpod_cli/src/generator/shared.dart';
 import 'package:serverpod_service_client/serverpod_service_client.dart';
 
 part 'future_calls_library_generator.dart';
+part 'serverpod_library_generator.dart';
 
 const mapRecordToJsonFuncName = 'mapRecordToJson';
 const mapContainerToJsonFunctionName = 'mapContainerToJson';

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/serverpod_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/serverpod_library_generator.dart
@@ -16,6 +16,17 @@ extension ServerpodLibraryGenerator on LibraryGenerator {
       Directive.export(serverpodUrl(true), hide: const ['Serverpod']),
     );
 
+    // The futureCalls getter is an extension, which is only applicable when
+    // imported without a prefix, so it must be re-exported here as well.
+    if (protocolDefinition.shouldGenerateFutureCalls) {
+      library.directives.add(
+        Directive.export(
+          'future_calls.dart',
+          show: const ['ServerpodFutureCallsGetter'],
+        ),
+      );
+    }
+
     library.body.add(
       Class(
         (c) => c

--- a/tools/serverpod_cli/lib/src/generator/dart/library_generators/serverpod_library_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/library_generators/serverpod_library_generator.dart
@@ -1,0 +1,191 @@
+part of 'library_generator.dart';
+
+extension ServerpodLibraryGenerator on LibraryGenerator {
+  /// Generates the project's `Serverpod` class, a subclass of the framework's
+  /// `Serverpod` that is pre-configured with the generated `Protocol` and
+  /// `Endpoints`, so a server can be created with just `Serverpod(args)`.
+  ///
+  /// Executing this only makes sense for server packages of type
+  /// [PackageType.server] (modules are never booted on their own).
+  Library generateServerpodClass() {
+    var library = LibraryBuilder();
+
+    // Re-export the framework, hiding its Serverpod class in favor of the
+    // generated one, so `server.dart` only needs to import this file.
+    library.directives.add(
+      Directive.export(serverpodUrl(true), hide: const ['Serverpod']),
+    );
+
+    library.body.add(
+      Class(
+        (c) => c
+          ..docs.addAll([
+            '/// The Serverpod server for this project.',
+            '///',
+            '/// Pre-configured with the generated Protocol serialization manager and',
+            '/// Endpoints, so a server can be created with just the command line',
+            '/// arguments:',
+            '///',
+            '/// ```dart',
+            '/// final pod = Serverpod(args);',
+            '/// ```',
+          ])
+          ..name = 'Serverpod'
+          ..extend = refer('Serverpod', serverpodUrl(true))
+          ..constructors.add(
+            Constructor((c) {
+              c
+                ..requiredParameters.add(
+                  Parameter(
+                    (p) => p
+                      ..type = refer('List<String>')
+                      ..name = 'args',
+                  ),
+                )
+                ..optionalParameters.addAll([
+                  Parameter(
+                    (p) => p
+                      ..name = 'serverDirectory'
+                      ..named = true
+                      ..type = refer('Directory?', 'dart:io'),
+                  ),
+                  Parameter(
+                    (p) => p
+                      ..name = 'config'
+                      ..named = true
+                      ..type = refer('ServerpodConfig?', serverpodUrl(true)),
+                  ),
+                  Parameter(
+                    (p) => p
+                      ..name = 'configOverride'
+                      ..named = true
+                      ..type = FunctionType(
+                        (f) => f
+                          ..isNullable = true
+                          ..returnType = TypeReference(
+                            (t) => t
+                              ..symbol = 'ServerpodConfig'
+                              ..url = serverpodUrl(true)
+                              ..isNullable = false,
+                          )
+                          ..requiredParameters.add(
+                            TypeReference(
+                              (t) => t
+                                ..symbol = 'ServerpodConfig'
+                                ..url = serverpodUrl(true)
+                                ..isNullable = false,
+                            ),
+                          ),
+                      ),
+                  ),
+                  Parameter(
+                    (p) => p
+                      ..name = 'authenticationHandler'
+                      ..named = true
+                      ..type = refer(
+                        'AuthenticationHandler?',
+                        serverpodUrl(true),
+                      ),
+                  ),
+                  Parameter(
+                    (p) => p
+                      ..name = 'healthCheckHandler'
+                      ..named = true
+                      ..type = refer('HealthCheckHandler?', serverpodUrl(true)),
+                  ),
+                  Parameter(
+                    (p) => p
+                      ..name = 'healthConfig'
+                      ..named = true
+                      ..type = refer('HealthConfig?', serverpodUrl(true)),
+                  ),
+                  Parameter(
+                    (p) => p
+                      ..name = 'httpResponseHeaders'
+                      ..named = true
+                      ..type = refer('Headers?', serverpodUrl(true)),
+                  ),
+                  Parameter(
+                    (p) => p
+                      ..name = 'httpOptionsResponseHeaders'
+                      ..named = true
+                      ..type = refer('Headers?', serverpodUrl(true)),
+                  ),
+                  Parameter(
+                    (p) => p
+                      ..name = 'securityContextConfig'
+                      ..named = true
+                      ..type = refer(
+                        'SecurityContextConfig?',
+                        serverpodUrl(true),
+                      ),
+                  ),
+                  Parameter(
+                    (p) => p
+                      ..name = 'experimentalFeatures'
+                      ..named = true
+                      ..type = refer(
+                        'ExperimentalFeatures?',
+                        serverpodUrl(true),
+                      ),
+                  ),
+                  Parameter(
+                    (p) => p
+                      ..name = 'runtimeParametersBuilder'
+                      ..named = true
+                      ..type = refer(
+                        'RuntimeParametersListBuilder?',
+                        serverpodUrl(true),
+                      ),
+                  ),
+                  Parameter(
+                    (p) => p
+                      ..name = 'databaseInterceptor'
+                      ..named = true
+                      ..type = refer(
+                        'DatabaseInterceptor?',
+                        serverpodUrl(true),
+                      ),
+                  ),
+                ])
+                ..initializers.add(
+                  refer('super')
+                      .call(
+                        [
+                          refer('args'),
+                          refer('Protocol', 'protocol.dart').call([]),
+                          refer('Endpoints', 'endpoints.dart').call([]),
+                        ],
+                        {
+                          'serverDirectory': refer('serverDirectory'),
+                          'config': refer('config'),
+                          'configOverride': refer('configOverride'),
+                          'authenticationHandler': refer(
+                            'authenticationHandler',
+                          ),
+                          'healthCheckHandler': refer('healthCheckHandler'),
+                          'healthConfig': refer('healthConfig'),
+                          'httpResponseHeaders': refer('httpResponseHeaders'),
+                          'httpOptionsResponseHeaders': refer(
+                            'httpOptionsResponseHeaders',
+                          ),
+                          'securityContextConfig': refer(
+                            'securityContextConfig',
+                          ),
+                          'experimentalFeatures': refer('experimentalFeatures'),
+                          'runtimeParametersBuilder': refer(
+                            'runtimeParametersBuilder',
+                          ),
+                          'databaseInterceptor': refer('databaseInterceptor'),
+                        },
+                      )
+                      .code,
+                );
+            }),
+          ),
+      ),
+    );
+
+    return library.build();
+  }
+}

--- a/tools/serverpod_cli/lib/src/generator/dart/server_code_generator.dart
+++ b/tools/serverpod_cli/lib/src/generator/dart/server_code_generator.dart
@@ -75,6 +75,17 @@ class DartServerCodeGenerator extends CodeGenerator {
       ),
     };
 
+    // Modules are never booted on their own, so only server packages get the
+    // pre-wired Serverpod entry point.
+    if (config.type == PackageType.server) {
+      var serverpodPath = p.joinAll(
+        config.generatedServerServerpodFilePathParts,
+      );
+      codeMap[serverpodPath] = serverClassGenerator
+          .generateServerpodClass()
+          .generateCode(formatter: GeneratedDartFormatters.of(serverpodPath));
+    }
+
     var generatedServerTestToolsPathParts =
         config.generatedServerTestToolsPathParts;
     if (generatedServerTestToolsPathParts != null) {

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/serverpod_class_constructor_sync_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/serverpod_class_constructor_sync_test.dart
@@ -1,0 +1,107 @@
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/src/analyzer/protocol_definition.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/builders/generator_config_builder.dart';
+
+/// Guards against the generated `Serverpod` subclass drifting from the
+/// framework's `Serverpod` constructor: a named parameter added to the
+/// framework without updating `generateServerpodClass` would silently not be
+/// forwarded, since the subclass re-declares every parameter.
+void main() {
+  var frameworkSourcePath = path.join(
+    '..',
+    '..',
+    'packages',
+    'serverpod',
+    'lib',
+    'src',
+    'server',
+    'serverpod.dart',
+  );
+
+  test(
+    'Given the framework Serverpod constructor when comparing with the '
+    'generated Serverpod subclass then all named parameters are declared and '
+    'forwarded.',
+    () {
+      var frameworkFile = File(frameworkSourcePath);
+      if (!frameworkFile.existsSync()) {
+        markTestSkipped(
+          'Framework source not found at $frameworkSourcePath; '
+          'this test only runs in the Serverpod mono-repo.',
+        );
+        return;
+      }
+
+      var frameworkConstructor = _unnamedConstructorOfClass(
+        parseString(content: frameworkFile.readAsStringSync()).unit,
+        'Serverpod',
+      );
+      var frameworkParameters = _namedParameterNames(frameworkConstructor);
+
+      var config = GeneratorConfigBuilder().withName('example_project').build();
+      var codeMap = const DartServerCodeGenerator().generateProtocolCode(
+        protocolDefinition: const ProtocolDefinition(
+          endpoints: [],
+          models: [],
+          futureCalls: [],
+        ),
+        config: config,
+      );
+      var generatedFile =
+          codeMap[path.join('lib', 'src', 'generated', 'serverpod.dart')]!;
+
+      var generatedConstructor = _unnamedConstructorOfClass(
+        parseString(content: generatedFile).unit,
+        'Serverpod',
+      );
+      var generatedParameters = _namedParameterNames(generatedConstructor);
+      var forwardedParameters = generatedConstructor.initializers
+          .whereType<SuperConstructorInvocation>()
+          .single
+          .argumentList
+          .arguments
+          .whereType<NamedExpression>()
+          .map((argument) => argument.name.label.name)
+          .toSet();
+
+      const outOfSyncReason =
+          'The framework Serverpod constructor and the generated Serverpod '
+          'subclass are out of sync. Update generateServerpodClass in '
+          'lib/src/generator/dart/library_generators/'
+          'serverpod_library_generator.dart.';
+
+      expect(generatedParameters, frameworkParameters, reason: outOfSyncReason);
+      expect(forwardedParameters, frameworkParameters, reason: outOfSyncReason);
+    },
+  );
+}
+
+ConstructorDeclaration _unnamedConstructorOfClass(
+  CompilationUnit unit,
+  String className,
+) {
+  // The replacements (namePart, body) only exist in analyzer 10+, and the
+  // pubspec range starts at 8.1.0 (exercised by the CI downgrade legs).
+  return unit.declarations
+      .whereType<ClassDeclaration>()
+      // ignore: deprecated_member_use
+      .singleWhere((declaration) => declaration.name.lexeme == className)
+      // ignore: deprecated_member_use
+      .members
+      .whereType<ConstructorDeclaration>()
+      .singleWhere((constructor) => constructor.name == null);
+}
+
+Set<String> _namedParameterNames(ConstructorDeclaration constructor) {
+  return constructor.parameters.parameters
+      .where((parameter) => parameter.isNamed)
+      .map((parameter) => parameter.name!.lexeme)
+      .toSet();
+}

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/serverpod_class_constructor_sync_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/serverpod_class_constructor_sync_test.dart
@@ -26,9 +26,9 @@ void main() {
   );
 
   test(
-    'Given the framework Serverpod constructor when comparing with the '
-    'generated Serverpod subclass then all named parameters are declared and '
-    'forwarded.',
+    'Given the framework Serverpod constructor '
+    'when comparing with the generated Serverpod subclass '
+    'then all named parameters are declared and forwarded.',
     () {
       var frameworkFile = File(frameworkSourcePath);
       if (!frameworkFile.existsSync()) {

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/serverpod_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/serverpod_class_test.dart
@@ -1,0 +1,90 @@
+import 'package:path/path.dart' as path;
+import 'package:serverpod_cli/src/analyzer/protocol_definition.dart';
+import 'package:serverpod_cli/src/config/config.dart';
+import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
+import 'package:test/test.dart';
+
+import '../../../test_util/builders/generator_config_builder.dart';
+
+const projectName = 'example_project';
+const generator = DartServerCodeGenerator();
+
+const protocolDefinition = ProtocolDefinition(
+  endpoints: [],
+  models: [],
+  futureCalls: [],
+);
+
+void main() {
+  var expectedFileName = path.join(
+    'lib',
+    'src',
+    'generated',
+    'serverpod.dart',
+  );
+
+  group(
+    'Given a server package when generating protocol code',
+    () {
+      late Map<String, String> codeMap;
+      late String? serverpodFile;
+      setUpAll(() {
+        var config = GeneratorConfigBuilder().withName(projectName).build();
+
+        codeMap = generator.generateProtocolCode(
+          protocolDefinition: protocolDefinition,
+          config: config,
+        );
+        serverpodFile = codeMap[expectedFileName];
+      });
+
+      test('then the serverpod file is created.', () {
+        expect(codeMap, contains(expectedFileName));
+      });
+
+      group('then the serverpod file', () {
+        test('declares a Serverpod class extending the framework class.', () {
+          expect(
+            serverpodFile,
+            matches(r'class Serverpod extends _i\d+\.Serverpod'),
+          );
+        });
+
+        test('re-exports the framework hiding its Serverpod class.', () {
+          expect(
+            serverpodFile,
+            contains(
+              "export 'package:serverpod/serverpod.dart' hide Serverpod;",
+            ),
+          );
+        });
+
+        test(
+          'wires the generated Protocol and Endpoints in the super call.',
+          () {
+            expect(serverpodFile, matches(r'_i\d+\.Protocol\(\)'));
+            expect(serverpodFile, matches(r'_i\d+\.Endpoints\(\)'));
+          },
+        );
+      });
+    },
+  );
+
+  test(
+    'Given a module package when generating protocol code then no serverpod '
+    'file is created.',
+    () {
+      var config = GeneratorConfigBuilder()
+          .withName(projectName)
+          .withPackageType(PackageType.module)
+          .build();
+
+      var codeMap = generator.generateProtocolCode(
+        protocolDefinition: protocolDefinition,
+        config: config,
+      );
+
+      expect(codeMap.keys, isNot(contains(expectedFileName)));
+    },
+  );
+}

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/serverpod_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/serverpod_class_test.dart
@@ -105,8 +105,9 @@ void main() {
   );
 
   test(
-    'Given a module package when generating protocol code then no serverpod '
-    'file is created.',
+    'Given a module package '
+    'when generating protocol code '
+    'then no serverpod file is created.',
     () {
       var config = GeneratorConfigBuilder()
           .withName(projectName)

--- a/tools/serverpod_cli/test/generator/dart/server_code_generator/serverpod_class_test.dart
+++ b/tools/serverpod_cli/test/generator/dart/server_code_generator/serverpod_class_test.dart
@@ -4,6 +4,7 @@ import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/generator/dart/server_code_generator.dart';
 import 'package:test/test.dart';
 
+import '../../../test_util/builders/future_call_definition_builder.dart';
 import '../../../test_util/builders/generator_config_builder.dart';
 
 const projectName = 'example_project';
@@ -65,6 +66,39 @@ void main() {
             expect(serverpodFile, matches(r'_i\d+\.Protocol\(\)'));
             expect(serverpodFile, matches(r'_i\d+\.Endpoints\(\)'));
           },
+        );
+
+        test('does not export the future calls getter.', () {
+          expect(serverpodFile, isNot(contains("export 'future_calls.dart'")));
+        });
+      });
+    },
+  );
+
+  group(
+    'Given a server package with future calls when generating protocol code',
+    () {
+      late String? serverpodFile;
+      setUpAll(() {
+        var config = GeneratorConfigBuilder().withName(projectName).build();
+
+        var codeMap = generator.generateProtocolCode(
+          protocolDefinition: ProtocolDefinition(
+            endpoints: [],
+            models: [],
+            futureCalls: [FutureCallDefinitionBuilder().build()],
+          ),
+          config: config,
+        );
+        serverpodFile = codeMap[expectedFileName];
+      });
+
+      test('then the serverpod file exports the future calls getter.', () {
+        expect(
+          serverpodFile,
+          contains(
+            "export 'future_calls.dart' show ServerpodFutureCallsGetter;",
+          ),
         );
       });
     },


### PR DESCRIPTION
Adds a generated `lib/src/generated/serverpod.dart` to every server package: a `Serverpod` subclass pre-configured with the project's generated `Protocol` and `Endpoints`, so a server can now be created with just:
```dart
import 'src/generated/serverpod.dart';
final pod = Serverpod(args);
```

- The generated class extends the framework's Serverpod, re-declares all of its named constructor parameters, and forwards them while injecting `Protocol()` and `Endpoints()` in the super call.
- The file re-exports `package:serverpod/serverpod.dart`, so `server.dart` needs only the single generated import.
- Generation is gated to PackageType.server

Closes #4544

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None