### PR TITLE
feat: Relic HTML document login with SAS HttpOnly cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/docs/design/web_auth_httponly_cookies.md
+++ b/docs/design/web_auth_httponly_cookies.md
@@ -4,7 +4,7 @@ Moves Serverpod's web authentication off JavaScript-readable token storage and
 onto httpOnly cookies (issue
 https://github.com/serverpod/serverpod/issues/4045).
 
-Scope: browser (Flutter/Dart web) clients. Native and desktop clients already
+Scope: browser (Flutter/Dart web) clients **and Relic HTML document login**. Native and desktop clients already
 use OS-backed secure storage (Keychain / encrypted shared preferences) and keep
 header authentication; they are unchanged.
 
@@ -25,8 +25,10 @@ SPA pattern is access token in memory, refresh token in an httpOnly cookie.
 Goals: secure storage and transport for browser clients (both auth strategies);
 opt-in (no forced break outside a major); cross-subdomain support.
 
-Non-goals: native/mobile/desktop storage; a BFF / OAuth-confidential-client
-rearchitecture; changes to the identity providers (email, OAuth, passkeys).
+Non-goals: native/mobile/desktop storage; JWT access-token-in-cookie; changes
+to identity-provider *business* APIs (email, OAuth, passkeys). Relic HTML
+login **is** in scope: the BFF and `/auth/*` UI live in the **auth package**,
+not Relic core.
 
 ## Design
 
@@ -167,17 +169,21 @@ never auto-attaches it). The posture is defense in depth:
    only for cross-site embedding (rejected without `Secure`). SameSite alone
    does not cover a same-registrable-domain sibling subdomain, which the next
    two layers do.
-2. Origin validation against `allowedOrigins`, on both HTTP cookie reads and
-   the WebSocket handshake, independent of the browser's own CORS enforcement.
-   A present-but-non-allow-listed `Origin` is rejected; a missing `Origin`
-   (native / server-to-server) is allowed.
-3. Marker-header requirement: the auth cookie only authenticates a request
-   carrying the `cookie` marker. A cross-site form or simple request cannot set
-   a custom header without a CORS preflight, which fails for non-allow-listed
-   origins. (WebSocket handshakes cannot send custom headers; the WS path
-   relies on layer 2.)
-4. Optional double-submit CSRF token, held in reserve for `SameSite=None`
-   (future work).
+2. Origin validation against `allowedOrigins`. **RPC** still allows a missing
+   `Origin` (native / server-to-server). **Relic** is stricter when the request
+   was authenticated **from** the auth cookie on an unsafe method: missing
+   Origin is 403. Cookie-less Relic POSTs (Apple `form_post`, anonymous login)
+   are not Origin-gated at this layer.
+3. Marker-header requirement **for RPC only**: the auth cookie only
+   authenticates an API request carrying the `cookie` marker. Relic HTML does
+   not send the marker; `_SessionMiddleware` hydrates `WebCallSession` from
+   the cookie instead. A Flutter cookie-mode client talking to Relic with
+   `x-serverpod-auth-mode: cookie-transport` stays anonymous.
+4. Form double-submit CSRF on `/auth/*` login and logout (HttpOnly CSRF cookie
+   plus hidden field). App Relic POSTs outside `/auth/*` are not form-CSRF'd
+   in v1; prefer GET `WidgetRoute`s plus Origin. HTML Apple uses an HMAC'd
+   `state` form field Apple echoes — **not** the Lax OAuth cookie, which
+   `form_post` would not send.
 
 The cookie read fails closed on an ambiguous `Cookie` header: when more than
 one cookie carries the configured name (e.g. a sibling subdomain plants a
@@ -190,9 +196,11 @@ requirements.
 
 ## Future work
 
-- Optional double-submit CSRF token for `SameSite=None`.
-- BFF guidance for deployments with stricter requirements.
+- Optional double-submit CSRF token for `SameSite=None` on app Relic POSTs.
+- BFF guidance for deployments with stricter requirements (the auth-package
+  HTML BFF is the v1 website path).
 - Account linking, which will extend the sign-in policy with a merge flow.
+- JWT access-token-in-cookie; email register/reset HTML; Facebook HTML.
 
 ## Sources
 

--- a/examples/auth/auth_server/README.md
+++ b/examples/auth/auth_server/README.md
@@ -43,3 +43,11 @@ To enable Google Sign-In, you need to set up OAuth 2.0 credentials in the
 5. Save the generated client ID and client secret, as you will need them for your Serverpod configuration.
 
 The downloaded credentials JSON should be added to the `config/passwords.yaml` on the `googleClientSecret` field, as shown in the template file.
+
+Register **two** Google redirect URIs if you use both Flutter and Relic HTML: Flutter (e.g. `http://localhost:7357`) and `http://localhost:8082/auth/google/callback`. `configureWebAuthRoutes` throws if `redirectUris` is non-empty and does not include that HTML callback.
+
+### Relic HTML login
+
+`development.yaml` enables `authCookie` (`secure: false` on localhost) and `allowedOrigins`. Add `webAuthOAuthStatePepper` to `passwords.yaml` (do not reuse `sessionKeyHashPepper`). After `initializeAuthServices`, `server.dart` calls `configureWebAuthRoutes(loginSuccessPath: '/account')` and mounts `requireLogin` only on `/account`.
+
+Visit `http://localhost:8082/auth/login`. Do not wrap `/` with `requireLogin`. HTML Apple uses `POST /auth/apple/web/callback`; Flutter Apple stays on `/auth/callback`.

--- a/examples/auth/auth_server/config/development.yaml
+++ b/examples/auth/auth_server/config/development.yaml
@@ -27,6 +27,14 @@ webServer:
   publicPort: 8082
   publicScheme: http
 
+# HttpOnly SAS cookie for Relic HTML login. `secure: false` is required on
+# http://localhost. `sameSite: strict` is rejected by configureWebAuthRoutes.
+authCookie:
+  secure: false
+  # sameSite: lax
+allowedOrigins:
+  - http://localhost:8082
+
 # This is the database setup for your server.
 database:
   host: localhost

--- a/examples/auth/auth_server/config/template.passwords.yaml
+++ b/examples/auth/auth_server/config/template.passwords.yaml
@@ -22,6 +22,7 @@ development:
   serverSideSessionKeyHashPepper: 'test_session_key_pepper'
   jwtRefreshTokenHashPepper: 'test_refresh_token_pepper'
   jwtHmacSha512PrivateKey: 'test_private_key'
+  webAuthOAuthStatePepper: 'YOUR_WEB_AUTH_OAUTH_STATE_PEPPER'
 
   # Email Sign In configuration
   emailSecretHashPepper: 'test_email_password_hash_pepper'

--- a/examples/auth/auth_server/lib/server.dart
+++ b/examples/auth/auth_server/lib/server.dart
@@ -11,6 +11,7 @@ import 'package:serverpod_auth_idp_server/providers/passkey.dart';
 
 import 'src/generated/endpoints.dart';
 import 'src/generated/protocol.dart';
+import 'src/web/routes/account.dart';
 
 // This is the starting point of your Serverpod server. In most cases, you will
 // only need to make additions to this file if you add future calls,  are
@@ -123,6 +124,13 @@ void run(List<String> args) async {
     revokedNotificationRoutePath: '/hooks/apple-notification',
     webAuthenticationCallbackRoutePath: '/auth/callback',
   );
+
+  pod.configureWebAuthRoutes(loginSuccessPath: '/account');
+  pod.webServer.addMiddleware(
+    requireLogin(redirectTo: '/auth/login'),
+    '/account',
+  );
+  pod.webServer.addRoute(AccountRoute(), '/account');
 
   // Start the server.
   await pod.start();

--- a/examples/auth/auth_server/lib/server_from_passwords.dart
+++ b/examples/auth/auth_server/lib/server_from_passwords.dart
@@ -13,6 +13,7 @@ import 'package:serverpod_auth_idp_server/core.dart';
 
 import 'src/generated/protocol.dart';
 import 'src/generated/endpoints.dart';
+import 'src/web/routes/account.dart';
 
 // This is the starting point of your Serverpod server. In most cases, you will
 // only need to make additions to this file if you add future calls,  are
@@ -48,6 +49,13 @@ void run(List<String> args) async {
     revokedNotificationRoutePath: '/hooks/apple-notification',
     webAuthenticationCallbackRoutePath: '/auth/callback',
   );
+
+  pod.configureWebAuthRoutes(loginSuccessPath: '/account');
+  pod.webServer.addMiddleware(
+    requireLogin(redirectTo: '/auth/login'),
+    '/account',
+  );
+  pod.webServer.addRoute(AccountRoute(), '/account');
 
   // Start the server.
   await pod.start();

--- a/examples/auth/auth_server/lib/src/web/routes/account.dart
+++ b/examples/auth/auth_server/lib/src/web/routes/account.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_idp_server/core.dart';
+
+/// Signed-in account page with a CSRF logout form.
+class AccountRoute extends Route {
+  @override
+  Future<Result> handleCall(
+    Session session,
+    Request request,
+  ) async {
+    final authCookie = session.serverpod.config.authCookie!;
+    final csrfToken = generateCsrfToken();
+    setCsrfCookie(session, authCookie, token: csrfToken);
+    final user = session.authenticated?.userIdentifier ?? 'unknown';
+    final html =
+        '''
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Account</title>
+</head>
+<body>
+<h1>Account</h1>
+<p>Signed in as ${HtmlEscape(HtmlEscapeMode.element).convert(user)}</p>
+<form method="post" action="/auth/logout">
+<input type="hidden" name="csrf" value="${HtmlEscape(HtmlEscapeMode.attribute).convert(csrfToken)}">
+<button type="submit">Sign out</button>
+</form>
+</body>
+</html>
+''';
+    return Response.ok(
+      body: Body.fromString(html, mimeType: MimeType.html),
+      headers: Headers.build((mh) {
+        mh.cacheControl = CacheControlHeader(noStore: true);
+      }),
+    );
+  }
+}

--- a/integrations/serverpod_cloud_storage/CHANGELOG.md
+++ b/integrations/serverpod_cloud_storage/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/integrations/serverpod_cloud_storage_gcp/CHANGELOG.md
+++ b/integrations/serverpod_cloud_storage_gcp/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/integrations/serverpod_cloud_storage_r2/CHANGELOG.md
+++ b/integrations/serverpod_cloud_storage_r2/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/integrations/serverpod_cloud_storage_s3/CHANGELOG.md
+++ b/integrations/serverpod_cloud_storage_s3/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/integrations/serverpod_cloud_storage_s3_compat/CHANGELOG.md
+++ b/integrations/serverpod_cloud_storage_s3_compat/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/legacy/serverpod_auth/serverpod_auth_apple_flutter/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_apple_flutter/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/legacy/serverpod_auth/serverpod_auth_client/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_client/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/legacy/serverpod_auth/serverpod_auth_email_flutter/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_email_flutter/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/legacy/serverpod_auth/serverpod_auth_firebase_flutter/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_firebase_flutter/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/legacy/serverpod_auth/serverpod_auth_google_flutter/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_google_flutter/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/legacy/serverpod_auth/serverpod_auth_server/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_server/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/legacy/serverpod_auth/serverpod_auth_shared_flutter/CHANGELOG.md
+++ b/modules/legacy/serverpod_auth/serverpod_auth_shared_flutter/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_client/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_flutter/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_bridge/serverpod_auth_bridge_server/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_client/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/jwt/endpoints/jwt_tokens_endpoint.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/jwt/endpoints/jwt_tokens_endpoint.dart
@@ -2,7 +2,6 @@ import 'package:serverpod/serverpod.dart';
 
 import '../../common/business/auth_services.dart';
 import '../jwt.dart';
-import '../util/jwt_refresh_cookie_path.dart';
 
 /// Endpoint for JWT tokens management.
 abstract class RefreshJwtTokensEndpoint extends Endpoint {

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/jwt/jwt.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_server/lib/src/jwt/jwt.dart
@@ -20,4 +20,5 @@ export 'business/jwt_config.dart';
 export 'business/refresh_token_exceptions.dart';
 export 'endpoints/jwt_tokens_endpoint.dart';
 export 'util/jwt_auth_success_extension.dart' show AuthSuccessJwtRefreshTokenId;
+export 'util/jwt_refresh_cookie_path.dart' show jwtRefreshCookiePath;
 export 'util/jwt_token_info_extension.dart' show JwtTokenInfoExtension;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_client/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter_facebook/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter_facebook/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter_firebase/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_flutter_firebase/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/config/passwords.yaml
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/config/passwords.yaml
@@ -9,6 +9,9 @@
 # Note that this file should not be under version control. Store it in a safe
 # place.
 
+shared:
+  webAuthOAuthStatePepper: 'test_web_auth_oauth_state_pepper'
+
 test:
   database: 'DB_TEST_PASSWORD'
   redis: 'REDIS_TEST_PASSWORD'

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/core.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/core.dart
@@ -17,4 +17,21 @@ export 'src/common/rate_limited_request_attempt/rate_limited_request_attempt_uti
 export 'src/common/secret_challenge/secret_challenge_config.dart';
 export 'src/common/secret_challenge/secret_challenge_exceptions.dart';
 export 'src/common/secret_challenge/secret_challenge_util.dart';
+export 'src/common/web/configure_web_auth_routes.dart';
+export 'src/common/web/hmac_payload.dart'
+    show
+        decodeHmacPayload,
+        encodeHmacPayload,
+        generateSecureRandomString,
+        oauthStateMaxAge,
+        pkceS256Challenge,
+        timingSafeEquals,
+        webAuthOAuthStatePepperPasswordKey;
+export 'src/common/web/oauth_web_flow.dart'
+    show
+        OAuthCallbackRoute,
+        OAuthLoginFn,
+        OAuthStartRoute,
+        oauthStateCookieName;
+export 'src/common/web/web_auth_helpers.dart' show WebAuthFlowConfig;
 export 'src/generated/protocol.dart' hide Protocol;

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/core.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/core.dart
@@ -18,6 +18,8 @@ export 'src/common/secret_challenge/secret_challenge_config.dart';
 export 'src/common/secret_challenge/secret_challenge_exceptions.dart';
 export 'src/common/secret_challenge/secret_challenge_util.dart';
 export 'src/common/web/configure_web_auth_routes.dart';
+export 'src/common/web/csrf.dart'
+    show csrfCookieName, generateCsrfToken, setCsrfCookie;
 export 'src/common/web/hmac_payload.dart'
     show
         decodeHmacPayload,

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/configure_web_auth_routes.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/configure_web_auth_routes.dart
@@ -1,0 +1,188 @@
+import 'package:meta/meta.dart';
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
+
+import '../../providers/email/business/email_idp.dart';
+import '../../providers/email/routes/email_web_routes.dart';
+import '../../providers/github/business/github_idp.dart';
+import '../../providers/github/routes/github_web_routes.dart';
+import '../../providers/google/business/google_idp.dart';
+import '../../providers/google/routes/google_web_routes.dart';
+import 'csrf.dart';
+import 'hmac_payload.dart';
+import 'oauth_web_flow.dart';
+import 'web_auth_helpers.dart';
+
+/// HTML `/auth/*` login, logout, and OAuth BFF routes.
+extension ConfigureWebAuthRoutes on Serverpod {
+  /// Registers Relic routes for browser document login.
+  ///
+  /// Call after [AuthServicesInit.initializeAuthServices] and before
+  /// [Serverpod.start]. SAS must be the primary token manager; [authCookie]
+  /// must be configured; `sameSite: strict` is rejected because the OAuth
+  /// return GET would drop the state cookie.
+  ///
+  /// Only providers present on [AuthServices] are mounted. Email missing
+  /// means no email form and POST `/auth/login` is 404. Google/GitHub
+  /// missing means no button and those paths 404.
+  ///
+  /// The HMAC key is `webAuthOAuthStatePepper` in `passwords.yaml` and must
+  /// not reuse `sessionKeyHashPepper`.
+  ///
+  /// Do not mount HTML Google at `/auth/callback`;
+  /// [FlutterWebAuth2CallbackRoute] lives there.
+  void configureWebAuthRoutes({
+    final String pathPrefix = '/auth',
+    final String loginSuccessPath = '/',
+    @visibleForTesting final OAuthLoginFn? googleLoginOverride,
+    @visibleForTesting final OAuthLoginFn? githubLoginOverride,
+  }) {
+    final AuthServices authServices;
+    try {
+      authServices = AuthServices.instance;
+    } on StateError {
+      throw StateError(
+        'AuthServices is not initialized. Call initializeAuthServices '
+        'before configureWebAuthRoutes.',
+      );
+    }
+
+    final authCookie = config.authCookie;
+    if (authCookie == null) {
+      throw StateError(
+        'configureWebAuthRoutes requires ServerpodConfig.authCookie.',
+      );
+    }
+
+    final primary = authServices.tokenManager.primaryTokenManager;
+    if (primary is! ServerSideSessionsTokenManager) {
+      throw StateError(
+        'configureWebAuthRoutes requires ServerSideSessionsTokenManager '
+        'as the primary token manager (SAS first in tokenManagerBuilders).',
+      );
+    }
+
+    final safeLoginSuccess = trySafeReturnTo(loginSuccessPath);
+    if (safeLoginSuccess == null) {
+      throw ArgumentError.value(
+        loginSuccessPath,
+        'loginSuccessPath',
+        'Must be a safe same-origin relative path.',
+      );
+    }
+
+    if (authCookie.sameSite == CookieSameSite.strict) {
+      throw ArgumentError.value(
+        authCookie.sameSite,
+        'authCookie.sameSite',
+        'strict drops the OAuth state cookie on the provider return GET. '
+            'Use lax (default) or none.',
+      );
+    }
+
+    final hmacPepper = getPassword(webAuthOAuthStatePepperPasswordKey);
+    if (hmacPepper == null || hmacPepper.isEmpty) {
+      throw PasswordNotFoundException(webAuthOAuthStatePepperPasswordKey);
+    }
+
+    if (csrfCookieName(authCookie) == authCookie.refreshName) {
+      throw ArgumentError(
+        'CSRF cookie name "${csrfCookieName(authCookie)}" must not equal '
+        'authCookie.refreshName.',
+      );
+    }
+
+    final prefix = _normalizePathPrefix(pathPrefix);
+    final webServer = config.webServer;
+    if (webServer == null) {
+      throw StateError(
+        'configureWebAuthRoutes requires ServerpodConfig.webServer.',
+      );
+    }
+
+    final allowedOrigins = config.allowedOrigins;
+    if (allowedOrigins == null || allowedOrigins.isEmpty) {
+      throw StateError(
+        'configureWebAuthRoutes requires a non-empty allowedOrigins list.',
+      );
+    }
+
+    final emailIdp = authServices.providers.whereType<EmailIdp>().firstOrNull;
+    final googleIdp = authServices.providers.whereType<GoogleIdp>().firstOrNull;
+    final githubIdp = authServices.providers.whereType<GitHubIdp>().firstOrNull;
+
+    if (googleIdp != null) {
+      final expected = publicWebOrigin(
+        webServer,
+        '$prefix/google/callback',
+      ).toString();
+      final redirectUris = googleIdp.config.clientSecret.redirectUris;
+      if (redirectUris.isNotEmpty && !redirectUris.contains(expected)) {
+        throw ArgumentError(
+          'GoogleClientSecret.redirectUris must include the HTML callback '
+          'URI $expected (built from webServer public scheme/host/port).',
+        );
+      }
+    }
+
+    final flow = WebAuthFlowConfig(
+      pathPrefix: prefix,
+      loginSuccessPath: safeLoginSuccess,
+      hmacPepper: hmacPepper,
+      authCookie: authCookie,
+      webServer: webServer,
+      allowedOrigins: allowedOrigins,
+    );
+
+    this.webServer.addRoute(
+      LoginRoute(
+        config: flow,
+        emailIdp: emailIdp,
+        showGoogle: googleIdp != null,
+        showGitHub: githubIdp != null,
+      ),
+      flow.loginPath,
+    );
+    this.webServer.addRoute(LogoutRoute(config: flow), flow.logoutPath);
+
+    if (googleIdp != null) {
+      addGoogleWebRoutes(
+        webServer: this.webServer,
+        config: flow,
+        googleIdp: googleIdp,
+        loginOverride: googleLoginOverride,
+      );
+    }
+    if (githubIdp != null) {
+      addGitHubWebRoutes(
+        webServer: this.webServer,
+        config: flow,
+        githubIdp: githubIdp,
+        loginOverride: githubLoginOverride,
+      );
+    }
+  }
+}
+
+String _normalizePathPrefix(final String pathPrefix) {
+  var prefix = pathPrefix.trim();
+  if (prefix.isEmpty) {
+    throw ArgumentError.value(
+      pathPrefix,
+      'pathPrefix',
+      'Must be a non-empty path starting with /.',
+    );
+  }
+  if (!prefix.startsWith('/')) {
+    throw ArgumentError.value(
+      pathPrefix,
+      'pathPrefix',
+      'Must start with /.',
+    );
+  }
+  while (prefix.length > 1 && prefix.endsWith('/')) {
+    prefix = prefix.substring(0, prefix.length - 1);
+  }
+  return prefix;
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/configure_web_auth_routes.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/configure_web_auth_routes.dart
@@ -3,12 +3,16 @@ import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
 
+import '../../providers/apple/business/apple_idp.dart';
+import '../../providers/apple/routes/apple_web_routes.dart';
 import '../../providers/email/business/email_idp.dart';
 import '../../providers/email/routes/email_web_routes.dart';
 import '../../providers/github/business/github_idp.dart';
 import '../../providers/github/routes/github_web_routes.dart';
 import '../../providers/google/business/google_idp.dart';
 import '../../providers/google/routes/google_web_routes.dart';
+import '../../providers/microsoft/business/microsoft_idp.dart';
+import '../../providers/microsoft/routes/microsoft_web_routes.dart';
 import 'csrf.dart';
 import 'hmac_payload.dart';
 import 'oauth_web_flow.dart';
@@ -24,19 +28,23 @@ extension ConfigureWebAuthRoutes on Serverpod {
   /// return GET would drop the state cookie.
   ///
   /// Only providers present on [AuthServices] are mounted. Email missing
-  /// means no email form and POST `/auth/login` is 404. Google/GitHub
-  /// missing means no button and those paths 404.
+  /// means no email form and POST `/auth/login` is 404. Google/GitHub/
+  /// Microsoft/Apple missing means no button and those paths 404.
   ///
   /// The HMAC key is `webAuthOAuthStatePepper` in `passwords.yaml` and must
   /// not reuse `sessionKeyHashPepper`.
   ///
   /// Do not mount HTML Google at `/auth/callback`;
-  /// [FlutterWebAuth2CallbackRoute] lives there.
+  /// [FlutterWebAuth2CallbackRoute] lives there. HTML Apple is
+  /// `POST /auth/apple/web/callback`, distinct from
+  /// [AppleIdpConfigureRoutes.configureAppleIdpRoutes].
   void configureWebAuthRoutes({
     final String pathPrefix = '/auth',
     final String loginSuccessPath = '/',
     @visibleForTesting final OAuthLoginFn? googleLoginOverride,
     @visibleForTesting final OAuthLoginFn? githubLoginOverride,
+    @visibleForTesting final MicrosoftWebLoginFn? microsoftLoginOverride,
+    @visibleForTesting final AppleWebLoginFn? appleLoginOverride,
   }) {
     final AuthServices authServices;
     try {
@@ -111,6 +119,10 @@ extension ConfigureWebAuthRoutes on Serverpod {
     final emailIdp = authServices.providers.whereType<EmailIdp>().firstOrNull;
     final googleIdp = authServices.providers.whereType<GoogleIdp>().firstOrNull;
     final githubIdp = authServices.providers.whereType<GitHubIdp>().firstOrNull;
+    final microsoftIdp = authServices.providers
+        .whereType<MicrosoftIdp>()
+        .firstOrNull;
+    final appleIdp = authServices.providers.whereType<AppleIdp>().firstOrNull;
 
     if (googleIdp != null) {
       final expected = publicWebOrigin(
@@ -141,6 +153,8 @@ extension ConfigureWebAuthRoutes on Serverpod {
         emailIdp: emailIdp,
         showGoogle: googleIdp != null,
         showGitHub: githubIdp != null,
+        showMicrosoft: microsoftIdp != null,
+        showApple: appleIdp != null,
       ),
       flow.loginPath,
     );
@@ -160,6 +174,22 @@ extension ConfigureWebAuthRoutes on Serverpod {
         config: flow,
         githubIdp: githubIdp,
         loginOverride: githubLoginOverride,
+      );
+    }
+    if (microsoftIdp != null) {
+      addMicrosoftWebRoutes(
+        webServer: this.webServer,
+        config: flow,
+        microsoftIdp: microsoftIdp,
+        loginOverride: microsoftLoginOverride,
+      );
+    }
+    if (appleIdp != null) {
+      addAppleWebRoutes(
+        webServer: this.webServer,
+        config: flow,
+        appleIdp: appleIdp,
+        loginOverride: appleLoginOverride,
       );
     }
   }

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/csrf.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/csrf.dart
@@ -1,0 +1,68 @@
+import 'package:serverpod/serverpod.dart';
+
+import 'hmac_payload.dart';
+
+/// Cookie name for the double-submit CSRF token, derived from [authCookie].
+String csrfCookieName(final WebAuthCookieConfig authCookie) =>
+    '${authCookie.name}_csrf';
+
+/// A new high-entropy CSRF token.
+String generateCsrfToken() => generateSecureRandomString(32);
+
+/// Queues a CSRF cookie on [session], copying Domain / Path / Secure from
+/// [authCookie]. SameSite is always Lax: this cookie is for same-origin forms.
+void setCsrfCookie(
+  final Session session,
+  final WebAuthCookieConfig authCookie, {
+  required final String token,
+}) {
+  session.setResponseCookie(
+    csrfSetCookie(
+      authCookie,
+      token,
+      maxAge: const Duration(hours: 8).inSeconds,
+    ),
+  );
+}
+
+/// Builds the CSRF `Set-Cookie` for [authCookie].
+SetCookie csrfSetCookie(
+  final WebAuthCookieConfig authCookie,
+  final String value, {
+  required final int maxAge,
+}) {
+  final domain = authCookie.domain;
+  return SetCookie(
+    name: csrfCookieName(authCookie),
+    value: value,
+    httpOnly: true,
+    secure: authCookie.secure,
+    sameSite: SameSite.lax,
+    path: authCookie.path,
+    domain: domain == null ? null : Host.parse(domain),
+    maxAge: maxAge,
+  );
+}
+
+/// Reads the CSRF cookie from [request], failing closed on duplicates.
+String? readCsrfCookie(
+  final Request request,
+  final WebAuthCookieConfig authCookie,
+) {
+  return request.getCookieValue(csrfCookieName(authCookie));
+}
+
+/// Verifies the double-submit CSRF cookie against the form field.
+///
+/// Returns false (caller should 403) when the cookie or field is missing,
+/// duplicated, or the values do not match.
+bool verifyCsrfDoubleSubmit({
+  required final Request request,
+  required final WebAuthCookieConfig authCookie,
+  required final String? formToken,
+}) {
+  if (formToken == null || formToken.isEmpty) return false;
+  final cookieToken = readCsrfCookie(request, authCookie);
+  if (cookieToken == null || cookieToken.isEmpty) return false;
+  return timingSafeEquals(cookieToken, formToken);
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/hmac_payload.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/hmac_payload.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:clock/clock.dart';
+import 'package:crypto/crypto.dart';
+
+final _random = Random.secure();
+
+/// Key in `passwords.yaml` for the HMAC that signs HTML OAuth state.
+const String webAuthOAuthStatePepperPasswordKey = 'webAuthOAuthStatePepper';
+
+/// Lifetime of HMAC'd OAuth state (cookie or Apple `state` field).
+const Duration oauthStateMaxAge = Duration(minutes: 10);
+
+/// A cryptographically random URL-safe string of [byteLength] bytes.
+String generateSecureRandomString(final int byteLength) {
+  final bytes = List<int>.generate(
+    byteLength,
+    (final _) => _random.nextInt(256),
+  );
+  return base64Url.encode(bytes).replaceAll('=', '');
+}
+
+/// Timing-safe equality for two strings of any length.
+bool timingSafeEquals(final String a, final String b) {
+  final aBytes = utf8.encode(a);
+  final bBytes = utf8.encode(b);
+  final length = aBytes.length > bBytes.length ? aBytes.length : bBytes.length;
+  final paddedA = Uint8List(length)..setRange(0, aBytes.length, aBytes);
+  final paddedB = Uint8List(length)..setRange(0, bBytes.length, bBytes);
+  var diff = aBytes.length ^ bBytes.length;
+  for (var i = 0; i < length; i++) {
+    diff |= paddedA[i] ^ paddedB[i];
+  }
+  return diff == 0;
+}
+
+String _macB64(final String payloadB64, final String pepper) {
+  final hmac = Hmac(sha256, utf8.encode(pepper));
+  return base64Url
+      .encode(hmac.convert(utf8.encode(payloadB64)).bytes)
+      .replaceAll('=', '');
+}
+
+/// Encodes [payload] as `base64url(hmac).base64url(json)` keyed by [pepper].
+///
+/// Adds `iat` (UTC milliseconds) when the payload does not already include it.
+String encodeHmacPayload(
+  final Map<String, Object?> payload,
+  final String pepper,
+) {
+  final withIat = Map<String, Object?>.from(payload);
+  withIat.putIfAbsent(
+    'iat',
+    () => clock.now().toUtc().millisecondsSinceEpoch,
+  );
+  final payloadB64 = base64Url
+      .encode(utf8.encode(jsonEncode(withIat)))
+      .replaceAll('=', '');
+  return '${_macB64(payloadB64, pepper)}.$payloadB64';
+}
+
+/// Decodes and verifies an [encodeHmacPayload] token.
+///
+/// Returns null if the token is malformed, the HMAC does not match, or [iat]
+/// is missing / older than [maxAge]. A one-minute clock-skew allowance is
+/// applied for tokens that appear slightly in the future.
+Map<String, Object?>? decodeHmacPayload(
+  final String token,
+  final String pepper, {
+  final Duration maxAge = oauthStateMaxAge,
+}) {
+  final dot = token.indexOf('.');
+  if (dot <= 0 || dot == token.length - 1) return null;
+  final mac = token.substring(0, dot);
+  final payloadB64 = token.substring(dot + 1);
+  if (!timingSafeEquals(mac, _macB64(payloadB64, pepper))) return null;
+
+  Map<String, dynamic> json;
+  try {
+    final padded = payloadB64.padRight(
+      payloadB64.length + (4 - payloadB64.length % 4) % 4,
+      '=',
+    );
+    json =
+        jsonDecode(utf8.decode(base64Url.decode(padded)))
+            as Map<String, dynamic>;
+  } on FormatException {
+    return null;
+  } on ArgumentError {
+    return null;
+  }
+
+  final iat = json['iat'];
+  if (iat is! int) return null;
+  final issuedAt = DateTime.fromMillisecondsSinceEpoch(iat, isUtc: true);
+  final now = clock.now().toUtc();
+  if (now.difference(issuedAt) > maxAge) return null;
+  if (issuedAt.isAfter(now.add(const Duration(minutes: 1)))) return null;
+  return Map<String, Object?>.from(json);
+}
+
+/// SHA-256 S256 code challenge for [codeVerifier] (base64url, no padding).
+String pkceS256Challenge(final String codeVerifier) {
+  final digest = sha256.convert(utf8.encode(codeVerifier));
+  return base64Url.encode(digest.bytes).replaceAll('=', '');
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/oauth_web_flow.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/oauth_web_flow.dart
@@ -1,0 +1,216 @@
+import 'package:serverpod/serverpod.dart';
+
+import 'hmac_payload.dart';
+import 'web_auth_helpers.dart';
+
+/// Completes an OAuth authorization-code + PKCE login on a Relic session.
+typedef OAuthLoginFn =
+    Future<void> Function(
+      Session session, {
+      required String code,
+      required String codeVerifier,
+      required String redirectUri,
+    });
+
+/// Cookie name for the HMAC'd OAuth BFF state, derived from [authCookie].
+String oauthStateCookieName(final WebAuthCookieConfig authCookie) =>
+    '${authCookie.name}_oauth';
+
+SetCookie _oauthCookie(
+  final WebAuthCookieConfig authCookie,
+  final String value, {
+  required final int maxAge,
+}) {
+  final domain = authCookie.domain;
+  return SetCookie(
+    name: oauthStateCookieName(authCookie),
+    value: value,
+    httpOnly: true,
+    secure: authCookie.secure,
+    sameSite: relicSameSite(authCookie.sameSite),
+    path: authCookie.path,
+    domain: domain == null ? null : Host.parse(domain),
+    maxAge: maxAge,
+  );
+}
+
+void _clearOAuthCookie(
+  final Session session,
+  final WebAuthCookieConfig authCookie,
+) {
+  session.setResponseCookie(_oauthCookie(authCookie, '', maxAge: 0));
+}
+
+/// GET start of a confidential-client OAuth + PKCE flow.
+///
+/// Stores HMAC'd `{state, code_verifier, return_to, provider, iat}` in an
+/// HttpOnly cookie. The browser never sees [code_verifier].
+final class OAuthStartRoute extends Route {
+  /// Shared HTML auth config.
+  final WebAuthFlowConfig config;
+
+  /// Provider id stored in the HMAC payload (`google`, `github`, `microsoft`).
+  final String provider;
+
+  /// OAuth client id.
+  final String clientId;
+
+  /// Provider authorize endpoint, without query.
+  final Uri authorizeUrl;
+
+  /// Space-joinable scopes sent as `scope`.
+  final List<String> scopes;
+
+  /// Path passed to [publicWebOrigin] for `redirect_uri`.
+  final String callbackPath;
+
+  /// Extra authorize query parameters (e.g. Microsoft `prompt`).
+  final Map<String, String> extraQuery;
+
+  /// Creates an [OAuthStartRoute].
+  OAuthStartRoute({
+    required this.config,
+    required this.provider,
+    required this.clientId,
+    required this.authorizeUrl,
+    required this.scopes,
+    required this.callbackPath,
+    this.extraQuery = const {},
+  }) : super(methods: {Method.get});
+
+  @override
+  Future<Result> handleCall(
+    final Session session,
+    final Request request,
+  ) async {
+    final returnTo = safeReturnTo(
+      request.url.queryParameters['return_to'],
+      fallback: config.loginSuccessPath,
+    );
+    final state = generateSecureRandomString(16);
+    final codeVerifier = generateSecureRandomString(32);
+    final token = encodeHmacPayload(
+      {
+        'state': state,
+        'code_verifier': codeVerifier,
+        'return_to': returnTo,
+        'provider': provider,
+      },
+      config.hmacPepper,
+    );
+    session.setResponseCookie(
+      _oauthCookie(
+        config.authCookie,
+        token,
+        maxAge: oauthStateMaxAge.inSeconds,
+      ),
+    );
+
+    final redirectUri = publicWebOrigin(config.webServer, callbackPath);
+    final query = <String, String>{
+      'client_id': clientId,
+      'redirect_uri': redirectUri.toString(),
+      'response_type': 'code',
+      'state': state,
+      'code_challenge': pkceS256Challenge(codeVerifier),
+      'code_challenge_method': 'S256',
+      'scope': scopes.join(' '),
+      ...extraQuery,
+    };
+
+    return Response.found(
+      authorizeUrl.replace(queryParameters: query),
+      headers: authPageHeaders(),
+    );
+  }
+}
+
+/// GET callback that verifies HMAC + PKCE state, then runs [login].
+final class OAuthCallbackRoute extends Route {
+  /// Shared HTML auth config.
+  final WebAuthFlowConfig config;
+
+  /// Provider id that must match the HMAC payload.
+  final String provider;
+
+  /// Path passed to [publicWebOrigin]; must match the start `redirect_uri`.
+  final String callbackPath;
+
+  /// IDP login (or a test double).
+  final OAuthLoginFn login;
+
+  /// Creates an [OAuthCallbackRoute].
+  OAuthCallbackRoute({
+    required this.config,
+    required this.provider,
+    required this.callbackPath,
+    required this.login,
+  }) : super(methods: {Method.get});
+
+  @override
+  Future<Result> handleCall(
+    final Session session,
+    final Request request,
+  ) async {
+    final cookieValue = request.getCookieValue(
+      oauthStateCookieName(config.authCookie),
+    );
+    _clearOAuthCookie(session, config.authCookie);
+
+    final code = request.url.queryParameters['code'];
+    final error = request.url.queryParameters['error'];
+    if ((code == null || code.isEmpty) && error != null && error.isNotEmpty) {
+      return authSeeOther(config.loginPath);
+    }
+
+    final payload = cookieValue == null
+        ? null
+        : decodeHmacPayload(cookieValue, config.hmacPepper);
+    if (payload == null) {
+      return authForbidden();
+    }
+
+    final storedState = payload['state'] as String?;
+    final queryState = request.url.queryParameters['state'];
+    if (storedState == null ||
+        queryState == null ||
+        !timingSafeEquals(storedState, queryState)) {
+      return authForbidden();
+    }
+
+    if (payload['provider'] != provider) {
+      return authForbidden();
+    }
+
+    final returnToRaw = payload['return_to'] as String?;
+    final returnTo = trySafeReturnTo(returnToRaw);
+    if (returnTo == null) {
+      return authForbidden();
+    }
+
+    final codeVerifier = payload['code_verifier'] as String?;
+    if (code == null || code.isEmpty || codeVerifier == null) {
+      return authForbidden();
+    }
+
+    await signOutBeforeHtmlLogin(session);
+
+    final redirectUri = publicWebOrigin(
+      config.webServer,
+      callbackPath,
+    ).toString();
+
+    try {
+      await login(
+        session,
+        code: code,
+        codeVerifier: codeVerifier,
+        redirectUri: redirectUri,
+      );
+    } on Exception {
+      return authSeeOther(config.loginPath);
+    }
+
+    return authSeeOther(returnTo);
+  }
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/pages/login_page.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/pages/login_page.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+
+import '../web_auth_helpers.dart';
+
+const _htmlEscape = HtmlEscape(HtmlEscapeMode.element);
+const _attrEscape = HtmlEscape(HtmlEscapeMode.attribute);
+
+/// Renders the HTML login hub.
+String renderLoginPage({
+  required final WebAuthFlowConfig config,
+  required final String csrfToken,
+  required final String returnTo,
+  required final bool showEmail,
+  required final bool showGoogle,
+  required final bool showGitHub,
+  final bool showMicrosoft = false,
+  final bool showApple = false,
+  final bool signedIn = false,
+  final String? errorMessage,
+}) {
+  final returnToAttr = _attrEscape.convert(returnTo);
+  final csrfAttr = _attrEscape.convert(csrfToken);
+  final loginAction = _attrEscape.convert(config.loginPath);
+  final logoutAction = _attrEscape.convert(config.logoutPath);
+  final oauthQuery = Uri(queryParameters: {'return_to': returnTo}).query;
+
+  final buffer = StringBuffer()
+    ..writeln('<!DOCTYPE html>')
+    ..writeln('<html lang="en">')
+    ..writeln('<head>')
+    ..writeln('<meta charset="utf-8">')
+    ..writeln(
+      '<meta name="viewport" content="width=device-width, initial-scale=1">',
+    )
+    ..writeln('<title>Sign in</title>')
+    ..writeln('</head>')
+    ..writeln('<body>')
+    ..writeln('<h1>Sign in</h1>');
+
+  if (errorMessage != null && errorMessage.isNotEmpty) {
+    buffer.writeln(
+      '<p role="alert">${_htmlEscape.convert(errorMessage)}</p>',
+    );
+  }
+
+  if (signedIn) {
+    buffer
+      ..writeln('<p>You are signed in.</p>')
+      ..writeln(
+        '<form method="post" action="$logoutAction">'
+        '<input type="hidden" name="csrf" value="$csrfAttr">'
+        '<button type="submit">Sign out</button>'
+        '</form>',
+      );
+  }
+
+  if (showEmail) {
+    buffer
+      ..writeln('<form method="post" action="$loginAction">')
+      ..writeln(
+        '<input type="hidden" name="csrf" value="$csrfAttr">',
+      )
+      ..writeln(
+        '<input type="hidden" name="return_to" value="$returnToAttr">',
+      )
+      ..writeln(
+        '<label>Email <input type="email" name="email" required></label>',
+      )
+      ..writeln(
+        '<label>Password <input type="password" name="password" required></label>',
+      )
+      ..writeln('<button type="submit">Sign in with email</button>')
+      ..writeln('</form>')
+      ..writeln(
+        '<p>Registration, email verification, and password reset are not '
+        'available on this page.</p>',
+      );
+  }
+
+  if (showGoogle) {
+    final href = _attrEscape.convert('${config.pathPrefix}/google?$oauthQuery');
+    buffer.writeln('<p><a href="$href">Continue with Google</a></p>');
+  }
+  if (showGitHub) {
+    final href = _attrEscape.convert('${config.pathPrefix}/github?$oauthQuery');
+    buffer.writeln('<p><a href="$href">Continue with GitHub</a></p>');
+  }
+  if (showMicrosoft) {
+    final href = _attrEscape.convert(
+      '${config.pathPrefix}/microsoft?$oauthQuery',
+    );
+    buffer.writeln('<p><a href="$href">Continue with Microsoft</a></p>');
+  }
+  if (showApple) {
+    final href = _attrEscape.convert('${config.pathPrefix}/apple?$oauthQuery');
+    buffer.writeln('<p><a href="$href">Continue with Apple</a></p>');
+  }
+
+  if (!showEmail &&
+      !showGoogle &&
+      !showGitHub &&
+      !showMicrosoft &&
+      !showApple) {
+    buffer.writeln('<p>No sign-in methods are configured.</p>');
+  }
+
+  buffer
+    ..writeln('</body>')
+    ..writeln('</html>');
+  return buffer.toString();
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/web_auth_helpers.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/common/web/web_auth_helpers.dart
@@ -1,0 +1,136 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_core_server/serverpod_auth_core_server.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
+
+/// Revokes the current device's token and clears the web auth cookie.
+///
+/// Same order as [StatusEndpoint.signOutDevice]: clear the cookie first, then
+/// [TokenManager.revokeToken] for this `authId` only (not all devices).
+Future<void> signOutCurrentDevice(final Session session) async {
+  session.clearWebAuthCookie(
+    refreshCookiePath: jwtRefreshCookiePath(session),
+  );
+  final authInfoIdStr = session.authenticated?.authId;
+  if (authInfoIdStr == null) return;
+  final authInfoId = UuidValue.withValidation(authInfoIdStr);
+  await AuthServices.instance.tokenManager.revokeToken(
+    session,
+    tokenId: authInfoId.toString(),
+  );
+  // Drop the cached caller so a later issueToken in this same request
+  // (HTML sign-out-before-login) is not treated as switching users.
+  session.updateAuthenticated(null);
+}
+
+/// If the Relic session is already authenticated, signs out this device so
+/// a subsequent [TokenIssuer.issueToken] does not throw
+/// [SignInWhileAuthenticatedException].
+///
+/// Must run only after CSRF / OAuth HMAC checks succeed.
+Future<void> signOutBeforeHtmlLogin(final Session session) async {
+  if (session.authenticated == null) return;
+  await signOutCurrentDevice(session);
+}
+
+/// Whether a same-origin form POST may proceed.
+///
+/// Origin is required when present. Referer is used only if Origin is absent
+/// (anonymous login POST). Cookie-authenticated POSTs are already Origin-gated
+/// by Relic when the cookie authenticates.
+bool originAllowedForAuthForm(
+  final Request request,
+  final List<String> allowedOrigins,
+) {
+  final origin = requestOrigin(request);
+  if (origin != null) {
+    return allowedOrigins.contains(origin);
+  }
+  final referer = request.headers[Headers.refererHeader]?.firstOrNull;
+  if (referer == null || referer.isEmpty) return false;
+  final Uri refererUri;
+  try {
+    refererUri = Uri.parse(referer);
+  } on FormatException {
+    return false;
+  }
+  if (!refererUri.hasScheme || refererUri.host.isEmpty) return false;
+  final refererOrigin = normalizeOriginValue(refererUri.origin);
+  return refererOrigin != null && allowedOrigins.contains(refererOrigin);
+}
+
+/// Parses `application/x-www-form-urlencoded` body into a map.
+Future<Map<String, String>> readFormFields(final Request request) async {
+  final body = await request.readAsString();
+  if (body.isEmpty) return const {};
+  return Uri.splitQueryString(body);
+}
+
+/// Standard headers for `/auth/*` HTML and OAuth start responses.
+Headers authPageHeaders() {
+  return Headers.build((final mh) {
+    mh.cacheControl = CacheControlHeader(noStore: true);
+    mh['x-frame-options'] = ['DENY'];
+  });
+}
+
+/// HTML 200 with [authPageHeaders].
+Response authHtmlOk(final String html) {
+  return Response.ok(
+    body: Body.fromString(html, mimeType: MimeType.html),
+    headers: authPageHeaders(),
+  );
+}
+
+/// 303 See Other with [authPageHeaders].
+Response authSeeOther(final String location) {
+  return Response.seeOther(Uri.parse(location), headers: authPageHeaders());
+}
+
+/// 403 Forbidden with [authPageHeaders].
+Response authForbidden() {
+  return Response.forbidden(headers: authPageHeaders());
+}
+
+/// Relic [SameSite] for [CookieSameSite].
+SameSite relicSameSite(final CookieSameSite sameSite) => switch (sameSite) {
+  CookieSameSite.lax => SameSite.lax,
+  CookieSameSite.strict => SameSite.strict,
+  CookieSameSite.none => SameSite.none,
+};
+
+/// Shared configuration for HTML `/auth/*` routes.
+final class WebAuthFlowConfig {
+  /// Path prefix, without a trailing slash (e.g. `/auth`).
+  final String pathPrefix;
+
+  /// Safe same-origin path to send the browser after a successful login.
+  final String loginSuccessPath;
+
+  /// HMAC pepper from `passwords.yaml` (`webAuthOAuthStatePepper`).
+  final String hmacPepper;
+
+  /// Cookie settings copied onto CSRF / OAuth cookies.
+  final WebAuthCookieConfig authCookie;
+
+  /// Public web server used to build OAuth `redirect_uri` values.
+  final ServerConfig webServer;
+
+  /// Origin allow-list; required whenever [authCookie] is configured.
+  final List<String> allowedOrigins;
+
+  /// Creates a [WebAuthFlowConfig].
+  WebAuthFlowConfig({
+    required this.pathPrefix,
+    required this.loginSuccessPath,
+    required this.hmacPepper,
+    required this.authCookie,
+    required this.webServer,
+    required this.allowedOrigins,
+  });
+
+  /// GET/POST login hub path.
+  String get loginPath => '$pathPrefix/login';
+
+  /// POST logout path.
+  String get logoutPath => '$pathPrefix/logout';
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/routes/apple_web_routes.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/apple/routes/apple_web_routes.dart
@@ -1,0 +1,222 @@
+import 'dart:convert';
+
+import 'package:serverpod/serverpod.dart';
+
+import '../../../common/web/hmac_payload.dart';
+import '../../../common/web/web_auth_helpers.dart';
+import '../business/apple_idp.dart';
+
+/// Completes an Apple HTML `form_post` login.
+typedef AppleWebLoginFn =
+    Future<void> Function(
+      Session session, {
+      required String identityToken,
+      required String authorizationCode,
+      required bool isNativeApplePlatformSignIn,
+      String? firstName,
+      String? lastName,
+    });
+
+/// Apple authorize endpoint for HTML Sign in with Apple.
+final appleWebAuthorizeUrl = Uri.https(
+  'appleid.apple.com',
+  '/auth/authorize',
+);
+
+/// Scopes requested by HTML Apple sign-in.
+const appleWebScopes = ['name', 'email'];
+
+/// Registers GET `/auth/apple` and POST `/auth/apple/web/callback`.
+void addAppleWebRoutes({
+  required final WebServer webServer,
+  required final WebAuthFlowConfig config,
+  required final AppleIdp appleIdp,
+  final AppleWebLoginFn? loginOverride,
+}) {
+  final callbackPath = '${config.pathPrefix}/apple/web/callback';
+  webServer.addRoute(
+    AppleWebStartRoute(
+      config: config,
+      appleIdp: appleIdp,
+      callbackPath: callbackPath,
+    ),
+    '${config.pathPrefix}/apple',
+  );
+  webServer.addRoute(
+    AppleWebCallbackRoute(
+      config: config,
+      appleIdp: appleIdp,
+      loginOverride: loginOverride,
+    ),
+    callbackPath,
+  );
+}
+
+/// GET start of HTML Apple Sign in. State lives in the HMAC'd `state` query
+/// parameter Apple echoes on `form_post` — not a Lax OAuth cookie.
+final class AppleWebStartRoute extends Route {
+  /// Shared HTML auth config.
+  final WebAuthFlowConfig config;
+
+  /// Apple IDP (for `serviceIdentifier`).
+  final AppleIdp appleIdp;
+
+  /// Path passed to [publicWebOrigin] for `redirect_uri`.
+  final String callbackPath;
+
+  /// Creates an [AppleWebStartRoute].
+  AppleWebStartRoute({
+    required this.config,
+    required this.appleIdp,
+    required this.callbackPath,
+  }) : super(methods: {Method.get});
+
+  @override
+  Future<Result> handleCall(
+    final Session session,
+    final Request request,
+  ) async {
+    final returnTo = safeReturnTo(
+      request.url.queryParameters['return_to'],
+      fallback: config.loginSuccessPath,
+    );
+    final nonce = generateSecureRandomString(16);
+    final state = encodeHmacPayload(
+      {
+        'nonce': nonce,
+        'return_to': returnTo,
+        'provider': 'apple',
+      },
+      config.hmacPepper,
+    );
+
+    final redirectUri = publicWebOrigin(config.webServer, callbackPath);
+    final query = <String, String>{
+      'client_id': appleIdp.config.serviceIdentifier,
+      'redirect_uri': redirectUri.toString(),
+      'response_type': 'code id_token',
+      'response_mode': 'form_post',
+      'state': state,
+      'nonce': nonce,
+      'scope': appleWebScopes.join(' '),
+    };
+
+    return Response.found(
+      appleWebAuthorizeUrl.replace(queryParameters: query),
+      headers: authPageHeaders(),
+    );
+  }
+}
+
+/// POST callback for HTML Apple `form_post`. Not Origin-gated and not
+/// double-submit CSRF'd: Apple's origin is `https://appleid.apple.com`, and
+/// SameSite=Lax cookies are not sent.
+final class AppleWebCallbackRoute extends Route {
+  /// Shared HTML auth config.
+  final WebAuthFlowConfig config;
+
+  /// Apple IDP used when [loginOverride] is null.
+  final AppleIdp appleIdp;
+
+  /// Test double for [AppleIdp.login].
+  final AppleWebLoginFn? loginOverride;
+
+  /// Creates an [AppleWebCallbackRoute].
+  AppleWebCallbackRoute({
+    required this.config,
+    required this.appleIdp,
+    this.loginOverride,
+  }) : super(methods: {Method.post});
+
+  @override
+  Future<Result> handleCall(
+    final Session session,
+    final Request request,
+  ) async {
+    final fields = await readFormFields(request);
+    final code = fields['code'];
+    final error = fields['error'];
+    if ((code == null || code.isEmpty) && error != null && error.isNotEmpty) {
+      return authSeeOther(config.loginPath);
+    }
+
+    final payload = fields['state'] == null
+        ? null
+        : decodeHmacPayload(fields['state']!, config.hmacPepper);
+    if (payload == null || payload['provider'] != 'apple') {
+      return authForbidden();
+    }
+
+    final returnTo = trySafeReturnTo(payload['return_to'] as String?);
+    if (returnTo == null) {
+      return authForbidden();
+    }
+
+    final identityToken = fields['id_token'];
+    if (code == null ||
+        code.isEmpty ||
+        identityToken == null ||
+        identityToken.isEmpty) {
+      return authForbidden();
+    }
+
+    final names = _appleUserNames(fields['user']);
+    try {
+      final login = loginOverride ?? _defaultLogin;
+      await login(
+        session,
+        identityToken: identityToken,
+        authorizationCode: code,
+        isNativeApplePlatformSignIn: false,
+        firstName: names.firstName,
+        lastName: names.lastName,
+      );
+    } on Exception {
+      return authSeeOther(config.loginPath);
+    }
+
+    return authSeeOther(returnTo);
+  }
+
+  Future<void> _defaultLogin(
+    final Session session, {
+    required final String identityToken,
+    required final String authorizationCode,
+    required final bool isNativeApplePlatformSignIn,
+    final String? firstName,
+    final String? lastName,
+  }) {
+    return appleIdp.login(
+      session,
+      identityToken: identityToken,
+      authorizationCode: authorizationCode,
+      isNativeApplePlatformSignIn: isNativeApplePlatformSignIn,
+      firstName: firstName,
+      lastName: lastName,
+    );
+  }
+}
+
+({String? firstName, String? lastName}) _appleUserNames(
+  final String? userJson,
+) {
+  if (userJson == null || userJson.isEmpty) {
+    return (firstName: null, lastName: null);
+  }
+  try {
+    final decoded = jsonDecode(userJson);
+    if (decoded is! Map) {
+      return (firstName: null, lastName: null);
+    }
+    final name = decoded['name'];
+    if (name is! Map) {
+      return (firstName: null, lastName: null);
+    }
+    return (
+      firstName: name['firstName'] as String?,
+      lastName: name['lastName'] as String?,
+    );
+  } on FormatException {
+    return (firstName: null, lastName: null);
+  }
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/email/routes/email_web_routes.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/email/routes/email_web_routes.dart
@@ -1,0 +1,181 @@
+import 'package:serverpod/serverpod.dart';
+
+import '../../../common/web/csrf.dart';
+import '../../../common/web/pages/login_page.dart';
+import '../../../common/web/web_auth_helpers.dart';
+import '../../../generated/protocol.dart'
+    show EmailAccountLoginException, EmailAccountLoginExceptionReason;
+import '../business/email_idp.dart';
+
+/// GET/POST `/auth/login` hub and POST `/auth/logout`.
+final class LoginRoute extends Route {
+  /// Shared HTML auth config.
+  final WebAuthFlowConfig config;
+
+  /// Email IDP, or null when email is not configured.
+  final EmailIdp? emailIdp;
+
+  /// Whether to render a Google button.
+  final bool showGoogle;
+
+  /// Whether to render a GitHub button.
+  final bool showGitHub;
+
+  /// Whether to render a Microsoft button.
+  final bool showMicrosoft;
+
+  /// Whether to render an Apple button.
+  final bool showApple;
+
+  /// Creates a [LoginRoute].
+  LoginRoute({
+    required this.config,
+    required this.emailIdp,
+    required this.showGoogle,
+    required this.showGitHub,
+    this.showMicrosoft = false,
+    this.showApple = false,
+  }) : super(methods: {Method.get, Method.post});
+
+  @override
+  Future<Result> handleCall(
+    final Session session,
+    final Request request,
+  ) async {
+    if (request.method == Method.get) {
+      return _get(session, request);
+    }
+    if (emailIdp == null) {
+      return Response.notFound(headers: authPageHeaders());
+    }
+    return _post(session, request, emailIdp!);
+  }
+
+  Result _get(final Session session, final Request request) {
+    final csrfToken = generateCsrfToken();
+    setCsrfCookie(session, config.authCookie, token: csrfToken);
+    final returnTo = safeReturnTo(
+      request.url.queryParameters['return_to'],
+      fallback: config.loginSuccessPath,
+    );
+    return authHtmlOk(
+      renderLoginPage(
+        config: config,
+        csrfToken: csrfToken,
+        returnTo: returnTo,
+        showEmail: emailIdp != null,
+        showGoogle: showGoogle,
+        showGitHub: showGitHub,
+        showMicrosoft: showMicrosoft,
+        showApple: showApple,
+        signedIn: session.authenticated != null,
+      ),
+    );
+  }
+
+  Future<Result> _post(
+    final Session session,
+    final Request request,
+    final EmailIdp emailIdp,
+  ) async {
+    final fields = await readFormFields(request);
+    if (!verifyCsrfDoubleSubmit(
+      request: request,
+      authCookie: config.authCookie,
+      formToken: fields['csrf'],
+    )) {
+      return authForbidden();
+    }
+    if (!originAllowedForAuthForm(request, config.allowedOrigins)) {
+      return authForbidden();
+    }
+
+    final returnTo = safeReturnTo(
+      fields['return_to'],
+      fallback: config.loginSuccessPath,
+    );
+
+    await signOutBeforeHtmlLogin(session);
+
+    final email = fields['email'] ?? '';
+    final password = fields['password'] ?? '';
+    try {
+      await emailIdp.login(session, email: email, password: password);
+    } on EmailAccountLoginException catch (e) {
+      return _loginError(
+        session,
+        returnTo: returnTo,
+        message: _emailErrorMessage(e),
+      );
+    } on Exception {
+      return _loginError(
+        session,
+        returnTo: returnTo,
+        message: 'Sign-in failed.',
+      );
+    }
+
+    return authSeeOther(returnTo);
+  }
+
+  Result _loginError(
+    final Session session, {
+    required final String returnTo,
+    required final String message,
+  }) {
+    final csrfToken = generateCsrfToken();
+    setCsrfCookie(session, config.authCookie, token: csrfToken);
+    return authHtmlOk(
+      renderLoginPage(
+        config: config,
+        csrfToken: csrfToken,
+        returnTo: returnTo,
+        showEmail: true,
+        showGoogle: showGoogle,
+        showGitHub: showGitHub,
+        showMicrosoft: showMicrosoft,
+        showApple: showApple,
+        errorMessage: message,
+      ),
+    );
+  }
+
+  String _emailErrorMessage(final EmailAccountLoginException exception) {
+    return switch (exception.reason) {
+      EmailAccountLoginExceptionReason.tooManyAttempts =>
+        'Too many attempts. Try again later.',
+      EmailAccountLoginExceptionReason.invalidCredentials ||
+      EmailAccountLoginExceptionReason.unknown => 'Invalid email or password.',
+    };
+  }
+}
+
+/// POST `/auth/logout`.
+final class LogoutRoute extends Route {
+  /// Shared HTML auth config.
+  final WebAuthFlowConfig config;
+
+  /// Creates a [LogoutRoute].
+  LogoutRoute({required this.config}) : super(methods: {Method.post});
+
+  @override
+  Future<Result> handleCall(
+    final Session session,
+    final Request request,
+  ) async {
+    final fields = await readFormFields(request);
+    if (!verifyCsrfDoubleSubmit(
+      request: request,
+      authCookie: config.authCookie,
+      formToken: fields['csrf'],
+    )) {
+      return authForbidden();
+    }
+    if (!originAllowedForAuthForm(request, config.allowedOrigins)) {
+      return authForbidden();
+    }
+
+    await signOutCurrentDevice(session);
+    return authSeeOther(config.loginPath);
+  }
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/routes/github_web_routes.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/github/routes/github_web_routes.dart
@@ -1,0 +1,58 @@
+import 'package:serverpod/serverpod.dart';
+
+import '../../../common/web/oauth_web_flow.dart';
+import '../../../common/web/web_auth_helpers.dart';
+import '../business/github_idp.dart';
+
+/// GitHub authorize endpoint for the HTML BFF.
+final githubWebAuthorizeUrl = Uri.https(
+  'github.com',
+  '/login/oauth/authorize',
+);
+
+/// Scopes requested by HTML GitHub sign-in.
+const githubWebScopes = ['read:user', 'user:email'];
+
+/// Registers GET `/auth/github` and GET `/auth/github/callback`.
+void addGitHubWebRoutes({
+  required final WebServer webServer,
+  required final WebAuthFlowConfig config,
+  required final GitHubIdp githubIdp,
+  final OAuthLoginFn? loginOverride,
+}) {
+  final callbackPath = '${config.pathPrefix}/github/callback';
+  webServer.addRoute(
+    OAuthStartRoute(
+      config: config,
+      provider: 'github',
+      clientId: githubIdp.config.clientId,
+      authorizeUrl: githubWebAuthorizeUrl,
+      scopes: githubWebScopes,
+      callbackPath: callbackPath,
+    ),
+    '${config.pathPrefix}/github',
+  );
+  webServer.addRoute(
+    OAuthCallbackRoute(
+      config: config,
+      provider: 'github',
+      callbackPath: callbackPath,
+      login:
+          loginOverride ??
+          (
+            final session, {
+            required final code,
+            required final codeVerifier,
+            required final redirectUri,
+          }) {
+            return githubIdp.login(
+              session,
+              code: code,
+              codeVerifier: codeVerifier,
+              redirectUri: redirectUri,
+            );
+          },
+    ),
+    callbackPath,
+  );
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/google/routes/google_web_routes.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/google/routes/google_web_routes.dart
@@ -1,0 +1,58 @@
+import 'package:serverpod/serverpod.dart';
+
+import '../../../common/web/oauth_web_flow.dart';
+import '../../../common/web/web_auth_helpers.dart';
+import '../business/google_idp.dart';
+
+/// Google authorize endpoint for the HTML BFF.
+final googleWebAuthorizeUrl = Uri.https(
+  'accounts.google.com',
+  '/o/oauth2/v2/auth',
+);
+
+/// Scopes requested by HTML Google sign-in (`openid` is required for `id_token`).
+const googleWebScopes = ['openid', 'email', 'profile'];
+
+/// Registers GET `/auth/google` and GET `/auth/google/callback`.
+void addGoogleWebRoutes({
+  required final WebServer webServer,
+  required final WebAuthFlowConfig config,
+  required final GoogleIdp googleIdp,
+  final OAuthLoginFn? loginOverride,
+}) {
+  final callbackPath = '${config.pathPrefix}/google/callback';
+  webServer.addRoute(
+    OAuthStartRoute(
+      config: config,
+      provider: 'google',
+      clientId: googleIdp.config.clientSecret.clientId,
+      authorizeUrl: googleWebAuthorizeUrl,
+      scopes: googleWebScopes,
+      callbackPath: callbackPath,
+    ),
+    '${config.pathPrefix}/google',
+  );
+  webServer.addRoute(
+    OAuthCallbackRoute(
+      config: config,
+      provider: 'google',
+      callbackPath: callbackPath,
+      login:
+          loginOverride ??
+          (
+            final session, {
+            required final code,
+            required final codeVerifier,
+            required final redirectUri,
+          }) {
+            return googleIdp.loginWithCode(
+              session,
+              code: code,
+              codeVerifier: codeVerifier,
+              redirectUri: redirectUri,
+            );
+          },
+    ),
+    callbackPath,
+  );
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/microsoft/routes/microsoft_web_routes.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/lib/src/providers/microsoft/routes/microsoft_web_routes.dart
@@ -1,0 +1,82 @@
+import 'package:serverpod/serverpod.dart';
+
+import '../../../common/web/oauth_web_flow.dart';
+import '../../../common/web/web_auth_helpers.dart';
+import '../business/microsoft_idp.dart';
+
+/// Completes a Microsoft HTML login. [isWebPlatform] is always `true` so the
+/// token exchange includes the client secret.
+typedef MicrosoftWebLoginFn =
+    Future<void> Function(
+      Session session, {
+      required String code,
+      required String codeVerifier,
+      required String redirectUri,
+      required bool isWebPlatform,
+    });
+
+/// Scopes requested by HTML Microsoft sign-in (same as Flutter).
+const microsoftWebScopes = [
+  'openid',
+  'profile',
+  'email',
+  'offline_access',
+  'https://graph.microsoft.com/User.Read',
+];
+
+/// Registers GET `/auth/microsoft` and GET `/auth/microsoft/callback`.
+void addMicrosoftWebRoutes({
+  required final WebServer webServer,
+  required final WebAuthFlowConfig config,
+  required final MicrosoftIdp microsoftIdp,
+  final MicrosoftWebLoginFn? loginOverride,
+}) {
+  final callbackPath = '${config.pathPrefix}/microsoft/callback';
+  final authorizeUrl = Uri.https(
+    microsoftIdp.config.authorityHost,
+    '/${microsoftIdp.config.tenant}/oauth2/v2.0/authorize',
+  );
+  webServer.addRoute(
+    OAuthStartRoute(
+      config: config,
+      provider: 'microsoft',
+      clientId: microsoftIdp.config.clientId,
+      authorizeUrl: authorizeUrl,
+      scopes: microsoftWebScopes,
+      callbackPath: callbackPath,
+    ),
+    '${config.pathPrefix}/microsoft',
+  );
+  webServer.addRoute(
+    OAuthCallbackRoute(
+      config: config,
+      provider: 'microsoft',
+      callbackPath: callbackPath,
+      login:
+          (
+            final session, {
+            required final code,
+            required final codeVerifier,
+            required final redirectUri,
+          }) {
+            if (loginOverride != null) {
+              return loginOverride(
+                session,
+                code: code,
+                codeVerifier: codeVerifier,
+                redirectUri: redirectUri,
+                isWebPlatform: true,
+              );
+            }
+            return microsoftIdp.login(
+              session,
+              code: code,
+              codeVerifier: codeVerifier,
+              redirectUri: redirectUri,
+              isWebPlatform: true,
+            );
+          },
+    ),
+    callbackPath,
+  );
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
@@ -13,6 +13,7 @@ resolution: workspace
 
 dependencies:
   clock: ^1.1.1
+  crypto: ^3.0.2
   dart_jsonwebtoken: ^3.1.0
   email_validator: '>=2.1.17 <4.0.0'
   googleapis: '>=11.0.0 <17.0.0'

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/apple_web_auth_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/apple_web_auth_test.dart
@@ -1,0 +1,209 @@
+import 'package:http/http.dart' as http;
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:serverpod_auth_idp_server/providers/apple.dart';
+import 'package:test/test.dart';
+
+import 'web_auth_test_utils.dart';
+
+void main() {
+  late http.Client client;
+
+  setUpAll(() {
+    client = http.Client();
+  });
+
+  tearDownAll(() => client.close());
+
+  group('Given HTML web auth with Apple', () {
+    late Serverpod pod;
+    late Uri base;
+    late bool? capturedNative;
+    late String pepper;
+
+    setUp(() async {
+      capturedNative = null;
+      pod = createWebAuthPod();
+      initSasAuth(
+        pod,
+        identityProviderBuilders: [appleTestConfig],
+      );
+      pod.configureWebAuthRoutes(
+        loginSuccessPath: '/account',
+        appleLoginOverride:
+            (
+              final session, {
+              required final identityToken,
+              required final authorizationCode,
+              required final isNativeApplePlatformSignIn,
+              final firstName,
+              final lastName,
+            }) async {
+              capturedNative = isNativeApplePlatformSignIn;
+              session.writeWebAuthCookie('issued');
+            },
+      );
+      pod.configureAppleIdpRoutes(
+        webAuthenticationCallbackRoutePath: '/auth/callback',
+      );
+      await pod.start();
+      base = Uri.parse('http://localhost:${pod.webServer.port}');
+      pepper = pod.getPassword(webAuthOAuthStatePepperPasswordKey)!;
+    });
+
+    tearDown(() async {
+      await pod.shutdown(exitProcess: false);
+    });
+
+    Future<http.Response> appleCallback({
+      required final String state,
+      final String? code = 'ok',
+      final String? idToken = 'id-token',
+      final String? error,
+      final String? cookie,
+      final String? origin,
+      final String? user,
+    }) {
+      final fields = <String, String>{'state': state};
+      if (code != null) fields['code'] = code;
+      if (idToken != null) fields['id_token'] = idToken;
+      if (error != null) fields['error'] = error;
+      if (user != null) fields['user'] = user;
+      return send(
+        client,
+        base,
+        'POST',
+        '/auth/apple/web/callback',
+        origin: origin,
+        cookie: cookie,
+        body: formBody(fields),
+      );
+    }
+
+    test(
+      'when Apple starts then the response is 302 with form_post, HMAC state, '
+      'and no OAuth cookie.',
+      () async {
+        final response = await send(client, base, 'GET', '/auth/apple');
+        expect(response.statusCode, 302);
+        expect(response.headers['cache-control'], contains('no-store'));
+        final location = Uri.parse(response.headers['location']!);
+        expect(location.host, 'appleid.apple.com');
+        expect(location.path, '/auth/authorize');
+        expect(location.queryParameters['response_mode'], 'form_post');
+        expect(location.queryParameters['response_type'], 'code id_token');
+        expect(location.queryParameters['client_id'], 'test.apple.service');
+        expect(
+          location.queryParameters['redirect_uri'],
+          'http://localhost:8082/auth/apple/web/callback',
+        );
+        expect(location.queryParameters['scope'], 'name email');
+        final state = location.queryParameters['state']!;
+        final payload = decodeHmacPayload(state, pepper);
+        expect(payload, isNotNull);
+        expect(payload!['provider'], 'apple');
+        expect(payload['nonce'], location.queryParameters['nonce']);
+        expect(
+          setCookieValue(
+            response,
+            oauthStateCookieName(pod.config.authCookie!),
+          ),
+          isNull,
+        );
+      },
+    );
+
+    test(
+      'when the callback POST has no auth cookie then HMAC state still '
+      'completes login.',
+      () async {
+        final start = await send(client, base, 'GET', '/auth/apple');
+        final state = Uri.parse(
+          start.headers['location']!,
+        ).queryParameters['state']!;
+        final response = await appleCallback(state: state);
+        expect(response.statusCode, 303);
+        expect(response.headers['location'], '/account');
+        expect(setCookieValue(response, authCookieName), 'issued');
+        expect(capturedNative, isFalse);
+      },
+    );
+
+    test(
+      'when the callback POST has Origin https://appleid.apple.com then it '
+      'is not Origin-gated.',
+      () async {
+        final start = await send(client, base, 'GET', '/auth/apple');
+        final state = Uri.parse(
+          start.headers['location']!,
+        ).queryParameters['state']!;
+        final response = await appleCallback(
+          state: state,
+          origin: 'https://appleid.apple.com',
+        );
+        expect(response.statusCode, 303);
+        expect(setCookieValue(response, authCookieName), 'issued');
+      },
+    );
+
+    test(
+      'when a leftover SAS cookie is not sent then Origin from Apple does '
+      'not 403.',
+      () async {
+        final start = await send(client, base, 'GET', '/auth/apple');
+        final state = Uri.parse(
+          start.headers['location']!,
+        ).queryParameters['state']!;
+        final response = await appleCallback(
+          state: state,
+          origin: 'https://appleid.apple.com',
+          cookie: null,
+        );
+        expect(response.statusCode, isNot(403));
+        expect(response.statusCode, 303);
+      },
+    );
+
+    test(
+      'when Apple state is tampered then the callback is 403 and no auth '
+      'cookie is set.',
+      () async {
+        final start = await send(client, base, 'GET', '/auth/apple');
+        final state = Uri.parse(
+          start.headers['location']!,
+        ).queryParameters['state']!;
+        final tampered = '${state.substring(0, 4)}xxxx${state.substring(8)}';
+        final response = await appleCallback(state: tampered);
+        expect(response.statusCode, 403);
+        expect(setCookieValue(response, authCookieName), isNull);
+      },
+    );
+
+    test(
+      'when Flutter /auth/callback is requested then '
+      'AppleWebAuthenticationCallbackRoute is unchanged.',
+      () async {
+        final response = await send(
+          client,
+          base,
+          'POST',
+          '/auth/callback',
+          body: formBody({'code': 'x'}),
+        );
+        expect(response.statusCode, 303);
+        expect(
+          response.headers['location'],
+          contains('https://example.com/app'),
+        );
+      },
+    );
+
+    test(
+      'when GET /auth/login is requested then the Apple button is shown.',
+      () async {
+        final response = await send(client, base, 'GET', '/auth/login');
+        expect(response.body, contains('Continue with Apple'));
+      },
+    );
+  });
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/configure_web_auth_routes_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/configure_web_auth_routes_test.dart
@@ -1,0 +1,125 @@
+import 'dart:io';
+
+import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:serverpod_auth_idp_server/providers/google.dart';
+import 'package:serverpod_shared/serverpod_shared.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
+
+import 'web_auth_test_utils.dart';
+
+void main() {
+  group('Given AuthServices is not initialized', () {
+    test(
+      'when configureWebAuthRoutes is called then it throws StateError.',
+      () {
+        final pod = createWebAuthPod();
+        expect(pod.configureWebAuthRoutes, throwsA(isA<StateError>()));
+      },
+    );
+  });
+
+  group('Given AuthServices initialized with SAS', () {
+    test(
+      'when authCookie is unset then configureWebAuthRoutes throws.',
+      () {
+        final pod = createWebAuthPod(authCookie: null, allowedOrigins: null);
+        initSasAuth(pod);
+        expect(pod.configureWebAuthRoutes, throwsA(isA<StateError>()));
+      },
+    );
+
+    test(
+      'when loginSuccessPath is unsafe then configureWebAuthRoutes throws.',
+      () {
+        final pod = createWebAuthPod();
+        initSasAuth(pod);
+        expect(
+          () => pod.configureWebAuthRoutes(loginSuccessPath: '//evil'),
+          throwsA(isA<ArgumentError>()),
+        );
+      },
+    );
+
+    test(
+      'when authCookie.sameSite is strict then configureWebAuthRoutes throws.',
+      () {
+        final pod = createWebAuthPod(
+          authCookie: const WebAuthCookieConfig(
+            secure: false,
+            sameSite: CookieSameSite.strict,
+          ),
+        );
+        initSasAuth(pod);
+        expect(pod.configureWebAuthRoutes, throwsA(isA<ArgumentError>()));
+      },
+    );
+
+    test(
+      'when the HMAC pepper is missing then configureWebAuthRoutes throws.',
+      () async {
+        await d.dir('config', [
+          d.file('passwords.yaml', 'test:\n  database: "test"\n'),
+        ]).create();
+        final pod = createWebAuthPod(serverDirectory: Directory(d.sandbox));
+        initSasAuth(pod);
+        expect(
+          pod.configureWebAuthRoutes,
+          throwsA(isA<PasswordNotFoundException>()),
+        );
+      },
+    );
+
+    test(
+      'when Google redirectUris does not include the HTML callback '
+      'then configureWebAuthRoutes throws.',
+      () {
+        final pod = createWebAuthPod();
+        initSasAuth(
+          pod,
+          identityProviderBuilders: [
+            GoogleIdpConfig(
+              clientSecret: googleSecret(
+                redirectUris: ['https://evil.example/callback'],
+              ),
+            ),
+          ],
+        );
+        expect(pod.configureWebAuthRoutes, throwsA(isA<ArgumentError>()));
+      },
+    );
+
+    test(
+      'when Google redirectUris is empty then configureWebAuthRoutes succeeds.',
+      () {
+        final pod = createWebAuthPod();
+        initSasAuth(
+          pod,
+          identityProviderBuilders: [
+            GoogleIdpConfig(
+              clientSecret: googleSecret(redirectUris: const []),
+            ),
+          ],
+        );
+        expect(pod.configureWebAuthRoutes, returnsNormally);
+      },
+    );
+  });
+
+  group('Given JWT as the primary token manager', () {
+    test('when configureWebAuthRoutes is called then it throws.', () {
+      final pod = createWebAuthPod();
+      pod.initializeAuthServices(
+        tokenManagerBuilders: [
+          JwtConfig(
+            refreshTokenHashPepper: 'test-pepper-long-enough',
+            algorithm: JwtAlgorithm.hmacSha512(
+              SecretKey('test-private-key-for-HS512'),
+            ),
+          ),
+        ],
+      );
+      expect(pod.configureWebAuthRoutes, throwsA(isA<StateError>()));
+    });
+  });
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/email_web_auth_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/email_web_auth_test.dart
@@ -1,0 +1,357 @@
+import 'package:http/http.dart' as http;
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:serverpod_auth_idp_server/providers/email.dart';
+import 'package:test/test.dart';
+
+import '../email/test_utils/email_idp_test_fixture.dart';
+import '../test_tools/serverpod_test_tools.dart';
+import 'web_auth_test_utils.dart';
+
+void main() {
+  withServerpod(
+    'Given HTML email web auth',
+    rollbackDatabase: RollbackDatabase.disabled,
+    configOverride: (final config) => config.copyWith(
+      authCookie: const WebAuthCookieConfig(secure: false),
+      allowedOrigins: const [allowedOrigin],
+    ),
+    (final sessionBuilder, final endpoints) {
+      late http.Client client;
+      late Uri base;
+      late Session session;
+      late EmailIdpTestFixture fixture;
+      late AuthUsers authUsers;
+
+      const emailA = 'a@serverpod.dev';
+      const emailB = 'b@serverpod.dev';
+      const password = 'Password123!';
+
+      setUpAll(() async {
+        final pod = Serverpod.instance;
+        pod.initializeAuthServices(
+          tokenManagerBuilders: [
+            ServerSideSessionsConfig(sessionKeyHashPepper: 'test-pepper'),
+          ],
+          identityProviderBuilders: [
+            const EmailIdpConfig(secretHashPepper: 'pepper'),
+          ],
+        );
+        pod.configureWebAuthRoutes(loginSuccessPath: '/');
+        pod.webServer.addRoute(WhoAmIRoute(), '/whoami');
+        if (!pod.webServer.running) {
+          await pod.webServer.start();
+        }
+        client = http.Client();
+        base = Uri.parse('http://localhost:${pod.webServer.port}');
+      });
+
+      tearDownAll(() => client.close());
+
+      setUp(() async {
+        session = sessionBuilder.build();
+        fixture = EmailIdpTestFixture();
+        authUsers = const AuthUsers();
+      });
+
+      tearDown(() async {
+        await fixture.tearDown(session);
+      });
+
+      Future<UuidValue> createAccount(final String email) async {
+        final user = await authUsers.create(session);
+        await fixture.createEmailAccount(
+          session,
+          authUserId: user.id,
+          email: email,
+          password: EmailAccountPassword.fromString(password),
+        );
+        return user.id;
+      }
+
+      Future<http.Response> getLogin({final String? cookie}) {
+        return send(client, base, 'GET', '/auth/login', cookie: cookie);
+      }
+
+      Future<http.Response> postLogin({
+        required final String csrf,
+        required final String email,
+        required final String password,
+        required final String cookie,
+        final String returnTo = '/',
+      }) {
+        return send(
+          client,
+          base,
+          'POST',
+          '/auth/login',
+          origin: allowedOrigin,
+          cookie: cookie,
+          body: formBody({
+            'csrf': csrf,
+            'email': email,
+            'password': password,
+            'return_to': returnTo,
+          }),
+        );
+      }
+
+      test(
+        'when login POST succeeds then Set-Cookie is issued and the next GET '
+        'is authenticated.',
+        () async {
+          await createAccount(emailA);
+          final page = await getLogin();
+          final csrf = setCookieValue(page, '${authCookieName}_csrf')!;
+          final login = await postLogin(
+            csrf: csrf,
+            email: emailA,
+            password: password,
+            cookie: '${authCookieName}_csrf=$csrf',
+          );
+          expect(login.statusCode, 303);
+          final token = setCookieValue(login, authCookieName);
+          expect(token, isNotEmpty);
+
+          final who = await send(
+            client,
+            base,
+            'GET',
+            '/whoami',
+            cookie: '$authCookieName=$token',
+          );
+          expect(who.statusCode, 200);
+          expect(who.body, isNot('anonymous'));
+        },
+      );
+
+      test(
+        'when the password is wrong then no auth cookie is set and the page '
+        'shows an error.',
+        () async {
+          await createAccount(emailA);
+          final page = await getLogin();
+          final csrf = setCookieValue(page, '${authCookieName}_csrf')!;
+          final login = await postLogin(
+            csrf: csrf,
+            email: emailA,
+            password: 'WrongPassword123!',
+            cookie: '${authCookieName}_csrf=$csrf',
+          );
+          expect(login.statusCode, 200);
+          expect(login.body, contains('Invalid email or password'));
+          expect(setCookieValue(login, authCookieName), isNull);
+        },
+      );
+
+      test(
+        'when CSRF is missing then the response is 403.',
+        () async {
+          await createAccount(emailA);
+          final login = await send(
+            client,
+            base,
+            'POST',
+            '/auth/login',
+            origin: allowedOrigin,
+            body: formBody({
+              'email': emailA,
+              'password': password,
+            }),
+          );
+          expect(login.statusCode, 403);
+        },
+      );
+
+      test(
+        'when CSRF does not match then the response is 403.',
+        () async {
+          await createAccount(emailA);
+          final page = await getLogin();
+          final csrf = setCookieValue(page, '${authCookieName}_csrf')!;
+          final login = await postLogin(
+            csrf: 'not-the-cookie',
+            email: emailA,
+            password: password,
+            cookie: '${authCookieName}_csrf=$csrf',
+          );
+          expect(login.statusCode, 403);
+        },
+      );
+
+      test(
+        'when duplicate CSRF cookies are sent then the response is 403.',
+        () async {
+          await createAccount(emailA);
+          final page = await getLogin();
+          final csrf = setCookieValue(page, '${authCookieName}_csrf')!;
+          final login = await send(
+            client,
+            base,
+            'POST',
+            '/auth/login',
+            origin: allowedOrigin,
+            cookie:
+                '${authCookieName}_csrf=$csrf; ${authCookieName}_csrf=other',
+            body: formBody({
+              'csrf': csrf,
+              'email': emailA,
+              'password': password,
+            }),
+          );
+          expect(login.statusCode, 403);
+        },
+      );
+
+      test(
+        'when already signed in with a bad CSRF token then the session is '
+        'not revoked.',
+        () async {
+          final userId = await createAccount(emailA);
+          final page = await getLogin();
+          final csrf = setCookieValue(page, '${authCookieName}_csrf')!;
+          final login = await postLogin(
+            csrf: csrf,
+            email: emailA,
+            password: password,
+            cookie: '${authCookieName}_csrf=$csrf',
+          );
+          final token = setCookieValue(login, authCookieName)!;
+
+          final page2 = await getLogin(cookie: '$authCookieName=$token');
+          final csrf2 = setCookieValue(page2, '${authCookieName}_csrf')!;
+          final bad = await postLogin(
+            csrf: 'nope',
+            email: emailA,
+            password: password,
+            cookie: '$authCookieName=$token; ${authCookieName}_csrf=$csrf2',
+          );
+          expect(bad.statusCode, 403);
+
+          final who = await send(
+            client,
+            base,
+            'GET',
+            '/whoami',
+            cookie: '$authCookieName=$token',
+          );
+          expect(who.body, userId.toString());
+        },
+      );
+
+      test(
+        'when already signed in as A then logging in as B revokes A and '
+        'sets B cookie.',
+        () async {
+          final userA = await createAccount(emailA);
+          final userB = await createAccount(emailB);
+
+          final pageA = await getLogin();
+          final csrfA = setCookieValue(pageA, '${authCookieName}_csrf')!;
+          final loginA = await postLogin(
+            csrf: csrfA,
+            email: emailA,
+            password: password,
+            cookie: '${authCookieName}_csrf=$csrfA',
+          );
+          final tokenA = setCookieValue(loginA, authCookieName)!;
+
+          final pageB = await getLogin(cookie: '$authCookieName=$tokenA');
+          final csrfB = setCookieValue(pageB, '${authCookieName}_csrf')!;
+          final loginB = await postLogin(
+            csrf: csrfB,
+            email: emailB,
+            password: password,
+            cookie: '$authCookieName=$tokenA; ${authCookieName}_csrf=$csrfB',
+          );
+          expect(loginB.statusCode, 303);
+          final tokenB = setCookieValue(loginB, authCookieName);
+          expect(tokenB, isNotEmpty);
+          expect(tokenB, isNot(tokenA));
+
+          final whoB = await send(
+            client,
+            base,
+            'GET',
+            '/whoami',
+            cookie: '$authCookieName=$tokenB',
+          );
+          expect(whoB.body, userB.toString());
+
+          final whoA = await send(
+            client,
+            base,
+            'GET',
+            '/whoami',
+            cookie: '$authCookieName=$tokenA',
+          );
+          expect(whoA.body, 'anonymous');
+          expect(userA, isNot(userB));
+        },
+      );
+
+      test(
+        'when logging out then this device token is revoked, the cookie is '
+        'cleared, and another device token remains.',
+        () async {
+          final userId = await createAccount(emailA);
+          final page = await getLogin();
+          final csrf = setCookieValue(page, '${authCookieName}_csrf')!;
+          final login = await postLogin(
+            csrf: csrf,
+            email: emailA,
+            password: password,
+            cookie: '${authCookieName}_csrf=$csrf',
+          );
+          final token = setCookieValue(login, authCookieName)!;
+
+          await AuthServices.instance.tokenManager.createToken(
+            session,
+            authUserId: userId,
+            method: 'email',
+          );
+          final before = await AuthServices.instance.tokenManager.listTokens(
+            session,
+            authUserId: userId,
+          );
+          expect(before, hasLength(2));
+
+          final accountPage = await getLogin(
+            cookie: '$authCookieName=$token',
+          );
+          final csrfOut = setCookieValue(
+            accountPage,
+            '${authCookieName}_csrf',
+          )!;
+          final logout = await send(
+            client,
+            base,
+            'POST',
+            '/auth/logout',
+            origin: allowedOrigin,
+            cookie: '$authCookieName=$token; ${authCookieName}_csrf=$csrfOut',
+            body: formBody({'csrf': csrfOut}),
+          );
+          expect(logout.statusCode, 303);
+          expect(logout.headers['location'], '/auth/login');
+          expect(setCookieCleared(logout, authCookieName), isTrue);
+
+          final after = await AuthServices.instance.tokenManager.listTokens(
+            session,
+            authUserId: userId,
+          );
+          expect(after, hasLength(1));
+
+          final who = await send(
+            client,
+            base,
+            'GET',
+            '/whoami',
+            cookie: '$authCookieName=$token',
+          );
+          expect(who.body, 'anonymous');
+        },
+      );
+    },
+  );
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/hmac_payload_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/hmac_payload_test.dart
@@ -1,0 +1,73 @@
+import 'package:clock/clock.dart';
+import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const pepper = 'test-pepper';
+
+  test(
+    'Given a payload, when encoded and decoded with the same pepper, '
+    'then the original fields are returned.',
+    () {
+      final token = encodeHmacPayload(
+        {'state': 'abc', 'return_to': '/account'},
+        pepper,
+      );
+      final decoded = decodeHmacPayload(token, pepper);
+      expect(decoded, isNotNull);
+      expect(decoded!['state'], 'abc');
+      expect(decoded['return_to'], '/account');
+      expect(decoded['iat'], isA<int>());
+    },
+  );
+
+  test(
+    'Given a token, when decoded with a different pepper, then null is returned.',
+    () {
+      final token = encodeHmacPayload({'state': 'abc'}, pepper);
+      expect(decodeHmacPayload(token, 'other'), isNull);
+    },
+  );
+
+  test(
+    'Given a token, when the payload is tampered with, then null is returned.',
+    () {
+      final token = encodeHmacPayload({'return_to': '/ok'}, pepper);
+      final parts = token.split('.');
+      final tampered = encodeHmacPayload({
+        'return_to': 'https://evil',
+      }, 'wrong');
+      final forged = '${parts[0]}.${tampered.split('.')[1]}';
+      expect(decodeHmacPayload(forged, pepper), isNull);
+    },
+  );
+
+  test(
+    'Given a token older than maxAge, when decoded, then null is returned.',
+    () {
+      late String token;
+      withClock(Clock.fixed(DateTime.utc(2020)), () {
+        token = encodeHmacPayload({'state': 'abc'}, pepper);
+      });
+      withClock(Clock.fixed(DateTime.utc(2020, 1, 1, 0, 15)), () {
+        expect(
+          decodeHmacPayload(
+            token,
+            pepper,
+            maxAge: const Duration(minutes: 10),
+          ),
+          isNull,
+        );
+      });
+    },
+  );
+
+  test(
+    'Given unequal strings, when compared with timingSafeEquals, then false.',
+    () {
+      expect(timingSafeEquals('abc', 'abd'), isFalse);
+      expect(timingSafeEquals('abc', 'ab'), isFalse);
+      expect(timingSafeEquals('abc', 'abc'), isTrue);
+    },
+  );
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/microsoft_web_auth_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/microsoft_web_auth_test.dart
@@ -1,0 +1,140 @@
+import 'package:http/http.dart' as http;
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:serverpod_auth_idp_server/providers/microsoft.dart';
+import 'package:test/test.dart';
+
+import 'web_auth_test_utils.dart';
+
+void main() {
+  late http.Client client;
+
+  setUpAll(() {
+    client = http.Client();
+  });
+
+  tearDownAll(() => client.close());
+
+  group('Given HTML web auth with Microsoft', () {
+    late Serverpod pod;
+    late Uri base;
+    late bool? capturedIsWebPlatform;
+
+    setUp(() async {
+      capturedIsWebPlatform = null;
+      pod = createWebAuthPod();
+      initSasAuth(
+        pod,
+        identityProviderBuilders: [
+          MicrosoftIdpConfig(
+            clientId: 'test-microsoft-client-id',
+            clientSecret: 'test-microsoft-secret',
+            tenant: 'common',
+            authorityHost: 'login.microsoftonline.com',
+          ),
+        ],
+      );
+      pod.configureWebAuthRoutes(
+        loginSuccessPath: '/account',
+        microsoftLoginOverride:
+            (
+              final session, {
+              required final code,
+              required final codeVerifier,
+              required final redirectUri,
+              required final isWebPlatform,
+            }) async {
+              capturedIsWebPlatform = isWebPlatform;
+              session.writeWebAuthCookie('issued');
+            },
+      );
+      pod.webServer.addMiddleware(
+        requireLogin(redirectTo: '/auth/login'),
+        '/account',
+      );
+      pod.webServer.addRoute(WhoAmIRoute(), '/account');
+      await pod.start();
+      base = Uri.parse('http://localhost:${pod.webServer.port}');
+    });
+
+    tearDown(() async {
+      await pod.shutdown(exitProcess: false);
+    });
+
+    test(
+      'when OAuth starts then the response is 302 to the tenant authorize '
+      'URL with Flutter-matching scopes.',
+      () async {
+        final response = await send(client, base, 'GET', '/auth/microsoft');
+        expect(response.statusCode, 302);
+        expect(response.headers['cache-control'], contains('no-store'));
+        final location = Uri.parse(response.headers['location']!);
+        expect(location.host, 'login.microsoftonline.com');
+        expect(location.path, '/common/oauth2/v2.0/authorize');
+        expect(
+          location.queryParameters['client_id'],
+          'test-microsoft-client-id',
+        );
+        expect(
+          location.queryParameters['scope'],
+          'openid profile email offline_access '
+          'https://graph.microsoft.com/User.Read',
+        );
+        expect(
+          location.queryParameters['redirect_uri'],
+          'http://localhost:8082/auth/microsoft/callback',
+        );
+        expect(location.queryParameters['code_challenge_method'], 'S256');
+      },
+    );
+
+    test(
+      'when login is mocked then the callback calls login with '
+      'isWebPlatform: true and sets the auth cookie.',
+      () async {
+        final start = await send(client, base, 'GET', '/auth/microsoft');
+        final name = oauthStateCookieName(pod.config.authCookie!);
+        final oauthCookie = setCookieValue(start, name)!;
+        final state = Uri.parse(
+          start.headers['location']!,
+        ).queryParameters['state']!;
+        final streamed = await client.send(
+          http.Request(
+              'GET',
+              base.replace(
+                path: '/auth/microsoft/callback',
+                queryParameters: {'code': 'ok', 'state': state},
+              ),
+            )
+            ..followRedirects = false
+            ..headers['cookie'] = '$name=$oauthCookie',
+        );
+        final response = await http.Response.fromStream(streamed);
+        expect(response.statusCode, 303);
+        expect(response.headers['location'], '/account');
+        expect(setCookieValue(response, authCookieName), 'issued');
+        expect(capturedIsWebPlatform, isTrue);
+      },
+    );
+
+    test(
+      'when GET /auth/login is requested then the Microsoft button is shown.',
+      () async {
+        final response = await send(client, base, 'GET', '/auth/login');
+        expect(response.body, contains('Continue with Microsoft'));
+      },
+    );
+
+    test(
+      'when requireLogin is mounted only on /account then /auth/login is '
+      'public and /account redirects.',
+      () async {
+        final login = await send(client, base, 'GET', '/auth/login');
+        expect(login.statusCode, 200);
+        final account = await send(client, base, 'GET', '/account');
+        expect(account.statusCode, 303);
+        expect(account.headers['location'], contains('/auth/login'));
+      },
+    );
+  });
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/oauth_web_flow_test.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/oauth_web_flow_test.dart
@@ -1,0 +1,411 @@
+import 'package:http/http.dart' as http;
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:serverpod_auth_idp_server/providers/github.dart';
+import 'package:serverpod_auth_idp_server/providers/google.dart';
+import 'package:test/test.dart';
+
+import 'web_auth_test_utils.dart';
+
+void main() {
+  late http.Client client;
+
+  setUpAll(() {
+    client = http.Client();
+  });
+
+  tearDownAll(() => client.close());
+
+  group('Given HTML web auth with Google and GitHub', () {
+    late Serverpod pod;
+    late Uri base;
+    late String pepper;
+
+    setUp(() async {
+      pod = createWebAuthPod();
+      initSasAuth(
+        pod,
+        identityProviderBuilders: [
+          GoogleIdpConfig(clientSecret: googleSecret()),
+          GitHubIdpConfig(
+            clientId: 'test-github-client-id',
+            clientSecret: 'test-github-secret',
+          ),
+        ],
+      );
+      pod.authenticationHandler = (final session, final token) async {
+        if (token == 'good') {
+          return AuthenticationInfo('mario', {}, authId: 'good');
+        }
+        return null;
+      };
+      pod.configureWebAuthRoutes(
+        googleLoginOverride:
+            (
+              final session, {
+              required final code,
+              required final codeVerifier,
+              required final redirectUri,
+            }) async {
+              session.writeWebAuthCookie('issued');
+            },
+      );
+      pod.webServer.addRoute(WhoAmIRoute(), '/whoami');
+      pod.webServer.addRoute(
+        FlutterWebAuth2CallbackRoute(),
+        '/auth/callback',
+      );
+      await pod.start();
+      base = Uri.parse('http://localhost:${pod.webServer.port}');
+      pepper = pod.getPassword(webAuthOAuthStatePepperPasswordKey)!;
+    });
+
+    tearDown(() async {
+      await pod.shutdown(exitProcess: false);
+    });
+
+    Future<http.Response> req(
+      final String method,
+      final String path, {
+      final String? cookie,
+      final String? origin,
+    }) {
+      return send(
+        client,
+        base,
+        method,
+        path,
+        cookie: cookie,
+        origin: origin,
+      );
+    }
+
+    test(
+      'when OAuth starts then the response is 302 with client_id, '
+      'code_challenge, S256, no-store, and an HMAC state cookie.',
+      () async {
+        final response = await req('GET', '/auth/google');
+        expect(response.statusCode, 302);
+        expect(response.headers['cache-control'], contains('no-store'));
+        final location = Uri.parse(response.headers['location']!);
+        expect(location.host, 'accounts.google.com');
+        expect(location.queryParameters['client_id'], 'test-google-client-id');
+        expect(location.queryParameters['code_challenge'], isNotEmpty);
+        expect(location.queryParameters['code_challenge_method'], 'S256');
+        expect(
+          location.queryParameters['redirect_uri'],
+          'http://localhost:8082/auth/google/callback',
+        );
+        final oauthCookie = setCookieValue(
+          response,
+          oauthStateCookieName(pod.config.authCookie!),
+        );
+        expect(oauthCookie, isNotEmpty);
+        final payload = decodeHmacPayload(oauthCookie!, pepper);
+        expect(payload, isNotNull);
+        expect(payload!['provider'], 'google');
+        expect(payload['state'], location.queryParameters['state']);
+      },
+    );
+
+    test(
+      'when return_to is an open redirect then the HMAC cookie stores '
+      'loginSuccessPath.',
+      () async {
+        final streamed = await client.send(
+          http.Request(
+            'GET',
+            base.replace(
+              path: '/auth/google',
+              queryParameters: {'return_to': 'https://evil'},
+            ),
+          )..followRedirects = false,
+        );
+        final res = await http.Response.fromStream(streamed);
+        final oauthCookie = setCookieValue(
+          res,
+          oauthStateCookieName(pod.config.authCookie!),
+        );
+        final payload = decodeHmacPayload(oauthCookie!, pepper);
+        expect(payload!['return_to'], '/');
+      },
+    );
+
+    test(
+      'when return_to is /foo/..//evil.com then the HMAC cookie stores '
+      'loginSuccessPath.',
+      () async {
+        final streamed = await client.send(
+          http.Request(
+            'GET',
+            base.replace(
+              path: '/auth/google',
+              queryParameters: {'return_to': '/foo/..//evil.com'},
+            ),
+          )..followRedirects = false,
+        );
+        final res = await http.Response.fromStream(streamed);
+        final oauthCookie = setCookieValue(
+          res,
+          oauthStateCookieName(pod.config.authCookie!),
+        );
+        final payload = decodeHmacPayload(oauthCookie!, pepper);
+        expect(payload!['return_to'], '/');
+      },
+    );
+
+    test(
+      'when the OAuth state cookie is tampered then the callback is 403 '
+      'and the user is not signed out.',
+      () async {
+        final start = await req('GET', '/auth/google');
+        final name = oauthStateCookieName(pod.config.authCookie!);
+        final oauthCookie = setCookieValue(start, name)!;
+        final tampered =
+            '${oauthCookie.substring(0, 4)}xxxx${oauthCookie.substring(8)}';
+        final response = await req(
+          'GET',
+          '/auth/google/callback',
+          cookie: '$authCookieName=good; $name=$tampered',
+        );
+        expect(response.statusCode, 403);
+        expect(setCookieValue(response, authCookieName), isNull);
+        expect(setCookieCleared(response, name), isTrue);
+
+        final who = await req(
+          'GET',
+          '/whoami',
+          cookie: '$authCookieName=good',
+        );
+        expect(who.body, 'mario');
+      },
+    );
+
+    test(
+      'when the OAuth state query does not match then the callback is 403, '
+      'the OAuth cookie is cleared, and the user is not signed out.',
+      () async {
+        final start = await req('GET', '/auth/google');
+        final name = oauthStateCookieName(pod.config.authCookie!);
+        final oauthCookie = setCookieValue(start, name)!;
+        final response = await req(
+          'GET',
+          '/auth/google/callback',
+          cookie: '$authCookieName=good; $name=$oauthCookie',
+        );
+        expect(response.statusCode, 403);
+        expect(setCookieValue(response, authCookieName), isNull);
+        expect(setCookieCleared(response, name), isTrue);
+        final who = await req(
+          'GET',
+          '/whoami',
+          cookie: '$authCookieName=good',
+        );
+        expect(who.body, 'mario');
+      },
+    );
+
+    test(
+      'when a GitHub OAuth cookie is sent to the Google callback then 403 '
+      'and the user is not signed out.',
+      () async {
+        final start = await req('GET', '/auth/github');
+        final name = oauthStateCookieName(pod.config.authCookie!);
+        final oauthCookie = setCookieValue(start, name)!;
+        final location = Uri.parse(start.headers['location']!);
+        final state = location.queryParameters['state'];
+        final streamed = await client.send(
+          http.Request(
+              'GET',
+              base.replace(
+                path: '/auth/google/callback',
+                queryParameters: {'state': state, 'code': 'x'},
+              ),
+            )
+            ..followRedirects = false
+            ..headers['cookie'] = '$authCookieName=good; $name=$oauthCookie',
+        );
+        final response = await http.Response.fromStream(streamed);
+        expect(response.statusCode, 403);
+        final who = await req(
+          'GET',
+          '/whoami',
+          cookie: '$authCookieName=good',
+        );
+        expect(who.body, 'mario');
+      },
+    );
+
+    test(
+      'when the provider returns error=access_denied then the OAuth cookie '
+      'is cleared, the response is 303 to login, and no auth cookie is set.',
+      () async {
+        final start = await req('GET', '/auth/google');
+        final name = oauthStateCookieName(pod.config.authCookie!);
+        final oauthCookie = setCookieValue(start, name)!;
+        final streamed = await client.send(
+          http.Request(
+              'GET',
+              base.replace(
+                path: '/auth/google/callback',
+                queryParameters: {'error': 'access_denied'},
+              ),
+            )
+            ..followRedirects = false
+            ..headers['cookie'] = '$name=$oauthCookie',
+        );
+        final response = await http.Response.fromStream(streamed);
+        expect(response.statusCode, 303);
+        expect(response.headers['location'], '/auth/login');
+        expect(setCookieCleared(response, name), isTrue);
+        expect(setCookieValue(response, authCookieName), isNull);
+      },
+    );
+
+    test(
+      'when loginWithCode is mocked then the callback sets the auth cookie '
+      'and 303s to the safe return_to.',
+      () async {
+        final streamedStart = await client.send(
+          http.Request(
+            'GET',
+            base.replace(
+              path: '/auth/google',
+              queryParameters: {'return_to': '/account'},
+            ),
+          )..followRedirects = false,
+        );
+        final start = await http.Response.fromStream(streamedStart);
+        final name = oauthStateCookieName(pod.config.authCookie!);
+        final oauthCookie = setCookieValue(start, name)!;
+        final state = Uri.parse(
+          start.headers['location']!,
+        ).queryParameters['state']!;
+        final streamed = await client.send(
+          http.Request(
+              'GET',
+              base.replace(
+                path: '/auth/google/callback',
+                queryParameters: {'code': 'ok', 'state': state},
+              ),
+            )
+            ..followRedirects = false
+            ..headers['cookie'] = '$name=$oauthCookie',
+        );
+        final response = await http.Response.fromStream(streamed);
+        expect(response.statusCode, 303);
+        expect(response.headers['location'], '/account');
+        expect(setCookieValue(response, authCookieName), 'issued');
+      },
+    );
+
+    test(
+      'when GET /auth/callback is requested then FlutterWebAuth2CallbackRoute '
+      'still serves the callback page.',
+      () async {
+        final response = await req('GET', '/auth/callback');
+        expect(response.statusCode, 200);
+        expect(response.body, contains('postAuthenticationMessage'));
+      },
+    );
+
+    test(
+      'when Email IDP is not configured then GET /auth/login has no form '
+      'and POST is 404.',
+      () async {
+        final getResponse = await req('GET', '/auth/login');
+        expect(getResponse.statusCode, 200);
+        expect(getResponse.body, isNot(contains('name="email"')));
+        expect(getResponse.headers['cache-control'], contains('no-store'));
+        expect(getResponse.body, contains('Continue with Google'));
+        expect(getResponse.body, contains('Continue with GitHub'));
+
+        final post = await send(
+          client,
+          base,
+          'POST',
+          '/auth/login',
+          origin: allowedOrigin,
+          body: formBody({'csrf': 'x', 'email': 'a', 'password': 'b'}),
+        );
+        expect(post.statusCode, 404);
+      },
+    );
+  });
+
+  group('Given HTML web auth with https public port 443', () {
+    late Serverpod pod;
+    late Uri base;
+
+    setUp(() async {
+      pod = createWebAuthPod(
+        webServer: ServerConfig(
+          port: 0,
+          publicScheme: 'https',
+          publicHost: 'example.com',
+          publicPort: 443,
+        ),
+      );
+      initSasAuth(
+        pod,
+        identityProviderBuilders: [
+          GoogleIdpConfig(
+            clientSecret: googleSecret(
+              redirectUris: const ['https://example.com/auth/google/callback'],
+            ),
+          ),
+        ],
+      );
+      pod.configureWebAuthRoutes();
+      await pod.start();
+      base = Uri.parse('http://localhost:${pod.webServer.port}');
+    });
+
+    tearDown(() async {
+      await pod.shutdown(exitProcess: false);
+    });
+
+    test(
+      'when OAuth starts then redirect_uri omits :443.',
+      () async {
+        final streamed = await client.send(
+          http.Request('GET', base.replace(path: '/auth/google'))
+            ..followRedirects = false,
+        );
+        final response = await http.Response.fromStream(streamed);
+        expect(response.statusCode, 302);
+        final location = Uri.parse(response.headers['location']!);
+        expect(
+          location.queryParameters['redirect_uri'],
+          'https://example.com/auth/google/callback',
+        );
+      },
+    );
+  });
+
+  group('Given HTML web auth with SAS only', () {
+    late Serverpod pod;
+    late Uri base;
+
+    setUp(() async {
+      pod = createWebAuthPod();
+      initSasAuth(pod);
+      pod.configureWebAuthRoutes();
+      await pod.start();
+      base = Uri.parse('http://localhost:${pod.webServer.port}');
+    });
+
+    tearDown(() async {
+      await pod.shutdown(exitProcess: false);
+    });
+
+    test('when Google is not configured then /auth/google is 404.', () async {
+      final streamed = await client.send(
+        http.Request('GET', base.replace(path: '/auth/google'))
+          ..followRedirects = false,
+      );
+      final response = await http.Response.fromStream(streamed);
+      expect(response.statusCode, 404);
+    });
+  });
+}

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/web_auth_test_utils.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/web_auth_test_utils.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:serverpod/serverpod.dart';
 import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:serverpod_auth_idp_server/providers/apple.dart';
 import 'package:serverpod_auth_idp_server/providers/google.dart';
 import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart';
 
@@ -29,6 +30,16 @@ GoogleClientSecret googleSecret({
     },
   });
 }
+
+const appleTestConfig = AppleIdpConfig(
+  serviceIdentifier: 'test.apple.service',
+  bundleIdentifier: 'test.bundle',
+  redirectUri: 'https://example.com/flutter-apple',
+  teamId: 'TESTTEAM',
+  keyId: 'TESTKEYID',
+  key: 'test-key',
+  webRedirectUri: 'https://example.com/app',
+);
 
 Serverpod createWebAuthPod({
   final WebAuthCookieConfig? authCookie = const WebAuthCookieConfig(

--- a/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/web_auth_test_utils.dart
+++ b/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/test/web/web_auth_test_utils.dart
@@ -1,0 +1,143 @@
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_auth_idp_server/core.dart';
+import 'package:serverpod_auth_idp_server/providers/google.dart';
+import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart';
+
+const allowedOrigin = 'http://localhost:9999';
+const authCookieName = WebAuthCookieConfig.defaultName;
+
+final portZero = ServerConfig(
+  port: 0,
+  publicScheme: 'http',
+  publicHost: 'localhost',
+  publicPort: 0,
+);
+
+GoogleClientSecret googleSecret({
+  final List<String> redirectUris = const [
+    'http://localhost:8082/auth/google/callback',
+  ],
+}) {
+  return GoogleClientSecret.fromJson({
+    'web': {
+      'client_id': 'test-google-client-id',
+      'client_secret': 'test-google-secret',
+      'redirect_uris': redirectUris,
+    },
+  });
+}
+
+Serverpod createWebAuthPod({
+  final WebAuthCookieConfig? authCookie = const WebAuthCookieConfig(
+    secure: false,
+  ),
+  final List<String>? allowedOrigins = const [allowedOrigin],
+  final ServerConfig? webServer,
+  final List<String> args = const ['-m', 'test'],
+  final Directory? serverDirectory,
+}) {
+  return Serverpod(
+    args,
+    Protocol(),
+    Endpoints(),
+    config: ServerpodConfig(
+      apiServer: portZero,
+      webServer:
+          webServer ??
+          ServerConfig(
+            port: 0,
+            publicScheme: 'http',
+            publicHost: 'localhost',
+            publicPort: 8082,
+          ),
+      authCookie: authCookie,
+      allowedOrigins: allowedOrigins,
+    ),
+    serverDirectory: serverDirectory,
+  );
+}
+
+void initSasAuth(
+  final Serverpod pod, {
+  final List<IdentityProviderBuilder> identityProviderBuilders = const [],
+}) {
+  pod.initializeAuthServices(
+    tokenManagerBuilders: [
+      ServerSideSessionsConfig(
+        sessionKeyHashPepper: 'test-pepper',
+      ),
+    ],
+    identityProviderBuilders: identityProviderBuilders,
+  );
+}
+
+final class WhoAmIRoute extends Route {
+  @override
+  Future<Result> handleCall(
+    final Session session,
+    final Request request,
+  ) async {
+    return Response.ok(
+      body: Body.fromString(
+        session.authenticated?.userIdentifier ?? 'anonymous',
+      ),
+    );
+  }
+}
+
+String? setCookieValue(final http.Response response, final String name) {
+  final header = response.headers['set-cookie'];
+  if (header == null) return null;
+  String? lastNonEmpty;
+  for (final match in RegExp(
+    '(?:^|,\\s*)${RegExp.escape(name)}=([^;,]*)',
+  ).allMatches(header)) {
+    final value = match.group(1);
+    if (value != null && value.isNotEmpty) lastNonEmpty = value;
+  }
+  return lastNonEmpty;
+}
+
+bool setCookieCleared(final http.Response response, final String name) {
+  final header = response.headers['set-cookie'];
+  if (header == null) return false;
+  return RegExp(
+    '(?:^|,\\s*)${RegExp.escape(name)}=[^;]*;[^,]*(?:Max-Age|max-age)=0',
+    caseSensitive: false,
+  ).hasMatch(header);
+}
+
+Future<http.Response> send(
+  final http.Client client,
+  final Uri base,
+  final String method,
+  final String path, {
+  final Map<String, String>? headers,
+  final String? body,
+  final String? cookie,
+  final String? origin,
+}) async {
+  final request = http.Request(method, base.replace(path: path))
+    ..followRedirects = false;
+  if (headers != null) request.headers.addAll(headers);
+  if (cookie != null) request.headers['cookie'] = cookie;
+  if (origin != null) request.headers['origin'] = origin;
+  if (body != null) {
+    request.headers['content-type'] = 'application/x-www-form-urlencoded';
+    request.body = body;
+  }
+  final streamed = await client.send(request);
+  return http.Response.fromStream(streamed);
+}
+
+String formBody(final Map<String, String> fields) {
+  return fields.entries
+      .map(
+        (final e) =>
+            '${Uri.encodeQueryComponent(e.key)}=${Uri.encodeQueryComponent(e.value)}',
+      )
+      .join('&');
+}

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_client/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/CHANGELOG.md
+++ b/modules/serverpod_auth/serverpod_auth_migration/serverpod_auth_migration_server/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/packages/serverpod/CHANGELOG.md
+++ b/packages/serverpod/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/packages/serverpod/lib/server.dart
+++ b/packages/serverpod/lib/server.dart
@@ -22,6 +22,7 @@ export 'src/server/serverpod.dart' hide ServerpodInternalMethods;
 export 'src/server/session.dart' hide SessionInternalMethods;
 export 'src/server/auth_cookie.dart'
     show WebAuthCookieBuilder, WebAuthCookieSession;
+export 'src/server/request_origin.dart';
 export 'src/config/security_context_config.dart' show SecurityContextConfig;
 export 'src/redis/controller.dart';
 

--- a/packages/serverpod/lib/src/server/auth_cookie.dart
+++ b/packages/serverpod/lib/src/server/auth_cookie.dart
@@ -16,22 +16,28 @@ final _basePathRegExp = RegExp(r'^/[^;\s\x00-\x1f\x7f]{0,255}$');
 /// Web-auth-cookie helpers on [Session]: decides whether a request wants
 /// cookie-based web auth and writes/clears the auth cookie accordingly.
 extension WebAuthCookieSession on Session {
-  /// Whether the request participates in cookie-based web auth transport (via
-  /// the [webAuthModeHeaderName] header) and the server has a
-  /// [ServerpodConfig.authCookie] configured.
+  /// Whether the auth token should be issued or cleared as an `HttpOnly`
+  /// cookie (see [writeWebAuthCookie] / [clearWebAuthCookie]).
   ///
-  /// True for both [webAuthModeCookie] and [webAuthModeCookieTransport];
-  /// whether the main auth cookie may authenticate the call is decided
-  /// separately by the server from the strict [webAuthModeCookie] value.
+  /// True when [ServerpodConfig.authCookie] is configured and either:
+  /// - the request carries [webAuthModeHeaderName] as [webAuthModeCookie] or
+  ///   [webAuthModeCookieTransport] (RPC cookie-mode clients), or
+  /// - this is a [WebCallSession] (Relic HTML; a second delivery path that
+  ///   does not send the marker header).
   ///
-  /// When true the auth token should be issued as an `HttpOnly` cookie (see
-  /// [writeWebAuthCookie]) and omitted from the response body, so it never
-  /// reaches client-side JavaScript.
+  /// The marker is not the single source of truth for cookie delivery.
+  /// Authenticating an incoming Relic request from the auth cookie is
+  /// decided separately by `_SessionMiddleware`, never from the JWT refresh
+  /// cookie. Whether the main auth cookie may authenticate an RPC call is
+  /// decided by the server from the strict [webAuthModeCookie] value.
   bool get isWebAuthCookieRequest {
     if (serverpod.config.authCookie == null) return false;
     final authMode = request?.headers[webAuthModeHeaderName]?.firstOrNull;
-    return authMode == webAuthModeCookie ||
-        authMode == webAuthModeCookieTransport;
+    if (authMode == webAuthModeCookie ||
+        authMode == webAuthModeCookieTransport) {
+      return true;
+    }
+    return this is WebCallSession;
   }
 
   /// If [isWebAuthCookieRequest], writes [token] as the auth cookie and returns
@@ -99,11 +105,10 @@ extension WebAuthCookieSession on Session {
 
   /// Clears the auth cookie for cookie-mode requests (a no-op otherwise).
   ///
-  /// Gated on [isWebAuthCookieRequest] just like [writeWebAuthCookie], so the
-  /// marker is the single source of truth for "this request participates in
-  /// cookie auth": a header/native client signing out gets no stray
-  /// `Set-Cookie`. Cookie clients send the marker on every call (including
-  /// sign-out), so their cookie is still cleared.
+  /// Gated on [isWebAuthCookieRequest] just like [writeWebAuthCookie], so a
+  /// header/native client signing out gets no stray `Set-Cookie`. Cookie
+  /// clients send the marker on every call (including sign-out); Relic HTML
+  /// qualifies via [WebCallSession], so [clearWebAuthCookie] still runs.
   ///
   /// [refreshCookiePath] must match the path the refresh cookie was set with,
   /// or browsers will not remove it.

--- a/packages/serverpod/lib/src/server/request_origin.dart
+++ b/packages/serverpod/lib/src/server/request_origin.dart
@@ -1,0 +1,34 @@
+import 'package:relic/relic.dart';
+
+/// Trims, lowercases, and drops a trailing slash from an `Origin` header value.
+///
+/// Returns null when [origin] is null or empty after normalization. Shared by
+/// Relic and RPC so the allow-list compare cannot drift.
+String? normalizeOriginValue(String? origin) {
+  if (origin == null) return null;
+  final normalized = origin.trim().toLowerCase().replaceFirst(
+    RegExp(r'/+$'),
+    '',
+  );
+  return normalized.isEmpty ? null : normalized;
+}
+
+/// The `Origin` header of [req] after [normalizeOriginValue], or null if absent.
+String? requestOrigin(Request req) =>
+    normalizeOriginValue(req.headers[Headers.originHeader]?.firstOrNull);
+
+/// Whether [req] carries an `Origin` that is present but not in
+/// [allowedOrigins].
+///
+/// A missing `Origin` (native / mobile / server-to-server, which don't send
+/// one) or an unset allow-list is not rejected. Relic is stricter on missing
+/// Origin only when authenticating from the auth cookie; that policy is not
+/// shared from here.
+bool isPresentOriginDisallowed(
+  Request req,
+  List<String>? allowedOrigins,
+) {
+  if (allowedOrigins == null) return false;
+  final origin = requestOrigin(req);
+  return origin != null && !allowedOrigins.contains(origin);
+}

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -68,7 +68,11 @@ class Server implements RouterInjectable {
   late AuthenticationHandler _authenticationHandler;
 
   /// [AuthenticationHandler] responsible for authenticating users.
-  AuthenticationHandler get authenticationHandler => _authenticationHandler;
+  ///
+  /// Prefers [Serverpod.authenticationHandler] when that field is set, so a
+  /// handler assigned after [start] is visible to Relic and API sessions.
+  AuthenticationHandler get authenticationHandler =>
+      serverpod.authenticationHandler ?? _authenticationHandler;
 
   /// Caches used by the server.
   final Caches caches;

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -69,10 +69,20 @@ class Server implements RouterInjectable {
 
   /// [AuthenticationHandler] responsible for authenticating users.
   ///
-  /// Prefers [Serverpod.authenticationHandler] when that field is set, so a
-  /// handler assigned after [start] is visible to Relic and API sessions.
-  AuthenticationHandler get authenticationHandler =>
-      serverpod.authenticationHandler ?? _authenticationHandler;
+  /// The user-facing API server prefers [Serverpod.authenticationHandler] when
+  /// that field is set, so a handler assigned after [start] (for example by
+  /// `initializeAuthServices` in a `withServerpod` test) is visible to Relic
+  /// and API sessions.
+  ///
+  /// Insights keeps the service handler passed to [start]. Sharing the user
+  /// handler would reject the service secret and break Insights, migration
+  /// e2e, and the service protocol.
+  AuthenticationHandler get authenticationHandler {
+    if (!identical(this, serverpod.server)) {
+      return _authenticationHandler;
+    }
+    return serverpod.authenticationHandler ?? _authenticationHandler;
+  }
 
   /// Caches used by the server.
   final Caches caches;

--- a/packages/serverpod/lib/src/server/server.dart
+++ b/packages/serverpod/lib/src/server/server.dart
@@ -328,27 +328,16 @@ class Server implements RouterInjectable {
     };
   }
 
-  /// The `Origin` header of [req] normalized to lowercase with any trailing
-  /// slash dropped, or null if absent.
-  String? _requestOrigin(Request req) => req
-      .headers[Headers.originHeader]
-      ?.firstOrNull
-      ?.trim()
-      .toLowerCase()
-      .replaceFirst(RegExp(r'/+$'), '');
-
   /// Whether [req] carries an `Origin` that is present but not in
   /// [ServerpodConfig.allowedOrigins].
   ///
   /// A missing `Origin` (native / mobile / server-to-server, which don't send
   /// one) or an unset allow-list is not rejected. Shared by the WebSocket
   /// handshake and the HTTP cookie-auth origin gates so the two cannot drift.
-  bool _isOriginDisallowed(Request req) {
-    var allowedOrigins = serverpod.config.allowedOrigins;
-    if (allowedOrigins == null) return false;
-    var origin = _requestOrigin(req);
-    return origin != null && !allowedOrigins.contains(origin);
-  }
+  /// Relic HTML is stricter on missing Origin when authenticating from the
+  /// auth cookie; that policy lives in `_SessionMiddleware`.
+  bool _isOriginDisallowed(Request req) =>
+      isPresentOriginDisallowed(req, serverpod.config.allowedOrigins);
 
   /// When cookie-based web auth is enabled, credentialed CORS requires echoing
   /// the specific request `Origin` (the wildcard `*` is invalid with
@@ -359,7 +348,7 @@ class Server implements RouterInjectable {
     if (serverpod.config.authCookie == null) return headers;
 
     var allowedOrigins = serverpod.config.allowedOrigins;
-    var origin = _requestOrigin(req);
+    var origin = requestOrigin(req);
 
     // Echo the specific origin (the wildcard `*` is invalid with credentials)
     // only for an allow-listed origin. Guard the parse so a

--- a/packages/serverpod/lib/src/server/session.dart
+++ b/packages/serverpod/lib/src/server/session.dart
@@ -322,13 +322,21 @@ class MethodCallSession extends Session {
 /// created. It contains all data associated with the current connection and
 /// provides easy access to the database.
 class WebCallSession extends Session {
-  /// Creates a new [Session] for a method call to an endpoint.
+  final Request _request;
+
+  /// The [Request] associated with the call.
+  @override
+  Request get request => _request;
+
+  /// Creates a new [Session] for a web-server call.
   WebCallSession._({
     required super.server,
     required super.endpoint,
     required super.authenticationKey,
+    required Request request,
     super.enableLogging = true,
-  });
+  }) : _request = request,
+       super(request: request);
 }
 
 /// When a connection is made to the [Server] to an endpoint method that uses a
@@ -658,12 +666,14 @@ extension SessionInternalMethods on Session {
     required Server server,
     required String endpoint,
     required String? authenticationKey,
+    required Request request,
     bool enableLogging = true,
   }) async {
     final session = WebCallSession._(
       server: server,
       endpoint: endpoint,
       authenticationKey: authenticationKey,
+      request: request,
       enableLogging: enableLogging,
     );
     await session.initializeAuthentication();

--- a/packages/serverpod/lib/src/web_server/middleware/require_login_middleware.dart
+++ b/packages/serverpod/lib/src/web_server/middleware/require_login_middleware.dart
@@ -1,0 +1,56 @@
+import 'package:serverpod/serverpod.dart';
+
+/// Relic middleware that requires `session.authenticated` for the wrapped
+/// routes.
+///
+/// When [redirectTo] is null, unauthenticated requests receive `401`.
+/// Otherwise they receive `303 See Other` to [redirectTo] with a `return_to`
+/// query of the current path and query (after [safeReturnTo]).
+///
+/// [redirectTo] must itself be a safe same-origin relative path; invalid
+/// values throw at construction. This is Relic middleware and is unrelated
+/// to [Endpoint.requireLogin].
+///
+/// Do not mount at `/`: that would wrap `/auth/*` login routes and the
+/// `/livez` `/readyz` `/startupz` health probes.
+Middleware requireLogin({String? redirectTo}) {
+  final String? safeRedirectTo;
+  if (redirectTo != null) {
+    final validated = trySafeReturnTo(redirectTo);
+    if (validated == null) {
+      throw ArgumentError.value(
+        redirectTo,
+        'redirectTo',
+        'Must be a safe same-origin relative path.',
+      );
+    }
+    safeRedirectTo = validated;
+  } else {
+    safeRedirectTo = null;
+  }
+
+  return (Handler next) {
+    return (Request req) async {
+      final session = await req.session;
+      if (session.authenticated != null) {
+        return next(req);
+      }
+
+      if (safeRedirectTo == null) {
+        return Response.unauthorized();
+      }
+
+      final current = _pathAndQuery(req);
+      final returnTo = safeReturnTo(current);
+      return Response.seeOther(
+        Uri.parse(withReturnToQuery(safeRedirectTo, returnTo)),
+      );
+    };
+  };
+}
+
+String _pathAndQuery(Request req) {
+  final path = req.url.path;
+  if (!req.url.hasQuery) return path;
+  return '$path?${req.url.query}';
+}

--- a/packages/serverpod/lib/src/web_server/public_web_origin.dart
+++ b/packages/serverpod/lib/src/web_server/public_web_origin.dart
@@ -1,0 +1,21 @@
+import 'package:serverpod_shared/serverpod_shared.dart';
+
+/// The public origin of the web server with [path] appended.
+///
+/// Scheme, host, and port come from [webServer] (`publicScheme` / `publicHost`
+/// / `publicPort`). The port is omitted for `http` on 80 and `https` on 443.
+/// [path] is the route path; it is never taken from the request, `Host`, or
+/// `X-Forwarded-Host`.
+Uri publicWebOrigin(ServerConfig webServer, String path) {
+  final scheme = webServer.publicScheme;
+  final port = webServer.publicPort;
+  final omitPort =
+      (scheme == 'http' && port == 80) || (scheme == 'https' && port == 443);
+  final normalizedPath = path.startsWith('/') ? path : '/$path';
+  return Uri(
+    scheme: scheme,
+    host: webServer.publicHost,
+    port: omitPort ? null : port,
+    path: normalizedPath,
+  );
+}

--- a/packages/serverpod/lib/src/web_server/safe_return_to.dart
+++ b/packages/serverpod/lib/src/web_server/safe_return_to.dart
@@ -1,0 +1,99 @@
+/// Maximum accepted length of a `return_to` candidate before it is rejected.
+const int maxReturnToLength = 512;
+
+/// Maximum number of URL-decode passes before a still-changing value is
+/// treated as unsafe.
+const int maxReturnToDecodeIterations = 5;
+
+/// Returns a same-origin relative path from [candidate], or [fallback] if
+/// [candidate] is missing or unsafe.
+///
+/// Used for open-redirect protection on login, OAuth `return_to`, and
+/// [requireLogin].
+String safeReturnTo(String? candidate, {String fallback = '/'}) {
+  return trySafeReturnTo(candidate) ?? fallback;
+}
+
+/// Returns the normalized same-origin relative path, or null if [candidate]
+/// is missing or unsafe.
+///
+/// Prefer [safeReturnTo] at request time. Use this when an invalid value must
+/// throw (for example `requireLogin(redirectTo:)` at construction).
+String? trySafeReturnTo(String? candidate) {
+  if (candidate == null || candidate.isEmpty) return null;
+  if (candidate.length > maxReturnToLength) return null;
+  if (_hasUnsafeChars(candidate)) return null;
+
+  var current = candidate;
+  var stabilized = false;
+  for (var i = 0; i < maxReturnToDecodeIterations; i++) {
+    String decoded;
+    try {
+      decoded = Uri.decodeComponent(current);
+    } on FormatException {
+      return null;
+    } on ArgumentError {
+      return null;
+    }
+    if (decoded == current) {
+      stabilized = true;
+      break;
+    }
+    current = decoded;
+    if (_hasUnsafeChars(current)) return null;
+  }
+  if (!stabilized) return null;
+
+  final withoutFragment = current.split('#').first;
+  if (withoutFragment.isEmpty) return null;
+
+  final queryIndex = withoutFragment.indexOf('?');
+  final pathPart = queryIndex == -1
+      ? withoutFragment
+      : withoutFragment.substring(0, queryIndex);
+  final queryPart = queryIndex == -1
+      ? ''
+      : withoutFragment.substring(queryIndex);
+
+  if (!_isSafePath(pathPart)) return null;
+
+  final normalized = '$pathPart$queryPart';
+  if (!_isSafePath(
+    queryIndex == -1 ? normalized : normalized.substring(0, queryIndex),
+  )) {
+    return null;
+  }
+  return normalized;
+}
+
+/// Appends `return_to=` to [path] using `?` or `&` depending on whether
+/// [path] already has a query.
+String withReturnToQuery(String path, String returnTo) {
+  final separator = path.contains('?') ? '&' : '?';
+  return '$path${separator}return_to=${Uri.encodeQueryComponent(returnTo)}';
+}
+
+bool _hasUnsafeChars(String value) {
+  for (final code in value.codeUnits) {
+    // C0 controls, DEL, and backslash (raw or decoded).
+    if (code <= 0x1f || code == 0x7f || code == 0x5c) return true;
+  }
+  return false;
+}
+
+bool _isSafePath(String path) {
+  if (!path.startsWith('/') || path.startsWith('//')) return false;
+
+  final segments = path.split('/');
+  // segments[0] is empty because of the leading `/`.
+  for (var i = 1; i < segments.length; i++) {
+    final segment = segments[i];
+    if (segment == '..') return false;
+    // Empty middle segments would produce `//` in the path. A trailing slash
+    // leaves an empty last segment and is allowed.
+    if (segment.isEmpty && i != segments.length - 1) return false;
+  }
+
+  final rebuilt = segments.join('/');
+  return rebuilt.startsWith('/') && !rebuilt.startsWith('//');
+}

--- a/packages/serverpod/lib/src/web_server/web_server.dart
+++ b/packages/serverpod/lib/src/web_server/web_server.dart
@@ -8,6 +8,7 @@ import 'package:serverpod_shared/log.dart';
 import 'package:serverpod/src/server/dev_auto_refresh_script.dart';
 import 'package:serverpod/src/server/diagnostic_events/diagnostic_events.dart';
 import 'package:serverpod/src/server/health/health_routes.dart';
+import 'package:serverpod/src/server/response_output.dart';
 import 'package:serverpod/src/server/serverpod.dart';
 import 'package:serverpod/src/server/session.dart';
 
@@ -36,7 +37,7 @@ class WebServer {
     ..injectAt('*/', HealthRoutes(serverpod))
     ..use('*/', _devHtmlInjection)
     ..inject(_ReportExceptionMiddleware(this))
-    ..inject(_SessionMiddleware(serverpod.server));
+    ..inject(_SessionMiddleware(this));
 
   /// Security context if the web server is running over https.
   final SecurityContext? _securityContext;
@@ -123,7 +124,7 @@ class WebServer {
   set fallbackRoute(Route route) =>
       _app.fallback = _ReportExceptionMiddleware(this)(
         _SessionMiddleware(
-          serverpod.server,
+          this,
         )(route.asHandler),
       );
 
@@ -276,19 +277,21 @@ class WebServer {
 }
 
 class _SessionMiddleware extends MiddlewareObject {
-  final Server _server;
+  final WebServer _webServer;
 
-  const _SessionMiddleware(this._server);
+  const _SessionMiddleware(this._webServer);
+
+  Server get _server => _webServer.serverpod.server;
 
   @override
   Handler call(Handler next) {
     return (req) async {
-      String? authenticationKey;
+      final config = _server.serverpod.config;
+
+      String? authenticationHeaderValue;
       try {
-        authenticationKey = unwrapAuthHeaderValue(
-          req.getAuthorizationHeaderValue(
-            _server.serverpod.config.validateHeaders,
-          ),
+        authenticationHeaderValue = req.getAuthorizationHeaderValue(
+          config.validateHeaders,
         );
       } on HeaderException catch (_) {
         // If validation is enabled and header is malformed, return 400
@@ -297,22 +300,90 @@ class _SessionMiddleware extends MiddlewareObject {
         );
       }
 
+      String? authenticationKey;
+      var authenticatedFromCookie = false;
+
+      if (authenticationHeaderValue != null) {
+        // Authorization present (even if the token is garbage): do not fall
+        // back to the auth cookie.
+        authenticationKey = unwrapAuthHeaderValue(authenticationHeaderValue);
+      } else if (config.authCookie != null) {
+        final authMode = req.headers[webAuthModeHeaderName]?.firstOrNull;
+        if (authMode != webAuthModeCookieTransport) {
+          authenticationKey = req.getAuthCookieValue(config.authCookie);
+          authenticatedFromCookie = authenticationKey != null;
+        }
+      }
+
+      if (authenticatedFromCookie && _isUnsafeMethod(req.method)) {
+        final origin = requestOrigin(req);
+        final allowedOrigins = config.allowedOrigins;
+        if (origin == null ||
+            allowedOrigins == null ||
+            !allowedOrigins.contains(origin)) {
+          return Response.forbidden(
+            body: Body.fromString('Request origin not allowed.'),
+          );
+        }
+      }
+
       final deferredSession = _Deferred(
         () => SessionInternalMethods.createWebCallSession(
           server: _server,
           endpoint: req.url.path,
           authenticationKey: authenticationKey,
+          request: req,
         ),
       );
       _sessionProperty[req] = deferredSession;
       try {
-        return await next(req);
+        final result = await next(req);
+        return await _applyQueuedOutput(result, deferredSession);
+      } catch (e, stackTrace) {
+        Session? session;
+        try {
+          session = await deferredSession.ifInitiatedRun((s) => s);
+        } catch (_) {
+          session = null;
+        }
+        await _webServer._reportException(
+          e,
+          stackTrace,
+          space: OriginSpace.application,
+          session: session != null ? Future.value(session) : null,
+          request: req,
+        );
+        if (session != null) {
+          return applyResponseOutput(
+            Response.internalServerError(),
+            headers: session.responseHeaders,
+            cookies: session.responseCookies,
+          );
+        }
+        return Response.internalServerError();
       } finally {
         await deferredSession.ifInitiatedRun((s) => s.close());
       }
     };
   }
+
+  Future<Result> _applyQueuedOutput(
+    Result result,
+    _Deferred<Session> deferredSession,
+  ) async {
+    if (result is! Response) return result;
+    final session = await deferredSession.ifInitiatedRun((s) => s);
+    if (session == null) return result;
+    return applyResponseOutput(
+      result,
+      headers: session.responseHeaders,
+      cookies: session.responseCookies,
+    );
+  }
 }
+
+bool _isUnsafeMethod(Method method) =>
+    method != Method.get && method != Method.head && method != Method.options;
 
 class _ReportExceptionMiddleware extends MiddlewareObject {
   final WebServer _webServer;

--- a/packages/serverpod/lib/web_server.dart
+++ b/packages/serverpod/lib/web_server.dart
@@ -1,8 +1,11 @@
 export 'src/web_server/middleware/fallback_middleware.dart';
+export 'src/web_server/middleware/require_login_middleware.dart';
 export 'src/web_server/middleware/wasm_headers_middleware.dart';
+export 'src/web_server/public_web_origin.dart';
 export 'src/web_server/routes/flutter_route.dart';
 export 'src/web_server/routes/spa_route.dart';
 export 'src/web_server/routes/static_route.dart';
+export 'src/web_server/safe_return_to.dart';
 export 'src/web_server/templates.dart';
 export 'src/web_server/web_server.dart';
 export 'src/web_server/widgets/web_widget.dart';

--- a/packages/serverpod/skills/serverpod-auth/SKILL.md
+++ b/packages/serverpod/skills/serverpod-auth/SKILL.md
@@ -59,6 +59,42 @@ final authUser = await authUsers.get(
 );
 ```
 
+## Relic HTML (document login)
+
+SAS must be the **primary** token manager and `authCookie` must be set (with `allowedOrigins`). Call after `initializeAuthServices` and before `pod.start()`:
+
+```yaml
+authCookie:
+  secure: false          # http://localhost only
+  # sameSite: lax        # default; strict is rejected (OAuth return GET drops the state cookie)
+allowedOrigins:
+  - http://localhost:8082
+```
+
+```yaml
+# config/passwords.yaml — dedicated HMAC key, do not reuse sessionKeyHashPepper
+shared:
+  webAuthOAuthStatePepper: 'a long random secret'
+```
+
+```dart
+pod.configureWebAuthRoutes(loginSuccessPath: '/account');
+pod.webServer.addMiddleware(
+  requireLogin(redirectTo: '/auth/login'),
+  '/account',
+);
+```
+
+Do **not** mount `requireLogin` at `/` — it wraps `/auth/*` and health probes.
+
+Login hub is `GET/POST /auth/login`. Providers that are registered on `AuthServices` also mount `/auth/google`, `/auth/github`, `/auth/microsoft`, `/auth/apple`. HTML Google callback is `/auth/google/callback` (not Flutter's `/auth/callback`). HTML Apple is `POST /auth/apple/web/callback` (HMAC'd `state` form field; Lax cookies are not sent on Apple `form_post`).
+
+Same-site SAS cookie is how a website and Flutter cookie-mode can share a login. JWT Flutter clients will not pick up the Relic cookie.
+
+Relic POSTs outside `/auth/*` are not form-CSRF'd; prefer GET pages plus Origin. Cookie-less homemade login POSTs are login-CSRF-able — use `configureWebAuthRoutes`.
+
+If the API host ≠ the web host, set `authCookie.domain` and list **both** origins. Register both Flutter and HTML redirect URIs at each provider. Out of scope: email register/reset HTML, Facebook HTML, JWT-in-cookie.
+
 ## Flutter app
 
 Use `SignInWidget` to sign the user in. It provides its own Material surface, so it also renders correctly when mixed with non-Material design systems:

--- a/packages/serverpod/skills/serverpod-webserver/SKILL.md
+++ b/packages/serverpod/skills/serverpod-webserver/SKILL.md
@@ -27,7 +27,16 @@ class HelloRoute extends Route {
 pod.webServer.addRoute(HelloRoute(), '/api/hello');
 ```
 
-Routes matched in registration order. `Session` provides DB, logging, and auth access just like in endpoints.
+Routes matched in registration order. `Session` provides DB, logging, and auth access just like in endpoints. With `authCookie` configured, Relic hydrates `session.authenticated` from the `Authorization` header if present, otherwise from the SAS auth cookie. Protect HTML paths with `requireLogin` (never at `/`):
+
+```dart
+pod.webServer.addMiddleware(
+  requireLogin(redirectTo: '/auth/login'),
+  '/account',
+);
+```
+
+Document login lives in the auth package (`configureWebAuthRoutes`). See [serverpod-auth](../serverpod-auth/SKILL.md).
 
 ## HTTP methods
 

--- a/packages/serverpod/test/server/request_origin_test.dart
+++ b/packages/serverpod/test/server/request_origin_test.dart
@@ -1,0 +1,26 @@
+import 'package:serverpod/src/server/request_origin.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given an Origin header value', () {
+    test(
+      'when it is mixed case with a trailing slash '
+      'then it is lowercased and the slash is dropped.',
+      () {
+        expect(
+          normalizeOriginValue('HTTPS://App.Example.com/'),
+          'https://app.example.com',
+        );
+      },
+    );
+
+    test('when it is the literal null then it is preserved.', () {
+      expect(normalizeOriginValue('null'), 'null');
+    });
+
+    test('when it is blank then it is treated as absent.', () {
+      expect(normalizeOriginValue('  '), isNull);
+      expect(normalizeOriginValue(null), isNull);
+    });
+  });
+}

--- a/packages/serverpod/test/web_server/public_web_origin_test.dart
+++ b/packages/serverpod/test/web_server/public_web_origin_test.dart
@@ -1,0 +1,54 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+void main() {
+  ServerConfig config({
+    String scheme = 'https',
+    String host = 'example.com',
+    int port = 443,
+  }) => ServerConfig(
+    port: 8080,
+    publicScheme: scheme,
+    publicHost: host,
+    publicPort: port,
+  );
+
+  test(
+    'Given https on port 443 '
+    'when building a public web origin '
+    'then the port is omitted.',
+    () {
+      expect(
+        publicWebOrigin(config(), '/auth/google/callback').toString(),
+        'https://example.com/auth/google/callback',
+      );
+    },
+  );
+
+  test(
+    'Given http on port 80 '
+    'when building a public web origin '
+    'then the port is omitted.',
+    () {
+      expect(
+        publicWebOrigin(
+          config(scheme: 'http', port: 80),
+          '/auth/login',
+        ).toString(),
+        'http://example.com/auth/login',
+      );
+    },
+  );
+
+  test(
+    'Given https on a non-default port '
+    'when building a public web origin '
+    'then the port is included.',
+    () {
+      expect(
+        publicWebOrigin(config(port: 8443), '/account').toString(),
+        'https://example.com:8443/account',
+      );
+    },
+  );
+}

--- a/packages/serverpod/test/web_server/require_login_test.dart
+++ b/packages/serverpod/test/web_server/require_login_test.dart
@@ -1,0 +1,26 @@
+import 'package:serverpod/serverpod.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'Given requireLogin with an unsafe redirectTo '
+    'when constructed '
+    'then it throws.',
+    () {
+      expect(
+        () => requireLogin(redirectTo: '//evil'),
+        throwsA(isA<ArgumentError>()),
+      );
+    },
+  );
+
+  test(
+    'Given requireLogin with a safe redirectTo '
+    'when constructed '
+    'then it succeeds.',
+    () {
+      expect(() => requireLogin(redirectTo: '/auth/login'), returnsNormally);
+      expect(() => requireLogin(), returnsNormally);
+    },
+  );
+}

--- a/packages/serverpod/test/web_server/safe_return_to_test.dart
+++ b/packages/serverpod/test/web_server/safe_return_to_test.dart
@@ -1,0 +1,89 @@
+import 'package:serverpod/src/web_server/safe_return_to.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Given a safeReturnTo candidate', () {
+    test('when it is a same-origin path then it is returned.', () {
+      expect(safeReturnTo('/account'), '/account');
+      expect(safeReturnTo('/account?tab=1'), '/account?tab=1');
+    });
+
+    test('when it is null or empty then the fallback is returned.', () {
+      expect(safeReturnTo(null), '/');
+      expect(safeReturnTo(''), '/');
+      expect(safeReturnTo(null, fallback: '/home'), '/home');
+    });
+
+    test('when it is an absolute URL then it is rejected.', () {
+      expect(safeReturnTo('https://evil.example'), '/');
+    });
+
+    test('when it is a protocol-relative URL then it is rejected.', () {
+      expect(safeReturnTo('//evil'), '/');
+      expect(safeReturnTo('//evil.example/phish'), '/');
+    });
+
+    test('when it contains parent-directory segments then it is rejected.', () {
+      expect(safeReturnTo('/foo/..//evil.com'), '/');
+      expect(safeReturnTo('/foo/../../evil'), '/');
+    });
+
+    test('when it contains CR LF then it is rejected.', () {
+      expect(safeReturnTo('/ok%0d%0aSet-Cookie:x=1'), '/');
+      expect(safeReturnTo('/ok\r\nSet-Cookie:x=1'), '/');
+    });
+
+    test('when it contains a backslash then it is rejected.', () {
+      expect(safeReturnTo('/ok\\evil'), '/');
+      expect(safeReturnTo('/ok%5cevil'), '/');
+    });
+
+    test('when it is double-encoded as a protocol-relative URL '
+        'then it is rejected.', () {
+      expect(safeReturnTo('%252F%252Fevil.example'), '/');
+    });
+
+    test('when it exceeds the length limit then it is rejected.', () {
+      expect(safeReturnTo('/${'a' * 512}'), '/');
+    });
+
+    test('when it has a trailing slash then it is kept.', () {
+      expect(safeReturnTo('/account/'), '/account/');
+    });
+
+    test('when it has a fragment then the fragment is stripped.', () {
+      expect(safeReturnTo('/account#secret'), '/account');
+    });
+
+    test('when it has empty middle segments then it is rejected.', () {
+      expect(safeReturnTo('/foo//bar'), '/');
+    });
+  });
+
+  group('Given withReturnToQuery', () {
+    test('when the path has no query then it uses ?.', () {
+      expect(
+        withReturnToQuery('/auth/login', '/account'),
+        '/auth/login?return_to=${Uri.encodeQueryComponent('/account')}',
+      );
+    });
+
+    test('when the path already has a query then it uses &.', () {
+      expect(
+        withReturnToQuery('/auth/login?from=nav', '/account'),
+        '/auth/login?from=nav&return_to=${Uri.encodeQueryComponent('/account')}',
+      );
+    });
+  });
+
+  group('Given trySafeReturnTo', () {
+    test('when the candidate is unsafe then it returns null.', () {
+      expect(trySafeReturnTo('//evil'), isNull);
+      expect(trySafeReturnTo('/foo/..//evil.com'), isNull);
+    });
+
+    test('when the candidate is safe then it returns the path.', () {
+      expect(trySafeReturnTo('/account'), '/account');
+    });
+  });
+}

--- a/packages/serverpod_client/CHANGELOG.md
+++ b/packages/serverpod_client/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/packages/serverpod_database/CHANGELOG.md
+++ b/packages/serverpod_database/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/packages/serverpod_embedded_postgres/CHANGELOG.md
+++ b/packages/serverpod_embedded_postgres/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/packages/serverpod_flutter/CHANGELOG.md
+++ b/packages/serverpod_flutter/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/packages/serverpod_lints/CHANGELOG.md
+++ b/packages/serverpod_lints/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/packages/serverpod_serialization/CHANGELOG.md
+++ b/packages/serverpod_serialization/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/packages/serverpod_service_client/CHANGELOG.md
+++ b/packages/serverpod_service_client/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/packages/serverpod_shared/CHANGELOG.md
+++ b/packages/serverpod_shared/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/packages/serverpod_test/CHANGELOG.md
+++ b/packages/serverpod_test/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_idp/serverpod_auth_idp_server/pubspec.yaml
@@ -12,6 +12,7 @@ resolution: workspace
 
 dependencies:
   clock: ^1.1.1
+  crypto: ^3.0.2
   dart_jsonwebtoken: ^3.1.0
   email_validator: '>=2.1.17 <4.0.0'
   googleapis: '>=11.0.0 <17.0.0'

--- a/templates/serverpod_templates/CHANGELOG.md
+++ b/templates/serverpod_templates/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_auth_test/serverpod_auth_test_client/CHANGELOG.md
+++ b/tests/serverpod_auth_test/serverpod_auth_test_client/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_auth_test/serverpod_auth_test_flutter/CHANGELOG.md
+++ b/tests/serverpod_auth_test/serverpod_auth_test_flutter/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_auth_test/serverpod_auth_test_server/CHANGELOG.md
+++ b/tests/serverpod_auth_test/serverpod_auth_test_server/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_test_client/CHANGELOG.md
+++ b/tests/serverpod_test_client/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_test_flutter/CHANGELOG.md
+++ b/tests/serverpod_test_flutter/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_test_module/serverpod_test_module_client/CHANGELOG.md
+++ b/tests/serverpod_test_module/serverpod_test_module_client/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_test_module/serverpod_test_module_server/CHANGELOG.md
+++ b/tests/serverpod_test_module/serverpod_test_module_server/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/CHANGELOG.md
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_client/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/CHANGELOG.md
+++ b/tests/serverpod_test_nonvector/serverpod_test_nonvector_server/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_test_server/CHANGELOG.md
+++ b/tests/serverpod_test_server/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_test_server/test_integration/web_server/session_cookie_auth_test.dart
+++ b/tests/serverpod_test_server/test_integration/web_server/session_cookie_auth_test.dart
@@ -1,0 +1,628 @@
+import 'dart:async';
+
+import 'package:http/http.dart' as http;
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/src/generated/endpoints.dart';
+import 'package:serverpod_test_server/src/generated/protocol.dart';
+import 'package:test/test.dart';
+
+const _allowedOrigin = 'http://localhost:9999';
+const _authCookieName = WebAuthCookieConfig.defaultName;
+const _refreshCookieName = '${WebAuthCookieConfig.defaultName}_refresh';
+const _goodToken = 'good';
+
+final _portZeroConfig = ServerConfig(
+  port: 0,
+  publicScheme: 'http',
+  publicHost: 'localhost',
+  publicPort: 0,
+);
+
+void main() {
+  late http.Client client;
+
+  setUpAll(() {
+    client = http.Client();
+  });
+
+  tearDownAll(() {
+    client.close();
+  });
+
+  group('Given a web server with authCookie and an authenticationHandler', () {
+    late Serverpod pod;
+    late int port;
+    late Uri base;
+
+    setUp(() async {
+      pod = _createPod(
+        authCookie: const WebAuthCookieConfig(secure: false),
+        allowedOrigins: const [_allowedOrigin],
+      );
+
+      pod.webServer.addRoute(_WhoAmIRoute(), '/whoami');
+      pod.webServer.addRoute(_SetCookieRoute(), '/set-cookie');
+      pod.webServer.addRoute(_WriteAuthCookieRoute(), '/write-auth-cookie');
+      pod.webServer.addRoute(_ThrowCookieRoute(), '/throw-cookie');
+      pod.webServer.addRoute(_ThrowAuthCookieRoute(), '/throw-auth-cookie');
+      pod.webServer.addRoute(_HtmlCookieRoute(), '/html-cookie');
+      pod.webServer.fallbackRoute = _FallbackCookieRoute();
+
+      pod.webServer.addMiddleware(
+        requireLogin(redirectTo: '/login'),
+        '/private',
+      );
+      pod.webServer.addRoute(_WhoAmIRoute(), '/private');
+
+      pod.webServer.addMiddleware(requireLogin(), '/locked');
+      pod.webServer.addRoute(_WhoAmIRoute(), '/locked');
+
+      pod.webServer.addMiddleware(
+        requireLogin(redirectTo: '/login?from=nav'),
+        '/with-query',
+      );
+      pod.webServer.addRoute(_WhoAmIRoute(), '/with-query');
+
+      await pod.start();
+      port = pod.webServer.port!;
+      base = Uri.parse('http://localhost:$port');
+    });
+
+    tearDown(() async {
+      await pod.shutdown(exitProcess: false);
+    });
+
+    Future<http.Response> send(
+      String method,
+      String path, {
+      Map<String, String>? headers,
+    }) async {
+      final request = http.Request(method, base.replace(path: path))
+        ..followRedirects = false;
+      if (headers != null) request.headers.addAll(headers);
+      final streamed = await client.send(request);
+      return http.Response.fromStream(streamed);
+    }
+
+    test(
+      'when a Bearer token is sent '
+      'then the request is authenticated from the header.',
+      () async {
+        final response = await send(
+          'GET',
+          '/whoami',
+          headers: {'authorization': 'Bearer $_goodToken'},
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, 'mario');
+      },
+    );
+
+    test(
+      'when the auth cookie is sent without an Authorization header '
+      'then the request is authenticated from the cookie.',
+      () async {
+        final response = await send(
+          'GET',
+          '/whoami',
+          headers: {'cookie': '$_authCookieName=$_goodToken'},
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, 'mario');
+      },
+    );
+
+    test(
+      'when neither header nor cookie is sent '
+      'then the request is anonymous.',
+      () async {
+        final response = await send('GET', '/whoami');
+        expect(response.statusCode, 200);
+        expect(response.body, 'anonymous');
+      },
+    );
+
+    test(
+      'when both a Bearer token and an auth cookie are sent '
+      'then the header wins.',
+      () async {
+        final response = await send(
+          'GET',
+          '/whoami',
+          headers: {
+            'authorization': 'Bearer $_goodToken',
+            'cookie': '$_authCookieName=other',
+          },
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, 'mario');
+      },
+    );
+
+    test(
+      'when an invalid Bearer token and a valid auth cookie are sent '
+      'then the request is anonymous (cookie is not a fallback).',
+      () async {
+        final response = await send(
+          'GET',
+          '/whoami',
+          headers: {
+            'authorization': 'Bearer bad',
+            'cookie': '$_authCookieName=$_goodToken',
+          },
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, 'anonymous');
+      },
+    );
+
+    test(
+      'when cookie-transport is set with an auth cookie '
+      'then the request is anonymous.',
+      () async {
+        final response = await send(
+          'GET',
+          '/whoami',
+          headers: {
+            webAuthModeHeaderName: webAuthModeCookieTransport,
+            'cookie': '$_authCookieName=$_goodToken',
+          },
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, 'anonymous');
+      },
+    );
+
+    test(
+      'when only the refresh cookie is sent '
+      'then the request is anonymous.',
+      () async {
+        final response = await send(
+          'GET',
+          '/whoami',
+          headers: {'cookie': '$_refreshCookieName=$_goodToken'},
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, 'anonymous');
+      },
+    );
+
+    test(
+      'when the auth cookie name is duplicated '
+      'then the request is anonymous.',
+      () async {
+        final response = await send(
+          'GET',
+          '/whoami',
+          headers: {
+            'cookie': '$_authCookieName=$_goodToken; $_authCookieName=other',
+          },
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, 'anonymous');
+      },
+    );
+
+    test(
+      'when the auth cookie is garbage '
+      'then the request is anonymous and not 500.',
+      () async {
+        final response = await send(
+          'GET',
+          '/whoami',
+          headers: {'cookie': '$_authCookieName=not-a-token'},
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, 'anonymous');
+      },
+    );
+
+    test(
+      'when setResponseCookie is called '
+      'then Set-Cookie is present on success.',
+      () async {
+        final response = await send('GET', '/set-cookie');
+        expect(response.statusCode, 200);
+        expect(response.headers['set-cookie'], contains('queued=1'));
+      },
+    );
+
+    test(
+      'when setResponseCookie is called and the handler throws '
+      'then Set-Cookie is present on the 500.',
+      () async {
+        final response = await send('GET', '/throw-cookie');
+        expect(response.statusCode, 500);
+        expect(response.headers['set-cookie'], contains('queued=1'));
+      },
+    );
+
+    test(
+      'when writeWebAuthCookie is called from a Relic route '
+      'then the auth cookie is delivered (WebCallSession is cookie-mode).',
+      () async {
+        final response = await send('GET', '/write-auth-cookie');
+        expect(response.statusCode, 200);
+        expect(response.headers['set-cookie'], contains('$_authCookieName='));
+      },
+    );
+
+    test(
+      'when writeWebAuthCookie is called and the handler throws '
+      'then the auth cookie is still delivered.',
+      () async {
+        final response = await send('GET', '/throw-auth-cookie');
+        expect(response.statusCode, 500);
+        expect(response.headers['set-cookie'], contains('$_authCookieName='));
+      },
+    );
+
+    test(
+      'when the fallback route queues a cookie '
+      'then Set-Cookie is present.',
+      () async {
+        final response = await send('GET', '/no-such-route');
+        expect(response.statusCode, 200);
+        expect(response.body, 'fallback');
+        expect(response.headers['set-cookie'], contains('fallback=1'));
+      },
+    );
+
+    test(
+      'when a cookie-authenticated POST is missing Origin '
+      'then the response is 403.',
+      () async {
+        final response = await send(
+          'POST',
+          '/whoami',
+          headers: {'cookie': '$_authCookieName=$_goodToken'},
+        );
+        expect(response.statusCode, 403);
+      },
+    );
+
+    test(
+      'when a cookie-authenticated POST has Origin null '
+      'then the response is 403.',
+      () async {
+        final response = await send(
+          'POST',
+          '/whoami',
+          headers: {
+            'cookie': '$_authCookieName=$_goodToken',
+            'origin': 'null',
+          },
+        );
+        expect(response.statusCode, 403);
+      },
+    );
+
+    test(
+      'when a cookie-authenticated POST has a disallowed Origin '
+      'then the response is 403.',
+      () async {
+        final response = await send(
+          'POST',
+          '/whoami',
+          headers: {
+            'cookie': '$_authCookieName=$_goodToken',
+            'origin': 'https://evil.example',
+          },
+        );
+        expect(response.statusCode, 403);
+      },
+    );
+
+    test(
+      'when a cookie-authenticated POST has an allow-listed Origin '
+      'with different case and a trailing slash '
+      'then the request is served.',
+      () async {
+        final response = await send(
+          'POST',
+          '/whoami',
+          headers: {
+            'cookie': '$_authCookieName=$_goodToken',
+            'origin': 'HTTP://LOCALHOST:9999/',
+          },
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, 'mario');
+      },
+    );
+
+    test(
+      'when a cookie-less POST has a foreign Origin '
+      'then it is not Origin-gated.',
+      () async {
+        final response = await send(
+          'POST',
+          '/whoami',
+          headers: {'origin': 'https://evil.example'},
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, 'anonymous');
+      },
+    );
+
+    test(
+      'when a cookie-authenticated GET has a disallowed Origin '
+      'then the request is still served.',
+      () async {
+        final response = await send(
+          'GET',
+          '/whoami',
+          headers: {
+            'cookie': '$_authCookieName=$_goodToken',
+            'origin': 'https://evil.example',
+          },
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, 'mario');
+      },
+    );
+
+    test(
+      'when a cookie-authenticated HEAD is missing Origin '
+      'then it is not Origin-gated.',
+      () async {
+        final response = await send(
+          'HEAD',
+          '/whoami',
+          headers: {'cookie': '$_authCookieName=$_goodToken'},
+        );
+        expect(response.statusCode, isNot(403));
+      },
+    );
+
+    test(
+      'when a cookie-authenticated OPTIONS is missing Origin '
+      'then it is not Origin-gated.',
+      () async {
+        final response = await send(
+          'OPTIONS',
+          '/whoami',
+          headers: {'cookie': '$_authCookieName=$_goodToken'},
+        );
+        expect(response.statusCode, isNot(403));
+      },
+    );
+
+    for (final method in ['PUT', 'PATCH', 'DELETE']) {
+      test(
+        'when a cookie-authenticated $method is missing Origin '
+        'then the response is 403.',
+        () async {
+          final response = await send(
+            method,
+            '/whoami',
+            headers: {'cookie': '$_authCookieName=$_goodToken'},
+          );
+          expect(response.statusCode, 403);
+        },
+      );
+    }
+
+    test(
+      'when an unauthenticated client hits a requireLogin path with redirectTo '
+      'then the response is 303 with a safe return_to.',
+      () async {
+        final response = await send('GET', '/private');
+        expect(response.statusCode, 303);
+        expect(
+          response.headers['location'],
+          '/login?return_to=${Uri.encodeQueryComponent('/private')}',
+        );
+      },
+    );
+
+    test(
+      'when an unauthenticated client hits a requireLogin path without redirectTo '
+      'then the response is 401.',
+      () async {
+        final response = await send('GET', '/locked');
+        expect(response.statusCode, 401);
+      },
+    );
+
+    test(
+      'when redirectTo already contains a query '
+      'then return_to is appended with &.',
+      () async {
+        final response = await send('GET', '/with-query');
+        expect(response.statusCode, 303);
+        expect(
+          response.headers['location'],
+          '/login?from=nav&return_to=${Uri.encodeQueryComponent('/with-query')}',
+        );
+      },
+    );
+
+    test(
+      'when an authenticated client hits a requireLogin path '
+      'then the request is served.',
+      () async {
+        final response = await send(
+          'GET',
+          '/private',
+          headers: {'cookie': '$_authCookieName=$_goodToken'},
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, 'mario');
+      },
+    );
+  });
+
+  group('Given a web server without authCookie', () {
+    late Serverpod pod;
+    late int port;
+
+    setUp(() async {
+      pod = _createPod();
+      pod.webServer.addRoute(_WhoAmIRoute(), '/whoami');
+      pod.webServer.addRoute(_WriteAuthCookieRoute(), '/write-auth-cookie');
+      await pod.start();
+      port = pod.webServer.port!;
+    });
+
+    tearDown(() async {
+      await pod.shutdown(exitProcess: false);
+    });
+
+    test(
+      'when an auth cookie is sent '
+      'then it is ignored and the request is anonymous.',
+      () async {
+        final response = await client.get(
+          Uri.parse('http://localhost:$port/whoami'),
+          headers: {'cookie': '$_authCookieName=$_goodToken'},
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, 'anonymous');
+      },
+    );
+
+    test(
+      'when writeWebAuthCookie is called '
+      'then no Set-Cookie is issued.',
+      () async {
+        final response = await client.get(
+          Uri.parse('http://localhost:$port/write-auth-cookie'),
+        );
+        expect(response.statusCode, 200);
+        expect(response.headers['set-cookie'], isNull);
+      },
+    );
+  });
+
+  group('Given a web server in dev mode', () {
+    late Serverpod pod;
+    late int port;
+
+    setUp(() async {
+      pod = _createPod(
+        authCookie: const WebAuthCookieConfig(secure: false),
+        allowedOrigins: const [_allowedOrigin],
+      );
+      pod.webServer.addRoute(_HtmlCookieRoute(), '/html-cookie');
+      pod.webServer.setDevModeForTesting(true);
+      await pod.start();
+      port = pod.webServer.port!;
+    });
+
+    tearDown(() async {
+      await pod.shutdown(exitProcess: false);
+    });
+
+    test(
+      'when an HTML route queues a cookie '
+      'then Set-Cookie is preserved after script injection.',
+      () async {
+        final response = await client.get(
+          Uri.parse('http://localhost:$port/html-cookie'),
+        );
+        expect(response.statusCode, 200);
+        expect(response.body, contains('/__dev/version'));
+        expect(response.headers['set-cookie'], contains('html=1'));
+      },
+    );
+  });
+}
+
+Serverpod _createPod({
+  WebAuthCookieConfig? authCookie,
+  List<String>? allowedOrigins,
+}) {
+  return Serverpod(
+    [],
+    Protocol(),
+    Endpoints(),
+    config: ServerpodConfig(
+      apiServer: _portZeroConfig,
+      webServer: _portZeroConfig,
+      authCookie: authCookie,
+      allowedOrigins: allowedOrigins,
+    ),
+    authenticationHandler: (session, token) async {
+      if (token == _goodToken) {
+        return AuthenticationInfo('mario', {}, authId: 'good');
+      }
+      return null;
+    },
+  );
+}
+
+const _allMethods = {
+  Method.get,
+  Method.head,
+  Method.post,
+  Method.put,
+  Method.patch,
+  Method.delete,
+  Method.options,
+};
+
+class _WhoAmIRoute extends Route {
+  _WhoAmIRoute() : super(methods: _allMethods);
+
+  @override
+  FutureOr<Result> handleCall(Session session, Request request) {
+    final auth = session.authenticated;
+    return Response.ok(
+      body: Body.fromString(auth == null ? 'anonymous' : auth.userIdentifier),
+    );
+  }
+}
+
+class _SetCookieRoute extends Route {
+  @override
+  FutureOr<Result> handleCall(Session session, Request request) {
+    session.setResponseCookie(SetCookie(name: 'queued', value: '1'));
+    return Response.ok();
+  }
+}
+
+class _WriteAuthCookieRoute extends Route {
+  @override
+  FutureOr<Result> handleCall(Session session, Request request) {
+    final wrote = session.writeWebAuthCookie('issued-token');
+    return Response.ok(body: Body.fromString('$wrote'));
+  }
+}
+
+class _ThrowCookieRoute extends Route {
+  @override
+  FutureOr<Result> handleCall(Session session, Request request) {
+    session.setResponseCookie(SetCookie(name: 'queued', value: '1'));
+    throw Exception('handler boom');
+  }
+}
+
+class _ThrowAuthCookieRoute extends Route {
+  @override
+  FutureOr<Result> handleCall(Session session, Request request) {
+    session.writeWebAuthCookie('issued-token');
+    throw Exception('handler boom');
+  }
+}
+
+class _HtmlCookieRoute extends Route {
+  @override
+  FutureOr<Result> handleCall(Session session, Request request) {
+    session.setResponseCookie(SetCookie(name: 'html', value: '1'));
+    return Response.ok(
+      body: Body.fromString(
+        '<html><body></body></html>',
+        mimeType: MimeType.html,
+      ),
+    );
+  }
+}
+
+class _FallbackCookieRoute extends Route {
+  @override
+  FutureOr<Result> handleCall(Session session, Request request) {
+    session.setResponseCookie(SetCookie(name: 'fallback', value: '1'));
+    return Response.ok(body: Body.fromString('fallback'));
+  }
+}

--- a/tests/serverpod_test_server/test_integration/web_server/session_cookie_auth_test.dart
+++ b/tests/serverpod_test_server/test_integration/web_server/session_cookie_auth_test.dart
@@ -505,6 +505,7 @@ void main() {
         allowedOrigins: const [_allowedOrigin],
       );
       pod.webServer.addRoute(_HtmlCookieRoute(), '/html-cookie');
+      // ignore: invalid_use_of_visible_for_testing_member
       pod.webServer.setDevModeForTesting(true);
       await pod.start();
       port = pod.webServer.port!;

--- a/tests/serverpod_test_shared/CHANGELOG.md
+++ b/tests/serverpod_test_shared/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/CHANGELOG.md
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_client/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_flutter/CHANGELOG.md
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_flutter/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/CHANGELOG.md
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_server/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tests/serverpod_test_sqlite/serverpod_test_sqlite_shared/CHANGELOG.md
+++ b/tests/serverpod_test_sqlite/serverpod_test_sqlite_shared/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/tools/serverpod_cli/CHANGELOG.md
+++ b/tools/serverpod_cli/CHANGELOG.md
@@ -105,6 +105,7 @@ To allow easily building offline-first Flutter apps, the experimental `database:
 
 #### Authentication:
 
+- feat: Adds Relic HTML document login (`configureWebAuthRoutes`) with SAS HttpOnly cookies. Closes #4818. (RFC #2008)
 - feat: Adds account merging mechanics to the auth module. ([@craiglabenz](https://github.com/craiglabenz))
 - feat: Adds `ServerpodCloudEmailIdpConfig` as default email IDP using Serverpod Cloud.
 - feat: Allows replacing the Google Sign-In for web with OAuth2 PKCE flow for a better UX.

--- a/util/run_tests_integration_concurrently
+++ b/util/run_tests_integration_concurrently
@@ -64,8 +64,34 @@ fi
 # Tests tagged migration_artifacts mutate the checked-out migrations/protocol
 # directories and have a dedicated serial CI suite; running them here can race
 # every other isolate while it loads those files during server startup.
-echo "### Running concurrent integration tests (${#shard_test_files[@]} files, shard $shard_index/$total_shards)"
-INTEGRATION_TEST_SERVERPOD_MODE=test dart test "${shard_test_files[@]}" -t integration -x migration_artifacts --reporter=failures-only
+#
+# Timing-tagged files (wall-clock bounds, 4s start-timeout child, 32MB
+# existence-cost) currently all land in shard 9. Starting them in the same
+# dart test as the rest of the shard starves withServerpod's 120s start
+# timeout - CI then fails at ~2m. Run them serially first, then the rest.
+timing_test_files=()
+other_test_files=()
+for test_file in "${shard_test_files[@]}"; do
+    if grep -Fq "@Tags(['timing'])" "$test_file"; then
+        timing_test_files+=("$test_file")
+    else
+        other_test_files+=("$test_file")
+    fi
+done
+
+if [ ${#timing_test_files[@]} -gt 0 ]; then
+    echo "### Running timing integration tests serially (${#timing_test_files[@]} files, shard $shard_index/$total_shards)"
+    INTEGRATION_TEST_SERVERPOD_MODE=test dart test "${timing_test_files[@]}" \
+        -t integration -x migration_artifacts --concurrency=1 --reporter=failures-only
+fi
+
+if [ ${#other_test_files[@]} -eq 0 ]; then
+    echo "### No non-timing test files assigned to shard $shard_index/$total_shards"
+else
+    echo "### Running concurrent integration tests (${#other_test_files[@]} files, shard $shard_index/$total_shards)"
+    INTEGRATION_TEST_SERVERPOD_MODE=test dart test "${other_test_files[@]}" \
+        -t integration -x migration_artifacts -x timing --reporter=failures-only
+fi
 
 # Verify the embedded data path was created. Don't remove it here: the tests
 # leave the postmaster running (it is reaped on the next start), so an rm would


### PR DESCRIPTION
## Summary
- Relic hydrates `session.authenticated` from the SAS auth cookie and delivers `Set-Cookie` on HTML success and throw.
- `configureWebAuthRoutes` mounts `/auth/*` in the auth package (email, Google, GitHub, Microsoft, Apple HTML on a path distinct from Flutter).
- Example `/account` is protected with `requireLogin`; docs and changelog close #4818 (RFC #2008).

## Test plan
- [ ] `dart test test_integration/web_server/session_cookie_auth_test.dart` in `tests/serverpod_test_server`
- [ ] `dart test test/web/` in `serverpod_auth_idp_server`
- [ ] `requireLogin` is only on `/account` in the auth example; `/auth/login` stays public

Review commit-by-commit.

## Notes
- Once `authCookie` is on, custom Relic POSTs that authenticate from the cookie are CSRF-sensitive. v1 expects GET `WidgetRoute`s plus Origin. Form CSRF is only on `/auth/*` login/logout.
- Cookie-less custom login POSTs are login-CSRF-able until the app adds CSRF. Use `configureWebAuthRoutes` rather than a homemade POST login.
- `requireLogin` at `/` breaks `/auth/*` and health probes.
- Relic cookie hydration needs a real `authenticationHandler`.
- `clearWebAuthCookie` only runs if `isWebAuthCookieRequest` commit 1 must make `WebCallSession` qualify.
- Sign out **after** CSRF/HMAC, or GET OAuth callback is logout CSRF.
- Sign out before login, or `SignInWhileAuthenticatedException` fires because Relic hydrated the cookie.
- Do not authenticate page loads from the JWT refresh cookie.
- Login GET and OAuth start must be `no-store`.
- CSRF/OAuth cookies must copy Domain/Path/Secure from `authCookie`.
- Catch Google profile-validation failures (default requires name, fullName, verifiedEmail).
- Apple HTML does not use the Lax OAuth cookie; HMAC’d `state` form field only.
- Sign-out-first cannot run on Apple HTML callback (Lax cookie not sent); leftover SAS row until expiry is accepted for v1.