### PR TITLE
chore: Remove stale lint rule exceptions from serverpod_shared

### DIFF
--- a/packages/serverpod_shared/analysis_options.yaml
+++ b/packages/serverpod_shared/analysis_options.yaml
@@ -4,8 +4,6 @@ include: package:serverpod_lints/public.yaml
 linter:
   rules:
     # Temporary disable the following so that each can be fixed one by one.
-    directives_ordering: false
     prefer_final_in_for_each: false
     prefer_final_locals: false
     prefer_final_parameters: false
-    sort_pub_dependencies: false


### PR DESCRIPTION
Two of the temporarily disabled lint rules in `packages/serverpod_shared/analysis_options.yaml` — `directives_ordering` and `sort_pub_dependencies` — no longer suppress anything: the package analyzes cleanly with both rules active (`dart analyze --fatal-infos` reports no issues). This removes the two stale exceptions so the rules are enforced again, with no code changes required.

The remaining three exceptions (`prefer_final_in_for_each`, `prefer_final_locals`, `prefer_final_parameters`) still have violations and are left in place, to be handled separately per the one-by-one approach described in the issue.

Part of #3251.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making. (Config-only change: the existing analyzer run in CI is the validation — `dart analyze --fatal-infos` passes with the rules active, and all 257 `serverpod_shared` tests pass unchanged.)
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

## Breaking changes

None.
