### PR TITLE
refactor: Extract client setup into client.dart in template

### DIFF
--- a/templates/serverpod_templates/projectname_flutter_upgrade/lib/client.dart
+++ b/templates/serverpod_templates/projectname_flutter_upgrade/lib/client.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+
+import 'package:projectname_client/projectname_client.dart';
+// {{#auth}}
+import 'package:serverpod_auth_idp_flutter/serverpod_auth_idp_flutter.dart';
+// {{/auth}}
+import 'package:serverpod_flutter/serverpod_flutter.dart';
+
+// When you are running the app on a physical device, you need to set the
+// server URL to the IP address of your computer. You can find the IP
+// address by running `ipconfig` on Windows or `ifconfig` on Mac/Linux.
+//
+// You can set the variable when running or building your app like this:
+// E.g. `flutter run --dart-define=SERVER_URL=https://api.example.com/`.
+//
+// Otherwise, the server URL is fetched from the assets/config.json file or
+// defaults to http://$localhost:8080/ if not found.
+final serverUrl = getServerUrl();
+
+/// Sets up a global client object that can be used to talk to the server from
+/// anywhere in our app. The client is generated from your server code
+/// and is set up to connect to a Serverpod running on a local server on
+/// the default port. You will need to modify this to connect to staging or
+/// production servers.
+/// In a larger app, you may want to use the dependency injection of your choice
+/// instead of using a global client object. This is just a simple example.
+late final Client client;
+
+Future<void> initializeClient() async {
+  client = Client(await serverUrl)
+    ..connectivityMonitor = FlutterConnectivityMonitor()
+    // {{#auth}}
+    ..authSessionManager = FlutterAuthSessionManager()
+  // {{/auth}}
+  ;
+  // {{#auth}}
+  unawaited(client.auth.initialize());
+  // {{/auth}}
+}

--- a/templates/serverpod_templates/projectname_flutter_upgrade/lib/main.dart
+++ b/templates/serverpod_templates/projectname_flutter_upgrade/lib/main.dart
@@ -1,48 +1,11 @@
-import 'package:projectname_client/projectname_client.dart';
 import 'package:flutter/material.dart';
-import 'package:serverpod_flutter/serverpod_flutter.dart';
-// {{#auth}}
-import 'package:serverpod_auth_idp_flutter/serverpod_auth_idp_flutter.dart';
-// {{/auth}}
 
+import 'client.dart';
 import 'screens/greetings_screen.dart';
-
-/// Sets up a global client object that can be used to talk to the server from
-/// anywhere in our app. The client is generated from your server code
-/// and is set up to connect to a Serverpod running on a local server on
-/// the default port. You will need to modify this to connect to staging or
-/// production servers.
-/// In a larger app, you may want to use the dependency injection of your choice
-/// instead of using a global client object. This is just a simple example.
-late final Client client;
-
-late String serverUrl;
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-
-  // When you are running the app on a physical device, you need to set the
-  // server URL to the IP address of your computer. You can find the IP
-  // address by running `ipconfig` on Windows or `ifconfig` on Mac/Linux.
-  //
-  // You can set the variable when running or building your app like this:
-  // E.g. `flutter run --dart-define=SERVER_URL=https://api.example.com/`.
-  //
-  // Otherwise, the server URL is fetched from the assets/config.json file or
-  // defaults to http://$localhost:8080/ if not found.
-  final serverUrl = await getServerUrl();
-
-  client = Client(serverUrl)
-    ..connectivityMonitor = FlutterConnectivityMonitor()
-    // {{#auth}}
-    ..authSessionManager = FlutterAuthSessionManager()
-  // {{/auth}}
-  ;
-
-  // {{#auth}}
-  client.auth.initialize();
-  // {{/auth}}
-
+  await initializeClient();
   runApp(const MyApp());
 }
 

--- a/templates/serverpod_templates/projectname_flutter_upgrade/lib/screens/greetings_screen.dart
+++ b/templates/serverpod_templates/projectname_flutter_upgrade/lib/screens/greetings_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../main.dart';
+import '../client.dart';
 
 class GreetingsScreen extends StatefulWidget {
   final Future<void> Function()? onSignOut;

--- a/templates/serverpod_templates/projectname_flutter_upgrade/lib/screens/{{#auth}}sign_in_screen{{!auth}}.dart
+++ b/templates/serverpod_templates/projectname_flutter_upgrade/lib/screens/{{#auth}}sign_in_screen{{!auth}}.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:serverpod_auth_idp_flutter/serverpod_auth_idp_flutter.dart';
 
-import '../main.dart';
+import '../client.dart';
 
 class SignInScreen extends StatefulWidget {
   final Widget child;

--- a/tests/bootstrap_project/test/auth_test.dart
+++ b/tests/bootstrap_project/test/auth_test.dart
@@ -30,6 +30,7 @@ void main() async {
     group('when creating a new project', () {
       late File serverFile;
       late File mainFile;
+      late File clientFile;
 
       setUpAll(() async {
         var process = await startServerpodCli(
@@ -55,6 +56,9 @@ void main() async {
         );
         mainFile = File(
           path.join(d.sandbox, flutterDir, 'lib', 'main.dart'),
+        );
+        clientFile = File(
+          path.join(d.sandbox, flutterDir, 'lib', 'client.dart'),
         );
       });
 
@@ -116,8 +120,8 @@ void main() async {
         expect(content, contains('JwtConfigFromPasswords'));
       });
 
-      test('then the flutter main.dart contains auth imports', () {
-        final content = mainFile.readAsStringSync();
+      test('then the flutter client.dart contains auth imports', () {
+        final content = clientFile.readAsStringSync();
         expect(content, contains('serverpod_auth_idp_flutter'));
       });
 
@@ -126,10 +130,13 @@ void main() async {
         expect(content, contains('SignInScreen'));
       });
 
-      test('then the flutter main.dart contains FlutterAuthSessionManager', () {
-        final content = mainFile.readAsStringSync();
-        expect(content, contains('FlutterAuthSessionManager'));
-      });
+      test(
+        'then the flutter client.dart contains FlutterAuthSessionManager',
+        () {
+          final content = clientFile.readAsStringSync();
+          expect(content, contains('FlutterAuthSessionManager'));
+        },
+      );
     });
   });
 }

--- a/tests/bootstrap_project/test_perform_create/auth_test.dart
+++ b/tests/bootstrap_project/test_perform_create/auth_test.dart
@@ -154,10 +154,10 @@ void main() {
       );
 
       test(
-        'then the flutter main.dart contains auth configurations',
+        'then the flutter client.dart contains auth configurations',
         () async {
           final file = File(
-            p.join(project.flutterDir, 'lib', 'main.dart'),
+            p.join(project.flutterDir, 'lib', 'client.dart'),
           );
           final content = await file.readAsString();
           expect(
@@ -170,13 +170,7 @@ void main() {
             content,
             contains('..authSessionManager = FlutterAuthSessionManager()'),
           );
-          expect(content, contains('client.auth.initialize();'));
-          expect(
-            content,
-            contains(
-              '// To test authentication in this example app, uncomment the line below',
-            ),
-          );
+          expect(content, contains('unawaited(client.auth.initialize());'));
         },
       );
 


### PR DESCRIPTION
Changes templates to avoid circular import between _main.dart_ and files in _screens/_. Apart from circular imports being ugly, this helps sidestep https://github.com/flutter/flutter/issues/192054

Fixes: #5657