### PR TITLE
chore: Bump `googleapis` to accept `17.x`

### DIFF
--- a/integrations/serverpod_cloud_storage_gcp/lib/src/native/native_google_cloud_storage.dart
+++ b/integrations/serverpod_cloud_storage_gcp/lib/src/native/native_google_cloud_storage.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
+// Version 17 deprecated this library in favor of `package:google_cloud_storage`
+// ignore: deprecated_member_use
 import 'package:googleapis/storage/v1.dart' as gcs;
 import 'package:googleapis_auth/auth_io.dart' as gcs;
 import 'package:http/http.dart' as http;

--- a/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -15,7 +15,7 @@ resolution: workspace
 
 dependencies:
   crypto: ^3.0.2
-  googleapis: ">=11.0.0 <17.0.0"
+  googleapis: ">=11.0.0 <18.0.0"
   googleapis_auth: ">=1.6.0 <3.0.0"
   http: '>=1.1.0 <2.0.0'
   mime: ^2.0.0

--- a/integrations/serverpod_cloud_storage_gcp/test/native/native_google_cloud_storage_test.dart
+++ b/integrations/serverpod_cloud_storage_gcp/test/native/native_google_cloud_storage_test.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+// Version 17 deprecated this library in favor of `package:google_cloud_storage`
+// ignore: deprecated_member_use
 import 'package:googleapis/storage/v1.dart' as gcs;
 import 'package:googleapis_auth/auth_io.dart' as gcs;
 import 'package:http/http.dart' as http;

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -14,7 +14,7 @@ resolution: workspace
 dependencies:
   crypto: ^3.0.2
   email_validator: '>=2.1.17 <4.0.0'
-  googleapis: '>=11.0.0 <17.0.0'
+  googleapis: '>=11.0.0 <18.0.0'
   googleapis_auth: '>=1.6.0 <3.0.0'
   http: '>=1.1.0 <2.0.0'
   image: ^4.0.15

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   clock: ^1.1.1
   dart_jsonwebtoken: ^3.1.0
   email_validator: '>=2.1.17 <4.0.0'
-  googleapis: '>=11.0.0 <17.0.0'
+  googleapis: '>=11.0.0 <18.0.0'
   googleapis_auth: '>=1.6.0 <3.0.0'
   http: '>=1.1.0 <2.0.0'
   meta: ^1.15.0

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
@@ -15,8 +15,6 @@ dependencies:
   clock: ^1.1.1
   dart_jsonwebtoken: ^3.1.0
   email_validator: '>=2.1.17 <4.0.0'
-  googleapis: '>=11.0.0 <18.0.0'
-  googleapis_auth: '>=1.6.0 <3.0.0'
   http: '>=1.1.0 <2.0.0'
   meta: ^1.15.0
   passkeys_server: ^1.0.0

--- a/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
+++ b/templates/pubspecs/integrations/serverpod_cloud_storage_gcp/pubspec.yaml
@@ -14,7 +14,7 @@ resolution: workspace
 
 dependencies:
   crypto: ^3.0.2
-  googleapis: ">=11.0.0 <17.0.0"
+  googleapis: ">=11.0.0 <18.0.0"
   googleapis_auth: ">=1.6.0 <3.0.0"
   http: '>=1.1.0 <2.0.0'
   mime: ^2.0.0

--- a/templates/pubspecs/modules/legacy/serverpod_auth/serverpod_auth_server/pubspec.yaml
+++ b/templates/pubspecs/modules/legacy/serverpod_auth/serverpod_auth_server/pubspec.yaml
@@ -13,7 +13,7 @@ resolution: workspace
 dependencies:
   crypto: ^3.0.2
   email_validator: '>=2.1.17 <4.0.0'
-  googleapis: '>=11.0.0 <17.0.0'
+  googleapis: '>=11.0.0 <18.0.0'
   googleapis_auth: '>=1.6.0 <3.0.0'
   http: '>=1.1.0 <2.0.0'
   image: ^4.0.15

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
@@ -14,8 +14,6 @@ dependencies:
   clock: ^1.1.1
   dart_jsonwebtoken: ^3.1.0
   email_validator: '>=2.1.17 <4.0.0'
-  googleapis: '>=11.0.0 <18.0.0'
-  googleapis_auth: '>=1.6.0 <3.0.0'
   http: '>=1.1.0 <2.0.0'
   meta: ^1.15.0
   passkeys_server: ^1.0.0

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   clock: ^1.1.1
   dart_jsonwebtoken: ^3.1.0
   email_validator: '>=2.1.17 <4.0.0'
-  googleapis: '>=11.0.0 <17.0.0'
+  googleapis: '>=11.0.0 <18.0.0'
   googleapis_auth: '>=1.6.0 <3.0.0'
   http: '>=1.1.0 <2.0.0'
   meta: ^1.15.0


### PR DESCRIPTION
Extends the range of the `googleapis` package.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._