### PR TITLE
test: Fix start timeout flaky test

### DIFF
--- a/tests/serverpod_test_server/test_integration/test_tools/start_timeout_test/start_timeout_test.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/start_timeout_test/start_timeout_test.dart
@@ -51,7 +51,7 @@ void main() async {
   );
 
   test(
-    'Given that withServerpod can find the database and has a timeout set to 4 seconds '
+    'Given that withServerpod can find the database and has a timeout that covers startup '
     'when running the test '
     'then should pass',
     () async {

--- a/tests/serverpod_test_server/test_integration/test_tools/start_timeout_test/test_that_will_not_timeout.dart
+++ b/tests/serverpod_test_server/test_integration/test_tools/start_timeout_test/test_that_will_not_timeout.dart
@@ -6,7 +6,11 @@ import '../serverpod_test_tools.dart';
 void main() {
   withServerpod(
     'Given that runMode is set to test when calling withServerpod',
-    serverpodStartTimeout: Duration(seconds: 4),
+    // Starting Serverpod creates this group's database and applies the full
+    // schema, which takes seconds - how many depends on the machine. This case
+    // only asserts that a timeout long enough to cover startup does not fire,
+    // so the timeout must stay well clear of any machine-speed bound.
+    serverpodStartTimeout: Duration(seconds: 30),
     runMode: ServerpodRunMode.test,
     (sessionBuilder, endpoints) {
       test('then set up will not timeout and dummy test passes', () async {


### PR DESCRIPTION
Too strict timeout issue.

## Pre-launch Checklist

- [ ] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [ ] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [ ] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [ ] All existing and new tests are passing.
- [ ] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

_If you have done any breaking changes, make sure to outline them here, so that they can be included in the notes for the next release._