### PR TITLE
fix: Fix `serverpod_database` not compiling to WASM clients

### DIFF
--- a/packages/serverpod_database/lib/src/interface/provider.dart
+++ b/packages/serverpod_database/lib/src/interface/provider.dart
@@ -7,7 +7,7 @@ import 'database_connection.dart';
 import 'database_pool_manager.dart';
 import 'definition_restrictions.dart';
 import 'migration_runner.dart';
-import 'provider/io.dart' if (dart.library.html) 'provider/web.dart';
+import 'provider/io.dart' if (dart.library.js_interop) 'provider/web.dart';
 import 'serialization_manager.dart';
 
 /// Abstract interface for database providers.


### PR DESCRIPTION
Very simple fix on the gate to decide whether to use the web-safe imports or the native. Did not add a test for now since we don't have official support for WASM on the database yet (currently `sqlite_async` supports WASM only as beta).

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.