### PR TITLE
fix: Update start TUI app status on spontaneous exit, launcher divider color, and clickable app URL

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -252,6 +252,7 @@ class FlutterAppManager {
 
     runtime.spawnInFlight = true;
     runtime.readySignaled = false;
+    runtime.stopSignaled = false;
     final isRelaunch = runtime.relaunchInProgress;
     runtime.relaunchInProgress = false;
 
@@ -295,6 +296,19 @@ class FlutterAppManager {
     runtime.process = process;
     runtime.spawnInFlight = false;
 
+    // A ready app whose process exits without an explicit [stop] - browser
+    // window closed (heartbeat teardown), daemon app.stop, crash - must still
+    // reach [onStop]. Never-ready exits are launch failures, signaled by
+    // [_connectAfterLaunch] instead. The process check drops a stale listener
+    // once a relaunch has installed a new process.
+    unawaited(
+      process.exitCode.then((_) {
+        if (runtime.process != process) return;
+        runtime.process = null;
+        if (runtime.readySignaled) _signalStopped(runtime);
+      }),
+    );
+
     // Configured targets are reported by `cli.session_start`; this is the
     // usage side, so a platform declared once and never run does not weigh as
     // much as one launched every session.
@@ -326,6 +340,9 @@ class FlutterAppManager {
     if (runtime == null) return;
 
     runtime.relaunchInProgress = runtime.process != null;
+    // The relaunch resets the tab via [onEnsureAppTab]; a stop signal in
+    // between would only flash a stopped state.
+    runtime.stopSignaled = true;
     await runtime.process?.stop();
     runtime.process = null;
     await launch(appId);
@@ -337,11 +354,10 @@ class FlutterAppManager {
   Future<void> stop(String appId) async {
     final runtime = _runtimeFor(appId);
     if (runtime == null) return;
-    final app = runtime.app;
     runtime.relaunchInProgress = false;
     await runtime.process?.stop();
     runtime.process = null;
-    onStop(app);
+    _signalStopped(runtime);
   }
 
   /// Loads configured apps from [serverPubspecFile].
@@ -406,6 +422,8 @@ class FlutterAppManager {
   /// Stops every running app and removes per-app VM-service info files.
   Future<void> stopAll() async {
     await _runtimes.values.map((runtime) async {
+      // Session shutdown; don't churn [onStop] consumers per app.
+      runtime.stopSignaled = true;
       await runtime.process?.stop();
       runtime.process = null;
       await File(runtime.infoFile).deleteIfExists();
@@ -538,6 +556,15 @@ class FlutterAppManager {
     onReady(runtime.app, url);
   }
 
+  /// Invokes [onStop] at most once per launch. Stop has several sources - an
+  /// explicit [stop] and the process exiting on its own - so a second signal
+  /// is swallowed here.
+  void _signalStopped(_AppRuntime runtime) {
+    if (runtime.stopSignaled) return;
+    runtime.stopSignaled = true;
+    onStop(runtime.app);
+  }
+
   Future<void> _connectAfterLaunch(
     _AppRuntime runtime,
     FlutterProcess process, {
@@ -604,4 +631,5 @@ class _AppRuntime {
   bool spawnInFlight = false;
   bool relaunchInProgress = false;
   bool readySignaled = false;
+  bool stopSignaled = false;
 }

--- a/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/app.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
 import 'package:nocterm/nocterm.dart' hide LogEntry;
-import 'package:serverpod_shared/log.dart';
+import 'package:serverpod_cli/src/util/browser_launcher.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:serverpod_shared/log.dart' hide log;
 import 'package:serverpod_tui/serverpod_tui.dart';
 
 import 'inspectable_scroll_controller.dart';
@@ -15,6 +17,9 @@ class StartAppStateHolder extends TuiAppStateHolder<ServerWatchState> {
   StartAppStateHolder(this._state);
 
   final ServerWatchState _state;
+
+  /// Opens a URL in the default browser. Overridable in tests.
+  Future<bool> Function(Uri url) openUrl = BrowserLauncher.openUrl;
 
   ServerpodWatchAppState? _widgetState;
   VoidCallback? _onHotReload;
@@ -302,6 +307,18 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
     return false;
   }
 
+  /// Opens the URL of [tab]'s running app in the default browser. Bound to
+  /// clicking the URL in the app tab's status line.
+  void _openAppUrl(AppLogTab tab) {
+    final url = tab.url;
+    if (url == null) return;
+    unawaited(
+      component.holder.openUrl(Uri.parse(url)).then((ok) {
+        if (!ok) log.warning('Could not open browser at $url');
+      }),
+    );
+  }
+
   @override
   void onExit() {
     final quit = onQuit;
@@ -349,6 +366,7 @@ class ServerpodWatchAppState extends TuiAppState<ServerpodWatchApp> {
           onCopyAlert: copyAlert,
           onDismissAlert: dismissAlert,
           onStopOrCloseAppTab: _stopOrCloseAppTab,
+          onOpenAppUrl: _openAppUrl,
           onToggleStackTrace: (entry) {
             state.toggleStackTrace(entry);
             _rebuild();

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -263,7 +263,7 @@ class MainScreen extends StatelessComponent {
                   ),
                 ),
               ),
-              const Divider(indent: -1, endIndent: -1),
+              Divider(color: st.subtleDivider, indent: -1, endIndent: -1),
               Expanded(
                 child: Scrollbar(
                   controller: appPanelScrollController,

--- a/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/tui/main_screen.dart
@@ -31,6 +31,7 @@ class MainScreen extends StatelessComponent {
     required this.onDismissAlert,
     required this.onStopOrCloseAppTab,
     required this.onToggleStackTrace,
+    required this.onOpenAppUrl,
   });
 
   final ServerWatchState state;
@@ -61,6 +62,10 @@ class MainScreen extends StatelessComponent {
   /// Flips the stack-trace visibility of one log entry, invoked by clicking
   /// its expand/collapse affordance (`E` toggles all entries at once).
   final void Function(LogEntry entry) onToggleStackTrace;
+
+  /// Opens the running app's published URL in the browser, invoked by
+  /// clicking the URL in the app tab's status line.
+  final void Function(AppLogTab tab) onOpenAppUrl;
 
   List<(String, List<(String, String)>)> get _helpBindings => [
     (
@@ -499,7 +504,8 @@ class MainScreen extends StatelessComponent {
   /// Breadcrumb for a Flutter app tab: a muted app id and the URL or startup
   /// stage, with a pinned `X Stop App`/`X Close Tab` hint. Only the status text
   /// shimmers while launching, and it is truncated when the line is too narrow
-  /// so the hint always stays visible.
+  /// so the hint always stays visible. A running app's URL is underlined and
+  /// opens in the browser when clicked.
   Component? _buildFlutterStatusLine(ServerpodThemeData st, AppLogTab tab) {
     final mutedText = TextStyle(
       color: st.debugLevel,
@@ -549,8 +555,23 @@ class MainScreen extends StatelessComponent {
                   labelPart.length + labelSep.length + xHintPlain.length + 1;
               final shownStatus = _fit(statusText, maxWidth - reserved);
 
-              Component status = Text(shownStatus, style: mutedText);
-              if (loading) status = Shimmer(child: status);
+              // A published URL is underlined and clickable, opening the
+              // running web app in the browser.
+              Component status;
+              if (tab.ready && tab.url != null) {
+                status = GestureDetector(
+                  onTap: () => onOpenAppUrl(tab),
+                  child: Text(
+                    shownStatus,
+                    style: mutedText.copyWith(
+                      decoration: TextDecoration.underline,
+                    ),
+                  ),
+                );
+              } else {
+                status = Text(shownStatus, style: mutedText);
+                if (loading) status = Shimmer(child: status);
+              }
 
               return Row(
                 children: [

--- a/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
@@ -525,19 +525,19 @@ void main() {
     'on its own',
     () {
       late _ManagerFixture f;
-      late Directory exitDir;
-      late File exitFile;
+      late Directory pidDir;
+      late File pidFile;
       late Completer<String?> ready;
       late int stopCalls;
 
       setUp(() async {
         ready = Completer<String?>();
         stopCalls = 0;
-        exitDir = await Directory.systemTemp.createTemp('flutter_exit_');
-        exitFile = File(p.join(exitDir.path, 'exit'));
+        pidDir = await Directory.systemTemp.createTemp('flutter_exit_');
+        pidFile = File(p.join(pidDir.path, 'pid'));
         f = await _ManagerFixture.create(
           shim: 'emits_machine_events.dart',
-          shimArgs: ['--exit-file=${exitFile.path}'],
+          shimArgs: ['--pid-file=${pidFile.path}'],
           fakeVmService: true,
           onReady: (_, url) => ready.complete(url),
           onStop: (_) => stopCalls++,
@@ -548,16 +548,18 @@ void main() {
 
       tearDown(() async {
         await f.dispose();
-        await exitDir.deleteBestEffort(recursive: true);
+        await pidDir.deleteBestEffort(recursive: true);
       });
 
       test(
         'when the process exits without a stop call then onStop fires once '
         'and the app reports not running',
         () async {
-          // The shim exits once this file appears, simulating e.g. the
+          // Kill the shim out from under the manager, simulating e.g. the
           // heartbeat teardown after the app's browser window is closed.
-          exitFile.createSync();
+          // The shim wrote its pid on startup, before the ready event.
+          final shimPid = int.parse(pidFile.readAsStringSync());
+          Process.killPid(shimPid, ProcessSignal.sigkill);
 
           await _eventually(() => stopCalls > 0);
 

--- a/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_app_manager_test.dart
@@ -521,6 +521,68 @@ void main() {
   );
 
   group(
+    'Given an initialized FlutterAppManager running a web app that can exit '
+    'on its own',
+    () {
+      late _ManagerFixture f;
+      late Directory exitDir;
+      late File exitFile;
+      late Completer<String?> ready;
+      late int stopCalls;
+
+      setUp(() async {
+        ready = Completer<String?>();
+        stopCalls = 0;
+        exitDir = await Directory.systemTemp.createTemp('flutter_exit_');
+        exitFile = File(p.join(exitDir.path, 'exit'));
+        f = await _ManagerFixture.create(
+          shim: 'emits_machine_events.dart',
+          shimArgs: ['--exit-file=${exitFile.path}'],
+          fakeVmService: true,
+          onReady: (_, url) => ready.complete(url),
+          onStop: (_) => stopCalls++,
+        );
+        await f.manager.launch('project');
+        await ready.future.timeout(const Duration(seconds: 30));
+      });
+
+      tearDown(() async {
+        await f.dispose();
+        await exitDir.deleteBestEffort(recursive: true);
+      });
+
+      test(
+        'when the process exits without a stop call then onStop fires once '
+        'and the app reports not running',
+        () async {
+          // The shim exits once this file appears, simulating e.g. the
+          // heartbeat teardown after the app's browser window is closed.
+          exitFile.createSync();
+
+          await _eventually(() => stopCalls > 0);
+
+          expect(stopCalls, 1);
+          expect(f.manager.isRunning('project'), isFalse);
+          expect(f.manager.isLaunching('project'), isFalse);
+        },
+      );
+
+      test(
+        'when the app is stopped explicitly then onStop fires exactly once',
+        () async {
+          await f.manager.stop('project');
+
+          // Let the process-exit listener settle; it must not double-signal.
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+
+          expect(stopCalls, 1);
+          expect(f.manager.isRunning('project'), isFalse);
+        },
+      );
+    },
+  );
+
+  group(
     'Given an initialized FlutterAppManager running an app on a desktop device',
     () {
       late _ManagerFixture f;

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/emits_machine_events.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/emits_machine_events.dart
@@ -1,5 +1,7 @@
 // Test shim: emits a fixed `--machine` event sequence, then waits for
 // SIGINT/SIGTERM. `--ws=<uri>` overrides the wsUri in app.debugPort.
+// `--exit-file=<path>` makes the shim exit on its own once that file
+// appears, simulating a spontaneous app exit (e.g. browser closed).
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -44,6 +46,19 @@ Future<void> main(List<String> args) async {
   });
 
   final stopper = Completer<void>();
+
+  final exitFile = args
+      .where((a) => a.startsWith('--exit-file='))
+      .map((a) => a.substring('--exit-file='.length))
+      .firstOrNull;
+  if (exitFile != null) {
+    Timer.periodic(const Duration(milliseconds: 25), (timer) {
+      if (File(exitFile).existsSync()) {
+        // The signal watchers below keep the isolate alive; exit outright.
+        exit(0);
+      }
+    });
+  }
 
   ProcessSignal.sigint.watch().listen((_) {
     if (!stopper.isCompleted) stopper.complete();

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/emits_machine_events.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/emits_machine_events.dart
@@ -1,12 +1,19 @@
 // Test shim: emits a fixed `--machine` event sequence, then waits for
 // SIGINT/SIGTERM. `--ws=<uri>` overrides the wsUri in app.debugPort.
-// `--exit-file=<path>` makes the shim exit on its own once that file
-// appears, simulating a spontaneous app exit (e.g. browser closed).
+// `--pid-file=<path>` writes the shim's pid there on startup, so a test
+// can kill the process directly to simulate a spontaneous app exit
+// (e.g. browser closed).
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
 Future<void> main(List<String> args) async {
+  final pidFile = args
+      .where((a) => a.startsWith('--pid-file='))
+      .map((a) => a.substring('--pid-file='.length))
+      .firstOrNull;
+  if (pidFile != null) File(pidFile).writeAsStringSync('$pid');
+
   final wsUri = args
       .firstWhere(
         (a) => a.startsWith('--ws='),
@@ -46,19 +53,6 @@ Future<void> main(List<String> args) async {
   });
 
   final stopper = Completer<void>();
-
-  final exitFile = args
-      .where((a) => a.startsWith('--exit-file='))
-      .map((a) => a.substring('--exit-file='.length))
-      .firstOrNull;
-  if (exitFile != null) {
-    Timer.periodic(const Duration(milliseconds: 25), (timer) {
-      if (File(exitFile).existsSync()) {
-        // The signal watchers below keep the isolate alive; exit outright.
-        exit(0);
-      }
-    });
-  }
 
   ProcessSignal.sigint.watch().listen((_) {
     if (!stopper.isCompleted) stopper.complete();

--- a/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
@@ -334,6 +334,20 @@ void main() {
       expect(ts.getTextAt(0, topBorderRow, length: 1), '╭');
       expect(ts.getTextAt(119, topBorderRow, length: 1), '╮');
     });
+
+    test('then the title divider matches the panel border color', () {
+      final ts = tester.terminalState;
+
+      const panelLeft = 88;
+      final headerRule = ts.findText('├').first;
+
+      // The rule's line cells share the border's color instead of falling
+      // back to the default (bright) divider color. The reference cell is
+      // the panel's own left border, one row below the rule's junction.
+      expect(ts.getTextAt(panelLeft + 1, headerRule.y, length: 1), '─');
+      final rule = ts.getCellAt(panelLeft + 1, headerRule.y)!.style.color;
+      expect(rule, ts.getCellAt(panelLeft, headerRule.y + 1)!.style.color);
+    });
   });
 
   group('Given the launch panel is open with a stopped app focused', () {

--- a/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/main_screen_layout_test.dart
@@ -91,7 +91,12 @@ Future<NoctermTester> _pumpLaunchPanel({
 }
 
 /// Builds a single ready app tab with [device] and [url], then pumps it.
-Future<NoctermTester> _pumpReadyAppTab({String? device, String? url}) async {
+/// When [openUrl] is given, it replaces the holder's browser opener.
+Future<NoctermTester> _pumpReadyAppTab({
+  String? device,
+  String? url,
+  Future<bool> Function(Uri url)? openUrl,
+}) async {
   final state = ServerWatchState();
   state.showSplash = false;
   state.serverReady = true;
@@ -108,12 +113,18 @@ Future<NoctermTester> _pumpReadyAppTab({String? device, String? url}) async {
   tab.device = device;
   tab.url = url;
   state.tabs.focusTab(tab);
-  return _pump(state, const Size(200, 30));
+  return _pump(state, const Size(200, 30), openUrl: openUrl);
 }
 
 /// Pumps [state] at [size] and returns the tester, disposing it on teardown.
-Future<NoctermTester> _pump(ServerWatchState state, Size size) async {
+/// When [openUrl] is given, it replaces the holder's browser opener.
+Future<NoctermTester> _pump(
+  ServerWatchState state,
+  Size size, {
+  Future<bool> Function(Uri url)? openUrl,
+}) async {
   final holder = StartAppStateHolder(state);
+  if (openUrl != null) holder.openUrl = openUrl;
   final tester = await NoctermTester.create(size: size);
   addTearDown(() async {
     tester.dispose();
@@ -440,11 +451,17 @@ void main() {
 
   group('Given a ready Flutter app tab with a published URL', () {
     late NoctermTester tester;
+    late List<Uri> openedUrls;
 
     setUp(() async {
+      openedUrls = [];
       tester = await _pumpReadyAppTab(
         device: 'chrome',
         url: 'http://localhost:8080',
+        openUrl: (url) async {
+          openedUrls.add(url);
+          return true;
+        },
       );
     });
 
@@ -454,6 +471,22 @@ void main() {
         isTrue,
       );
       expect(tester.terminalState.containsText('Running on device'), isFalse);
+    });
+
+    test('then the URL renders underlined', () {
+      final urlText = tester.terminalState.getStyledText().firstWhere(
+        (s) => s.text.contains('http://localhost:8080'),
+      );
+      expect(urlText.style.decoration?.hasUnderline, isTrue);
+    });
+
+    test('when the URL is clicked then it opens in the browser', () async {
+      final url = tester.terminalState.findText('http://localhost:8080').first;
+
+      await tester.tap(url.x, url.y);
+      await tester.pump();
+
+      expect(openedUrls, [Uri.parse('http://localhost:8080')]);
     });
   });
 


### PR DESCRIPTION
Fixes three start-TUI issues:
1. 37f9a8d - The manager never learned about a Flutter process that exited on its own, so the tab strip kept its green running dot, the App Launcher only corrected itself on reopen, and `X Stop App` acted on stale state.
2. fa2ea41 - The App Launcher's title divider was the last rule left on the default divider color after #5597; it now matches the panel border.
3. 717dc10 - A running web app's URL in the status line is now underlined and opens the app in the default browser when clicked.

**Note:** Currently the apps's URL is just rendered as text. In order to render it as a native terminal hyperlink (OSC 8) would require an update to the nocterm repo to support this.

Fixes #5613
Fixes #5614
Fixes #5615

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None