### PR TITLE
fix: Add null comparison ops to ColumnSerializable

### DIFF
--- a/packages/serverpod_database/lib/src/concepts/columns.dart
+++ b/packages/serverpod_database/lib/src/concepts/columns.dart
@@ -64,7 +64,8 @@ class ColumnByteData extends Column<ByteData> {
 
 /// A [Column] holding an [SerializableModel]. The entity will be stored in the
 /// database as a json column.
-class ColumnSerializable<T> extends Column<T> {
+class ColumnSerializable<T> extends _ValueOperatorColumn<T>
+    with _NullableColumnDefaultOperations<T> {
   /// Creates a new [Column], this is typically done in generated code only.
   ColumnSerializable(
     super.columnName,
@@ -72,6 +73,10 @@ class ColumnSerializable<T> extends Column<T> {
     super.hasDefault,
     super.fieldName,
   });
+
+  @override
+  Expression _encodeValueForQuery(T value) =>
+      EscapedExpression(SerializationManager.encode(value));
 }
 
 /// A [Column] holding a [SerializableModel]. The entity will be stored in the

--- a/packages/serverpod_database/test/columns/column_serializable_test.dart
+++ b/packages/serverpod_database/test/columns/column_serializable_test.dart
@@ -26,5 +26,25 @@ void main() {
     test('when type is called then String is returned.', () {
       expect(column.type, String);
     });
+
+    group('with _NullableColumnDefaultOperations mixin', () {
+      test(
+        'when equals compared to NULL value then output is IS NULL expression.',
+        () {
+          var comparisonExpression = column.equals(null);
+
+          expect(comparisonExpression.toString(), '$column IS NULL');
+        },
+      );
+
+      test(
+        'when NOT equals compared to NULL value then output is IS NOT NULL expression.',
+        () {
+          var comparisonExpression = column.notEquals(null);
+
+          expect(comparisonExpression.toString(), '$column IS NOT NULL');
+        },
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
`ColumnSerializable` previously had no column operations, making null checks on nullable JSON columns (e.g. `List<T>?`) impossible.

This PR extends `ColumnSerializable` with `_NullableColumnDefaultOperations`, matching `ColumnUri` and similar types. `equals(null)` and `notEquals(null)` now produce `IS NULL` / `IS NOT NULL` expressions.

Fixes #1591

## Test plan
- [x] Added unit tests for null and non-null comparisons