### PR TITLE
feat: Require the .spy.yaml extension for model files

### DIFF
--- a/tests/serverpod_cli_e2e_test/test/create_migration_exit_code_test.dart
+++ b/tests/serverpod_cli_e2e_test/test/create_migration_exit_code_test.dart
@@ -115,7 +115,7 @@ void main() async {
 
         // Add a model with a table
         var modelFile = File(
-          path.join(serverDir, 'lib', 'src', 'protocol', 'example.yaml'),
+          path.join(serverDir, 'lib', 'src', 'protocol', 'example.spy.yaml'),
         );
         modelFile.parent.createSync(recursive: true);
         modelFile.writeAsStringSync('''

--- a/tests/serverpod_test_server/lib/test_util/migration_test_utils.dart
+++ b/tests/serverpod_test_server/lib/test_util/migration_test_utils.dart
@@ -92,7 +92,7 @@ abstract class MigrationTestUtils {
       var protocolFile = File(
         path.join(
           _migrationProtocolTestDirectory().path,
-          '$fileName.yaml',
+          '$fileName.spy.yaml',
         ),
       );
 

--- a/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/model_analyzer.dart
@@ -18,15 +18,6 @@ import 'package:source_span/source_span.dart';
 import 'package:yaml/src/error_listener.dart';
 import 'package:yaml/yaml.dart';
 
-String _transformFileNameWithoutPathOrExtension(Uri path) {
-  var fileName = path.pathSegments.last;
-
-  for (var ext in modelFileExtensions) {
-    fileName = fileName.replaceAll(ext, '');
-  }
-  return fileName;
-}
-
 /// Used to analyze a singe yaml model file.
 class SerializableModelAnalyzer {
   static const Set<String> _modelClassTypes = {
@@ -40,7 +31,7 @@ class SerializableModelAnalyzer {
     ModelSource modelSource,
     GeneratorConfig config,
   ) {
-    var outFileName = _transformFileNameWithoutPathOrExtension(
+    var outFileName = ModelHelper.modelFileNameWithoutExtension(
       modelSource.yamlSourceUri,
     );
     var yamlErrorCollector = ErrorCollector();

--- a/tools/serverpod_cli/lib/src/commands/create_migration.dart
+++ b/tools/serverpod_cli/lib/src/commands/create_migration.dart
@@ -7,6 +7,7 @@ import 'package:serverpod_cli/analyzer.dart';
 import 'package:serverpod_cli/src/migrations/create_migration_action.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
+import 'package:serverpod_cli/src/util/legacy_model_files.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/util/string_validators.dart';
 
@@ -83,6 +84,10 @@ class CreateMigrationCommand extends ServerpodCommand<CreateMigrationOption> {
     } catch (e) {
       log.error('$e');
       throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
+    }
+
+    if (await LegacyModelFiles.report(config)) {
+      throw ExitException.error();
     }
 
     late final CreateMigrationOutcome outcome;

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -16,6 +16,7 @@ import 'package:serverpod_cli/src/generator/generation_staleness.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
 import 'package:serverpod_cli/src/serverpod_packages_version_check/serverpod_packages_version_check.dart';
+import 'package:serverpod_cli/src/util/legacy_model_files.dart';
 import 'package:serverpod_cli/src/util/pubspec_lock_parser.dart';
 import 'package:serverpod_cli/src/util/pubspec_plus.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
@@ -89,6 +90,10 @@ class GenerateCommand extends ServerpodCommand<GenerateOption> {
     } catch (e) {
       log.error('$e');
       throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
+    }
+
+    if (await LegacyModelFiles.report(config)) {
+      throw ExitException.error();
     }
 
     var serverPubspecFile = File(

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -39,6 +39,7 @@ import 'package:serverpod_cli/src/migrations/create_repair_migration_action.dart
 import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
 import 'package:serverpod_cli/src/util/internal_error.dart';
+import 'package:serverpod_cli/src/util/legacy_model_files.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
 import 'package:serverpod_cli/src/vm_proxy/serverpod_hooks.dart';
@@ -159,6 +160,7 @@ class StartCommand extends ServerpodCommand<StartOption> {
 
       // Bail before the TUI takes over the terminal
       if (await _detectExistingInstance(config)) return;
+      if (await LegacyModelFiles.report(config)) throw ExitException.error();
 
       // Fire-and-forget: analytics must never delay session start.
       unawaited(
@@ -204,6 +206,7 @@ class StartCommand extends ServerpodCommand<StartOption> {
     }
 
     if (await _detectExistingInstance(config)) return;
+    if (await LegacyModelFiles.report(config)) throw ExitException.error();
 
     // Fire-and-forget: analytics must never delay session start.
     unawaited(

--- a/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
@@ -45,10 +45,6 @@ class FileChangeEvent {
   });
 }
 
-bool _isModelFile(String filePath) {
-  return spyModelFileExtensions.any((ext) => filePath.endsWith(ext));
-}
-
 bool _isWithinDartTool(String filePath) {
   return p.split(filePath).contains('.dart_tool');
 }
@@ -320,7 +316,7 @@ class FileWatcher {
             } else if (_isWithinDartTool(filePath)) {
               // Any other .dart_tool churn (build artifacts, the output dill,
               // a sibling resolution's pub artifacts) is ignored.
-            } else if (_isModelFile(filePath)) {
+            } else if (ModelHelper.isModelFile(filePath)) {
               modelFiles.add(filePath);
             } else if (p.extension(filePath) == '.dart') {
               dartFiles.add(filePath);

--- a/tools/serverpod_cli/lib/src/generator/analyzers.dart
+++ b/tools/serverpod_cli/lib/src/generator/analyzers.dart
@@ -130,7 +130,7 @@ class Analyzers {
 
     if (requirements.generateModels) {
       for (final path in affectedPaths) {
-        if (ModelHelper.isModelFile(path, loadConfig: config)) {
+        if (ModelHelper.isModelFile(path)) {
           shouldGenerate = true;
           final file = File(path);
           if (file.existsSync()) {

--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -182,16 +182,9 @@ Future<void> runLanguageServer({
 Future<void> _registerFileWatchers(Connection connection) {
   var options = DidChangeWatchedFilesRegistrationOptions(
     watchers: [
-      // Spy model files can live anywhere below a package's lib directory.
+      // Model files can live anywhere below a package's lib directory.
       FileSystemWatcher(
         globPattern: const Either2.t1('**/*.{spy,spy.yaml,spy.yml}'),
-      ),
-      // Bare yaml models are only recognized in the model and protocol
-      // directories, so other yaml files (pubspecs, workflows) are not watched.
-      FileSystemWatcher(
-        globPattern: const Either2.t1(
-          '**/lib/src/{models,protocol}/**/*.{yaml,yml}',
-        ),
       ),
       // Directory renames and deletions only surface as events on the
       // directory itself, which the model file globs never match.
@@ -226,7 +219,7 @@ bool _isRelevantFileEvent(FileEvent event, ServerProject project) {
     return false;
   }
 
-  if (ModelHelper.isModelFile(path, loadConfig: project.config)) return true;
+  if (ModelHelper.isModelFile(path)) return true;
 
   // Deleted or renamed-away directories no longer exist on disk; they can
   // only be recognized as a parent of a previously registered model.

--- a/tools/serverpod_cli/lib/src/util/legacy_model_files.dart
+++ b/tools/serverpod_cli/lib/src/util/legacy_model_files.dart
@@ -128,7 +128,8 @@ abstract final class LegacyModelFiles {
   }
 
   /// Whether [file] has a bare yaml extension and a top-level model key.
-  /// Files that do not parse as yaml maps are not models, and are ignored.
+  /// Files that cannot be read or parsed as yaml maps are not models, and
+  /// are ignored.
   static bool _isLegacyModelFile(File file) {
     var path = file.path;
     if (ModelHelper.isModelFile(path)) return false;
@@ -138,6 +139,8 @@ abstract final class LegacyModelFiles {
       var document = loadYaml(file.readAsStringSync());
       return document is YamlMap &&
           _modelKeys.any((key) => document.containsKey(key));
+    } on FileSystemException {
+      return false;
     } on YamlException {
       return false;
     }

--- a/tools/serverpod_cli/lib/src/util/legacy_model_files.dart
+++ b/tools/serverpod_cli/lib/src/util/legacy_model_files.dart
@@ -1,0 +1,145 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/config/config.dart';
+import 'package:serverpod_cli/src/util/model_helper.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:yaml/yaml.dart';
+
+/// A model file that uses a bare `.yaml`/`.yml` extension, which Serverpod
+/// no longer recognizes as a model file.
+class LegacyModelFile {
+  /// Absolute path of the file.
+  final String path;
+
+  /// Nickname of the module the file belongs to, or `null` when the file is
+  /// part of the project itself (server or shared package).
+  final String? moduleNickname;
+
+  LegacyModelFile(this.path, {this.moduleNickname});
+}
+
+/// Serverpod 3 accepted bare `.yaml`/`.yml` model files in these directories.
+/// Serverpod 4 requires one of the [modelFileExtensions], so such files are
+/// silently ignored unless reported to the user.
+abstract final class LegacyModelFiles {
+  static const _legacyExtensions = ['.yaml', '.yml'];
+  static const _legacyModelDirectories = [
+    ['lib', 'src', 'models'],
+    ['lib', 'src', 'protocol'],
+  ];
+  static const _modelKeys = ['class', 'enum', 'exception'];
+
+  /// Finds bare yaml model files in the project's server package, its shared
+  /// packages, and its dependent modules.
+  static Future<List<LegacyModelFile>> find(GeneratorConfig config) async {
+    var found = <LegacyModelFile>[];
+
+    await _collect(found, config.serverPackageDirectoryPathParts);
+    for (var sharedPathParts in config.sharedModelsSourcePathsParts.values) {
+      await _collect(found, [
+        ...config.serverPackageDirectoryPathParts,
+        ...sharedPathParts,
+      ]);
+    }
+
+    for (var module in config.modulesDependent) {
+      await _collect(
+        found,
+        module.serverPackageDirectoryPathParts,
+        moduleNickname: module.nickname,
+      );
+      for (var sharedPathParts in module.sharedPackageRootPathParts.values) {
+        await _collect(
+          found,
+          sharedPathParts,
+          moduleNickname: module.nickname,
+        );
+      }
+    }
+
+    found.sort((a, b) => a.path.compareTo(b.path));
+    return found;
+  }
+
+  /// Logs an error for any legacy model files found in [config], explaining
+  /// how to fix them. Returns `true` when at least one file was reported.
+  static Future<bool> report(GeneratorConfig config) async {
+    var files = await find(config);
+    if (files.isEmpty) return false;
+
+    var projectFiles = files.where((f) => f.moduleNickname == null).toList();
+    var moduleFiles = files.where((f) => f.moduleNickname != null).toList();
+
+    if (projectFiles.isNotEmpty) {
+      var serverDir = p.absolute(
+        p.joinAll(config.serverPackageDirectoryPathParts),
+      );
+      var buffer = StringBuffer(
+        'Model files must use the ${modelFileExtensions.first} extension. '
+        'The following files are ignored:\n',
+      );
+      for (var file in projectFiles) {
+        buffer.writeln('  ${p.relative(file.path, from: serverDir)}');
+      }
+      buffer.write(
+        'Rename the files to use the ${modelFileExtensions.first} extension '
+        'and run the command again.',
+      );
+      log.error(buffer.toString());
+    }
+
+    for (var nickname in moduleFiles.map((f) => f.moduleNickname).toSet()) {
+      var buffer = StringBuffer(
+        'The module "$nickname" contains model files without the '
+        '${modelFileExtensions.first} extension, which are ignored:\n',
+      );
+      for (var file in moduleFiles.where((f) => f.moduleNickname == nickname)) {
+        buffer.writeln('  ${file.path}');
+      }
+      buffer.write(
+        'Update the module to a version compatible with Serverpod 4.',
+      );
+      log.error(buffer.toString());
+    }
+
+    return true;
+  }
+
+  static Future<void> _collect(
+    List<LegacyModelFile> found,
+    List<String> packageRootPathParts, {
+    String? moduleNickname,
+  }) async {
+    for (var directoryParts in _legacyModelDirectories) {
+      var directory = Directory(
+        p.absolute(p.joinAll([...packageRootPathParts, ...directoryParts])),
+      );
+      if (!await directory.exists()) continue;
+
+      await for (var entity in directory.list(recursive: true)) {
+        if (entity is! File) continue;
+        if (!_isLegacyModelFile(entity)) continue;
+        found.add(
+          LegacyModelFile(entity.path, moduleNickname: moduleNickname),
+        );
+      }
+    }
+  }
+
+  /// Whether [file] has a bare yaml extension and a top-level model key.
+  /// Files that do not parse as yaml maps are not models, and are ignored.
+  static bool _isLegacyModelFile(File file) {
+    var path = file.path;
+    if (ModelHelper.isModelFile(path)) return false;
+    if (!_legacyExtensions.any(path.endsWith)) return false;
+
+    try {
+      var document = loadYaml(file.readAsStringSync());
+      return document is YamlMap &&
+          _modelKeys.any((key) => document.containsKey(key));
+    } on YamlException {
+      return false;
+    }
+  }
+}

--- a/tools/serverpod_cli/lib/src/util/model_helper.dart
+++ b/tools/serverpod_cli/lib/src/util/model_helper.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:path/path.dart';
 import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/util/unrendered_template_path.dart';
-import 'package:serverpod_shared/serverpod_shared.dart';
 
 const String defaultModuleAlias = 'protocol';
 
@@ -25,20 +24,12 @@ class ModelSource {
   String? get sharedPackageName => isSharedModel ? moduleAlias : null;
 }
 
-const spyModelFileExtensions = [
-  '.spy',
+/// File extensions recognized as Serverpod model files. Model files can be
+/// placed anywhere below a package's `lib` directory.
+const modelFileExtensions = [
   '.spy.yaml',
   '.spy.yml',
-];
-
-const yamlModelFileExtensions = [
-  '.yaml',
-  '.yml',
-];
-
-const modelFileExtensions = [
-  ...spyModelFileExtensions,
-  ...yamlModelFileExtensions,
+  '.spy',
 ];
 
 /// Relative path parts from package root to model roots (most specific first).
@@ -121,10 +112,7 @@ class ModelHelper {
     required String moduleAlias,
     required bool isSharedModel,
   }) async {
-    var files = await _loadAllModelFiles(
-      loadConfig: loadConfig,
-      absoluteSourcePathParts,
-    );
+    var files = await _loadAllModelFiles(absoluteSourcePathParts);
 
     List<ModelSource> sources = [];
     for (var model in files) {
@@ -167,32 +155,25 @@ class ModelHelper {
     return [];
   }
 
-  static bool isModelFile(
-    String path, {
-    required ModelLoadConfig loadConfig,
-  }) {
-    if (spyModelFileExtensions.any((ext) => path.endsWith(ext))) {
-      return true;
+  /// Whether [path] has one of the [modelFileExtensions].
+  static bool isModelFile(String path) {
+    return modelFileExtensions.any((ext) => path.endsWith(ext));
+  }
+
+  /// Returns the file name of [uri] without its model file extension.
+  static String modelFileNameWithoutExtension(Uri uri) {
+    var fileName = uri.pathSegments.last;
+    for (var ext in modelFileExtensions) {
+      if (fileName.endsWith(ext)) {
+        return fileName.substring(0, fileName.length - ext.length);
+      }
     }
-
-    var allowedYamlExtensionModelPaths = [
-      joinAll(loadConfig.relativeModelSourcePathParts),
-      joinAll(loadConfig.relativeProtocolSourcePathParts),
-    ];
-
-    var allowedYamlPath = path.containsAny(allowedYamlExtensionModelPaths);
-
-    var yamlExtension = yamlModelFileExtensions.any(
-      (ext) => path.endsWith(ext),
-    );
-
-    return allowedYamlPath && yamlExtension;
+    return fileName;
   }
 
   static Future<Iterable<File>> _loadAllModelFiles(
-    List<String> absolutePathParts, {
-    required ModelLoadConfig loadConfig,
-  }) async {
+    List<String> absolutePathParts,
+  ) async {
     List<FileSystemEntity> modelSourceFileList = [];
 
     var path = joinAll(absolutePathParts);
@@ -212,12 +193,7 @@ class ModelHelper {
     }
 
     return modelSourceFileList.whereType<File>().where(
-      (file) =>
-          !isUnrenderedTemplatePath(file.path) &&
-          isModelFile(
-            file.path,
-            loadConfig: loadConfig,
-          ),
+      (file) => !isUnrenderedTemplatePath(file.path) && isModelFile(file.path),
     );
   }
 

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/file_name_conflicts_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/file_name_conflicts_test.dart
@@ -56,7 +56,7 @@ void main() {
         var error = collector.errors.first;
         expect(
           error.message,
-          'File path collision detected: This model and "module/protocol/lib/src/protocol/example.yaml" would generate files at the same location. Please modify the path or filename to ensure each model generates to a unique location.',
+          'File path collision detected: This model and "module/protocol/lib/src/protocol/example.spy.yaml" would generate files at the same location. Please modify the path or filename to ensure each model generates to a unique location.',
         );
       },
     );

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_name_conflict_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/model_validation/model_name_conflict_test.dart
@@ -26,7 +26,7 @@ void main() {
           - value2
         ''',
             )
-            .withFileName('common_enum.yaml')
+            .withFileName('common_enum')
             .withModuleAlias(firstModuleAlias)
             .build(),
         ModelSourceBuilder()
@@ -38,7 +38,7 @@ void main() {
           - value2
         ''',
             )
-            .withFileName('common_enum.yaml')
+            .withFileName('common_enum')
             .withModuleAlias(defaultModuleAlias)
             .build(),
         ModelSourceBuilder()
@@ -87,7 +87,7 @@ void main() {
           - value2
         ''',
             )
-            .withFileName('common_enum.yaml')
+            .withFileName('common_enum')
             .withModuleAlias(firstModuleAlias)
             .build(),
         ModelSourceBuilder()
@@ -99,7 +99,7 @@ void main() {
           - value2
         ''',
             )
-            .withFileName('common_enum.yaml')
+            .withFileName('common_enum')
             .withModuleAlias(secondModuleAlias)
             .build(),
         ModelSourceBuilder().withYaml(
@@ -146,7 +146,7 @@ void main() {
           name: String
         ''',
             )
-            .withFileName('common_class.yaml')
+            .withFileName('common_class')
             .withModuleAlias(firstModuleAlias)
             .build(),
         ModelSourceBuilder()
@@ -158,7 +158,7 @@ void main() {
           name: String
         ''',
             )
-            .withFileName('common_class.yaml')
+            .withFileName('common_class')
             .withModuleAlias(defaultModuleAlias)
             .build(),
         ModelSourceBuilder()
@@ -202,7 +202,7 @@ void main() {
           name: String
         ''',
             )
-            .withFileName('common_class.yaml')
+            .withFileName('common_class')
             .withModuleAlias(firstModuleAlias)
             .build(),
         ModelSourceBuilder()
@@ -214,7 +214,7 @@ void main() {
           name: String
         ''',
             )
-            .withFileName('common_class.yaml')
+            .withFileName('common_class')
             .withModuleAlias(secondModuleAlias)
             .build(),
         ModelSourceBuilder().withYaml(

--- a/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/stateful_analyzer_test.dart
+++ b/tools/serverpod_cli/test/analyzer/models/stateful_analyzer/stateful_analyzer_test.dart
@@ -24,7 +24,7 @@ void main() {
     () {
       var statefulAnalyzer = StatefulAnalyzer(config, []);
 
-      var modelUri = Uri(path: 'lib/src/model/example.yaml');
+      var modelUri = Uri(path: 'lib/src/model/example.spy.yaml');
       var yamlSource = ModelSourceBuilder()
           .withYamlSourceUri(modelUri)
           .withYaml(
@@ -49,7 +49,7 @@ void main() {
     () {
       var statefulAnalyzer = StatefulAnalyzer(config, []);
 
-      var modelUri = Uri(path: 'lib/src/model/example.yaml');
+      var modelUri = Uri(path: 'lib/src/model/example.spy.yaml');
       statefulAnalyzer.removeYamlModel(modelUri);
 
       var models = statefulAnalyzer.validateAll();
@@ -101,7 +101,7 @@ void main() {
     () {
       var statefulAnalyzer = StatefulAnalyzer(config, []);
 
-      var modelUri = Uri(path: 'lib/src/model/example.yaml');
+      var modelUri = Uri(path: 'lib/src/model/example.spy.yaml');
       var yaml = '''
 class: Example
 fields:
@@ -249,7 +249,7 @@ and neither is this line
   test(
     'Given a model that was invalid on first validation, when validating the same model with an updated valid syntax, then the previous errors are cleared.',
     () {
-      var modelUri = Uri(path: 'lib/src/model/example.yaml');
+      var modelUri = Uri(path: 'lib/src/model/example.spy.yaml');
       var invalidSource = ModelSourceBuilder()
           .withYamlSourceUri(modelUri)
           .withYaml(

--- a/tools/serverpod_cli/test/integration/analytics/migration_analytics_test.dart
+++ b/tools/serverpod_cli/test/integration/analytics/migration_analytics_test.dart
@@ -45,7 +45,13 @@ name: ${projectName}_server
 
   void writeServerModel(String name) {
     File(
-        path.join(serverDirectory.path, 'lib', 'src', 'models', '$name.yaml'),
+        path.join(
+          serverDirectory.path,
+          'lib',
+          'src',
+          'models',
+          '$name.spy.yaml',
+        ),
       )
       ..createSync(recursive: true)
       ..writeAsStringSync('''
@@ -58,7 +64,13 @@ fields:
 
   void writeHostClientModel(String name) {
     File(
-        path.join(serverDirectory.path, 'lib', 'src', 'models', '$name.yaml'),
+        path.join(
+          serverDirectory.path,
+          'lib',
+          'src',
+          'models',
+          '$name.spy.yaml',
+        ),
       )
       ..createSync(recursive: true)
       ..writeAsStringSync('''

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -300,7 +300,6 @@ void main() {
         watchers.map((watcher) => watcher['globPattern']),
         containsAll([
           '**/*.{spy,spy.yaml,spy.yml}',
-          '**/lib/src/{models,protocol}/**/*.{yaml,yml}',
           '**/lib/**',
         ]),
       );

--- a/tools/serverpod_cli/test/integration/migrations/create_migration_client_gate_test.dart
+++ b/tools/serverpod_cli/test/integration/migrations/create_migration_client_gate_test.dart
@@ -50,7 +50,7 @@ name: ${projectName}_server
       ),
     )..createSync(recursive: true);
     File(
-      path.join(sharedModelsDir.path, 'shared_table_record.yaml'),
+      path.join(sharedModelsDir.path, 'shared_table_record.spy.yaml'),
     ).writeAsStringSync('''
 class: SharedTableRecord
 table: shared_table_record
@@ -65,7 +65,7 @@ fields:
       path.join(serverDirectory.path, 'lib', 'src', 'models'),
     )..createSync(recursive: true);
     File(
-      path.join(hostModelsDir.path, 'example.yaml'),
+      path.join(hostModelsDir.path, 'example.spy.yaml'),
     ).writeAsStringSync('''
 class: Example
 table: example
@@ -87,7 +87,7 @@ fields:
       path.join(moduleServerDirectory.path, 'lib', 'src', 'models'),
     )..createSync(recursive: true);
     File(
-      path.join(moduleModelsDir.path, 'user_info.yaml'),
+      path.join(moduleModelsDir.path, 'user_info.spy.yaml'),
     ).writeAsStringSync('''
 class: UserInfo
 table: serverpod_user_info

--- a/tools/serverpod_cli/test/integration/migrations/create_migration_dialect_rejection_test.dart
+++ b/tools/serverpod_cli/test/integration/migrations/create_migration_dialect_rejection_test.dart
@@ -52,7 +52,8 @@ name: ${projectName}_server
     var hostModelsDir = Directory(
       path.join(serverDirectory.path, 'lib', 'src', 'models'),
     )..createSync(recursive: true);
-    File(path.join(hostModelsDir.path, 'example.yaml')).writeAsStringSync('''
+    File(path.join(hostModelsDir.path, 'example.spy.yaml')).writeAsStringSync(
+      '''
 class: Example
 table: example
 database: all
@@ -63,20 +64,23 @@ indexes:
     fields: name
     unique: true
     nulls_distinct: $nullsDistinct
-''');
+''',
+    );
   }
 
   void writeClientTableModelWithSerial({required bool includeSerial}) {
     var hostModelsDir = Directory(
       path.join(serverDirectory.path, 'lib', 'src', 'models'),
     )..createSync(recursive: true);
-    File(path.join(hostModelsDir.path, 'example.yaml')).writeAsStringSync('''
+    File(path.join(hostModelsDir.path, 'example.spy.yaml')).writeAsStringSync(
+      '''
 class: Example
 table: example
 database: all
 fields:
   name: String${includeSerial ? '\n  syncVersion: int?, defaultPersist=serial' : ''}
-''');
+''',
+    );
   }
 
   void writeSqliteServerAndClientModels({
@@ -87,7 +91,9 @@ fields:
       path.join(serverDirectory.path, 'lib', 'src', 'models'),
     )..createSync(recursive: true);
 
-    File(path.join(hostModelsDir.path, 'server_only.yaml')).writeAsStringSync(
+    File(
+      path.join(hostModelsDir.path, 'server_only.spy.yaml'),
+    ).writeAsStringSync(
       '''
 class: ServerOnly
 table: server_only
@@ -102,7 +108,9 @@ indexes:
 ''',
     );
 
-    File(path.join(hostModelsDir.path, 'client_host.yaml')).writeAsStringSync(
+    File(
+      path.join(hostModelsDir.path, 'client_host.spy.yaml'),
+    ).writeAsStringSync(
       '''
 class: ClientHost
 table: client_host
@@ -445,7 +453,7 @@ fields:
             'lib',
             'src',
             'models',
-            'example.yaml',
+            'example.spy.yaml',
           ),
         ).writeAsStringSync('''
 class: Example

--- a/tools/serverpod_cli/test/integration/migrations/migration_generator_exceptions_test.dart
+++ b/tools/serverpod_cli/test/integration/migrations/migration_generator_exceptions_test.dart
@@ -113,7 +113,7 @@ void main() {
           'lib',
           'src',
           'protocol',
-          'example.yaml',
+          'example.spy.yaml',
         ),
       );
       modelFile.createSync(recursive: true);
@@ -217,7 +217,7 @@ fields:
           'lib',
           'src',
           'protocol',
-          'example.yaml',
+          'example.spy.yaml',
         ),
       );
       modelFile.createSync(recursive: true);

--- a/tools/serverpod_cli/test/integration/util/legacy_model_files_test.dart
+++ b/tools/serverpod_cli/test/integration/util/legacy_model_files_test.dart
@@ -150,7 +150,8 @@ values:
   });
 
   group(
-    'Given a server package with non-model yaml files in lib/src/models',
+    'Given a server package with unreadable and non-model yaml files in '
+    'lib/src/models',
     () {
       setUp(() async {
         await d.dir('server/lib/src/models', [
@@ -158,6 +159,16 @@ values:
           d.file('list.yaml', '- a\n- b\n'),
           d.file('broken.yaml', 'class: [\n'),
           d.file('empty.yaml', ''),
+          d.file('binary.yaml', [
+            0xff,
+            0xfe,
+            0x00,
+            0x63,
+            0x6c,
+            0x61,
+            0x73,
+            0x73,
+          ]),
         ]).create();
       });
 

--- a/tools/serverpod_cli/test/integration/util/legacy_model_files_test.dart
+++ b/tools/serverpod_cli/test/integration/util/legacy_model_files_test.dart
@@ -1,0 +1,260 @@
+import 'package:cli_tools/cli_tools.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/util/legacy_model_files.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+import '../../test_util/builders/generator_config_builder.dart';
+import '../../test_util/builders/module_config_builder.dart';
+
+const _modelYaml = '''
+class: Example
+fields:
+  name: String
+''';
+
+class _ErrorCapturingLogger extends VoidLogger {
+  final List<String> errors = [];
+
+  @override
+  void error(
+    String message, {
+    bool newParagraph = false,
+    StackTrace? stackTrace,
+    LogType? type,
+  }) {
+    errors.add(message);
+  }
+}
+
+void main() {
+  late _ErrorCapturingLogger logger;
+
+  setUp(() {
+    logger = _ErrorCapturingLogger();
+    initializeLoggerWith(logger);
+  });
+
+  tearDown(() async {
+    await closeLogger();
+  });
+
+  List<String> serverPathParts() => p.split(p.join(d.sandbox, 'server'));
+
+  group('Given a server package with a bare .yaml model in lib/src/models', () {
+    setUp(() async {
+      await d.dir('server/lib/src/models', [
+        d.file('example.yaml', _modelYaml),
+      ]).create();
+    });
+
+    test('when finding legacy model files then the file is found.', () async {
+      var config = GeneratorConfigBuilder()
+          .withServerPackageDirectoryPathParts(serverPathParts())
+          .withModules([])
+          .build();
+
+      var files = await LegacyModelFiles.find(config);
+
+      expect(files, hasLength(1));
+      expect(
+        files.single.path,
+        p.join(d.sandbox, 'server', 'lib', 'src', 'models', 'example.yaml'),
+      );
+      expect(files.single.moduleNickname, isNull);
+    });
+
+    test(
+      'when reporting legacy model files '
+      'then an error listing the file is logged and true is returned.',
+      () async {
+        var config = GeneratorConfigBuilder()
+            .withServerPackageDirectoryPathParts(serverPathParts())
+            .withModules([])
+            .build();
+
+        var reported = await LegacyModelFiles.report(config);
+
+        expect(reported, isTrue);
+        expect(logger.errors, hasLength(1));
+        expect(
+          logger.errors.single,
+          contains(p.join('lib', 'src', 'models', 'example.yaml')),
+        );
+        expect(logger.errors.single, contains('.spy.yaml'));
+      },
+    );
+  });
+
+  group('Given a server package with a bare .yml enum in lib/src/protocol', () {
+    setUp(() async {
+      await d.dir('server/lib/src/protocol', [
+        d.file('example.yml', '''
+enum: Example
+values:
+  - first
+'''),
+      ]).create();
+    });
+
+    test('when finding legacy model files then the file is found.', () async {
+      var config = GeneratorConfigBuilder()
+          .withServerPackageDirectoryPathParts(serverPathParts())
+          .withModules([])
+          .build();
+
+      var files = await LegacyModelFiles.find(config);
+
+      expect(files.map((f) => p.basename(f.path)), ['example.yml']);
+    });
+  });
+
+  group('Given a server package with only supported model files', () {
+    setUp(() async {
+      await d.dir('server/lib/src', [
+        d.dir('models', [
+          d.file('example.spy.yaml', _modelYaml),
+          d.file('other.spy', _modelYaml),
+        ]),
+        d.file('outside.yaml', _modelYaml),
+      ]).create();
+    });
+
+    test('when finding legacy model files then nothing is found.', () async {
+      var config = GeneratorConfigBuilder()
+          .withServerPackageDirectoryPathParts(serverPathParts())
+          .withModules([])
+          .build();
+
+      var files = await LegacyModelFiles.find(config);
+
+      expect(files, isEmpty);
+    });
+
+    test(
+      'when reporting legacy model files '
+      'then nothing is logged and false is returned.',
+      () async {
+        var config = GeneratorConfigBuilder()
+            .withServerPackageDirectoryPathParts(serverPathParts())
+            .withModules([])
+            .build();
+
+        var reported = await LegacyModelFiles.report(config);
+
+        expect(reported, isFalse);
+        expect(logger.errors, isEmpty);
+      },
+    );
+  });
+
+  group(
+    'Given a server package with non-model yaml files in lib/src/models',
+    () {
+      setUp(() async {
+        await d.dir('server/lib/src/models', [
+          d.file('analysis_options.yaml', 'include: package:lints/core.yaml\n'),
+          d.file('list.yaml', '- a\n- b\n'),
+          d.file('broken.yaml', 'class: [\n'),
+          d.file('empty.yaml', ''),
+        ]).create();
+      });
+
+      test('when finding legacy model files then nothing is found.', () async {
+        var config = GeneratorConfigBuilder()
+            .withServerPackageDirectoryPathParts(serverPathParts())
+            .withModules([])
+            .build();
+
+        var files = await LegacyModelFiles.find(config);
+
+        expect(files, isEmpty);
+      });
+    },
+  );
+
+  group('Given a shared package with a bare .yaml model in lib/src/models', () {
+    setUp(() async {
+      await d.dir('server/packages/shared/lib/src/models', [
+        d.file('shared.yaml', _modelYaml),
+      ]).create();
+    });
+
+    test(
+      'when finding legacy model files '
+      'then the file is found as a project file.',
+      () async {
+        var config = GeneratorConfigBuilder()
+            .withServerPackageDirectoryPathParts(serverPathParts())
+            .withSharedModelsSourcePathsParts({
+              'shared': ['packages', 'shared'],
+            })
+            .withModules([])
+            .build();
+
+        var files = await LegacyModelFiles.find(config);
+
+        expect(files.map((f) => p.basename(f.path)), ['shared.yaml']);
+        expect(files.single.moduleNickname, isNull);
+      },
+    );
+  });
+
+  group(
+    'Given a dependent module with a bare .yaml model in lib/src/models',
+    () {
+      setUp(() async {
+        await d.dir('module/lib/src/models', [
+          d.file('module_model.yaml', _modelYaml),
+        ]).create();
+      });
+
+      test(
+        'when finding legacy model files '
+        'then the file is found with the module nickname.',
+        () async {
+          var config = GeneratorConfigBuilder()
+              .withServerPackageDirectoryPathParts(serverPathParts())
+              .withModules([
+                ModuleConfigBuilder('test_module', 'test_alias')
+                    .withServerPackageDirectoryPathParts(
+                      p.split(p.join(d.sandbox, 'module')),
+                    )
+                    .build(),
+              ])
+              .build();
+
+          var files = await LegacyModelFiles.find(config);
+
+          expect(files.map((f) => p.basename(f.path)), ['module_model.yaml']);
+          expect(files.single.moduleNickname, 'test_alias');
+        },
+      );
+
+      test(
+        'when reporting legacy model files '
+        'then an error asking to update the module is logged.',
+        () async {
+          var config = GeneratorConfigBuilder()
+              .withServerPackageDirectoryPathParts(serverPathParts())
+              .withModules([
+                ModuleConfigBuilder('test_module', 'test_alias')
+                    .withServerPackageDirectoryPathParts(
+                      p.split(p.join(d.sandbox, 'module')),
+                    )
+                    .build(),
+              ])
+              .build();
+
+          var reported = await LegacyModelFiles.report(config);
+
+          expect(reported, isTrue);
+          expect(logger.errors, hasLength(1));
+          expect(logger.errors.single, contains('The module "test_alias"'));
+          expect(logger.errors.single, contains('module_model.yaml'));
+        },
+      );
+    },
+  );
+}

--- a/tools/serverpod_cli/test/integration/util/model_helper/model_file_load_test.dart
+++ b/tools/serverpod_cli/test/integration/util/model_helper/model_file_load_test.dart
@@ -19,327 +19,61 @@ void main() {
     testDirectory.deleteSync(recursive: true);
   });
 
-  group('Given a valid model class with *.yaml file ending', () {
-    var modelFileName = 'example.yaml';
-
-    late Directory testProject;
-    late GeneratorConfig config;
-    setUp(() {
-      testProject = Directory(join(testDirectory.path, const Uuid().v4()));
-      testProject.createSync(recursive: true);
-      config = GeneratorConfigBuilder()
-          .withServerPackageDirectoryPathParts(split(testProject.path))
-          .withModules([])
-          .build();
-    });
-
-    tearDown(() {
-      testProject.deleteSync(recursive: true);
-    });
-
-    group('placed in the "lib/src/models" directory when loaded', () {
-      late List<ModelSource> models;
-
-      setUp(() async {
-        var modelFile = File(
-          join(
-            testProject.path,
-            'lib',
-            'src',
-            'models',
-            modelFileName,
-          ),
-        );
-        modelFile.createSync(recursive: true);
-        modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-''');
-        models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-      });
-
-      test('then the class is serialized.', () async {
-        expect(models, hasLength(1));
-      });
-
-      test('then modelSource has no subDirPathParts.', () async {
-        expect(models.firstOrNull?.subDirPathParts, isEmpty);
-      });
-    });
-
-    group('placed in the "lib/src/protocol" directory when loaded', () {
-      late List<ModelSource> models;
-
-      setUp(() async {
-        var modelFile = File(
-          join(
-            testProject.path,
-            'lib',
-            'src',
-            'protocol',
-            modelFileName,
-          ),
-        );
-        modelFile.createSync(recursive: true);
-        modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-''');
-        models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-      });
-
-      test('then the class is serialized.', () async {
-        expect(models, hasLength(1));
-      });
-
-      test('then modelSource has no subDirPathParts.', () async {
-        expect(models.firstOrNull?.subDirPathParts, isEmpty);
-      });
-    });
-
+  for (var modelFileName in ['example.yaml', 'example.yml']) {
     group(
-      'placed in a subdirectory of the "lib/src/models" directory when loaded',
+      'Given a valid model class with a bare $modelFileName file ending',
       () {
-        late List<ModelSource> models;
+        late Directory testProject;
+        late GeneratorConfig config;
+        setUp(() {
+          testProject = Directory(join(testDirectory.path, const Uuid().v4()));
+          testProject.createSync(recursive: true);
+          config = GeneratorConfigBuilder()
+              .withServerPackageDirectoryPathParts(split(testProject.path))
+              .withModules([])
+              .build();
+        });
 
-        setUp(() async {
-          var modelFile = File(
-            join(
-              testProject.path,
-              'lib',
-              'src',
-              'models',
-              'sub',
-              modelFileName,
-            ),
-          );
-          modelFile.createSync(recursive: true);
-          modelFile.writeAsStringSync('''
+        tearDown(() {
+          testProject.deleteSync(recursive: true);
+        });
+
+        for (var modelDirectory in ['models', 'protocol']) {
+          group(
+            'placed in the "lib/src/$modelDirectory" directory when loaded',
+            () {
+              late List<ModelSource> models;
+
+              setUp(() async {
+                var modelFile = File(
+                  join(
+                    testProject.path,
+                    'lib',
+                    'src',
+                    modelDirectory,
+                    modelFileName,
+                  ),
+                );
+                modelFile.createSync(recursive: true);
+                modelFile.writeAsStringSync('''
 class: Example
 fields:
   name: String
-
 ''');
-          models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-        });
+                models = await ModelHelper.loadProjectYamlModelsFromDisk(
+                  config,
+                );
+              });
 
-        test('then the class is serialized.', () async {
-          expect(models, hasLength(1));
-        });
-
-        test('then modelSource has the correct subDirPathParts.', () async {
-          expect(models.firstOrNull?.subDirPathParts, ['sub']);
-        });
+              test('then the class is not serialized.', () async {
+                expect(models, isEmpty);
+              });
+            },
+          );
+        }
       },
     );
-
-    group('placed in the "lib/src" directory when loaded', () {
-      late List<ModelSource> models;
-
-      setUp(() async {
-        var modelFile = File(
-          join(
-            testProject.path,
-            'lib',
-            'src',
-            modelFileName,
-          ),
-        );
-        modelFile.createSync(recursive: true);
-        modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-''');
-        models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-      });
-
-      test('then the class is not serialized.', () async {
-        expect(models, hasLength(0));
-      });
-    });
-  });
-
-  group('Given a valid model class with *.yml file ending', () {
-    var modelFileName = 'example.yml';
-
-    late Directory testProject;
-    late GeneratorConfig config;
-    setUp(() {
-      testProject = Directory(join(testDirectory.path, const Uuid().v4()));
-      testProject.createSync(recursive: true);
-      config = GeneratorConfigBuilder()
-          .withServerPackageDirectoryPathParts(split(testProject.path))
-          .withModules([])
-          .build();
-    });
-
-    tearDown(() {
-      testProject.deleteSync(recursive: true);
-    });
-
-    group('placed in the "lib/src/models" directory when loaded', () {
-      late List<ModelSource> models;
-
-      setUp(() async {
-        var modelFile = File(
-          join(
-            testProject.path,
-            'lib',
-            'src',
-            'models',
-            modelFileName,
-          ),
-        );
-        modelFile.createSync(recursive: true);
-        modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-''');
-        models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-      });
-
-      test('then the class is serialized.', () async {
-        expect(models, hasLength(1));
-      });
-
-      test('then modelSource has no subDirPathParts.', () async {
-        expect(models.firstOrNull?.subDirPathParts, isEmpty);
-      });
-    });
-
-    group('placed in the "lib/src/protocol" directory when loaded', () {
-      late List<ModelSource> models;
-
-      setUp(() async {
-        var modelFile = File(
-          join(
-            testProject.path,
-            'lib',
-            'src',
-            'protocol',
-            modelFileName,
-          ),
-        );
-        modelFile.createSync(recursive: true);
-        modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-''');
-        models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-      });
-
-      test('then the class is serialized.', () async {
-        expect(models, hasLength(1));
-      });
-
-      test('then modelSource has no subDirPathParts.', () async {
-        expect(models.firstOrNull?.subDirPathParts, isEmpty);
-      });
-    });
-
-    group(
-      'placed in a subdirectory of the "lib/src/models" directory when loaded',
-      () {
-        late List<ModelSource> models;
-
-        setUp(() async {
-          var modelFile = File(
-            join(
-              testProject.path,
-              'lib',
-              'src',
-              'models',
-              'sub',
-              modelFileName,
-            ),
-          );
-          modelFile.createSync(recursive: true);
-          modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-
-''');
-          models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-        });
-
-        test('then the class is serialized.', () async {
-          expect(models, hasLength(1));
-        });
-
-        test('then modelSource has the correct subDirPathParts.', () async {
-          expect(models.firstOrNull?.subDirPathParts, ['sub']);
-        });
-      },
-    );
-
-    group(
-      'placed in a subdirectory of the "lib/src/protocol" directory when loaded',
-      () {
-        late List<ModelSource> models;
-
-        setUp(() async {
-          var modelFile = File(
-            join(
-              testProject.path,
-              'lib',
-              'src',
-              'protocol',
-              'sub',
-              modelFileName,
-            ),
-          );
-          modelFile.createSync(recursive: true);
-          modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-
-''');
-          models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-        });
-
-        test('then the class is serialized.', () async {
-          expect(models, hasLength(1));
-        });
-
-        test('then modelSource has the correct subDirPathParts.', () async {
-          expect(models.firstOrNull?.subDirPathParts, ['sub']);
-        });
-      },
-    );
-
-    group('placed in the "lib/src" directory when loaded', () {
-      late List<ModelSource> models;
-
-      setUp(() async {
-        var modelFile = File(
-          join(
-            testProject.path,
-            'lib',
-            'src',
-            modelFileName,
-          ),
-        );
-        modelFile.createSync(recursive: true);
-        modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-''');
-        models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-      });
-
-      test('then the class is not serialized.', () async {
-        expect(models, hasLength(0));
-      });
-    });
-  });
+  }
 
   group('Given a valid model class with *.spy file ending', () {
     var modelFileName = 'example.spy';

--- a/tools/serverpod_cli/test/integration/util/model_helper/model_helper_test.dart
+++ b/tools/serverpod_cli/test/integration/util/model_helper/model_helper_test.dart
@@ -534,7 +534,9 @@ fields:
           ),
         );
         serverModelsDir.createSync(recursive: true);
-        File(join(serverModelsDir.path, 'server_model.yaml')).writeAsStringSync(
+        File(
+          join(serverModelsDir.path, 'server_model.spy.yaml'),
+        ).writeAsStringSync(
           '''
 class: ServerModel
 fields:
@@ -553,7 +555,9 @@ fields:
           ),
         );
         sharedModelsDir.createSync(recursive: true);
-        File(join(sharedModelsDir.path, 'shared_model.yaml')).writeAsStringSync(
+        File(
+          join(sharedModelsDir.path, 'shared_model.spy.yaml'),
+        ).writeAsStringSync(
           '''
 class: SharedModel
 fields:

--- a/tools/serverpod_cli/test/integration/util/model_helper/module_model_file_load_test.dart
+++ b/tools/serverpod_cli/test/integration/util/model_helper/module_model_file_load_test.dart
@@ -24,335 +24,62 @@ void main() {
     testDirectory.deleteSync(recursive: true);
   });
 
-  group('Given a valid model class with *.yaml file ending', () {
-    var modelFileName = 'example.yaml';
+  for (var modelFileName in ['example.yaml', 'example.yml']) {
+    group('Given a valid model class with a bare $modelFileName file ending', () {
+      late Directory moduleProject;
+      late GeneratorConfig config;
+      setUp(() {
+        moduleProject = Directory(join(testDirectory.path, const Uuid().v4()));
+        moduleProject.createSync(recursive: true);
+        config = GeneratorConfigBuilder()
+            .withServerPackageDirectoryPathParts(testProjectPathParts)
+            .withModules([
+              ModuleConfigBuilder('test_module')
+                  .withServerPackageDirectoryPathParts(
+                    split(moduleProject.path),
+                  )
+                  .build(),
+            ])
+            .build();
+      });
 
-    late Directory moduleProject;
-    late GeneratorConfig config;
-    setUp(() {
-      moduleProject = Directory(join(testDirectory.path, const Uuid().v4()));
-      moduleProject.createSync(recursive: true);
-      config = GeneratorConfigBuilder()
-          .withServerPackageDirectoryPathParts(testProjectPathParts)
-          .withModules([
-            ModuleConfigBuilder('test_module')
-                .withServerPackageDirectoryPathParts(split(moduleProject.path))
-                .build(),
-          ])
-          .build();
-    });
+      tearDown(() {
+        moduleProject.deleteSync(recursive: true);
+      });
 
-    tearDown(() {
-      moduleProject.deleteSync(recursive: true);
-    });
+      for (var modelDirectory in ['models', 'protocol']) {
+        group(
+          'placed in the module "lib/src/$modelDirectory" directory when loaded',
+          () {
+            late List<ModelSource> models;
 
-    group('placed in the module "lib/src/models" directory when loaded', () {
-      late List<ModelSource> models;
+            setUp(() async {
+              var modelFile = File(
+                join(
+                  moduleProject.path,
+                  'lib',
+                  'src',
+                  modelDirectory,
+                  modelFileName,
+                ),
+              );
+              modelFile.createSync(recursive: true);
+              modelFile.writeAsStringSync('''
+class: Example
+fields:
+  name: String
+''');
+              models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
+            });
 
-      setUp(() async {
-        var modelFile = File(
-          join(
-            moduleProject.path,
-            'lib',
-            'src',
-            'models',
-            modelFileName,
-          ),
+            test('then the class is not serialized.', () async {
+              expect(models, isEmpty);
+            });
+          },
         );
-        modelFile.createSync(recursive: true);
-        modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-''');
-        models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-      });
-
-      test('then the class is serialized.', () async {
-        expect(models, hasLength(1));
-      });
-
-      test('then modelSource has no subDirPathParts.', () async {
-        expect(models.firstOrNull?.subDirPathParts, isEmpty);
-      });
+      }
     });
-
-    group('placed in the module "lib/src/protocol" directory when loaded', () {
-      late List<ModelSource> models;
-
-      setUp(() async {
-        var modelFile = File(
-          join(
-            moduleProject.path,
-            'lib',
-            'src',
-            'protocol',
-            modelFileName,
-          ),
-        );
-        modelFile.createSync(recursive: true);
-        modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-''');
-        models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-      });
-
-      test('then the class is serialized.', () async {
-        expect(models, hasLength(1));
-      });
-
-      test('then modelSource has no subDirPathParts.', () async {
-        expect(models.firstOrNull?.subDirPathParts, isEmpty);
-      });
-    });
-
-    group(
-      'placed in a subdirectory of the module "lib/src/models" directory when loaded',
-      () {
-        late List<ModelSource> models;
-
-        setUp(() async {
-          var modelFile = File(
-            join(
-              moduleProject.path,
-              'lib',
-              'src',
-              'models',
-              'sub',
-              modelFileName,
-            ),
-          );
-          modelFile.createSync(recursive: true);
-          modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-
-''');
-          models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-        });
-
-        test('then the class is serialized.', () async {
-          expect(models, hasLength(1));
-        });
-
-        test('then modelSource has the correct subDirPathParts.', () async {
-          expect(models.firstOrNull?.subDirPathParts, ['sub']);
-        });
-      },
-    );
-
-    group('placed in the module "lib/src" directory when loaded', () {
-      late List<ModelSource> models;
-
-      setUp(() async {
-        var modelFile = File(
-          join(
-            moduleProject.path,
-            'lib',
-            'src',
-            modelFileName,
-          ),
-        );
-        modelFile.createSync(recursive: true);
-        modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-''');
-        models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-      });
-
-      test('then the class is not serialized.', () async {
-        expect(models, hasLength(0));
-      });
-    });
-  });
-
-  group('Given a valid model class with *.yml file ending', () {
-    var modelFileName = 'example.yml';
-
-    late Directory moduleProject;
-    late GeneratorConfig config;
-    setUp(() {
-      moduleProject = Directory(join(testDirectory.path, const Uuid().v4()));
-      moduleProject.createSync(recursive: true);
-      config = GeneratorConfigBuilder()
-          .withServerPackageDirectoryPathParts(testProjectPathParts)
-          .withModules([
-            ModuleConfigBuilder('test_module')
-                .withServerPackageDirectoryPathParts(split(moduleProject.path))
-                .build(),
-          ])
-          .build();
-    });
-
-    tearDown(() {
-      moduleProject.deleteSync(recursive: true);
-    });
-
-    group('placed in the module "lib/src/models" directory when loaded', () {
-      late List<ModelSource> models;
-
-      setUp(() async {
-        var modelFile = File(
-          join(
-            moduleProject.path,
-            'lib',
-            'src',
-            'models',
-            modelFileName,
-          ),
-        );
-        modelFile.createSync(recursive: true);
-        modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-''');
-        models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-      });
-
-      test('then the class is serialized.', () async {
-        expect(models, hasLength(1));
-      });
-
-      test('then modelSource has no subDirPathParts.', () async {
-        expect(models.firstOrNull?.subDirPathParts, isEmpty);
-      });
-    });
-
-    group('placed in the module "lib/src/protocol" directory when loaded', () {
-      late List<ModelSource> models;
-
-      setUp(() async {
-        var modelFile = File(
-          join(
-            moduleProject.path,
-            'lib',
-            'src',
-            'protocol',
-            modelFileName,
-          ),
-        );
-        modelFile.createSync(recursive: true);
-        modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-''');
-        models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-      });
-
-      test('then the class is serialized.', () async {
-        expect(models, hasLength(1));
-      });
-
-      test('then modelSource has no subDirPathParts.', () async {
-        expect(models.firstOrNull?.subDirPathParts, isEmpty);
-      });
-    });
-
-    group(
-      'placed in a subdirectory of the module "lib/src/models" directory when loaded',
-      () {
-        late List<ModelSource> models;
-
-        setUp(() async {
-          var modelFile = File(
-            join(
-              moduleProject.path,
-              'lib',
-              'src',
-              'models',
-              'sub',
-              modelFileName,
-            ),
-          );
-          modelFile.createSync(recursive: true);
-          modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-
-''');
-          models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-        });
-
-        test('then the class is serialized.', () async {
-          expect(models, hasLength(1));
-        });
-
-        test('then modelSource has the correct subDirPathParts.', () async {
-          expect(models.firstOrNull?.subDirPathParts, ['sub']);
-        });
-      },
-    );
-
-    group(
-      'placed in a subdirectory of the module "lib/src/protocol" directory when loaded',
-      () {
-        late List<ModelSource> models;
-
-        setUp(() async {
-          var modelFile = File(
-            join(
-              moduleProject.path,
-              'lib',
-              'src',
-              'protocol',
-              'sub',
-              modelFileName,
-            ),
-          );
-          modelFile.createSync(recursive: true);
-          modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-
-''');
-          models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-        });
-
-        test('then the class is serialized.', () async {
-          expect(models, hasLength(1));
-        });
-
-        test('then modelSource has the correct subDirPathParts.', () async {
-          expect(models.firstOrNull?.subDirPathParts, ['sub']);
-        });
-      },
-    );
-
-    group('placed in the module "lib/src" directory when loaded', () {
-      late List<ModelSource> models;
-
-      setUp(() async {
-        var modelFile = File(
-          join(
-            moduleProject.path,
-            'lib',
-            'src',
-            modelFileName,
-          ),
-        );
-        modelFile.createSync(recursive: true);
-        modelFile.writeAsStringSync('''
-class: Example
-fields:
-  name: String
-''');
-        models = await ModelHelper.loadProjectYamlModelsFromDisk(config);
-      });
-
-      test('then the class is not serialized.', () async {
-        expect(models, hasLength(0));
-      });
-    });
-  });
+  }
 
   group('Given a valid model class with *.spy file ending', () {
     var modelFileName = 'example.spy';

--- a/tools/serverpod_cli/test/test_util/analytics_helpers.dart
+++ b/tools/serverpod_cli/test/test_util/analytics_helpers.dart
@@ -242,7 +242,7 @@ void _writeSharedModel(Directory projectDir) {
         'lib',
         'src',
         'models',
-        'shared_record.yaml',
+        'shared_record.spy.yaml',
       ),
     )
     ..createSync(recursive: true)

--- a/tools/serverpod_cli/test/test_util/builders/model_source_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/model_source_builder.dart
@@ -12,7 +12,7 @@ class ModelSourceBuilder {
   String fileExtension;
 
   ModelSourceBuilder()
-    : fileExtension = '.yaml',
+    : fileExtension = '.spy.yaml',
       subDirPathParts = [],
       fileName = 'example',
       yamlSourcePathParts = ['lib', 'src', 'model'],

--- a/tools/serverpod_cli/test/util/model_helper_test.dart
+++ b/tools/serverpod_cli/test/util/model_helper_test.dart
@@ -1,0 +1,53 @@
+import 'package:serverpod_cli/src/util/model_helper.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a file path with a model file extension', () {
+    for (var path in [
+      'lib/src/models/example.spy.yaml',
+      'lib/src/models/example.spy.yml',
+      'lib/src/models/example.spy',
+      'lib/example.spy.yaml',
+    ]) {
+      test('when checking "$path" then it is recognized as a model file.', () {
+        expect(ModelHelper.isModelFile(path), isTrue);
+      });
+    }
+  });
+
+  group('Given a file path without a model file extension', () {
+    for (var path in [
+      'lib/src/models/example.yaml',
+      'lib/src/models/example.yml',
+      'lib/src/protocol/example.yaml',
+      'lib/src/models/example.dart',
+      'pubspec.yaml',
+    ]) {
+      test(
+        'when checking "$path" then it is not recognized as a model file.',
+        () {
+          expect(ModelHelper.isModelFile(path), isFalse);
+        },
+      );
+    }
+  });
+
+  group('Given a model file uri', () {
+    for (var (fileName, expected) in [
+      ('example.spy.yaml', 'example'),
+      ('example.spy.yml', 'example'),
+      ('example.spy', 'example'),
+      ('my.model.spy.yaml', 'my.model'),
+      ('spy.spy.yaml', 'spy'),
+    ]) {
+      test(
+        'when extracting the file name of "$fileName" '
+        'then the model file extension is removed.',
+        () {
+          var uri = Uri.file('/project/lib/src/models/$fileName');
+          expect(ModelHelper.modelFileNameWithoutExtension(uri), expected);
+        },
+      );
+    }
+  });
+}

--- a/tools/serverpod_vscode_extension/CHANGELOG.md
+++ b/tools/serverpod_vscode_extension/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.0
+
+- refactor: BREAKING. Drops support for bare `.yaml`/`.yml` model files. The language server is only attached to `.spy.yaml`, `.spy.yml` and `.spy` files, and the extension no longer activates for every yaml file.
+
 ## 1.4.0
 
 - feat: Hooks into the device selection for VS Code debugger launch when no device is set on the config file.

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -8,7 +8,7 @@
     "color": "#020E24",
     "theme": "dark"
   },
-  "version": "1.4.0",
+  "version": "1.5.0",
   "engines": {
     "vscode": "^1.75.0"
   },
@@ -17,7 +17,6 @@
     "Linters"
   ],
   "activationEvents": [
-    "onLanguage:yaml",
     "onLanguage:serverpod",
     "onDebugResolve:dart"
   ],

--- a/tools/serverpod_vscode_extension/src/extension.ts
+++ b/tools/serverpod_vscode_extension/src/extension.ts
@@ -52,8 +52,6 @@ export function activate(context: ExtensionContext) {
 	const clientOptions: LanguageClientOptions = {
 		revealOutputChannelOn: RevealOutputChannelOn.Info,
 		documentSelector: [
-			{ scheme: 'file', language: 'yaml', pattern: '**/protocol/**/*.yaml' },
-			{ scheme: 'file', language: 'yaml', pattern: '**/models/**/*.yaml' },
 			{ scheme: 'file', pattern: '**/*.spy.yaml' },
 			{ scheme: 'file', pattern: '**/*.spy.yml' },
 			{ scheme: 'file', pattern: '**/*.spy' },

--- a/tools/serverpod_vscode_extension/src/test/extension.test.ts
+++ b/tools/serverpod_vscode_extension/src/test/extension.test.ts
@@ -48,7 +48,7 @@ suite('VS Code Extension', () => {
     suite('activate', () => {
         test('Given serverpod CLI is not installed when activate is called then it should show error message and not start language client.', () => {
             execSyncStub.throws(new Error('Command not found'));
-            const mockContext = {} as vscode.ExtensionContext;
+            const mockContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
 
             activate(mockContext);
 
@@ -61,7 +61,7 @@ suite('VS Code Extension', () => {
 
         test('Given serverpod CLI version is outdated when activate is called then it should show error message and not start language client.', () => {
             execSyncStub.returns(Buffer.from('Version: 1.1.0'));
-            const mockContext = {} as vscode.ExtensionContext;
+            const mockContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
 
             activate(mockContext);
 
@@ -74,7 +74,7 @@ suite('VS Code Extension', () => {
 
         test('Given serverpod version output contains extra whitespace when activate is called then it should trim and parse correctly.', () => {
             execSyncStub.returns(Buffer.from('  Version: 1.2.0  \n'));
-            const mockContext = {} as vscode.ExtensionContext;
+            const mockContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
             const languageClientStartStub = sinon.stub(LanguageClient.prototype, 'start');
 
             activate(mockContext);
@@ -85,7 +85,7 @@ suite('VS Code Extension', () => {
 
         test('Given all prerequisites are met when activate is called then it should create and start the LanguageClient with correct configuration.', () => {
             execSyncStub.returns(Buffer.from('Version: 1.2.0'));
-            const mockContext = {} as vscode.ExtensionContext;
+            const mockContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
             const languageClientStartStub = sinon.stub(LanguageClient.prototype, 'start');
 
             activate(mockContext);
@@ -96,7 +96,7 @@ suite('VS Code Extension', () => {
 
         test('Given all prerequisites are met when activate is called then the client should register all expected document selectors.', () => {
             execSyncStub.returns(Buffer.from('Version: 1.2.0'));
-            const mockContext = {} as vscode.ExtensionContext;
+            const mockContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
 
             let capturedClientOptions: any = null;
             const mockClient = {
@@ -115,11 +115,11 @@ suite('VS Code Extension', () => {
             assert.ok(capturedClientOptions, 'Client options should be captured');
             
             assert.ok(capturedClientOptions.documentSelector, 'Document selector should exist');
-            assert.strictEqual(capturedClientOptions.documentSelector.length, 5, 'Should have 5 document selectors');
+            assert.strictEqual(capturedClientOptions.documentSelector.length, 3, 'Should have 3 document selectors');
 
             const patterns = capturedClientOptions.documentSelector.map((s: any) => s.pattern);
-            assert.ok(patterns.includes('**/protocol/**/*.yaml'), 'Should include protocol YAML pattern');
-            assert.ok(patterns.includes('**/models/**/*.yaml'), 'Should include models YAML pattern');
+            assert.ok(!patterns.includes('**/protocol/**/*.yaml'), 'Should not include bare protocol YAML pattern');
+            assert.ok(!patterns.includes('**/models/**/*.yaml'), 'Should not include bare models YAML pattern');
             assert.ok(patterns.includes('**/*.spy.yaml'), 'Should include .spy.yaml pattern');
             assert.ok(patterns.includes('**/*.spy.yml'), 'Should include .spy.yml pattern');
             assert.ok(patterns.includes('**/*.spy'), 'Should include .spy pattern');
@@ -129,7 +129,7 @@ suite('VS Code Extension', () => {
     suite('deactivate', () => {
         test('Given client is initialized when deactivate is called then it should call client.stop() and return the Thenable.', () => {
             execSyncStub.returns(Buffer.from('Version: 1.2.0'));
-            const mockContext = {} as vscode.ExtensionContext;
+            const mockContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
             
             sinon.stub(LanguageClient.prototype, 'start');
             const stopStub = sinon.stub(LanguageClient.prototype, 'stop').returns(Promise.resolve());


### PR DESCRIPTION
Serverpod 4.0 requires the `.spy.yaml` extension for model files. Bare `.yaml` / `.yml` files in `lib/src/models` and `lib/src/protocol`, are no longer treated as models.

This removes the directory heuristics from model discovery, the extra bare-yaml watcher in the language server, and the `onLanguage:yaml` activation of the VS Code extension. It also makes `serverpod start` consistent with `generate`: its file watcher was already `.spy`-only, so bare yaml models never hot-regenerated.

To keep the upgrade from silently dropping models, `generate`, `create-migration` and `start` scan the legacy directories of the project, its shared packages and its dependent modules for bare yaml model files and exit with an error listing them:

```console
ERROR: Model files must use the .spy.yaml extension. The following files are
ignored:
  lib/src/models/user.yaml
Rename the files to use the .spy.yaml extension and run the command again.
```

Only files whose top-level yaml has a `class`, `enum` or `exception` key are reported, so unrelated yaml in those directories is ignored.

Closes #5537 

## After Merge
- serverpod_docs: update the models page wording and add an upgrade-guide step (drafted).
- Publish VS Code extension 1.5.0.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
- Model files must use the `.spy.yaml`, `.spy.yml` or `.spy` extension. Bare `.yaml` / `.yml` files in `lib/src/models` and `lib/src/protocol` the CLI reports them as an error and asks for them to be renamed.
- The VS Code extension only attaches the language server to `.spy.yaml`, `.spy.yml` and `.spy` files and no longer activates on other yaml files.