### PR TITLE
fix: Allow cross-origin WebSocket upgrades under relic 2.0.0-rc.1

### DIFF
--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -842,7 +842,12 @@ jobs:
       - name: Alias serverpod_test_server to localhost
         run: echo "127.0.0.1 serverpod_test_server" | sudo tee -a /etc/hosts
       # Firefox for the browser run; xvfb provides the virtual display (xvfb-run).
+      # Pinned: Firefox 154.0.1 extended Local Network Access permission prompts to
+      # WebSocket connections from HTTP pages, which blocks ws://serverpod_test_server
+      # under xvfb (nobody can click "Allow"). See the tracking issue linked in the PR.
       - uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1.7.2
+        with:
+          firefox-version: '154.0'
       - name: Install xvfb
         run: sudo apt-get update && sudo apt-get install -y xvfb
       - name: Run e2e web tests

--- a/.github/workflows/dart-tests.yaml
+++ b/.github/workflows/dart-tests.yaml
@@ -842,12 +842,7 @@ jobs:
       - name: Alias serverpod_test_server to localhost
         run: echo "127.0.0.1 serverpod_test_server" | sudo tee -a /etc/hosts
       # Firefox for the browser run; xvfb provides the virtual display (xvfb-run).
-      # Pinned: Firefox 154.0.1 extended Local Network Access permission prompts to
-      # WebSocket connections from HTTP pages, which blocks ws://serverpod_test_server
-      # under xvfb (nobody can click "Allow"). See the tracking issue linked in the PR.
       - uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1.7.2
-        with:
-          firefox-version: '154.0'
       - name: Install xvfb
         run: sudo apt-get update && sudo apt-get install -y xvfb
       - name: Run e2e web tests

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -438,7 +438,11 @@ class Server implements RouterInjectable {
         );
       }
 
-      return WebSocketUpgrade((webSocket) async {
+      // Origin policy is enforced above through `allowedOrigins`; opt out of
+      // relic's own same-host check (default since relic 2.0.0-rc.1) so a
+      // web client served from a different host than the API server can
+      // still open method streams when no allow-list is configured.
+      return WebSocketUpgrade(allowAnyOrigin: true, (webSocket) async {
         try {
           webSocket.pingInterval = serverpod.config.websocketPingInterval;
           var websocketKey = const Uuid().v4();

--- a/packages/serverpod/pubspec.yaml
+++ b/packages/serverpod/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   path: ^1.8.3
   postgres: ^3.4.0
   redis: ^4.0.0
-  relic: ^2.0.0-beta.1
+  relic: ^2.0.0-rc.1
   serverpod_database: 4.0.0-beta.4
   serverpod_serialization: 4.0.0-beta.4
   serverpod_shared: 4.0.0-beta.4

--- a/packages/serverpod_client/pubspec.yaml
+++ b/packages/serverpod_client/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   web_socket_channel: ^3.0.3
 
 dev_dependencies:
-  relic: ^2.0.0-beta.1
+  relic: ^2.0.0-rc.1
   serverpod_lints: 4.0.0-beta.4
   stream_channel: ^2.1.1
   test: ^1.25.5

--- a/templates/pubspecs/packages/serverpod/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   path: ^1.8.3
   postgres: ^3.4.0
   redis: ^4.0.0
-  relic: ^2.0.0-beta.1
+  relic: ^2.0.0-rc.1
   serverpod_database: SERVERPOD_VERSION
   serverpod_serialization: SERVERPOD_VERSION
   serverpod_shared: SERVERPOD_VERSION

--- a/templates/pubspecs/packages/serverpod_client/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_client/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   web_socket_channel: ^3.0.3
 
 dev_dependencies:
-  relic: ^2.0.0-beta.1
+  relic: ^2.0.0-rc.1
   serverpod_lints: SERVERPOD_VERSION
   stream_channel: ^2.1.1
   test: ^1.25.5

--- a/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
+++ b/templates/pubspecs/tests/serverpod_test_server/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   clock: ^1.1.1
   http: '>=1.1.0 <2.0.0'
-  relic: ^2.0.0-beta.1
+  relic: ^2.0.0-rc.1
   serverpod: SERVERPOD_VERSION
   serverpod_auth_server: SERVERPOD_VERSION
   serverpod_cloud_storage_s3: SERVERPOD_VERSION

--- a/tests/serverpod_test_server/pubspec.yaml
+++ b/tests/serverpod_test_server/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 dependencies:
   clock: ^1.1.1
   http: '>=1.1.0 <2.0.0'
-  relic: ^2.0.0-beta.1
+  relic: ^2.0.0-rc.1
   serverpod: 4.0.0-beta.4
   serverpod_auth_server: 4.0.0-beta.4
   serverpod_cloud_storage_s3: 4.0.0-beta.4


### PR DESCRIPTION
relic 2.0.0-rc.1 (published 2026-08-25) rejects cross-origin WebSocket upgrades with 403 by default. We depend on `^2.0.0-beta.1` with no lockfile, so every CI run since then resolves rc.1 and all E2E web shards fail with
`WebSocketException: Failed to connect WebSocket`: the test page is served from `localhost` while the socket goes to `serverpod_test_server`. The `vm` shards pass because dart:io clients send no `Origin` header.

This is not a test-only problem. Any web client served from a different host than the API server (e.g. `app.example.com` → `api.example.com`) would lose method streaming as soon as it picks up rc.1.

Serverpod already gates the handshake with `allowedOrigins`, `Server._isOriginDisallowed`, and that allow-list is required whenever cookie auth is enabled. This PR:
- Passes `allowAnyOrigin: true` to `WebSocketUpgrade` so Serverpod's own origin policy stays the one that decides. Behaviour is unchanged from before rc.1: with `allowedOrigins` configured only listed origins may connect; with it unset any origin may.
- Raises the relic floor to `^2.0.0-rc.1` (the `downgrade` analyzer jobs resolved beta.1, which has no `allowAnyOrigin` parameter).

Not in this PR, worth deciding separately: whether an unset `allowedOrigins` should default to same-host only (relic's new default) rather than any origin.

_List which issues are fixed by this PR. You must list at least one issue._

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._