### PR TITLE
fix: Remove active server scopes when their ServerProcess exits

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -756,6 +756,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       vmServiceInfoFile: podInfoFile,
       stdoutSink: serverStdoutSink,
       stderrSink: serverStderrSink,
+      onDispose: logHistory.discardActiveServerScopes,
     );
     await serverProcess.start(dillPath: dillPath);
     await serverProcess.connectToVmService();

--- a/tools/serverpod_cli/lib/src/commands/start/log_history.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/log_history.dart
@@ -33,6 +33,12 @@ class StartLogHistory {
   /// by scope id.
   final Map<String, TrackedOperation> activeOperations = {};
 
+  /// IDs of operations opened by the current server process.
+  ///
+  /// These distinguish server scopes from CLI-driven operations when the
+  /// process exits before it can emit matching `scope_end` events.
+  final Set<String> _activeServerScopeIds = {};
+
   final Map<String, BoundedQueueList<String>> _flutterLines = {};
 
   /// Called after every mutation so a presentation layer can schedule a
@@ -92,9 +98,14 @@ class StartLogHistory {
         if (label == 'INTERNAL') break;
         final id = data['id'] as String? ?? '';
         activeOperations[id] = TrackedOperation(id: id, label: label);
+        _activeServerScopeIds.add(id);
 
       case 'scope_end':
         final id = data['id'] as String? ?? '';
+        // Ignore events from a process whose scopes have already been
+        // discarded. This also prevents a delayed event from removing a
+        // non-server operation that later reused the same id.
+        if (!_activeServerScopeIds.remove(id)) break;
         final operation = activeOperations.remove(id);
         if (operation == null) break;
         operation.stopwatch.stop();
@@ -110,6 +121,18 @@ class StartLogHistory {
         );
     }
     onChanged?.call();
+  }
+
+  /// Discards every owned active scope.
+  void discardActiveServerScopes() {
+    if (_activeServerScopeIds.isEmpty) return;
+
+    var changed = false;
+    for (final id in _activeServerScopeIds) {
+      changed = activeOperations.remove(id) != null || changed;
+    }
+    _activeServerScopeIds.clear();
+    if (changed) onChanged?.call();
   }
 
   /// Records a structured log [event] from the Flutter app [appId], as

--- a/tools/serverpod_cli/lib/src/commands/start/server_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/server_process.dart
@@ -29,6 +29,10 @@ class ServerProcess {
   final IOSink _stdout;
   final IOSink _stderr;
 
+  /// Called at most once after a started process and its VM-service resources
+  /// have been discarded, whether it stopped normally or exited unexpectedly.
+  final void Function()? _onDispose;
+
   /// Path to write the VM service info JSON file to. When set, passed
   /// to the child via `--write-service-info` and the URI is read from
   /// the file instead of parsing stdout. IDEs use this path in their
@@ -60,13 +64,15 @@ class ServerProcess {
     String? vmServiceInfoFile,
     IOSink? stdoutSink,
     IOSink? stderrSink,
+    void Function()? onDispose,
   }) : _serverDir = serverDir,
        _serverArgs = serverArgs,
        _dartExecutable = dartExecutable ?? p.join(getSdkPath(), 'bin', 'dart'),
        _enableVmService = enableVmService,
        _vmServiceInfoFile = vmServiceInfoFile,
        _stdout = stdoutSink ?? stdout,
-       _stderr = stderrSink ?? stderr;
+       _stderr = stderrSink ?? stderr,
+       _onDispose = onDispose;
 
   /// Whether the server process is currently running.
   bool get isRunning => _process != null;
@@ -327,6 +333,8 @@ class ServerProcess {
 
     final completer = Completer<void>();
     _cleanupCompleter = completer;
+
+    unawaited(completer.future.whenComplete(() => _onDispose?.call()));
 
     try {
       _process = null;

--- a/tools/serverpod_cli/test/commands/start/log_history_test.dart
+++ b/tools/serverpod_cli/test/commands/start/log_history_test.dart
@@ -263,6 +263,76 @@ void main() {
     },
   );
 
+  group(
+    'Given open server scopes and a tracked active operation, '
+    'when the active server scopes are discarded, ',
+    () {
+      late int changeNotifications;
+
+      setUp(() {
+        changeNotifications = 0;
+        history.onChanged = () => changeNotifications++;
+        history.recordServerLogEvent(
+          _logEvent({
+            'type': 'scope_start',
+            'id': 'scope_1',
+            'label': 'GET /api/stream-one',
+          }),
+        );
+        history.recordServerLogEvent(
+          _logEvent({
+            'type': 'scope_start',
+            'id': 'scope_2',
+            'label': 'GET /api/stream-two',
+          }),
+        );
+        history.activeOperations['cli_scope'] = TrackedOperation(
+          id: 'cli_scope',
+          label: 'Compiling server',
+        );
+        changeNotifications = 0;
+        history.discardActiveServerScopes();
+      });
+
+      test('then only server scopes are removed.', () {
+        expect(history.activeOperations.keys, ['cli_scope']);
+        expect(history.serverEntries, isEmpty);
+      });
+
+      test('then observers are notified once.', () {
+        expect(changeNotifications, 1);
+      });
+
+      test(
+        'then a delayed scope_end event does not remove a replacement operation.',
+        () {
+          final replacement = TrackedOperation(
+            id: 'scope_1',
+            label: 'CLI replacement',
+          );
+          history.activeOperations['scope_1'] = replacement;
+
+          history.recordServerLogEvent(
+            _logEvent({
+              'type': 'scope_end',
+              'id': 'scope_1',
+              'success': true,
+            }),
+          );
+
+          expect(history.serverEntries, isEmpty);
+          expect(history.activeOperations['scope_1'], same(replacement));
+        },
+      );
+
+      test('then discarding the same process again is a no-op.', () {
+        history.discardActiveServerScopes();
+
+        expect(changeNotifications, 1);
+      });
+    },
+  );
+
   group('Given a Flutter framework error event, when it is recorded,', () {
     const error =
         "'package:flutter/src/widgets/framework.dart': Failed assertion: "

--- a/tools/serverpod_cli/test/commands/start/log_history_test.dart
+++ b/tools/serverpod_cli/test/commands/start/log_history_test.dart
@@ -303,25 +303,34 @@ void main() {
         expect(changeNotifications, 1);
       });
 
-      test(
-        'then a delayed scope_end event does not remove a replacement operation.',
+      group(
+        'when a discarded server scope ID is reused for a new active tracked operation',
         () {
-          final replacement = TrackedOperation(
-            id: 'scope_1',
-            label: 'CLI replacement',
-          );
-          history.activeOperations['scope_1'] = replacement;
+          late TrackedOperation replacement;
 
-          history.recordServerLogEvent(
-            _logEvent({
-              'type': 'scope_end',
-              'id': 'scope_1',
-              'success': true,
-            }),
-          );
+          setUp(() {
+            replacement = TrackedOperation(
+              id: 'scope_1',
+              label: 'CLI replacement',
+            );
+            history.activeOperations['scope_1'] = replacement;
+          });
 
-          expect(history.serverEntries, isEmpty);
-          expect(history.activeOperations['scope_1'], same(replacement));
+          test(
+            'then a scope_end event recorded on the server log does not remove the new tracked operation.',
+            () {
+              history.recordServerLogEvent(
+                _logEvent({
+                  'type': 'scope_end',
+                  'id': 'scope_1',
+                  'success': true,
+                }),
+              );
+
+              expect(history.serverEntries, isEmpty);
+              expect(history.activeOperations['scope_1'], same(replacement));
+            },
+          );
         },
       );
 

--- a/tools/serverpod_cli/test/commands/start/server_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/server_process_test.dart
@@ -57,8 +57,12 @@ void main() {
   group('Given a ServerProcess with a simple exit command', () {
     late Directory tempDir;
     late ServerProcess serverProcess;
+    late Completer<void> disposed;
+    late int disposeCalls;
 
     setUp(() async {
+      disposed = Completer<void>();
+      disposeCalls = 0;
       tempDir = await Directory.systemTemp.createTemp(
         'server_process_test_',
       );
@@ -72,6 +76,10 @@ void main() {
         serverArgs: [],
         stdoutSink: _NullIOSink(),
         stderrSink: _NullIOSink(),
+        onDispose: () {
+          disposeCalls++;
+          disposed.complete();
+        },
       );
     });
 
@@ -85,8 +93,10 @@ void main() {
       () async {
         await serverProcess.start();
         final exitCode = await serverProcess.exitCode;
+        await disposed.future;
         expect(exitCode, 0);
         expect(serverProcess.isRunning, isFalse);
+        expect(disposeCalls, 1);
       },
     );
   });
@@ -94,8 +104,10 @@ void main() {
   group('Given a ServerProcess with a long-running command', () {
     late Directory tempDir;
     late ServerProcess serverProcess;
+    late int disposeCalls;
 
     setUp(() async {
+      disposeCalls = 0;
       tempDir = await Directory.systemTemp.createTemp(
         'server_process_test_',
       );
@@ -113,6 +125,7 @@ void main() {
         serverArgs: [],
         stdoutSink: _NullIOSink(),
         stderrSink: _NullIOSink(),
+        onDispose: () => disposeCalls++,
       );
     });
 
@@ -130,6 +143,7 @@ void main() {
 
         await serverProcess.stop();
         expect(serverProcess.isRunning, isFalse);
+        expect(disposeCalls, 1);
       },
     );
 

--- a/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
+++ b/tools/serverpod_cli/test/commands/start/tui/event_handler_test.dart
@@ -381,6 +381,32 @@ void main() {
       completer.complete();
     });
 
+    test(
+      'when active server scopes are discarded during an action '
+      'then only the server scopes are removed',
+      () async {
+        history.recordServerLogEvent(
+          _logEvent({
+            'type': 'scope_start',
+            'id': 'stream_scope',
+            'label': 'GET /api/stream',
+          }),
+        );
+        final completer = Completer<void>();
+        runTrackedAction(holder, 'Restarting server', () => completer.future);
+
+        expect(state.activeOperations, hasLength(2));
+
+        history.discardActiveServerScopes();
+
+        expect(state.activeOperations, hasLength(1));
+        expect(state.activeOperations.values.single.label, 'Restarting server');
+        expect(state.actionBusy, isTrue);
+
+        completer.complete();
+      },
+    );
+
     test('when action succeeds then clears busy and adds completed', () async {
       runTrackedAction(holder, 'Reload', () async {});
 


### PR DESCRIPTION
When `ServerProcess` exits after opening active server scopes (e.g createStream session), the scopes become orphaned and never receive a `scope_end` event to terminate them, keeping them in the TUI. This PR clears active server scopes when `ServerProcess` exits.

Closes #5540 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None