### PR TITLE
feat: Create standalone serverpod_cloud_storage package

### DIFF
--- a/PUBLISHABLE_PACKAGES
+++ b/PUBLISHABLE_PACKAGES
@@ -1,6 +1,7 @@
 packages/serverpod_lints
 packages/serverpod_serialization
 packages/serverpod_shared
+packages/serverpod_cloud_storage
 packages/serverpod_embedded_postgres
 packages/serverpod_database
 packages/serverpod_client

--- a/packages/serverpod_cloud_storage/CHANGELOG.md
+++ b/packages/serverpod_cloud_storage/CHANGELOG.md
@@ -1,0 +1,1232 @@
+## 4.0.0-rc.1
+
+Release candidate for Serverpod 4.
+
+Serverpod 4 is a major overhaul of the development experience. It introduces a new development experience with an interactive command that boots your entire stack, makes Serverpod projects agent-ready out of the box, and lays the foundation for client-side databases with the new SQLite dialect.
+
+### Built for agentic development
+
+Serverpod projects are now set up for AI-assisted development from the moment they are created. The CLI ships with an MCP server, skills and agent instructions installed for the IDEs/Agents you select. The MCP server exposes all tools from `serverpod start` to agents for an immersive agentic development experience. Try out the reworked `serverpod create` and the new `serverpod quickstart` commands.
+
+### The new `serverpod start` command
+
+Serverpod 4 introduces `serverpod start`, a single command that runs everything your project needs and keeps it in sync while you work. No more juggling `docker compose`, `serverpod generate --watch`, the server and the Flutter app in separate terminals.
+
+Key features include:
+
+- A full terminal UI for the server, the database and your apps, with live logs and interactive actions.
+- Hot reload and hot restart of the server on every change, including generated code and dependencies.
+- Launching one or more Flutter apps, with integrated hot reload/restart and their logs in the same UI.
+- Creating and applying migrations without restarting the server.
+
+#### Zero-configuration local development database
+
+Running a database locally no longer requires any setup. Serverpod now ships custom PostgreSQL multi-platform binaries built with `pgvector` and `postgis` support that can be run in embedded mode when running the server or started standalone with `serverpod database start`. Projects that do not configure the `dataPath` parameter on the `database` config get the `docker compose` started automatically by `serverpod start` instead.
+
+### Client-side databases
+
+The same models, ORM and migrations you already know can now generate a client-side SQLite database when using the new `database` keyword. Migrations for the client are separate and generated as Dart code for easy integration in Flutter apps without having to deal with assets.
+
+#### Supporting offline-first applications
+
+To allow easily building offline-first Flutter apps, the experimental `database: sync` option will configure the models for synchronization with the server using the `serverpod_offline_sync` module. No other configuration is needed beyond annotating the models and adding the dependencies to the client and server. Check the [`serverpod_offline_sync` README](https://pub.dev/packages/serverpod_offline_sync) for more details on how to use it.
+
+### Additional changes
+
+#### Breaking changes
+
+- feat: BREAKING. Changes default message central delivery to global with fallback to local.
+- refactor: BREAKING. Refactors the `ServerpodClientException` hierarchy to introduce a proper exception for network errors. Previous HTTP-related exceptions now extend the sealed `ServerpodClientHttpException` class.
+- refactor: BREAKING. Refactors the database exception hierarchy to throw specific exceptions for common operation errors (unique/foreign key constraint violations, SQLite database locked, etc.).
+- refactor: BREAKING. Merges normal and `*withOptions` methods on the `CloudStorage` interface.
+- fix: BREAKING. Requires the `.spy.yaml` extension for model files.
+- fix: BREAKING. Removes the native Google Sign-In web implementation in favor of OAuth2.
+- fix: BREAKING. Removes dead email-related exceptions. ([@realmeylisdev](https://github.com/realmeylisdev))
+- fix: BREAKING. Removes the deprecated `authenticationKeyManager` client parameter.
+- fix: BREAKING. Removes the legacy streaming session and deprecated streaming APIs.
+- fix: BREAKING. Removes deprecated future call methods.
+- fix: BREAKING. Removes deprecated `orderDescending` parameter on ORM methods.
+- fix: BREAKING. Removes deprecated `ignoreEndpoint` annotation from the CLI.
+- fix: BREAKING. Removes deprecated `SerializationManagerServer` class.
+- fix: BREAKING. Removes deprecated web-server widgets and legacy static directory classes.
+- chore: BREAKING. Removes the `--mini` option from the `serverpod create` command.
+- chore: BREAKING. Bumps minimum Dart version to 3.12.2 and Flutter version to 3.44.4.
+
+#### Models, ORM and database:
+
+- feat: Allows using the `table` keyword on shared package models configured with `database: all`.
+- feat: Introduces new `upsert` and `upsertRow` methods on the ORM. ([@sedobrengocce](https://github.com/sedobrengocce))
+- feat: Adds a `noReturn` parameter to all ORM methods to allow skipping the returning the data.
+- feat: Adds support for `orderBy` and `orderByList` in `delete` and `deleteWhere` methods. ([@henycave](https://github.com/henycave))
+- feat: Introduces `asc()` / `desc()` convenience methods on orderable columns.
+- feat: Adds a `databaseInterceptor` parameter to `Serverpod` for intercepting database operations.
+- feat: Adds support for `dynamic` fields on models, database and endpoints.
+- feat: Adds support for `jsonb` columns and `GIN` indexes, with lossless `json` <-> `jsonb` column type migration. ([@developerjamiu](https://github.com/developerjamiu))
+- feat: Adds PostGIS geography types support with GiST and SP-GiST indexes. ([@charlesarchibong](https://github.com/charlesarchibong))
+- feat: Implements `Iterable` and `operator[]` on vector types.
+- feat: Allows using `serial` on regular `int` columns on PostgreSQL.
+- feat: Adds support for the `nulls_distinct` key on unique indexes on PostgreSQL.
+- feat: Exposes a `unique` keyword and `unique(per=...)` variant on models for simplified creation of unique indexes.
+- feat: Allows overriding a `column` name on models, with proper migration support.
+- feat: Allows the `fk` flag for declaring the owner of the foreign key on a `relation`.
+- feat: Generates the column specified as `field=` on relations that require the explicit foreign key.
+- feat: Introduces the `deferred` and `deferrable` flags on relations to postpone constraints evaluation inside transactions.
+- feat: Adds the `tail` keyword on models to configure the order of inherited fields.
+- feat: Allows `extends` and `sealed` properties on `Exception` models.
+- feat: Forwards shared package models through the owning module's server/client packages.
+- feat: Exposes datetime filter parameters on Insights logs endpoint.
+- refactor: Decouples all database-related code from `serverpod` into the new `serverpod_database` package.
+- refactor: Removes database-specific default values from the definition files.
+- fix: Preserves `ORDER BY` in nested `includeList` queries with `LIMIT`.
+- fix: Deprecates the manual creation of `Order` objects in favor of the new `asc()` / `desc()` methods.
+- fix: Gates unused Insights endpoint methods behind the `enableDatabaseAccess` config.
+
+#### Server, web server and client:
+
+- feat: Ensures at-least-once semantics for future calls execution.
+- feat: Adds dedicated support for recurring future calls.
+- feat: Exposes configuration options for finding and deleting broken future calls on server startup.
+- feat: Adds a `withSession` method on `Serverpod` for manual session usage with automatic teardown. ([@nicowalter256](https://github.com/nicowalter256))
+- feat: Exposes the Redis connection to allow users to build custom extensions.
+- feat: Makes the `global` cache fallback to local in development/testing.
+- feat: Adds opt-in `httpOnly` cookie authentication for web clients.
+- feat: Exposes health endpoints on the webserver.
+- feat: Adds support for cache busting with dedicated syntax in templating system.
+- feat: Changes the `WidgetRoute.build` method to return `WebWidget?` and easily throw a 404.
+- feat: Exposes the parameter `httpClientOverride` on the generated `Client` for HTTP client override.
+- refactor: Changes the way endpoints are called to pass the method on the route instead of the body.
+- fix: Exposes a new `serverDirectory` parameter on `Serverpod` to avoid depending on `Directory.current`.
+- fix: Releases sessions from `MessageCentral` when streams are cancelled before session close.
+- fix: Fixes a racing condition when closing a streaming method right after opening it.
+- fix: Exports WebSocket event types. ([@loopassembly](https://github.com/loopassembly))
+- fix: Throws `StateError` instead of `Exception` for not configured features. ([@realmeylisdev](https://github.com/realmeylisdev))
+- fix: Changes the default cache policy for Flutter web assets to `private, no-cache` for all files.
+- perf: Optimizes Insights queries 60x by using object relations and improved indexes.
+
+#### Authentication:
+
+- feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
+- feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
+- feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.
+- feat: Adds `FlutterWebAuth2RedirectRoute` for OAuth2 PKCE web sign-in flow.
+- feat: Adds `onAfterAccountCreated` callbacks to all IDPs for custom post-account creation logic. ([@kamil-matula](https://github.com/kamil-matula))
+- feat: Makes an additional request to get emails on GitHub IDP if missing in the first attempt.
+- feat: Adds `HmacSha256` JWT algorithm on the auth core package.
+- feat: Adds `kid` to JWT header for ES512 tokens.
+- feat: Adds legacy client support for Email auth migrations.
+- feat: Allows configuring localization for the sign in widgets. ([@justlunix](https://github.com/justlunix))
+- feat: Unifies and customizes social sign-in button styling.
+- feat: Disables the sign-in UI while authentication is in progress. ([@abdulawalarif](https://github.com/abdulawalarif))
+- fix: Fixes IDPs silently skipping `UserProfile` creation during first login if an exception occurs.
+- fix: Allows unverified emails in Firebase IDP for default account validation.
+- fix: Allows OWASP special characters in password field. ([@realmeylisdev](https://github.com/realmeylisdev))
+- fix: Adds missing `onRefreshTokenCreated` to `JwtConfigFromPasswords` constructor.
+- fix: Fixes the background of the `SignInWidget` and `EmailSignInWidget` not being transparent.
+- fix: Adds a `Material` wrapper to the `SignInWidget` for correct rendering when not using a Material app.
+- fix: Makes `TermsAndPrivacyText` sign-in widget respond to app theming.
+
+#### Command line and developer tooling:
+
+- feat: Exposes flags on the `serverpod create` command to customize the created project.
+- feat: Adds support for creating server only projects.
+- feat: Exposes unified access to `scloud` through the new `serverpod cloud` command.
+- feat: Replaces the docker image for PostgreSQL by the official `ghcr.io/serverpod/postgres:16`.
+- feat: Allows running tests with complete isolation and plain `dart test` using `withServerpod`.
+- feat: Generates a simplified `Serverpod` class for cleaner initialization.
+- fix: Updates language server state when model files change on disk.
+- fix: Forwards global options to the subcommands of the `serverpod` command.
+- fix: Adds back the missing `--empty` flag to the `create-migration` command.
+- fix: Adds validation that throws early if invalid chars are used on migration tag names.
+- fix: Prunes trailing empty migration dirs. ([@Moe1211](https://github.com/Moe1211))
+- fix: Improves the "Flutter web app not built" page on the template.
+- fix: Serves Flutter app config file on the correct path when project uses only webapp.
+- chore: Changes the template to serve the Flutter web app under root if website is not enabled.
+- chore: Removes automatic run of `flutter_build` during `create` command.
+- chore: Disables WASM by default on new projects.
+- chore: Avoid exposing unnecessary secrets on the template.
+- chore: Removes the requirement for Flutter to run the `serverpod_cli` on CI.
+- chore: Improves the analytics reporting on used Serverpod features.
+
+#### Code generation:
+
+- fix: Makes generated Dart code `dart format` clean respecting the project options.
+- fix: Fixes generator failing when the client or shared package are imported on the server.
+- fix: Fixes future calls generation if running `generate` for the first time from a clean state.
+- fix: Adds an error when unregistered custom classes are used in endpoints.
+- fix: Excludes static methods from endpoint code generation. ([@realmeylisdev](https://github.com/realmeylisdev))
+- fix: Changes `testObjectToJson` return type from `dynamic` to `Map<String, dynamic>`. ([@realmeylisdev](https://github.com/realmeylisdev))
+- fix: Generates `detach` and `detachRow` for named list relations without order dependence.
+- perf: Reduces the time taken to run incremental generation steps with the `--watch` flag by 15x and the regular `generate` command by 20%.
+- perf: Activates the staleness check on the `generate` command to avoid redundant work. Use `--force` to bypass.
+- chore: Generates stable import prefixes on generated code to reduce conflicts and diff noise.
+
+## 3.4.13
+
+- fix: BREAKING. Fixes Apple on legacy auth accepting unverified identities. Deployments using Sign in with Apple must set `appleClientIds`
+on `AuthConfig` to their bundle and services ids. Backported to 2.9.5.
+- fix: BREAKING. Fixes Firebase on legacy auth accepting unverified identities. Firebase sign-in with no email verification are still accepted, but won't register the e-mail on `UserInfo` and, therefore, won't merge with other sign-in options. Backported to 2.9.5.
+- fix: Restores inbound foreign keys on migrations when a table is recreated.
+- chore: Allows overriding the default cache headers for `StaticRoute` and `SpaRoute` from env vars.
+
+## 3.4.12
+
+- fix: Fixes Google Sign-In accepting an access token minted for a different OAuth client that could be used to takeover an account.
+- fix: Fixes improper neutralization of string values in Serverpod's ORM that exposes SQL injection from user input. Also backported to 2.9.4.
+- fix: Includes session key salt in the session key hash.
+- fix: Makes the login rate limit bound guesses per user.
+- fix: Prevents rotating a refresh token for a blocked auth user.
+- chore: Allows overriding the default cache header for `FlutterRoute` from env vars.
+- chore: Polishes and adds dark theme to the default Flutter app.
+
+## 3.4.11
+
+- fix: Adds missing export of `DeepCollectionEquality` for shared models.
+- fix: Prevents the creation of orphaned images on subsequent IDP logins.
+
+## 3.4.10
+
+- fix: Fixes malformed query when negating many-relation filters. ([@realmeylisdev](https://github.com/realmeylisdev))
+- fix: Fixes trying to complete the web socket listener twice on concurrent connections.
+
+## 3.4.9
+
+- fix: Fixes joins with long column names and deeply nested relations not mapping the correct columns.
+- fix: Fixes error when closing method stream command with error after already closed.
+- fix: Fixes migrations not being generated when changing columns of an index.
+- fix: Fixes Dockerfile after workspaces upgrade.
+- fix: Fixes GitHub workflows on project templates after workspaces upgrade.
+
+## 3.4.8
+
+- fix: Fixes Postgres throwing when using row-lock on `find*` methods with `includes`.
+- fix: Adds configurable clock skew tolerance to ID token validation on Google and Firebase IDPs.
+
+## 3.4.7
+
+- fix: Fixes constraints drop failing on Postgres due to already removed columns.
+- fix: Adds missing `configOverride` forward to the test server.
+- fix: Prevents triggering auth event listener when invalidating cache for JWT token refresh.
+
+## 3.4.6
+
+- fix: Removes wrong documentation link on `PasswordMissingException`.
+- fix: Adds top-level `.gitignore` on created projects to ignore the `.dart_tool` of the workspace.
+- fix: Allows `serverpod create .` in the current directory.
+- fix: Makes `insert` with `ignoreConflicts` and `!persist` fields atomic.
+- fix: Extends immutable non-constant default validation to cover id field.
+- fix: Adds missing `onSessionCreated` to `ServerSideSessionsConfigFromPasswords` constructor.
+- fix: Invalidates the cached refresh token before rotating in case the storage has changed.
+- chore: Bumps `jose` dependency on legacy auth to fix `CVE-2026-34240`. Also backported to 2.9.3.
+
+## 3.4.5
+
+- fix: Truncates logged error messages to prevent hanging on formatter issues during code generation.
+- fix: Fixes the CLI invoking the welcome page more than once per install.
+- chore: Moves the `flutter_secure_storage` override from the workspace to the created Flutter package on a new project.
+
+## 3.4.4
+
+- fix: Fixes Google Sign-In not handling error when invoked directly from the controller.
+- fix: Allows configuring the authority host for the Microsoft identity provider.
+- fix: Adds support for additional authentication parameters on the Microsoft identity provider.
+- fix: Adds support for additional authentication parameters on the GitHub identity provider.
+
+## 3.4.3
+
+- refactor: Changes the `session` parameter type on repository methods to `DatabaseSession`.
+- fix: Fixes serialization of model objects in named record fields when mapping to JSON.
+- fix: Fixes CLI showing warnings duplicated on projects with generated future calls.
+- fix: Fixes missing generated `_Undefined` class when parent sealed classes have nullable fields and children have only non-nullable fields.
+- fix: Fixes conflict on the `Cache` class import after `relic` upgrade to version `1.2.0`.
+
+## 3.4.2
+
+- fix: Fixes wrong import URL to `serverpod_service_client` of shared models referenced as fields in other shared models.
+- fix: Adds a warning to inform when the server is started with a `Protocol` class from an external package.
+- fix: Skips explicit `DROP CONSTRAINT` when referenced table is dropped via `CASCADE`.
+
+## 3.4.1
+
+- fix: Fixes shared models using inexistent `toJsonForProtocol` method if referenced as fields on models with `!persist` or `serverOnly` fields.
+- fix: Fixes not being able to reference shared models without the module alias on fields of other models.
+
+## 3.4.0
+
+Serverpod 3.4 comes with two long-awaited features: shared models between server and client and allowing caching any type of object to the local/Redis cache. It also brings two new Identity Providers (Facebook and Microsoft), a complete revamp to the cloud storage system, ignore conflicts on inserts and row-level locking on the database, shell completion support to the CLI and more improvements to the developer experience.
+
+### Core
+
+- feat: Allows generating shared models between server and client on shared packages.
+- feat: Allows caching any type of object to the local/Redis cache.
+- feat: Allows ignoring conflicts on inserts through the `ignoreConflicts` parameter of the `insert` method. ([@FXschwartz](https://github.com/FXschwartz))
+- feat: Adds PostgreSQL row-level locking through `find*` and `lockRows` methods. ([@FXschwartz](https://github.com/FXschwartz))
+- feat: Adds support for FutureCall methods with only the `Session` parameter.
+- fix: Fixes the time unit display on session log duration. ([@Tokotuu](https://github.com/Tokotuu))
+- chore: Logs a warning when server tries to run unregistered future calls.
+
+### Authentication
+
+- feat: Adds support to Facebook Identity Provider. ([@vfiruz97](https://github.com/vfiruz97))
+- feat: Adds Microsoft Identity Provider. ([@vfiruz97](https://github.com/vfiruz97))
+- feat: Allows attaching custom metadata to SSS/JWT tokens.
+- feat: Adds `expired` filter and `limit` parameter to `ServerSideSessions.listSessions`.
+- fix: Allows handling Android and Web redirection for Apple Sign In. ([@jakubgiminski](https://github.com/jakubgiminski))
+- fix: Correctly binds `AuthUsersConfig` to `AnonymousIdp`. ([@craiglabenz](https://github.com/craiglabenz))
+
+### Cloud Storage
+
+- feat: Introduces a shared `serverpod_cloud_storage_s3_compat` base package for S3-compatible storage integrations.
+- feat: Adds a native Google Cloud Storage implementation on the `serverpod_cloud_storage_gcp` package with Application Default Credentials support.
+- feat: Adds a new `serverpod_cloud_storage_r2` package for Cloudflare R2.
+- feat: Adds new parameters `preventOverwrite`, `maxFileSize`, `contentLength`, and `expirationDuration` for finer upload control.
+- refactor: Refactors the existing S3 and GCP storage packages to reduce code duplication by using the `serverpod_cloud_storage_s3_compat` package.
+- fix: Fixes several issues on the storage packages like silent error swallowing, HTTP client leaks, and buffer aliasing bugs.
+
+### Developer tooling
+
+- feat: Generates `.vscode/launch.json` with a composite project as default for full-stack debugging.
+- feat: Adds shell completion support to Serverpod CLI. ([@FXschwartz](https://github.com/FXschwartz))
+
+## 3.3.1
+
+- fix: Fixes text of GitHub IDP button not aligning correctly when using the left alignment. ([@vfiruz97](https://github.com/vfiruz97))
+- fix: Fixes missing `tokenExpiresAt` info on `AuthSuccess` for server-side sessions.
+
+## 3.3.0
+
+Serverpod 3.3 brings a lot of new features and improvements to the framework, including two new identity providers (GitHub and Anonymous), virtual host routing, a robust Kubernetes-ready monitoring system, JSON key aliases and enum properties on models, and several improvements to logging.
+
+> The Anonymous IDP is currently experimental and can not be completely used yet due to the missing support for account linking. The missing parts will be added in the next releases.
+
+### Core
+
+- feat: Adds Kubernetes-style health check endpoints `livez`, `readyz`, and `startupz` with support for custom health checks.
+- feat: Adds configurable log retention and automated purging.
+- feat: Allows defining custom `jsonKey` aliases in models to use in JSON serialization and deserialization. ([@FXschwartz](https://github.com/FXschwartz))
+- feat: Adds support for defining custom properties on enum models. ([@FXschwartz](https://github.com/FXschwartz))
+- fix: Preserves logging behavior settings when unrelated configs are set.
+- fix: Fixes missing source on linting error due to the `fields` key missing under `indexes`.
+- fix: Fixes console log timestamps showing actual event time instead of flush time. ([@Tokotuu](https://github.com/Tokotuu))
+- fix: Generates `const` defaults for `Duration` and `Uuid().v#obj()` types.
+- fix: Prevent import errors during generation when renaming the server on a project to `server`.
+- fix: Adds keep-alive pings and idle timeout detection from the client to improve reliability of streaming connections.
+- fix: Fixes CPU and memory metrics when running the server inside containers.
+
+### Authentication
+
+- feat: Adds Anonymous IDP (currently experimental). ([@craiglabenz](https://github.com/craiglabenz))
+- feat: Adds connected IDPs lookup on the server and client. ([@craiglabenz](https://github.com/craiglabenz))
+- feat: Adds GitHub identity provider support. ([@vfiruz97](https://github.com/vfiruz97))
+- feat: Adds an OAuth2 utility for building identity providers. ([@vfiruz97](https://github.com/vfiruz97))
+- fix: Fixes custom `--serverId` not being properly propagated to logs.
+- fix: Fixes Email IDP callbacks for sending verification codes not allowing `async` functions.
+- fix: Exposes `VerificationCodeConfig` in the `serverpod_auth_idp_flutter` package with no extra imports. ([@NeroSong](https://github.com/NeroSong))
+
+### Web server
+
+- feat: Adds virtual host routing to allow serving different content per based on the host of incoming requests.
+- feat: Exposes WebSocket ping interval for configuration via environment variables or configuration file.
+- chore: Serverpod now uses Relic 1.0.0! 🎉
+
+### Developer tooling
+
+- feat: Uses pub workspaces by default for new projects.
+
+## 3.2.3
+
+- fix: Fixes `flutter_build` script on the template project for Windows.
+
+## 3.2.2
+
+- fix: Fixes generated future calls producing import paths with backslashes on Windows.
+- fix: Fixes `serverpod generate` timer frozen while command is running.
+
+## 3.2.1
+
+- fix: Moves the `Firebase` IDP into a separate package to avoid unexpected compilation issues for non-users of the IDP.
+- fix: Prevents Google lightweight sign-in from automatically shadowing other identity providers.
+- fix: Fixes the CLI directory search failing when trying to access removed folders on Windows.
+
+## 3.2.0
+
+Serverpod 3.2 brings a completely reworked experience for future calls, enhanced platform support on `serverpod run`, the new Firebase identity provider and several minor improvements.
+
+### Core
+
+- feat: Adds new `FutureCall` experience with scheduling from generated type-safe classes ([@Crazelu](https://github.com/Crazelu)).
+- feat: Propagates deprecated annotations from endpoint parameters to generated client code.
+- feat: Adds a convenience `getServerUrl` function to the `serverpod_flutter` package.
+- fix: Fixes default values not being applied on models when the JSON key is missing.
+- fix: Fixes module-declared records not being encoded or decoded from the project.
+- chore: Marks legacy future call interaction methods of the `Serverpod` class as deprecated in favor of the new type-safe API.
+
+### Authentication
+
+- feat: Adds the `Firebase` identity provider to the authentication module.
+- feat: Improves performance of rate limit control tables for authentication IDP providers.
+- fix: Throws `PasswordNotFoundException` instead of null assertion in `JWT` and `ServerSideSessions` token managers.
+- fix: Fixes not being able to issue new verification codes for emails with pending registration.
+- fix: Fixes Google lightweight sign-in being invoked when user is already authenticated.
+- fix: Changes verification code default generation to use only numbers for a better UX.
+- fix: Changes `EmailSignInWidget` default start screen to favor user conversion.
+- docs: Clarifies the purpose of each `UserProfile` and `AuthUser` model variants.
+
+### Developer tooling
+
+- feat: Adds support for platform specific scripts in `serverpod run` command.
+- fix: Fixes wrong Dart SDK path on the CLI when invoked from compiled code (like when installed with `dart install`).
+
+## 3.1.1
+
+- fix: Fixes unknown encodings crashing the CLI when creating a new project.
+- fix: Fixes template web server serving the Flutter app config on the wrong path.
+
+## 3.1.0
+
+Serverpod 3.1 focuses on improving the developer experience with new tooling, enhanced Flutter web support, and important bug fixes.
+
+### Flutter web integration
+- feat: Serves a Flutter app for new project templates.
+- feat: Prevents caching of critical Flutter web files in `FlutterRoute`.
+
+### Developer tooling
+- feat: Adds `serverpod run` command for running scripts.
+- feat: Adds Serverpod script for starting the server and building flutter app.
+
+### Web server enhancements
+- feat: Adds HTTP methods support to `WidgetRoute`.
+
+### Model improvements
+- feat: Allows setting column name explicitly on models ([@jwelmac](https://github.com/jwelmac)).
+
+### Additional changes
+- feat: Prevents database operations on health check when the database is idle.
+- feat: Adds `validateHeaders` config option for backward compatibility with Serverpod 2 clients.
+
+### Bug fixes
+- fix: Fixes email sign in button not re-enabling after changing the password.
+- fix: Enforces only lowercase characters on email text field.
+- fix: Fixes email action button not following the material theme.
+- fix: Fixes consistency between spacing of sign in widget components.
+- fix: Improves project templates with easier structure to digest.
+- fix: Throws `PasswordNotFoundException` instead of null assertion in IDP `*FromPassword` config classes.
+- fix: Uses resolved server directory in migration commands.
+- fix: Ensures tailmatch (`/**`) is the default for `StaticRoute.directory`.
+- fix: Fixes deserialization of collections of `serverOnly` models.
+- fix: Prevents unnecessary table drops when removing foreign keys with constraint name collisions.
+- fix: Fixes incorrect import generation for modules with `serverpod` prefix.
+- fix: Stops Google Sign-In button spinner when authentication is canceled.
+
+## 3.0.1
+- fix: Allows the server address to be specified without trailing slash on the client.
+- fix: Fixes allowed `indexes` key on non-table base models to allow inheritance of indexes.
+- fix: Adds missing JWT refresh endpoint to the project template.
+
+## 3.0.0
+
+Serverpod 3 is a major overhaul of the authentication system and the web server.
+
+### Reworked web server
+Serverpod 3 introduces a fully reworked web server with improved performance, additional features, and increased extensibility.
+Built on top of the [Relic framework](https://pub.dev/packages/relic), it provides a more robust and flexible foundation for building web applications.
+
+Key improvements include:
+- Dynamic routes
+- Middleware support
+- Router fallbacks
+- Comprehensive static asset handling, including cache busting and HTTP range requests
+
+### New authentication module
+A new authentication module has been developed based on the [authentication RFC](https://github.com/serverpod/serverpod/issues/3126). It provides a more flexible and robust foundation and significantly simplifies adding new identity providers.
+
+Highlights:
+- Multiple authentication strategies (JWT, server-side sessions)
+- Multiple identity providers (Email, Google, Apple, Passkey) that can be configured and exposed independently
+- New `AuthUser` class representing the authenticated user, their scopes, and all associated authentication tokens — extensible with custom user data
+- Beautiful new UI components that provide a great user experience out of the box.
+- Complete decoupling between UI and authentication logic on controllers that allow easy customization and replacement of the default components.
+
+New packages:
+- **`serverpod_auth_core`** — Core authentication logic and session management
+- **`serverpod_auth_idp`** — Identity provider integrations (Email, Google, Apple, Passkey)
+- **`serverpod_auth_bridge`** — Migration bridge for legacy auth (Email currently supported)
+- **`serverpod_auth_migration`** — Tools and helpers for migrating auth data (Email currently supported)
+
+### Polymorphism support
+Serverpod now supports polymorphism on models and endpoints. This allows you to define a base class that can be extended by other classes using the `extends` keyword. The server will automatically handle the serialization and deserialization both to the database and in client server communication.
+
+- feat: Adds support for receiving and returning polymorphic models on endpoints.
+- feat: Removes the experimental flag on inheritance. Huge shoutout to [@BenAuerDev](https://github.com/BenAuerDev) for all the work on this feature!
+- feat: Generates abstract copyWith method to allow polymorphism on sealed models.
+- feat: Adds support for inheritance on `id` field for table models for `serverOnly` models.
+- fix: Handles unknown class names in polymorphic deserialization.
+
+### Additional changes
+
+#### Breaking changes
+- feat: BREAKING. Removes support for creating empty migrations using the `--force` flag.
+- feat: BREAKING. Use exit code `0` when no migrations are needed.
+- feat: BREAKING. Changes default enum serialization from `byIndex` to `byName`.
+- feat: BREAKING. Authenticated user id is now logged using a String to support multiple formats.
+- fix: BREAKING. Uses the Relic `Headers` class for configuring headers in the Serverpod server.
+- fix: BREAKING. Removes methods previously marked as deprecated.
+- fix: BREAKING. Removes deprecated `SerializableEntity` class.
+- fix: BREAKING. Changes the `userIdentifier` parameter in `AuthenticationInfo` from `Object` to `String`.
+- refactor: BREAKING. Renames `context` parameter to `request` in `Route.call` and `Route.handleCall` methods.
+- refactor(legacy auth): BREAKING. Replaces callbacks with exceptions and return object when validating password hash. ([@yashas-hm](https://github.com/yashas-hm))
+
+#### New features
+- feat: Adds `FlutterRoute` and `SpaRoute` to simplify routing in single page applications.
+- feat: Update template to include the new authentication module.
+- feat: Adds parameter `values` to the `TemplateWidget` class.
+- feat: Adds support for fetching `Request` from all session `Session` object through the `request` getter.
+- feat: Adds support for resolving Dart doc template macros in client code generation.
+- feat: Enable CLI commands to run from anywhere in a project directory. ([@FXschwartz](https://github.com/FXschwartz))
+- feat: Adds `-d` / `--directory` flag to the `serverpod generate` command.
+- feat: Adds support for configuring server output modes in the test framework, defaults to logging only errors.
+- feat: Adds support for endpoint inheritance in generated client code.
+- feat: Adds support for generating abstract endpoint classes in client code.
+- feat: Adds support for `immutable` keyword in models to generate immutable models. ([obiwanzenobi](https://github.com/obiwanzenobi), [@kamil-matula](https://github.com/kamil-matula))
+- feat: Adds support for partial database updates with the `updateWhere` and `updateById` methods.
+- feat: Adds support for `required` field keyword on nullable fields in model and exception definitions.
+- feat: Adds support for `@unauthenticatedClientCall` annotation for endpoints.
+- feat: Web server templates can now be placed in subdirectories. ([@nicowalter256](https://github.com/nicowalter256))
+- feat: Adds a `~` operator on expressions to perform `NOT` expression.
+- feat: Server now stops automatically if the integrity check fails in `development` mode.
+- feat: Introduces a new `authKeyProvider` interface to support multiple authentication key formats.
+
+#### Fixes
+- fix: Improves error message when there is a database mismatch on server startup.
+- fix: Disables future call execution when none are registered.
+- fix: Improves string representation for serializable exceptions.
+- fix: Allows disabling features in the `generator.yaml` configuration file.
+- fix: Fixes an issue on the deserialization engine that would prevent compilation on web in release mode.
+- fix: Prevents the usage of non-constant defaults on immutable models.
+- fix: Fixes missing inherited fields class constructor for table models with relation to inherited models.
+- fix: Improves database migration "version not found" error message.
+- fix: `SessionLogEntry.time` field now uses session start time.
+- fix: Prevents null check error when relation defined without table.
+- fix: Uses daemon exit code conventions for `SIGTERM` graceful shutdown.
+- fix: Makes `connectionTimeout` final to prevent post-initialization mutation.
+- fix: Always resolves the authenticated user for all requests, making `session.authenticated` synchronous.
+- fix: Sets default log level to `debug` in development mode.
+- fix: Fixes an issue where the `@deprecated` annotation was not propagated to test framework endpoints.
+- fix: Fixes an issue where `{@template}` markers were not removed from generated endpoint documentation.
+- fix: Fixes an issue where a failing database health check would fail the health check.
+- fix: Fixes an issue where request-specific information was included in error responses.
+- fix: Fixes an issue where the port retrieved from API and insights server would not be the actual port used by the service.
+- fix: Fixes an issue where updating a vector database entry would crash due to missing dimensions.
+- fix: Fixes a crash when persistent logging is disabled but database is enabled.
+- fix: Replaces health check manager crash on unsupported platform with error message.
+- fix: Index and table name collisions now give errors when generating project.
+- fix: Fixes an issue where the streaming connection handler would attempt to reconnect indefinitely if the connection was lost.
+- fix: Adds a clickable link to the web server when launched.
+- fix: Fixes an issue where invalid client code could be generated when using default values ([@ashishexee](https://github.com/ashishexee))
+- fix: Fixes an issue where the web server port would not reflect the actual port used by the server.
+- fix: Fixes an issue where Redis could not be enabled/disabled through configuration flag.
+- fix: Fixes an issue where constructor configuration could not be overridden by passed in arguments.
+- fix: Fixes an issue where SCP-lite Git URLs were not recognized when warning users about outdated lock files.
+- fix: Database methods intended to only be used by generated code are now annotated with `@internal`.
+- fix: Improves error messaging when database password cannot be resolved.
+- fix: Serverpod templates are now only downloaded during `serverpod create` execution.
+- fix: Add missing `public` parameter to file upload description ([@LeonidVeremchuk](https://github.com/LeonidVeremchuk))
+- fix: Fixes an issue where empty maps in endpoint parameters and server-side return types where not encoded correctly.
+- fix: Removes redundant null check in models using custom classes.
+- fix: `WebWidget` now uses `HTML` instead of `plainText` as the default `mimeType`.
+- fix(legacy auth): Fixes an issue where password length validation was not triggered for password reset and change password. ([@yashas-hm](https://github.com/yashas-hm))
+
+#### Misc
+- docs(legacy auth): Fixes a documentation error where Google was referenced in the Email identity provider. ([@emilakerman](https://github.com/emilakerman))
+- chore: Marks legacy streaming endpoints and associated code as deprecated. Streaming methods are now the preferred way to handle streaming between the server and client.
+- chore: Marks `AuthenticationKeyManager` as deprecated in favour of the new `ClientAuthKeyProvider` interface.
+- chore: Bumps minimum Dart version to 3.8.0 and Flutter version to 3.32.0.
+
+## 2.9.5
+- fix: BREAKING. Fixes Apple on legacy auth accepting unverified identities. Deployments using Sign in with Apple must set `appleClientIds`
+on `AuthConfig` to their bundle and services ids. Backported from 3.4.13.
+- fix: BREAKING. Fixes Firebase on legacy auth accepting unverified identities. Firebase sign-in with no email verification are still accepted, but won't register the e-mail on `UserInfo` and, therefore, won't merge with other sign-in options. Backported from 3.4.13.
+
+## 2.9.4
+- fix: Fixes improper neutralization of string values in Serverpod's ORM that exposes SQL injection from user input. Backported from 3.4.12.
+
+## 2.9.3
+- chore: Bumps `jose` dependency on legacy auth to fix `CVE-2026-34240`. Backported from 3.4.6.
+
+## 2.9.2
+- fix: Fixes a crash when persistent logging is disabled but database is enabled.
+
+## 2.9.1
+- feat: Makes it possible to configure a default page for `SignInWithEmailDialog`.
+- feat: Adds lints to project template.
+- feat: Warns users about using outdated lock file.
+- fix: Updates UUID generator reference to use `serverpod` package instead of `uuid`.
+- fix: Clears cache in between test runs.
+- fix: Removes database write from read/write test.
+- fix: Fixes code generation for type definitions from other folders.
+- fix: Fixes `getClassNameForObject` method in subclasses.
+
+## 2.9.0
+- feat: Adds support for `HalfVector`, `SparseVector` and `Bit` vector types in models and endpoints. ([@marcelomendoncasoares](https://github.com/marcelomendoncasoares))
+- feat: Adds support for changing model `id` type to `UUID`. ([@marcelomendoncasoares](https://github.com/marcelomendoncasoares))
+- feat: Adds support for setting runtime parameters on the database connection. ([@marcelomendoncasoares](https://github.com/marcelomendoncasoares))
+- feat: Adds support for supplying CLI arguments from environment variables when starting the server.
+- feat: Adds support for loading custom passwords from environment variables.
+- feat: Adds support for loading Google and Firebase secrets from environment variables in the auth module.
+- feat(EXPERIMENTAL): Adds support for registering shutdown tasks that are executed when the server is shutting down. ([yashas-hm](https://github.com/yashas-hm))
+- fix: Fixes an issue where unblocking a user would not invalidate the user cache. ([@LesYampolskyi](https://github.com/LesYampolskyi))
+- fix: Fixes an issue where paths starting with `v` would be stripped when serving static files in the web server.
+- fix: Fixes an issue where the endpoint description would not be generated when creating new projects.
+- fix: Fixes an issue where server configuration would not be loaded correctly if API configuration was missing.
+- fix: Reduce memory footprint of the client when uploading files with `FileUploader`.
+- fix: Improves duration formatting in human-readable log output.
+
+## 2.8.0
+- feat: Adds `DatabaseUtils` with support for executing code blocks in transactions or savepoints.
+- feat: Adds support for `Vector` type, with database `HNSW` and `IVFFLAT` indexing, in models and endpoints. ([@marcelomendoncasoares](https://github.com/marcelomendoncasoares))
+- feat: Adds support for SSL connections with Redis. ([@remonh87](https://github.com/remonh87))
+- fix: Fixes an issue where configured `user` would not be used when connecting to Redis. ([@remonh87](https://github.com/remonh87))
+- fix: Improves error message when failing to connect to database during startup.
+
+## 2.7.0
+- feat: Adds support for storing `String`-representable user id in `AuthenticationInfo`.
+- feat: Adds support for `UUIDv7` as a default value in models.
+- feat: Adds support for the `@doNotGenerate` annotation for endpoint methods. (Replaces `@ignoreEndpoint`.)
+- feat: Adds support for configuring execution, scan interval, and concurrency limit for future calls.
+- fix: Fixes an issue where migrations could add foreign key relations before their associated table was created.
+- fix: Prevents multiple servers from running migrations in parallel.
+- fix: Fixes an issue where the end of a call would not be logged to the console.
+- fix: Failed health checks now respond with a 503 status code.
+
+## 2.6.0
+- feat: Adds support for endpoint inheritance.
+- feat: Adds support for `@ignoreEndpoint` annotation for endpoint methods.
+- feat: Updates the starter template for new Serverpod projects.
+- fix: Removes unnecessary stack trace from platforms that do not support health checks.
+- fix: Fixes an issue where the `serverpod generate` command would fail in workspace setups.
+- fix: Silences error reporting for authentication rejections in legacy streaming endpoints.
+- feat(EXPERIMENTAL): Adds support for using `UuidValue` as the type for model `id` fields.
+
+## 2.5.1
+ - feat: Adds support for configuring database search path across all database connections.
+ - fix: Limits version compatibility check to `serverpod` and `serverpod_client` packages.
+ - fix: Fixes an issue where record parameters could only be named `record`.
+
+## 2.5.0
+- feat: Enables translations for SignInWithEmailDialog.
+- feat: Adds support for `Record` type in Streaming methods.
+- feat: Adds support for `Record` type in models.
+- feat: Adds support for defining a default value for `Enum` models.
+- feat(EXPERIMENTAL): Adds support for attaching custom data to diagnostic events.
+- fix: Always drains request bodies to prevent unexpected closed connections in the client.
+- fix: Prevents generated model file naming conflicts with framework-generated files.
+- fix: Fixes crash when validating Serverpod package version in CLI.
+- fix: Preserves stack trace in database query exceptions.
+- fix: Fixes crash in update queries for models without fields or when id column is specified.
+- fix: Fixes import issue causing WASM incompatibility in client.
+- fix: Re-enables support for models named "Record".
+- fix: Fixes issue where implicit relations could be dropped during update database operations.
+- fix: Fixes issue where implicit relations were not preserved during serialization roundtrips.
+- fix: Adds support for non-nullable `Set` in models.
+- fix(EXPERIMENTAL): Includes Uri path in diagnostic events.
+- fix(EXPERIMENTAL): Reports diagnostic event on exception during database start and health checks.
+
+## 2.4.0
+- feat: Adds support for configuring certificates for Serverpod API, Web, and Insights servers.
+- feat: Adds support for `Uri`, `BigInt`, and `Set` type in endpoints and models.
+- feat: Adds support for `Record` type in endpoint `Future` return and parameters.
+- feat: Adds support for `List` and `Set` containers in Streaming methods.
+- feat: Adds option to disable caching for static content matching a regexp path in the web server.
+- feat: Gracefully shuts down server on `SIGTERM` signal.
+- feat: Allows configuration of server id via the `SERVERPOD_SERVER_ID` environmental variable.
+- feat(EXPERIMENTAL): Adds support for exception event hooks to enable reporting diagnostic events to monitoring tools.
+- feat(EXPERIMENTAL): Adds API for submitting diagnostic events from user code.
+- fix: Fixes issue where filtering in insights didn’t work as expected with the provided Dockerfile.
+- fix: Fixes an issue so that `name` is now a supported value in Enum models.
+- fix: Removes debug prints from generated client code.
+- fix: Fixes issue where server-only relation fields didn’t enforce the relation as optional.
+- fix: Fixes crash when generator processes model many(`List`) relations without generics.
+- fix: Harmonizes local and global cache miss behavior to ensure proper cache miss handling.
+- fix: Returns a generic error message for internal server errors in web server routes.
+- fix: Adds doc comments to all generated model methods.
+- fix: Fixes issue with relative imports generating backwards slashes on Windows.
+- fix: Fixes crash in `create-migration` when server folder is renamed.
+- fix: Fixes issue where table renaming caused migrations that couldn’t be applied.
+
+## 2.3.1
+- fix: Resolved an issue where database exceptions failed to generate informative `toString` messages.
+- fix: Improves performance of HTTP request body parsing for both endpoints and the web server.
+
+## 2.3.0
+- feat: Adds support for transaction isolation levels.
+- feat: Adds typed interface for transaction savepoints.
+- feat: Adds support for endpoint definition placement anywhere in server's `src` directory.
+- feat: Adds support for model definitions placement anywhere in server's `src` directory.
+- fix: Adds additional diagnostic information to database query exceptions.
+- fix: Resolved an issue that caused premature closure of method stream websocket connections.
+- fix: Improves message transmission guarantee in method streams.
+
+## 2.2.2
+ - fix: Fixes possible import issue in generated code when the same model name is used in different modules.
+
+## 2.2.1
+ - fix: Fixes an issue where invalid Dart import paths would be generated on Windows.
+
+## 2.2.0
+ - feat: Improves Serverpod startup and lifecycle events logging.
+ - feat: Adds full support for testing framework.
+ - feat: Adds configuration for controlling log output location.
+ - feat: Adds support for signing out a user from a single device.
+ - feat: EXPERIMENTAL. Adds support for inheritance in models.
+ - feat: EXPERIMENTAL. Adds support for sealed classes in models.
+ - fix: Only reports invalid Dart endpoint definition files when using `--watch`.
+ - fix: Uses direct model import when protocol files are analyzed.
+ - fix: Removes redundant file collection from code generation.
+ - fix: Fixes error in `serverpod generate` when a `Session` is set as a named required parameter.
+ - fix: Responds with 400 when throwing serializable exceptions.
+ - fix: Correctly removes account requests after an account is created (auth module).
+ - fix: Passes `String` instead of `Error` object to logger in `session.close`.
+ - fix: Replaces `null` assert with error check in `WebWidget`.
+
+## 2.1.5
+ - feat: EXPERIMENTAL. Adds testing framework. [docs](https://docs.serverpod.dev/next/concepts/testing/get-started)
+ - fix: Correctly handles method and endpoint streams for modules.
+ - fix: Correctly handles errors in method streams.
+
+## 2.1.4
+ - feat: Adds detailed reporting for schema mismatches when checking database consistency.
+ - fix: Takes current transaction into account for include queries.
+ - fix: Loads passwords from env variables even if the `passwords.yaml` file doesn't exist.
+ - fix: Corrects type mismatch in `onTimeout` callback for cancelled subscriptions in `MethodStreamManager.closeAllStreams` method.
+ - fix: Correctly returns HTTP 400 error code if parameters passed to Serverpod are incorrect.
+
+## 2.1.3
+ - fix: Includes Dockerfile for Serverpod Mini projects.
+
+## 2.1.2
+ - fix: Supports updating full user name in auth module.
+ - fix: Adds missing transaction parameter in `deleteWhere` query.
+ - fix: Correctly preserves non-persisted fields during database insert and update operations.
+ - fix: Allows event listeners to remove themselves inside their handler.
+ - fix: Correctly checks settings before letting a user change name or image in auth module.
+
+## 2.1.1
+ - fix: Posts revoked authentication events locally if Redis is disabled.
+ - fix: Uses `dynamic` type for `fromJson` parameter in custom class serialization.
+
+## 2.1.0
+ - feat: Adds DevTools extension.
+ - feat: Adds support for `Stream` as parameters and return type in endpoint methods.
+ - feat: Adds stream subscriptions to message central.
+ - feat: Adds support for `willClose` listener on `Session`.
+ - feat: Adds support for default values in model files (types supported are `String`, `int`, `double`, `bool`, `DateTime`, `UuidValue`, `Duration`, enums)
+ - feat: Adds support for WASM compiled web apps.
+ - feat: Endpoint methods with `@Deprecated` annotation are now also annotated in the client.
+ - feat: Allows custom password hash generator in `AuthConfig`.
+ - feat: Allows rewrite rule in root path in static web directories.
+ - feat: Improves error handling in `SignInWithGoogle` by rethrowing exceptions.
+ - feat: Adds support for nullable types in `encodeWithType` and `decodeWithType`.
+ - feat: Adds `Uuid` identifier to sessions.
+ - feat: Supports configuration through environment variables instead of yaml.
+ - feat: Models can now be created without fields.
+ - feat: Adds ability to register custom environment variables to loaded as passwords.
+ - feat: Adds ability to modify `maxFileSize` and expiration time for GCP and AWS buckets.
+ - feat: Moves the auth key from the body of the request to the HTTP header in endpoint methods.
+ - feat: When sending a HTTP 400 Bad Request error message to the client, an error message may now be included in the client side exception.
+ - fix: Allows Serverpod defined models to be encoded and decoded with type.
+ - fix: Allows AWS deployments to update Dart version.
+ - fix: Fixes top error handling on server's request handler to ensure proper error boundary.
+ - fix: Fixes `copyWith` method for nested `List` and `Map` in models.
+ - fix: Fixes Dart version and other issues in AWS deployment templates.
+ - fix: Improved error message if there are missing tables.
+ - fix: Better error message if an error occurs when parsing the config files in CLI.
+ - fix: Adds validation of custom class names to look for potential collisions.
+ - fix: Only considers positional `Session` parameter when validating endpoint method.
+ - fix: Updates example documentation.
+ - fix: Before a session is closed, all logging is now awaited.
+ - fix: Adds new `WebCallSession` for Relic.
+ - fix: Correctly verifies `iss` value for all possible domains in Sign in with Google.
+ - fix: Add `methodName` and `endpointName` to base session class.
+ - fix: Handles malformed web server URI parameters more gracefully.
+ - fix: Uses `text` as `KeyboardType` for validation code in `SignInWithEmailDialog`.
+ - fix: Correctly orders logs in Insights.
+ - fix: Correctly strips data in serialization of `List` and `Map`.
+ - fix: Starts database pool manager on Serverpod instance creation.
+ - fix: Adds mechanism for awaiting pending future calls on shutdown.
+ - fix: Improvements to websocket lifecycle.
+ - fix: Registers cloud storage endpoint for any `storageId` with `db` storage.
+ - fix: Adds logging for when when uploads to buckets fail.
+ - fix: Removes redundant and non-prefixed `serverpod_serialization` import.
+ - fix: Sets the default authentication handler even when the database is disabled.
+ - chore: Updates dependencies.
+
+## 2.0.2
+- fix: Conditionally imports `HttpStatus` to improve compatibility.
+- fix: Improve `encodeForProtocol` method for `List` and `Map` input object types.
+
+## 2.0.1
+- fix: Writes websocket errors to stderr.
+- fix: Adds missing web socket connection notification on stream closed.
+- fix: Sign in with Email dialog can toggle visibility of passwords.
+- fix: Allows usage of user related Google API calls in `onUserCreated` callback.
+- fix: Disposes streaming connection listener when disposing handler.
+- fix: Only notifies listeners when streaming connection status changes.
+- fix: Adds ready check for websocket channel.
+- fix: Handles bad websocket upgrade requests.
+- fix: Makes sign in buttons customizable.
+- fix: Exposes getter for `Session` `authenticationKey`.
+- fix: `postMessage` in messages now returns `true` if successful.
+- fix: Improved Firebase login widget.
+- fix: Adds support for inserting models with only an `id` field.
+- fix: Throws exception if required fields are missing when parsing config files.
+- fix: Adds explicit exception types for client side exceptions.
+- fix: Correctly sets offset and length when encoding `ByteData` for database.
+- fix: Removes endpoint to validate validation code.
+- fix: Replaces asserts in auth module with throws and logs.
+- fix: Changes default values in auth config.
+- fix: Removes password reset verification code on usage attempt.
+- fix: Stops web server when shutdown method is called.
+- chore: Removes dependency to unsupported `firebase_admin` package.
+- chore: Bumps minimum Dart version to 3.2.0.
+- chore: Updates dependencies.
+
+## 2.0.0
+- fix: BREAKING. Database delete methods now return removed objects.
+- fix: BREAKING. Removes automatic redirect from Relic.
+- fix: BREAKING. Removes `SerializationManager` as a parameter from `fromJson` factory constructor.
+- fix: BREAKING. Remove allToJson method.
+- fix: BREAKING. Makes user name nullable in `UserInfo`.
+- fix: BREAKING. Removes deprecated methods.
+- fix: BREAKING. Introduces `DatabaseException`.
+- fix: BREAKING. Introduces new types for database result sets.
+- fix: BREAKING. Updates transaction interface in database.
+- fix: BREAKING. Changes `SerializableEntity` mixin into `SerializableModel` interface.
+- fix: BREAKING. Removes support for implicit string to expression conversion.
+- fix: BREAKING. Marks deprecated yaml keywords as `isRemoved`.
+- fix: BREAKING. Move authentication implementaqtions from core to auth module.
+- fix: BREAKING. Removes `customConstructor` map from protocol class.
+- chore: BREAKING. Updates Postgres library to new major version.
+- feat: Adds parameter arguments to unsafe database queries.
+- feat: Adds `upgrade` command to Serverpod CLI.
+- feat: Introduces `CacheMissHandler` to improve cache API.
+- feat: Serverpod mini. Allows running Serverpod without the database.
+- feat: Makes email verification code length customizable.
+- feat: Adds client entitlements to MacOS after creating Flutter project.
+- fix: Improves server only field validation.
+- fix: Retrieves and removes future call entries in a single operation.
+- fix: toJson now includes all fields of Serverpod Models.
+- fix: Maps Dart `int` to `bigint` in database.
+- fix: Generates thumbnails in isolates for auth and chat module.
+- fix: Improved logging in CLI.
+- fix: Changes root file name in modules to follow Dart standards.
+- fix: Removes useless stack trace print from database connection check.
+- fix: Uses user scopes from `UserInfo` when authenticating in all providers.
+- fix: Prevents silencing deserialization exceptions for unmatched class types.
+- fix: Removes deprecated `generated` folder from Serverpod's upgrade template.
+- fix: Endpoint requests can now respond with 401 or 403 on failed authentication.
+- fix: Gives error when enpoint classes have naming conflicts.
+- fix: Run `_storeSharedPrefs` in `logOut` method to preserve state.
+- fix: Prints streaming message handler exceptions to console.
+- chore: Bumps minimum required Dart version to 3.1.
+- docs: Corrects spelling mistakes.
+- docs: Improved documentation for chat module.
+
+## 1.2.7
+- fix: Spelling fix in UserAuthentication.
+- fix: Prevents crash when web or template directory is missing (webserver).
+- fix: Removes server only fields from client protocol deserialization.
+- fix: Improved error messages in email authentication.
+- fix: Minor log fixes.
+- fix: Prevents generating empty endpoints variable when no endpoints are defined.
+- fix: Adds Docker support for x86 architectures.
+- fix: Adds timestamps to `generate --watch` command.
+- chore: Updates dependencies.
+
+## 1.2.6
+- feat: Adds missing callbacks when sending chat messages in chat module.
+- fix: Updates password hash algorithm for email authentication. [Security Advisories](https://github.com/serverpod/serverpod/security/advisories)
+- fix: Improves client certificate security. [Security Advisories](https://github.com/serverpod/serverpod/security/advisories)
+- fix: Fixes issue when passing empty set in `inSet` and `notInSet`.
+- fix: Fixes issue with incorrect line breaks in CLI.
+
+## 1.2.5
+- fix: Custom classes respect nullable configuration.
+
+## 1.2.4
+- fix: Sets the correct output path for generated files on Windows.
+- fix: Prevents VS Code extension from crashing on startup.
+- fix: Marks file handling database methods as deprecated.
+- fix: Correctly handles transaction parameters for delete method.
+- fix: Correctly resolves and validates registered custom classes used as types in model fields.
+
+## 1.2.3
+- fix: Correctly cleans up health check manager when shutting down server.
+- fix: Supports projects without a config generator file in CLI.
+- fix: Adds additional requirements to Insights setup.
+- fix: Removes unnecessary database connection creation in pool manager.
+- fix: CLI gives error if non-string value is used as parent keyword.
+
+## 1.2.2
+- fix: Makes it possible to create modules from templates in developer mode.
+- fix: Correctly marks nested enum types in the analyzer.
+- fix: Adds support for all Serverpod's supported types as keys in Maps.
+- fix: Restrict fields with scopes other than all to be nullable.
+- fix: Uses pubspec override instead of direct paths (to improve score on pub.dev).
+- fix: Less restrictive enum naming rules.
+- fix: Pins Dart and Busybox docker image versions (only for new projects).
+- fix: Deterministically truncate list aliases in database relations.
+- fix: Enables server to start without migrated database.
+- fix: Adds missing deprecation messages.
+- fix: Adds placeholder for old postgres file, to aid users who are following old tutorials.
+- fix: Resolves internal relation pointers in class representations.
+
+## 1.2.1
+- fix: Removes old generated folder from Dockerfile.
+- fix: Prevents database analyzer from crashing when missing table.
+- fix: Fixes issue with DevTools extension not being bundled with the `serverpod` package.
+- fix: Ignores all null fields in JSON map serialization.
+- fix: Improved error message if port is in use when starting server.
+- chore: Bumps `vm_service` version to support latest version.
+
+## 1.2.0
+This is a summary of the new features in version 1.2.0. For the full list, please refer to the [commits](https://github.com/serverpod/serverpod/commits/main/) on Github. Instructions for updating from 1.1 of Serverpod is available in our documentation [here](https://docs.serverpod.dev/upgrading/upgrade-to-one-point-two).
+
+### Main new features and fixes
+- feat: Adds official support for Windows.
+- feat: Adds Visual Studio Code extension.
+- feat: Syntax highlighting in model files.
+- feat: Adds LSP server for analyzing model files.
+- feat: CLI automatically detects modules without the need to modify the generator file.
+- feat: Validates project names on `serverpod create`.
+- feat: Validates Serverpod packages and CLI version in `serverpod generate`.
+- feat: Prompts user to update Serverpod when running an old version of the CLI.
+- feat: Improves exit codes for CLI.
+- feat: Improvements to output from CLI, including different formats for different platforms and run-modes.
+- feat: Progress animations in CLI.
+- feat: Uses CommandRunner for CLI.
+- feat: Adds global `--verbose` and `--quiet` flags to control log level.
+- feat: Developer version of `serverpod create` now creates a project referring to the local version of Serverpod.
+- feat: Adds `copyWith` methods on all generated model files.
+- feat: Makes it possible to call endpoint methods by specifying the method name in the path.
+- feat: Makes return headers configurable for API and OPTION HTTP calls.
+- feat: Adds `fromYaml` constructor to `ServerpodConfig`.
+- feat: Adds reference to all modules in config.
+- feat: Makes HTTP timeout configurable.
+- feat: Improves compatibility for `serverpod create` by not running Docker through tooling.
+- fix: Makes endpoint classes public to enable Dart doc.
+- fix: Serializable exceptions now work with modules.
+- fix: Handles invalid return types when parsing endpoint methods.
+- fix: Fixes localhost on Android emulator.
+- fix: Use explicit version for all Serverpod packages.
+- fix: Uses git version of CLI in local tests.
+- fix: Fixes typos in `serverpod create` start instructions.
+- fix: Makes include class fields private.
+- fix: Adds flag to disable analytics reporting.
+- fix: Correctly resets error message state when and endpoint call was successful in template project.
+- fix: Closes session when protocol exception is thrown.
+- fix: Allows deeply nested `Map` and `List` in model files.
+- docs: Many improvements to API documentation.
+- chore: Updates to latest version of Flutter.
+- chore: Updates dependencies.
+- chore: Fixes deprecated methods.
+- chore: Makes Dart & Flutter version requirements consistent across packages.
+- chore: Adds serverpod_lints package.
+- ci: Now runs tests on multiple Flutter versions.
+- ci: Adds 2000 new tests.
+- ci: Unit tests are now running on Windows.
+
+### Database ORM
+- feat: Adds support for database migrations.
+- feat: Adds support for database repair migrations.
+- feat: Adds support for database relations.
+- feat: Support `IN`, `NOT IN`, `BETWEEN` and `NOT BETWEEN` query operations.
+- feat: Separates `Column` from `Expression` and harmonizes operations.
+- feat: Adds scoped database operations on generated models.
+- feat: Adds batch `insert`, `update`, and `delete` database operations.
+- feat: Exposes mapped results database query for public use.
+- feat: Adds `notLike` and `notILike` on database `String` expressions.
+- feat: Adds column selection to generated update method.
+- fix: Adds helpful error message if wrong table is used for `where` or `orderBy` expression.
+- fix: Change signature of `orderBy` and `orderByList` to callback taking a typed table.
+- fix: Removes old Postgres generator (replaced by migrations).
+
+### Model files (.spy.yaml) and code generation
+- feat: Dual pass parsing when validating model files.
+- feat: Validates field datatypes when running `serverpod generate`.
+- feat: Adds deprecation warnings to old model file keywords.
+- feat: Adds severity levels to reported errors in analyzer.
+- feat: Adds ability to toggle implicit key in stringified nodes.
+- feat: Reports severity level of errors.
+- feat: Adds `scope` and `persist` keywords to models.
+- feat: Adds `onDelete` and `onUpdate` bindings.
+- feat: Introduces reserved keywords in protocols.
+- feat: Adds serialization `byName` option for enums.
+- feat: Allow `.spy` file extension on model files (default is now `.spy.yaml`).
+- feat: Now loads model files from `src/lib/models` directory (old `protocol` directory is still supported for backward compatibility).
+- feat: Adds type validation to model files.
+- fix: Allows multiple uppercase characters in model class names.
+- fix: Protocol entities only allowed to be one type.
+- fix: Better error messages for `fields` in model files.
+- fix: Enforce index types to be a valid Postgres index type.
+- fix: Require all serialized enum values to be unique.
+- fix: Enforce that the `id` field isn't used for models that have a table defined.
+- fix: Enforce that `parent` keyword is only used if a model has an associated table.
+- fix: Report an error if the referenced parent table does not exists.
+- fix: Report an error if the table name in a model is not globally unique.
+- fix: Report an error if an index name is not globally unique.
+- fix: Report an error if a field is referenced twice in the same index.
+- fix: Allows complex types to be nullable.
+- fix: Parse the source location for all comma separated values in a field string.
+- fix: Restrict class names to now allow standard datatypes.
+- fix: Add automatic deprecated reporting of keys in analyzer.
+- fix: Set exit code to non-zero if generator finds issues.
+- fix: Correctly validate deeply nested datatypes in protocols.
+- fix: Enum value restrictions matches default linting in Dart.
+- fix: Less restrictive naming of model class names.
+- fix: Avoid generating code from broken protocol files.
+- fix: Deprecate `database` and `api` keywords.
+- fix: Stop generator from getting stuck on circular dependencies.
+- fix: Handle invalid YAML errors and report them.
+- fix: Only report duplicated and invalid negations once.
+- fix: Adds deep check of `DateTime` and `Uint8List` during deserialization.
+- fix: Deserialization of `DateTime` handles `null` explicitly.
+- fix: Only return valid entries from analyzer.
+- fix: Reintroduces generation of `protocol.yaml`.
+- fix: Use version command to check if a command exists.
+- fix: Prevents `generate --watch` from crashing.
+- fix: Prevents analyzer from crashing because of invalid Dart syntax.
+- fix: Prevents analyzer from crashing when an unsupported type is used.
+- fix: Avoid serializing null `Map` values.
+- fix: Restrict length of user defined Postgres identifier names.
+
+### Insights
+- feat: Insight endpoint methods for running queries and fetching full database configuration.
+- feat: Adds module name and Dart class names to table definitions in Insights protocol.
+- feat: Support for filtering bulk data fetched from Serverpod Insights.
+- feat: Adds API for accessing files local to the server.
+- fix: Include installed modules in all database definitions.
+
+### Auth module
+- feat: Improves auth example.
+- feat: Adds Sign in with Apple button.
+- feat: Adds Google Sign in on the web.
+- feat: Allows min and max password lengths to be configured in auth module.
+- feat: Allows label and icon to be customized for Sign in with Email button in auth.
+- fix: Removes dead code in auth module.
+- fix: Adds error message if email is already in use in auth.
+- fix: Properly close barrier when sign in is complete in auth.
+- fix: Corrects typo in sign in button.
+- fix: Require consent in order to generate refresh token for Google Signin.
+- fix: Throw descriptive error if Google auth secret is not loaded on the server.
+- fix: Typo in reset password example email.
+- fix: Enforces user blocked status on login.
+- fix: Allows Firebase phone auth and logs auth errors.
+
+### File storage
+- feat: Adds bulk file URL lookup method for file storage.
+
+### Chat module
+- fix: Adds missing return statement to require authentication.
+
+
+## 1.1.0
+- feat: Lightweight run mode and support for serverless platforms.
+- feat: Support for Google Cloud Platform deployments, including Terraform module.
+- feat: Adds serializable exceptions that can be passed from the server to the client.
+- feat: Adds `serverOnly` option to yaml-files, which is set to true will prevent the code to be generated for the client.
+- feat: Support for `UUID` in serialization.
+- feat: New supported static file types in Relic.
+- feat: Allows endpoints in sub directories.
+- feat: Support for GCP Cloud Storage.
+- feat: Support for connecting to Postgres through a UNIX socket.
+- feat: Adds database maintenance methods to Insights APIs (still experimental and API may change).
+- docs: Improved documentation.
+- fix: Better output on startup to aid in debugging connectivity issues.
+- fix: Prevents self referencing table to cause `serverpod generate` to hang.
+- fix: Adds email from Firebase to UserInfo in auth module.
+- fix: Don't print stack trace when Google signin disconnect fails.
+- fix: Return bool from `SessionManager.initialize()` to indicate if server was reached.
+- fix: Better recovery when parsing yaml-files.
+- chore: Migrates Firebase to new Flutter APIs.
+- chore: Updates dependencies.
+- chore: Refactors CLI tooling.
+
+## 1.0.1
+- Fixes import of generics in subdirectories.
+- Generated enums now respect their subdirectories.
+- Masks out passwords in email debug logging.
+- Replaces deprecated `docker-compose` with `docker compose`
+
+## 1.0.0
+- First stable release! :D
+- Fixes incorrectly set database index on health metrics.
+
+## 0.9.22
+- Adds support for snake case in fields.
+- Adds support for Duration data types in serialized objects.
+- Correctly sets CORS headers on failed calls.
+- Correctly imports generated files in subdirectories.
+- Allows documentation in yaml files.
+- Adds documentation for all generated code.
+- __Breaking changes__: Optimizes health metric data. Requires updates to two database tables. Detailed migration instructions here: [https://github.com/serverpod/serverpod/discussions/567](https://github.com/serverpod/serverpod/discussions/567)
+
+## 0.9.21
+- Supports sub directories for protocol class files.
+- Updates dependencies for auth module.
+- Nicer default web page for new projects.
+- Adds authentication example.
+- Correctly inserts ByteData into the database.
+- Much improved documentation for authentication.
+- __Breaking changes__: The `active` and `suspendedUntil` fields of `UserInfo` in the auth module has been removed. These fields need to be removed from the database for authentication to work.
+
+## 0.9.20
+- New serialization layer thanks to the extensive work of [Maximilian Fischer](https://github.com/fischerscode). This adds compatibility with custom serialization, such as [Freezed](https://pub.dev/packages/freezed). It also adds support for nested `Map`s and `List`s.
+- Updates examples.
+- More extensive test coverage.
+- Much improved documentation.
+- __Breaking changes__: This version updates the Serverpod protocol, which is now much more streamlined ahead of the 1.0 release. Unfortunately, it makes apps built with earlier versions incompatible with the latest version of Serverpod. More detailed migration instructions here: [https://github.com/serverpod/serverpod/discussions/401](https://github.com/serverpod/serverpod/discussions/401)
+
+## 0.9.19
+- Adds support for storing and reading binary ByteData to/from the database.
+
+## 0.9.18
+- Adds chat module to published packages.
+
+## 0.9.17
+- Reliability fix for FlutterConnectivityMonitor on web platform.
+
+## 0.9.16
+- Changes default log level to `info`.
+- Fixes issue with `serverpod create` command and updates template files with correct Flutter dependencies.
+
+## 0.9.15
+- Correctly sets 404 return code if no route is matched in Relic web server.
+- Templates are updated to use latest version of flutter_lints.
+- Adds connectivity monitor for streaming connections, which improves their reliability.
+
+## 0.9.14
+- Official support for Linux.
+- Improved support for Windows.
+- Adds tests for command line tools.
+
+## 0.9.13
+- Updates download path for template files.
+
+## 0.9.12
+- Adds `connecting` state to streaming connections.
+- Refactors streaming connection method names to be more consistent (backwards compatible with deprecations).
+- Adds `StreamingConnectionHandler` to automatically reconnect to the server when streaming connection is lost.
+- Automatically upgrades streaming connections when a user is signed it (`serverpod_auth` module).
+- Better error handling when providing invalid commands to the CLI.
+- Moves tests to `serverpod_test_server`.
+- Fixes error on `serverpod create --template module ...`
+- Hides errors produced by health checks.
+
+## 0.9.11
+- Adds support for Map structures in serialized objects.
+- Adds support for passing maps and lists as parameters to endpoint methods.
+- Much improved error checks in code generation.
+- Adds continuous code generation with `serverpod generate --watch`.
+- Removes the `serverpod run` command in favor for continuous generation.
+- Updates dependencies to latest versions.
+- Cleans up `serverpod help` command.
+
+## 0.9.10
+- Brings example code up-to-date with latest changes in Serverpod
+- Improved security for email sign in (limits sign in attempts based on a time period).
+- Dart docs are now copied to generated code, making it easier to document APIs.
+- Fixes issue with logging of queries in streaming sessions.
+- Adds support for Sign in with Firebase.
+- __Breaking changes__: Adds a new table for email sign in. Migration instructions here: [https://github.com/serverpod/serverpod/discussions/246](https://github.com/serverpod/serverpod/discussions/246)
+
+## 0.9.9
+- Improved Terraform scripts for AWS will use less resources. Most notably, only uses one load balancer which will fit within AWS free tier.
+- Adds web server to Terraform scripts.
+- Includes the Relic web server within the main Serverpod package.
+- Much improved logging and health checks.
+- Allows for monitoring of CPU and memory use.
+- Many smaller bug fixes and improvements.
+- __Breaking changes__: Updates config files and tables for logging. Migration instructions here: [https://github.com/serverpod/serverpod/discussions/190](https://github.com/serverpod/serverpod/discussions/190)
+
+## 0.9.8
+- Adds Terraform deployment scripts for AWS. Documentation here: [https://github.com/serverpod/serverpod/discussions/182](https://github.com/serverpod/serverpod/discussions/182)
+- __Breaking change__: Updates structure of config files. Migration instructions here: [https://github.com/serverpod/serverpod/discussions/182](https://github.com/serverpod/serverpod/discussions/182)
+- Moves Redis enabled option to config file and turns it off by default.
+- `serverpod run` no longer manages the Docker containers as it caused an issue with restarting the server.
+
+## 0.9.7
+- `serverpod create` and `serverpod generate` is now working on Windows. Tested on a fresh install of Windows 10.
+
+## 0.9.6
+- Improved, but still experimental support for Windows.
+- Fixes issue with error being thrown when internet connection is missing in CLI.
+- Correctly ignores overridden methods of Endpoints in code generation.
+- Makes using Redis optional.
+- Much improved [documentation](https://docs.serverpod.dev).
+
+## 0.9.5
+
+- Adds `serverpod run` command and improves `serverpod create`.
+- Continuous generation through `severpod run`.
+- Automatic restarts through `serverpod run`.
+
+## 0.9.4
+
+- Updates to documentation.
+- Makes it possible to cancel future calls.
+- Improves accuracy in future calls.
+- Saves/restores refresh tokens for Google sign in.
+
+## 0.9.3
+
+- Updates to documentation.
+
+## 0.9.2
+
+- Adds serverpod_auth module for authentication with email, Apple, and Google.
+
+## 0.9.1
+
+- Fixes broken images in documentation.
+
+## 0.9.0
+
+- Updates documentation and logos
+- Ready for 0.9 release!
+
+## 0.8.12
+
+- Updates default templates.
+
+## 0.8.11
+
+- Improved ORM.
+- Support for Docker.
+- Chat module.
+- Updated docs.
+
+## 0.8.10
+
+- Support for static file directories in Relic.
+- Adds logos (psd and pngs).
+- Adds example project.
+- Initial version of authentication module.
+- Cloud storage support.
+- Adds auth module
+
+## 0.8.6
+
+- Adds documentation.
+- Generates SQL files for creating database tables.
+
+## 0.8.5
+
+- Fixes compilation in broken serverpod_cli package
+
+## 0.8.4
+
+- Updates template files and fixes `serverpod create` command.
+- Adds CHANGELOG.md
+
+## 0.8.3
+
+- Initial working version.

--- a/packages/serverpod_cloud_storage/LICENSE
+++ b/packages/serverpod_cloud_storage/LICENSE
@@ -1,0 +1,21 @@
+Copyright 2020 The Serverpod authors
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/serverpod_cloud_storage/README.md
+++ b/packages/serverpod_cloud_storage/README.md
@@ -1,0 +1,9 @@
+![Serverpod banner](https://github.com/serverpod/serverpod/raw/main/misc/images/github-header.webp)
+
+# Serverpod
+This package is a core part of Serverpod. For documentation, visit: [https://docs.serverpod.dev](https://docs.serverpod.dev).
+
+## What is Serverpod?
+Serverpod is an open-source, scalable app server, written in Dart for the Flutter community. Check it out!
+
+[Serverpod.dev](https://serverpod.dev)

--- a/packages/serverpod_cloud_storage/analysis_options.yaml
+++ b/packages/serverpod_cloud_storage/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:serverpod_lints/public.yaml

--- a/packages/serverpod_cloud_storage/lib/serverpod_cloud_storage.dart
+++ b/packages/serverpod_cloud_storage/lib/serverpod_cloud_storage.dart
@@ -1,0 +1,4 @@
+export 'src/cloud_storage.dart';
+export 'src/cloud_storage_exception.dart';
+export 'src/cloud_storage_password_provider.dart';
+export 'src/upload_description.dart';

--- a/packages/serverpod_cloud_storage/lib/src/cloud_storage.dart
+++ b/packages/serverpod_cloud_storage/lib/src/cloud_storage.dart
@@ -1,0 +1,284 @@
+import 'dart:typed_data';
+
+import 'cloud_storage_exception.dart';
+import 'upload_description.dart';
+
+/// Interface for accessing cloud storage.
+abstract interface class CloudStorageSession {}
+
+/// The [CloudStorage] provides a standardized interface to store binary files
+/// in the cloud. The default implementation is to use the database for binary
+/// storage, but it can be extended to support Google Cloud, Amazon S3, or any
+/// other cloud storage service.
+///
+/// The storage needs to be registered with the Serverpod before starting the
+/// server. All methods in this class should throw an CloudStorageException if
+/// the method fails.
+abstract class CloudStorage {
+  /// Identifies the storage. You can use multiple cloud storage types in a
+  /// single Serverpod.
+  String storageId;
+
+  /// Creates a [CloudStorage] with the specified [storageId]. By default,
+  /// two storages are used by Serverpod `public` and `private`. The public
+  /// should be accessible to everyone (usually through a web interface),
+  /// while the private is accessed internally only.
+  CloudStorage(this.storageId);
+
+  /// Saves a file to the cloud. The path should be relative to the root
+  /// directory of the storage (i.e. the string shouldn't start with a
+  /// slash).
+  /// Throws a [CloudStorageException] if the file upload fails.
+  Future<void> storeFile({
+    required covariant CloudStorageSession session,
+    required String path,
+    required ByteData byteData,
+    StoreFileOptions options = const StoreFileOptions(),
+  });
+
+  /// Retrieves a file from the cloud storage.
+  ///
+  /// Throws a [CloudStorageFileNotFoundException] if no file exists at [path].
+  Future<ByteData> retrieveFile({
+    required covariant CloudStorageSession session,
+    required String path,
+  });
+
+  /// Returns metadata and properties for the file at [path].
+  ///
+  /// Throws a [CloudStorageFileNotFoundException] if no file exists at
+  /// [path].
+  Future<FileStat> statFile({
+    required covariant CloudStorageSession session,
+    required String path,
+  });
+
+  /// Returns true if the file exists.
+  Future<bool> fileExists({
+    required covariant CloudStorageSession session,
+    required String path,
+  }) async {
+    try {
+      await statFile(session: session, path: path);
+      return true;
+    } on CloudStorageFileNotFoundException {
+      return false;
+    }
+  }
+
+  /// Deletes the specified file if it exists. Does nothing if the file doesn't
+  /// exist.
+  Future<void> deleteFile({
+    required covariant CloudStorageSession session,
+    required String path,
+  });
+
+  /// Returns a public link to a file in the storage.
+  ///
+  /// Throws a [CloudStorageFileNotFoundException] if the file does not exist.
+  /// Throws a [CloudStorageUnsupportedOperationException] if the storage does
+  /// not provide public URLs.
+  Future<Uri> publicDownloadUrl({
+    required covariant CloudStorageSession session,
+    required String path,
+  });
+
+  /// Returns a temporary link to a file in the storage with a
+  /// [TemporaryDownloadUrlOptions.expirationDuration] time.
+  ///
+  /// Throws a [CloudStorageFileNotFoundException] if no file exists at [path].
+  /// Throws a [CloudStorageUnsupportedOperationException] if this storage does
+  /// not provide temporary URLs.
+  Future<Uri> temporaryDownloadUrl({
+    required covariant CloudStorageSession session,
+    required String path,
+    TemporaryDownloadUrlOptions options = const TemporaryDownloadUrlOptions(),
+  });
+
+  /// Creates an URL that a client can post a file to via http post, optionally
+  /// within the specified duration. After the file has been sent, the
+  /// [verifyUpload] method should be called. If the file upload
+  /// hasn't been confirmed before the URL expires, the file will be deleted.
+  ///
+  /// Throws a [CloudStorageUnsupportedOperationException] if this storage does not
+  /// support direct file uploads.
+  Future<UploadDescription> createUploadDescription({
+    required covariant CloudStorageSession session,
+    required String path,
+    UploadOptions options = const UploadOptions(),
+  });
+
+  /// Verifies a client upload at [path].
+  ///
+  /// Returns `true` when the upload was successfully verified and `false` when
+  /// no uploaded file exists.
+  Future<bool> verifyUpload({
+    required covariant CloudStorageSession session,
+    required String path,
+  });
+}
+
+/// Options used when the server stores a file directly.
+final class StoreFileOptions {
+  /// Time after which the file is considered expired.
+  final DateTime? expiration;
+
+  /// When true, the upload should fail if a file already exists at the
+  /// given path.
+  final bool preventOverwrite;
+
+  /// Metadata to attach to the file.
+  final FileMetadata metadata;
+
+  /// Creates store-file options.
+  const StoreFileOptions({
+    this.expiration,
+    this.preventOverwrite = false,
+    this.metadata = const FileMetadata(),
+  });
+}
+
+/// Options used when creating a client upload description.
+final class UploadOptions {
+  /// How long the upload authorization remains valid.
+  final Duration expirationDuration;
+
+  /// Maximum accepted file size in bytes.
+  final int maxFileSize;
+
+  /// Exact file size in bytes, when known. Lets the
+  /// provider pin the accepted size instead of allowing anything up to
+  /// [maxFileSize]. Must not exceed [maxFileSize].
+  final int? contentLength;
+
+  /// When true, the upload should fail if a file already exists at the
+  /// given path.
+  final bool preventOverwrite;
+
+  /// Metadata to attach to the file.
+  final FileMetadata metadata;
+
+  /// Creates upload options.
+  const UploadOptions({
+    this.expirationDuration = const Duration(minutes: 10),
+    this.maxFileSize = 10 * 1024 * 1024,
+    this.contentLength,
+    this.preventOverwrite = false,
+    this.metadata = const FileMetadata(),
+  });
+
+  /// Validates provided options.
+  void validate() {
+    if (expirationDuration <= Duration.zero) {
+      throw CloudStorageException(
+        'Upload expirationDuration must be positive.',
+      );
+    }
+    if (maxFileSize < 0) {
+      throw CloudStorageException('Upload maxFileSize must be >= 0.');
+    }
+    if (contentLength != null && contentLength! < 0) {
+      throw CloudStorageException('Upload contentLength must be >= 0.');
+    }
+    if (contentLength != null && contentLength! > maxFileSize) {
+      throw CloudStorageException(
+        'Content length ($contentLength bytes) exceeds maximum file size '
+        '($maxFileSize bytes).',
+      );
+    }
+  }
+}
+
+/// Options used to create a temporary download URL.
+final class TemporaryDownloadUrlOptions {
+  /// How long the URL remains valid.
+  final Duration expirationDuration;
+
+  /// Optional filename presented to the downloader.
+  final String? downloadFileName;
+
+  /// Optional response content type override.
+  final String? contentType;
+
+  /// Creates temporary-download URL options.
+  const TemporaryDownloadUrlOptions({
+    this.expirationDuration = const Duration(minutes: 10),
+    this.downloadFileName,
+    this.contentType,
+  });
+
+  /// Validates provided options.
+  void validate() {
+    if (expirationDuration <= Duration.zero) {
+      throw CloudStorageException(
+        'Temporary download URL expirationDuration must be positive.',
+      );
+    }
+  }
+}
+
+/// Portable metadata that can be attached to a stored file.
+final class FileMetadata {
+  /// MIME type of the file.
+  final String? contentType;
+
+  /// HTTP cache control value for the file.
+  final String? cacheControl;
+
+  /// HTTP content disposition value for the file.
+  final String? contentDisposition;
+
+  /// HTTP content encoding value for the file.
+  final String? contentEncoding;
+
+  /// User-defined metadata.
+  final Map<String, String> custom;
+
+  /// Creates file metadata.
+  const FileMetadata({
+    this.contentType,
+    this.cacheControl,
+    this.contentDisposition,
+    this.contentEncoding,
+    this.custom = const {},
+  });
+}
+
+/// Metadata and properties reported for a stored file.
+final class FileStat {
+  /// File size in bytes.
+  final int size;
+
+  /// Time at which the file was last modified, when supplied by the storage.
+  final DateTime? lastModified;
+
+  /// MIME type of the file, when supplied by the storage.
+  final String? contentType;
+
+  /// HTTP cache control value of the file, when supplied by the storage.
+  final String? cacheControl;
+
+  /// HTTP content disposition value, when supplied by the storage.
+  final String? contentDisposition;
+
+  /// HTTP content encoding value, when supplied by the storage.
+  final String? contentEncoding;
+
+  /// Provider entity tag or generation identifier.
+  final String? etag;
+
+  /// User-defined metadata returned by the storage.
+  final Map<String, String> custom;
+
+  /// Creates file statistics.
+  const FileStat({
+    required this.size,
+    this.lastModified,
+    this.contentType,
+    this.cacheControl,
+    this.contentDisposition,
+    this.contentEncoding,
+    this.etag,
+    this.custom = const {},
+  });
+}

--- a/packages/serverpod_cloud_storage/lib/src/cloud_storage_exception.dart
+++ b/packages/serverpod_cloud_storage/lib/src/cloud_storage_exception.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+/// Exception thrown by [CloudStorage].
+class CloudStorageException extends IOException {
+  /// Description of the exception.
+  String message;
+
+  /// Creates a new exception.
+  CloudStorageException(this.message) : super();
+
+  @override
+  String toString() {
+    return '$runtimeType: $message';
+  }
+}
+
+/// Exception thrown when a file does not exist in cloud storage.
+class CloudStorageFileNotFoundException extends CloudStorageException {
+  /// Creates a new [CloudStorageFileNotFoundException].
+  CloudStorageFileNotFoundException({
+    required this.storageId,
+    required this.path,
+  }) : super('No file exists at path "$path" in storage "$storageId".');
+
+  /// Identifier of the storage that does not contain the file.
+  final String storageId;
+
+  /// Path of the object that was not found.
+  final String path;
+}
+
+/// Exception thrown when a file cannot be stored without overwriting an
+/// existing file.
+class CloudStorageFileAlreadyExistsException extends CloudStorageException {
+  /// Creates a new [CloudStorageFileAlreadyExistsException].
+  CloudStorageFileAlreadyExistsException({
+    required this.storageId,
+    required this.path,
+  }) : super(
+         'A file already exists at path "$path" in storage "$storageId".',
+       );
+
+  /// Identifier of the storage containing the file.
+  final String storageId;
+
+  /// Path of the file that already exists.
+  final String path;
+}
+
+/// Exception thrown when a cloud storage operation is not supported.
+class CloudStorageUnsupportedOperationException extends CloudStorageException {
+  /// Creates a new [CloudStorageUnsupportedOperationException].
+  CloudStorageUnsupportedOperationException({
+    required this.storageId,
+    required this.operation,
+  }) : super('Storage "$storageId" does not support $operation.');
+
+  /// Identifier of the storage that does not support the operation.
+  final String storageId;
+
+  /// Description of the unsupported operation.
+  final String operation;
+}

--- a/packages/serverpod_cloud_storage/lib/src/cloud_storage_password_provider.dart
+++ b/packages/serverpod_cloud_storage/lib/src/cloud_storage_password_provider.dart
@@ -1,0 +1,18 @@
+/// Password callbacks used by storage providers that load credential.
+///
+/// [getPassword] retrieves a password by its configured key. [loadPasswords] registers mappings
+/// between environment variable names and password aliases.
+class CloudStoragePasswordProvider {
+  /// Creates a password provider backed by [getPassword] and [loadPasswords].
+  const CloudStoragePasswordProvider({
+    required this.getPassword,
+    required this.loadPasswords,
+  });
+
+  /// Retrieves a password by key, returning `null` when it is unavailable.
+  final String? Function(String key) getPassword;
+
+  /// Registers environment variable names and their corresponding aliases.
+  final void Function(List<({String envName, String alias})> envPasswords)
+  loadPasswords;
+}

--- a/packages/serverpod_cloud_storage/lib/src/upload_description.dart
+++ b/packages/serverpod_cloud_storage/lib/src/upload_description.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+
+/// Type of a cloud storage upload.
+enum UploadType {
+  /// Multipart HTTP upload.
+  multipart,
+
+  /// Binary upload.
+  binary,
+}
+
+/// Description for a cloud storage upload.
+sealed class UploadDescription {
+  /// Creates a new [UploadDescription].
+  const UploadDescription({required this.url});
+
+  /// Upload URL.
+  final Uri url;
+
+  /// Type of the upload.
+  UploadType get type;
+
+  /// Converts this upload description to its JSON representation.
+  Map<String, Object?> toJson();
+
+  /// Encodes this upload description for use by a `FileUploader`.
+  String encode() => jsonEncode(toJson());
+}
+
+/// Description for an upload using a binary HTTP request.
+final class BinaryUploadDescription extends UploadDescription {
+  /// Creates a new [BinaryUploadDescription].
+  const BinaryUploadDescription({
+    required super.url,
+    this.fileName,
+    this.method,
+    this.headers = const {},
+  });
+
+  @override
+  UploadType get type => UploadType.binary;
+
+  /// Name of the file.
+  final String? fileName;
+
+  /// Optional HTTP method.
+  final String? method;
+
+  /// Headers to be attached to the upload.
+  final Map<String, String> headers;
+
+  @override
+  Map<String, Object?> toJson() {
+    return {
+      'url': url.toString(),
+      'type': type.name,
+      'headers': headers,
+      if (fileName != null) 'file-name': fileName,
+      if (method != null) 'method': method,
+    };
+  }
+}
+
+/// Description for an upload using a multipart HTTP request.
+final class MultipartUploadDescription extends UploadDescription {
+  /// Creates a new [MultipartUploadDescription].
+  const MultipartUploadDescription({
+    required super.url,
+    required this.field,
+    required this.fileName,
+    this.requestFields = const {},
+  });
+
+  @override
+  UploadType get type => UploadType.multipart;
+
+  /// Name of the multipart form field containing the file.
+  final String field;
+
+  /// Name of the file.
+  final String fileName;
+
+  /// Additional fields to be attached to the multipart request.
+  final Map<String, String> requestFields;
+
+  @override
+  Map<String, Object?> toJson() {
+    return {
+      'url': url.toString(),
+      'type': type.name,
+      'field': field,
+      'file-name': fileName,
+      'request-fields': requestFields,
+    };
+  }
+}

--- a/packages/serverpod_cloud_storage/pubspec.yaml
+++ b/packages/serverpod_cloud_storage/pubspec.yaml
@@ -1,0 +1,18 @@
+# This file is generated. Do not modify, instead edit the files in the templates/pubspecs directory.
+# Mode: development
+
+name: serverpod_cloud_storage
+version: 4.0.0-rc.1
+description: Shared cloud storage abstractions for Serverpod integrations.
+repository: https://github.com/serverpod/serverpod
+homepage: https://serverpod.dev
+issue_tracker: https://github.com/serverpod/serverpod/issues
+
+environment:
+  sdk: '^3.12.2'
+
+resolution: workspace
+
+dev_dependencies:
+  serverpod_lints: 4.0.0-rc.1
+  test: ^1.25.5

--- a/packages/serverpod_cloud_storage/test/cloud_storage_test.dart
+++ b/packages/serverpod_cloud_storage/test/cloud_storage_test.dart
@@ -1,0 +1,178 @@
+import 'package:serverpod_cloud_storage/serverpod_cloud_storage.dart';
+import 'package:test/test.dart';
+
+class _StatStorage extends CloudStorage {
+  _StatStorage(this.statCallback) : super('test');
+
+  final Future<FileStat> Function() statCallback;
+
+  @override
+  Future<FileStat> statFile({
+    required CloudStorageSession session,
+    required String path,
+  }) => statCallback();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeSession implements CloudStorageSession {}
+
+void main() {
+  late CloudStorageSession session;
+
+  setUp(() {
+    session = _FakeSession();
+  });
+
+  group('Given a CloudStorage implementation', () {
+    test(
+      'when statFile succeeds, '
+      'then fileExists returns true',
+      () async {
+        final storage = _StatStorage(
+          () async => const FileStat(size: 1),
+        );
+
+        expect(
+          await storage.fileExists(session: session, path: 'file.txt'),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'when statFile throws CloudStorageFileNotFoundException, '
+      'then fileExists returns false',
+      () async {
+        final storage = _StatStorage(
+          () async => throw CloudStorageFileNotFoundException(
+            storageId: 'test',
+            path: 'missing.txt',
+          ),
+        );
+
+        expect(
+          await storage.fileExists(session: session, path: 'missing.txt'),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'when statFile throws any other exception, '
+      'then fileExists rethrows it',
+      () {
+        final storage = _StatStorage(
+          () async => throw CloudStorageException('Network failure.'),
+        );
+
+        expect(
+          () => storage.fileExists(session: session, path: 'file.txt'),
+          throwsA(
+            isA<CloudStorageException>().having(
+              (e) => e.message,
+              'message',
+              'Network failure.',
+            ),
+          ),
+        );
+      },
+    );
+  });
+
+  group('Given UploadOptions', () {
+    test(
+      'when expirationDuration is not positive, '
+      'then validate throws CloudStorageException',
+      () {
+        expect(
+          () => const UploadOptions(
+            expirationDuration: Duration.zero,
+          ).validate(),
+          throwsA(
+            isA<CloudStorageException>().having(
+              (e) => e.message,
+              'message',
+              contains('expirationDuration must be positive'),
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'when maxFileSize is negative, '
+      'then validate throws CloudStorageException',
+      () {
+        expect(
+          () => const UploadOptions(maxFileSize: -1).validate(),
+          throwsA(
+            isA<CloudStorageException>().having(
+              (e) => e.message,
+              'message',
+              'Upload maxFileSize must be >= 0.',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'when contentLength is negative, '
+      'then validate throws CloudStorageException',
+      () {
+        expect(
+          () => const UploadOptions(contentLength: -1).validate(),
+          throwsA(
+            isA<CloudStorageException>().having(
+              (e) => e.message,
+              'message',
+              'Upload contentLength must be >= 0.',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'when contentLength exceeds maxFileSize, '
+      'then validate throws CloudStorageException',
+      () {
+        expect(
+          () => const UploadOptions(
+            maxFileSize: 1,
+            contentLength: 2,
+          ).validate(),
+          throwsA(
+            isA<CloudStorageException>().having(
+              (e) => e.message,
+              'message',
+              contains('exceeds maximum file size'),
+            ),
+          ),
+        );
+      },
+    );
+  });
+
+  test(
+    'Given TemporaryDownloadUrlOptions'
+    'when expirationDuration is not positive, '
+    'then validate throws CloudStorageException',
+    () {
+      expect(
+        () => const TemporaryDownloadUrlOptions(
+          expirationDuration: Duration.zero,
+        ).validate(),
+        throwsA(
+          isA<CloudStorageException>().having(
+            (e) => e.message,
+            'message',
+            contains('expirationDuration must be positive'),
+          ),
+        ),
+      );
+    },
+  );
+}

--- a/packages/serverpod_cloud_storage/test/upload_description_test.dart
+++ b/packages/serverpod_cloud_storage/test/upload_description_test.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+
+import 'package:serverpod_cloud_storage/serverpod_cloud_storage.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a binary upload description', () {
+    test(
+      'when optional values are omitted then it encodes the minimum payload',
+      () {
+        final description = BinaryUploadDescription(
+          url: Uri.parse('https://storage.example.com/upload'),
+        );
+
+        expect(jsonDecode(description.encode()), {
+          'url': 'https://storage.example.com/upload',
+          'type': 'binary',
+          'headers': {},
+        });
+      },
+    );
+
+    test('when optional values are provided then it encodes all values', () {
+      final description = BinaryUploadDescription(
+        url: Uri.parse('https://storage.example.com/upload'),
+        fileName: 'example.txt',
+        method: 'PUT',
+        headers: const {'Content-Type': 'text/plain'},
+      );
+
+      expect(jsonDecode(description.encode()), {
+        'url': 'https://storage.example.com/upload',
+        'type': 'binary',
+        'file-name': 'example.txt',
+        'method': 'PUT',
+        'headers': {'Content-Type': 'text/plain'},
+      });
+    });
+  });
+
+  test(
+    'Given a multipart upload description then it encodes all required fields',
+    () {
+      final description = MultipartUploadDescription(
+        url: Uri.parse('https://storage.example.com/upload'),
+        field: 'file',
+        fileName: 'example.txt',
+        requestFields: const {'policy': 'signed-policy'},
+      );
+
+      expect(jsonDecode(description.encode()), {
+        'url': 'https://storage.example.com/upload',
+        'type': 'multipart',
+        'field': 'file',
+        'file-name': 'example.txt',
+        'request-fields': {'policy': 'signed-policy'},
+      });
+    },
+  );
+
+  test(
+    'Given a multipart upload description without request fields '
+    'then it encodes an empty request fields map',
+    () {
+      final description = MultipartUploadDescription(
+        url: Uri.parse('https://storage.example.com/upload'),
+        field: 'file',
+        fileName: 'example.txt',
+      );
+
+      expect(jsonDecode(description.encode()), {
+        'url': 'https://storage.example.com/upload',
+        'type': 'multipart',
+        'field': 'file',
+        'file-name': 'example.txt',
+        'request-fields': <String, String>{},
+      });
+    },
+  );
+}

--- a/templates/pubspecs/packages/serverpod_cloud_storage/pubspec.yaml
+++ b/templates/pubspecs/packages/serverpod_cloud_storage/pubspec.yaml
@@ -1,0 +1,17 @@
+# TEMPLATE
+
+name: serverpod_cloud_storage
+version: SERVERPOD_VERSION
+description: Shared cloud storage abstractions for Serverpod integrations.
+repository: https://github.com/serverpod/serverpod
+homepage: https://serverpod.dev
+issue_tracker: https://github.com/serverpod/serverpod/issues
+
+environment:
+  sdk: DART_VERSION
+
+resolution: workspace
+
+dev_dependencies:
+  serverpod_lints: SERVERPOD_VERSION
+  test: ^1.25.5

--- a/util/all_packages
+++ b/util/all_packages
@@ -35,6 +35,7 @@ declare -a DART_PACKAGES_PATHS=(
     "packages/serverpod_serialization"
     "packages/serverpod_service_client"
     "packages/serverpod_shared"
+    "packages/serverpod_cloud_storage"
     "packages/serverpod_database"
     "packages/serverpod_embedded_postgres"
     "packages/serverpod_test"

--- a/util/run_tests_analyze
+++ b/util/run_tests_analyze
@@ -27,6 +27,7 @@ declare -a projectPaths=(
     "packages/serverpod_serialization"
     "packages/serverpod_service_client"
     "packages/serverpod_shared"
+    "packages/serverpod_cloud_storage"
     "packages/serverpod_database"
     "packages/serverpod_embedded_postgres"
     "packages/serverpod_flutter"

--- a/util/update_pubspecs
+++ b/util/update_pubspecs
@@ -34,6 +34,7 @@ cp CHANGELOG.md packages/serverpod_client/CHANGELOG.md
 cp CHANGELOG.md packages/serverpod_serialization/CHANGELOG.md
 cp CHANGELOG.md packages/serverpod_service_client/CHANGELOG.md
 cp CHANGELOG.md packages/serverpod_shared/CHANGELOG.md
+cp CHANGELOG.md packages/serverpod_cloud_storage/CHANGELOG.md
 cp CHANGELOG.md packages/serverpod_database/CHANGELOG.md
 cp CHANGELOG.md packages/serverpod_embedded_postgres/CHANGELOG.md
 cp CHANGELOG.md packages/serverpod_flutter/CHANGELOG.md
@@ -91,6 +92,7 @@ cp README_subpackage.md packages/serverpod_client/README.md
 cp README_subpackage.md packages/serverpod_serialization/README.md
 cp README_subpackage.md packages/serverpod_service_client/README.md
 cp README_subpackage.md packages/serverpod_shared/README.md
+cp README_subpackage.md packages/serverpod_cloud_storage/README.md
 # cp README_subpackage.md packages/serverpod_database/README.md
 # cp README_subpackage.md packages/serverpod_embedded_postgres/README.md
 cp README_subpackage.md packages/serverpod_flutter/README.md


### PR DESCRIPTION
This PR adds a new standalone `serverpod_cloud_storage` package which holds the CloudStorage interface for the `serverpod` package and other integration packages to use.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None