### PR TITLE
chore: Remove the "already" from `generate` message when up to date

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/messages.dart
+++ b/tools/serverpod_cli/lib/src/commands/messages.dart
@@ -3,7 +3,7 @@ const initialCodeGenerationComplete =
     '✓ Initial code generation complete. Listening for changes.';
 const incrementalCodeGenerationComplete =
     '✓ Incremental code generation complete.';
-const generatedCodeAlreadyUpToDate = '✓ Generated code is already up to date.';
+const generatedCodeAlreadyUpToDate = 'Generated code is up to date.';
 
 // Start command messages
 const serverRunning = 'Server running.';


### PR DESCRIPTION
Removes the "already" from the `generate` message when a concurrent watcher already generated to avoid confusing agents.

Also fix the duplicate checkmark on the message, since it is issued from `success` info calls.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.