### PR TITLE
fix: Restore inbound foreign keys when a table is recreated

### DIFF
--- a/tests/serverpod_test_server/test_e2e_migrations/migrations_roundtrip_indexes_relations_test.dart
+++ b/tests/serverpod_test_server/test_e2e_migrations/migrations_roundtrip_indexes_relations_test.dart
@@ -1,4 +1,5 @@
 @Timeout(Duration(minutes: 5))
+import 'package:serverpod_database/serverpod_database.dart';
 import 'package:serverpod_test_server/test_util/migration_test_utils.dart';
 import 'package:serverpod_test_server/test_util/service_client.dart';
 import 'package:test/test.dart';
@@ -319,6 +320,111 @@ void main() {
           relations,
           isEmpty,
           reason: 'Could still find relation for migrated table.',
+        );
+      },
+    );
+  });
+
+  group('Given a protocol model referenced by a relation from another model,', () {
+    var parentTable = 'migrated_table_parent';
+    var childTable = 'migrated_table_child';
+
+    late String tag;
+    late String childProtocol;
+
+    setUp(() async {
+      tag = 'recreate-referenced-table';
+      childProtocol =
+          '''
+  class: MigratedTableChild
+  table: $childTable
+  fields:
+    parent: MigratedTableParent?, relation(onDelete=Cascade)
+  ''';
+
+      await MigrationTestUtils.createInitialState(
+        migrationProtocols: [
+          {
+            'migrated_table_parent':
+                '''
+  class: MigratedTableParent
+  table: $parentTable
+  fields:
+    anInt: int
+  ''',
+            'migrated_table_child': childProtocol,
+          },
+        ],
+        tag: tag,
+      );
+    });
+
+    tearDown(() async {
+      await MigrationTestUtils.migrationTestCleanup(
+        resetSql: 'DROP TABLE IF EXISTS $childTable, $parentTable CASCADE;',
+        serviceClient: serviceClient,
+      );
+    });
+
+    group(
+      'when the referenced model is changed so that its table has to be deleted and recreated,',
+      () {
+        late DatabaseDefinition liveDefinition;
+
+        setUp(() async {
+          // The added non-nullable field without a default cannot be added to an
+          // existing table, so the parent table is deleted and recreated.
+          var createMigrationExitCode =
+              await MigrationTestUtils.createMigrationFromProtocols(
+                protocols: {
+                  'migrated_table_parent':
+                      '''
+  class: MigratedTableParent
+  table: $parentTable
+  fields:
+    anInt: int
+    aRequiredString: String
+  ''',
+                  'migrated_table_child': childProtocol,
+                },
+                tag: tag,
+                force: true,
+              );
+          expect(
+            createMigrationExitCode,
+            0,
+            reason: 'Failed to create migration, exit code was not 0.',
+          );
+
+          var applyMigrationExitCode =
+              await MigrationTestUtils.runApplyMigrations();
+          expect(
+            applyMigrationExitCode,
+            0,
+            reason: 'Failed to apply migration, exit code was not 0.',
+          );
+
+          liveDefinition = await serviceClient.insights
+              .getLiveDatabaseDefinition();
+        });
+
+        test(
+          'then the relation of the referencing table is still in the database, with its delete action.',
+          () {
+            var liveChildTable = liveDefinition.tables.firstWhere(
+              (t) => t.name == childTable,
+            );
+
+            expect(
+              liveChildTable.foreignKeys.map(
+                (key) => (key.referenceTable, key.onDelete),
+              ),
+              [(parentTable, ForeignKeyAction.cascade)],
+              reason:
+                  'The referencing table lost its relation when the referenced '
+                  'table was dropped and recreated.',
+            );
+          },
         );
       },
     );

--- a/tools/serverpod_cli/lib/src/database/dialects/postgres.dart
+++ b/tools/serverpod_cli/lib/src/database/dialects/postgres.dart
@@ -453,6 +453,11 @@ extension PostgresDatabaseMigrationPgSqlGenerator on DatabaseMigration {
       foreignKeyActions += action.foreignRelationToSql();
     }
 
+    foreignKeyActions += _sqlRestoreInboundForeignKeys(
+      actions,
+      databaseDefinition,
+    );
+
     // Append all foreign key operations at the end
     out += foreignKeyActions;
 
@@ -654,6 +659,61 @@ extension PostgresColumnMigrationPgSqlGenerator on ColumnMigration {
 
     return out;
   }
+}
+
+/// Returns the SQL that restores foreign key constraints which other tables
+/// declare against a table that is dropped and recreated by this migration.
+///
+/// `DROP TABLE ... CASCADE` also drops the foreign key constraints that other
+/// tables have into the dropped table. The recreated table only brings back its
+/// own outbound foreign keys, so the inbound ones have to be re-added
+/// explicitly, or the database would silently diverge from the definition.
+///
+/// A constraint is skipped when its table is (re)created by this migration, or
+/// when an alter table action already adds it back, since those actions emit it
+/// themselves.
+String _sqlRestoreInboundForeignKeys(
+  List<DatabaseMigrationAction> actions,
+  DatabaseDefinition databaseDefinition,
+) {
+  var createdTables = <String>{
+    for (var action in actions)
+      if (action.createTable case var table?) table.name,
+  };
+  var recreatedTables = <String>{
+    for (var action in actions) ?action.deleteTable,
+  }.intersection(createdTables);
+  if (recreatedTables.isEmpty) return '';
+
+  var alteredForeignKeys = <String>{
+    for (var action in actions)
+      if (action.alterTable case var table?)
+        for (var key in table.addForeignKeys)
+          '${table.name}.${key.constraintName}',
+  };
+
+  var out = '';
+  for (var table in databaseDefinition.tables) {
+    if (table.managed == false) continue;
+    // Tables created by this migration already declare all their foreign keys.
+    if (createdTables.contains(table.name)) continue;
+
+    for (var foreignKey in table.foreignKeys) {
+      if (!recreatedTables.contains(foreignKey.referenceTable)) continue;
+      // The constraint is already re-added by an alter table action.
+      var key = '${table.name}.${foreignKey.constraintName}';
+      if (alteredForeignKeys.contains(key)) continue;
+
+      out += foreignKey.toPgSql(tableName: table.name);
+    }
+  }
+
+  if (out.isEmpty) return out;
+
+  return '--\n'
+      '-- ACTION RESTORE FOREIGN KEY\n'
+      '--\n'
+      '$out';
 }
 
 String _sqlStoreMigrationVersion({

--- a/tools/serverpod_cli/test/database/migration/recreate_table_and_inbound_foreign_key_test.dart
+++ b/tools/serverpod_cli/test/database/migration/recreate_table_and_inbound_foreign_key_test.dart
@@ -1,0 +1,268 @@
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_service_client/serverpod_service_client.dart';
+import 'package:test/test.dart';
+
+import '../../test_util/builders/database/column_definition_builder.dart';
+import '../../test_util/builders/database/database_definition_builder.dart';
+import '../../test_util/builders/database/table_definition_builder.dart';
+
+/// Builds the "parent_entity" table. Adding [withRequiredColumn] makes the
+/// table impossible to migrate in place, forcing a delete and recreate.
+TableDefinition _parentEntity({bool withRequiredColumn = false}) {
+  var builder = TableDefinitionBuilder().withName('parent_entity');
+
+  if (withRequiredColumn) {
+    builder.withColumn(
+      ColumnDefinitionBuilder()
+          .withName('requiredValue')
+          .withColumnType(ColumnType.text)
+          .withIsNullable(false)
+          .build(),
+    );
+  }
+
+  return builder.build();
+}
+
+/// Builds the "child_entity" table, holding a foreign key into
+/// "parent_entity".
+TableDefinition _childEntity({
+  ForeignKeyAction onDelete = ForeignKeyAction.cascade,
+  bool withRequiredColumn = false,
+  bool managed = true,
+}) {
+  var builder = TableDefinitionBuilder()
+      .withName('child_entity')
+      .withManaged(managed)
+      .withColumn(
+        ColumnDefinitionBuilder()
+            .withName('parentEntityId')
+            .withColumnType(ColumnType.bigint)
+            .withIsNullable(true)
+            .build(),
+      )
+      .withForeignKey(
+        ForeignKeyDefinition(
+          constraintName: 'child_entity_fk_0',
+          columns: ['parentEntityId'],
+          referenceTable: 'parent_entity',
+          referenceTableSchema: 'public',
+          referenceColumns: ['id'],
+          onUpdate: ForeignKeyAction.noAction,
+          onDelete: onDelete,
+          matchType: null,
+        ),
+      );
+
+  if (withRequiredColumn) {
+    builder.withColumn(
+      ColumnDefinitionBuilder()
+          .withName('requiredValue')
+          .withColumnType(ColumnType.text)
+          .withIsNullable(false)
+          .build(),
+    );
+  }
+
+  return builder.build();
+}
+
+String _generatePgSql({
+  required DatabaseDefinition source,
+  required DatabaseDefinition target,
+}) {
+  var migration = generateDatabaseMigration(
+    databaseSource: source,
+    databaseTarget: target,
+  );
+
+  return migration.toPgSql(
+    databaseDefinition: target,
+    installedModules: [],
+    removedModules: [],
+  );
+}
+
+void main() {
+  group(
+    'Given a table referenced by a foreign key from another table, '
+    'when the referenced table is deleted and recreated by the migration,',
+    () {
+      var psql = _generatePgSql(
+        source: DatabaseDefinitionBuilder()
+            .withDefaultModules()
+            .withTable(_parentEntity())
+            .withTable(_childEntity())
+            .build(),
+        target: DatabaseDefinitionBuilder()
+            .withDefaultModules()
+            .withTable(_parentEntity(withRequiredColumn: true))
+            .withTable(_childEntity())
+            .build(),
+      );
+
+      test(
+        'then the foreign key of the referencing table is added back.',
+        () {
+          expect(
+            psql,
+            contains(
+              'ALTER TABLE ONLY "child_entity"\n'
+              '    ADD CONSTRAINT "child_entity_fk_0"\n'
+              '    FOREIGN KEY("parentEntityId")\n'
+              '    REFERENCES "parent_entity"("id")\n'
+              '    ON DELETE CASCADE\n'
+              '    ON UPDATE NO ACTION;\n',
+            ),
+            reason:
+                'DROP TABLE CASCADE also drops the foreign keys that other '
+                'tables have into the recreated table.',
+          );
+        },
+      );
+
+      test(
+        'then the foreign key of the referencing table is added back after the referenced table is recreated.',
+        () {
+          var createTableIndex = psql.indexOf('CREATE TABLE "parent_entity"');
+          var addConstraintIndex = psql.indexOf(
+            'ADD CONSTRAINT "child_entity_fk_0"',
+          );
+
+          expect(createTableIndex, greaterThanOrEqualTo(0));
+          expect(addConstraintIndex, greaterThan(createTableIndex));
+        },
+      );
+
+      test('then the foreign key is added back only once.', () {
+        expect(
+          'ADD CONSTRAINT "child_entity_fk_0"'.allMatches(psql).length,
+          1,
+        );
+      });
+    },
+  );
+
+  group(
+    'Given a table referenced by a foreign key that is modified by the same migration, '
+    'when the referenced table is deleted and recreated,',
+    () {
+      var psql = _generatePgSql(
+        source: DatabaseDefinitionBuilder()
+            .withDefaultModules()
+            .withTable(_parentEntity())
+            .withTable(_childEntity(onDelete: ForeignKeyAction.noAction))
+            .build(),
+        target: DatabaseDefinitionBuilder()
+            .withDefaultModules()
+            .withTable(_parentEntity(withRequiredColumn: true))
+            .withTable(_childEntity(onDelete: ForeignKeyAction.cascade))
+            .build(),
+      );
+
+      test(
+        'then the foreign key is added only once, with the modified delete action.',
+        () {
+          expect(
+            'ADD CONSTRAINT "child_entity_fk_0"'.allMatches(psql).length,
+            1,
+          );
+          expect(
+            psql,
+            contains(
+              'ALTER TABLE ONLY "child_entity"\n'
+              '    ADD CONSTRAINT "child_entity_fk_0"\n'
+              '    FOREIGN KEY("parentEntityId")\n'
+              '    REFERENCES "parent_entity"("id")\n'
+              '    ON DELETE CASCADE\n'
+              '    ON UPDATE NO ACTION;\n',
+            ),
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given two tables with a foreign key relation that both have to be deleted and recreated, '
+    'when the migration is generated,',
+    () {
+      var psql = _generatePgSql(
+        source: DatabaseDefinitionBuilder()
+            .withDefaultModules()
+            .withTable(_parentEntity())
+            .withTable(_childEntity())
+            .build(),
+        target: DatabaseDefinitionBuilder()
+            .withDefaultModules()
+            .withTable(_parentEntity(withRequiredColumn: true))
+            .withTable(_childEntity(withRequiredColumn: true))
+            .build(),
+      );
+
+      test(
+        'then the foreign key is added only once.',
+        () {
+          expect(
+            'ADD CONSTRAINT "child_entity_fk_0"'.allMatches(psql).length,
+            1,
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given an unmanaged table with a foreign key into a managed table, '
+    'when the referenced table is deleted and recreated,',
+    () {
+      var psql = _generatePgSql(
+        source: DatabaseDefinitionBuilder()
+            .withDefaultModules()
+            .withTable(_parentEntity())
+            .withTable(_childEntity(managed: false))
+            .build(),
+        target: DatabaseDefinitionBuilder()
+            .withDefaultModules()
+            .withTable(_parentEntity(withRequiredColumn: true))
+            .withTable(_childEntity(managed: false))
+            .build(),
+      );
+
+      test(
+        'then the foreign key of the unmanaged table is not added back.',
+        () {
+          expect(
+            psql,
+            isNot(contains('child_entity_fk_0')),
+            reason:
+                'Unmanaged tables are not part of the schema Serverpod '
+                'creates, so the migration must not write to them.',
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'Given a table referenced by a foreign key from another table, '
+    'when the referenced table is deleted without being recreated,',
+    () {
+      var psql = _generatePgSql(
+        source: DatabaseDefinitionBuilder()
+            .withDefaultModules()
+            .withTable(_parentEntity())
+            .withTable(_childEntity())
+            .build(),
+        target: DatabaseDefinitionBuilder().withDefaultModules().build(),
+      );
+
+      test(
+        'then no foreign key into the deleted table is added back.',
+        () {
+          expect(psql, isNot(contains('ADD CONSTRAINT "child_entity_fk_0"')));
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
Fixes: #5626

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.