### PR TITLE
fix: Run serverpod create without TUI in default mode when stdin/stdout is not a TTY

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/create.dart
+++ b/tools/serverpod_cli/lib/src/commands/create.dart
@@ -1,4 +1,3 @@
-import 'package:ci/ci.dart' as ci;
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
 import 'package:serverpod_cli/src/commands/create/tui/runner.dart';
@@ -235,7 +234,7 @@ class CreateCommand extends ServerpodCommand<CreateOption> {
           .toList(),
     );
 
-    final useTui = (interactive ?? true) && !ci.isCI;
+    final useTui = shouldUseCreateTui(interactive);
 
     if (useTui) {
       await performCreateWithTui(

--- a/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
+++ b/tools/serverpod_cli/lib/src/commands/create/tui/runner.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:ci/ci.dart' as ci;
 import 'package:cli_tools/cli_tools.dart';
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/create/tui/app.dart';
@@ -103,6 +104,46 @@ Future<CreateConfigStateResult> getCreateConfigState({
     isUpgrade: isUpgrade,
     createDefaultMigrationForUpgrade: createDefaultMigrationForUpgrade,
   );
+}
+
+/// Whether [performCreateWithTui] can be used for this invocation, given the
+/// `--interactive` flag as [interactive] (null when the flag was not passed).
+///
+/// Starting the TUI captures stdin's echo and line modes so it can restore them
+/// on exit, and paints frames to stdout. When stdin cannot report those modes
+/// the capture throws before anything is rendered, and because the TUI logger
+/// is already installed by then the failure never reaches the user.
+///
+/// `stdin.hasTerminal` does not answer this: Dart reports every character
+/// device as a terminal, so `< /dev/null` passes that check and then throws
+/// anyway. Reading the mode is the only reliable probe.
+bool shouldUseCreateTui(bool? interactive) {
+  if (interactive == false) return false;
+  if (!ci.isCI && _stdinSupportsTerminalModes && stdout.hasTerminal) {
+    return true;
+  }
+
+  if (interactive == true) {
+    log.warning(
+      'Interactive mode was requested but this environment cannot run the '
+      'interactive setup screen. Continuing with the defaults.',
+    );
+  }
+
+  return false;
+}
+
+/// Whether stdin can report the terminal modes the TUI has to capture.
+///
+/// Any failure to read them means the TUI cannot start, so this deliberately
+/// treats every error as "unsupported".
+bool get _stdinSupportsTerminalModes {
+  try {
+    stdin.echoMode;
+    return true;
+  } catch (_) {
+    return false;
+  }
 }
 
 /// Creates a Serverpod project with the create TUI.

--- a/tools/serverpod_cli/lib/src/commands/quickstart.dart
+++ b/tools/serverpod_cli/lib/src/commands/quickstart.dart
@@ -1,4 +1,3 @@
-import 'package:ci/ci.dart' as ci;
 import 'package:cli_tools/cli_tools.dart';
 import 'package:config/config.dart';
 import 'package:serverpod_cli/src/commands/create/tui/config.dart';
@@ -133,7 +132,7 @@ class QuickstartCommand extends ServerpodCommand<QuickstartOption> {
       ides: [TemplateIde.claude, TemplateIde.cursor, TemplateIde.vscode],
     );
 
-    final useTui = (interactive ?? true) && !ci.isCI;
+    final useTui = shouldUseCreateTui(interactive);
 
     if (useTui) {
       await performCreateWithTui(

--- a/tools/serverpod_cli/test/commands/create/tui/runner_test.dart
+++ b/tools/serverpod_cli/test/commands/create/tui/runner_test.dart
@@ -1,0 +1,188 @@
+import 'dart:io';
+
+import 'package:ci/ci.dart' as ci;
+import 'package:serverpod_cli/src/commands/create/tui/runner.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:serverpod_logging_cli/serverpod_logging_cli.dart';
+import 'package:serverpod_shared/log_io.dart' show LogLevel, TestLogWriter;
+import 'package:test/test.dart';
+
+import '../../../test_util/mock_std.dart';
+
+class _TerminalStdin extends MockStdin {
+  @override
+  bool get hasTerminal => true;
+
+  @override
+  bool get echoMode => true;
+}
+
+/// Stdin that cannot report the terminal modes the TUI has to capture.
+///
+/// Reading `echoMode` is what actually decides whether the TUI can start, and
+/// it throws on a redirected stdin. `hasTerminal` is deliberately left true
+/// here to mirror `< /dev/null`, which Dart reports as a terminal because it
+/// classifies every character device as one.
+class _NonTerminalStdin extends MockStdin {
+  @override
+  bool get hasTerminal => true;
+
+  @override
+  bool get echoMode =>
+      throw const StdinException('Error getting terminal echo mode');
+}
+
+class _TerminalStdout extends MockStdout {
+  @override
+  bool get hasTerminal => true;
+}
+
+/// Runs [body] with `stdin` and `stdout` reporting the given terminal state.
+T _withTerminals<T>(
+  T Function() body, {
+  required bool stdin,
+  required bool stdout,
+}) {
+  return IOOverrides.runZoned(
+    body,
+    stdin: () => stdin ? _TerminalStdin() : _NonTerminalStdin(),
+    stdout: () => stdout ? _TerminalStdout() : MockStdout(),
+  );
+}
+
+void main() {
+  late TestLogWriter writer;
+
+  setUp(() {
+    writer = TestLogWriter();
+    initializeLoggerWith(ServerpodCliLogger(writer));
+  });
+
+  tearDown(closeLogger);
+
+  test(
+    'Given only stdin is attached to a terminal, '
+    'when calling shouldUseCreateTui with interactive set to null, '
+    'then it returns false.',
+    () {
+      final useTui = _withTerminals(
+        () => shouldUseCreateTui(null),
+        stdin: true,
+        stdout: false,
+      );
+
+      expect(useTui, isFalse);
+    },
+  );
+
+  test(
+    'Given only stdout is attached to a terminal, '
+    'when calling shouldUseCreateTui with interactive set to null, '
+    'then it returns false.',
+    () {
+      final useTui = _withTerminals(
+        () => shouldUseCreateTui(null),
+        stdin: false,
+        stdout: true,
+      );
+
+      expect(useTui, isFalse);
+    },
+  );
+
+  group('Given stdin and stdout are both attached to a terminal,', () {
+    test(
+      'when calling shouldUseCreateTui with interactive set to null, '
+      'then it returns true unless in CI.',
+      () {
+        final useTui = _withTerminals(
+          () => shouldUseCreateTui(null),
+          stdin: true,
+          stdout: true,
+        );
+
+        expect(useTui, equals(!ci.isCI));
+      },
+    );
+
+    test(
+      'when calling shouldUseCreateTui with interactive set to true, '
+      'then it returns true unless in CI.',
+      () {
+        final useTui = _withTerminals(
+          () => shouldUseCreateTui(true),
+          stdin: true,
+          stdout: true,
+        );
+
+        expect(useTui, equals(!ci.isCI));
+      },
+    );
+
+    test(
+      'when calling shouldUseCreateTui with interactive set to false, '
+      'then it returns false.',
+      () {
+        final useTui = _withTerminals(
+          () => shouldUseCreateTui(false),
+          stdin: true,
+          stdout: true,
+        );
+
+        expect(useTui, isFalse);
+      },
+    );
+  });
+
+  group('Given stdin and stdout are both not attached to a terminal,', () {
+    test(
+      'when calling shouldUseCreateTui with interactive set to null, '
+      'then it returns false.',
+      () {
+        final useTui = _withTerminals(
+          () => shouldUseCreateTui(null),
+          stdin: false,
+          stdout: false,
+        );
+
+        expect(useTui, isFalse);
+      },
+    );
+
+    test(
+      'when calling shouldUseCreateTui with interactive set to true, '
+      'then it logs a warning and returns false.',
+      () async {
+        final useTui = _withTerminals(
+          () => shouldUseCreateTui(true),
+          stdin: false,
+          stdout: false,
+        );
+
+        await log.flush();
+
+        expect(useTui, isFalse);
+        expect(writer.entries, hasLength(1));
+        expect(writer.entries.single.level, LogLevel.warning);
+        expect(
+          writer.entries.single.message,
+          contains('Interactive mode was requested'),
+        );
+      },
+    );
+
+    test(
+      'when calling shouldUseCreateTui with interactive set to false, '
+      'then it returns false.',
+      () {
+        final useTui = _withTerminals(
+          () => shouldUseCreateTui(false),
+          stdin: false,
+          stdout: false,
+        );
+
+        expect(useTui, isFalse);
+      },
+    );
+  });
+}


### PR DESCRIPTION
`serverpod create` and `serverpod quickstart` gated TUI use with CI check and the optional `interactive` flag (treated as enabled by default). When executed with stdin and/or stdout that is not a tty, the TUI is silently broken and project creation doesn't happen. This PR extends the TUI readiness check by probing stdin and stdout for tty.

Closes #5639 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None