### PR TITLE
fix: Fix SQLite missing exception mapping at transaction COMMIT

### DIFF
--- a/packages/serverpod/skills/serverpod-models/SKILL.md
+++ b/packages/serverpod/skills/serverpod-models/SKILL.md
@@ -178,7 +178,7 @@ fields:
 
 **Many-to-many:** Use a join table model with two relation fields.
 
-**Referential actions:** `relation(onDelete=Cascade)` and `relation(onUpdate=...)` map to the SQL foreign key actions (`Cascade`, `SetNull`, `SetDefault`, `Restrict`, `NoAction`). `SetNull` requires a nullable foreign key (a nullable object relation field, or `relation(optional)`). Add `deferrable` (or `deferred` for initially deferred) to check the constraint at the end of the transaction instead of per statement.
+**Referential actions:** `relation(onDelete=Cascade)` and `relation(onUpdate=...)` map to the SQL foreign key actions (`Cascade`, `SetNull`, `SetDefault`, `Restrict`, `NoAction`). `SetNull` requires a nullable foreign key (a nullable object relation field, or `relation(optional)`). Add `deferrable` to allow constraint checks to be deferred explicitly, or `deferred` to defer them by default until commit. `Restrict` actions are always checked immediately, even on a deferred constraint; use `NoAction` when the check must be deferrable.
 
 Querying: `include` for eager loading, `includeList` with `where`/`orderBy`/`limit`/`offset` for list relations. `attach`/`detach` for managing relations.
 

--- a/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
+++ b/packages/serverpod_database/lib/src/adapters/sqlite/database_connection.dart
@@ -907,6 +907,13 @@ class SqliteDatabaseConnection extends DatabaseConnection<SqlitePoolManager> {
       });
     } on _TransactionCancelledException catch (e) {
       return e.result;
+    } on DatabaseException {
+      rethrow;
+    } on SqliteException catch (exception, trace) {
+      Error.throwWithStackTrace(
+        _queryExceptionFromSqliteException(exception),
+        trace,
+      );
     } finally {
       _currentTransactionParentZone = null;
     }

--- a/tests/serverpod_test_server/test_integration/database_operations/transactions/deferrable_constraints_test.dart
+++ b/tests/serverpod_test_server/test_integration/database_operations/transactions/deferrable_constraints_test.dart
@@ -96,4 +96,22 @@ void main() async {
       expect(children, hasLength(1));
     },
   );
+
+  test(
+    'Given an initially deferred relation, '
+    'when a child references a missing parent at commit, '
+    'then the transaction throws a foreign key violation exception.',
+    () async {
+      await expectLater(
+        session.db.transaction((transaction) async {
+          await DeferrableRelationInitiallyDeferred.db.insertRow(
+            session,
+            DeferrableRelationInitiallyDeferred(parentId: 42004),
+            transaction: transaction,
+          );
+        }),
+        throwsA(isA<DatabaseForeignKeyViolationException>()),
+      );
+    },
+  );
 }

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/transactions/deferrable_constraints_test.dart
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/test_integration/database_operations/transactions/deferrable_constraints_test.dart
@@ -96,4 +96,22 @@ void main() async {
       expect(children, hasLength(1));
     },
   );
+
+  test(
+    'Given an initially deferred relation, '
+    'when a child references a missing parent at commit, '
+    'then the transaction throws a foreign key violation exception.',
+    () async {
+      await expectLater(
+        session.db.transaction((transaction) async {
+          await DeferrableRelationInitiallyDeferred.db.insertRow(
+            session,
+            DeferrableRelationInitiallyDeferred(parentId: 42004),
+            transaction: transaction,
+          );
+        }),
+        throwsA(isA<DatabaseForeignKeyViolationException>()),
+      );
+    },
+  );
 }


### PR DESCRIPTION
Fixes: #5634

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.