### PR TITLE
fix: Keep detecting pub artifact changes after recreation on Windows

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/file_watcher.dart
@@ -51,8 +51,8 @@ bool _isWithinDartTool(String filePath) {
 
 /// Watches one file across initial absence, deletion, and recreation.
 ///
-/// While the file exists, the platform [w.FileWatcher] provides native events.
-/// If it is absent, only that exact path is polled until it appears, avoiding a
+/// While the file exists, a [w.FileWatcher] reports changes to it. If it is
+/// absent, only that exact path is polled until it appears, avoiding a
 /// recursive watch of its potentially large and frequently changing parent.
 class _PersistentFileWatcher implements w.Watcher {
   @override
@@ -102,7 +102,7 @@ class _PersistentFileWatcher implements w.Watcher {
     }
 
     try {
-      final fileWatcher = w.FileWatcher(path);
+      final fileWatcher = w.FileWatcher(path, pollingDelay: pollingDelay);
       late final StreamSubscription<w.WatchEvent> subscription;
       subscription = fileWatcher.events.listen(
         (event) {
@@ -149,10 +149,18 @@ class _PersistentFileWatcher implements w.Watcher {
       _pollTimer?.cancel();
       _pollTimer = null;
 
-      // The underlying watcher cannot report a creation that happened while
-      // the path was absent, so synthesize the change before reattaching it.
-      _eventsController.add(w.WatchEvent(w.ChangeType.MODIFY, path));
+      // Reattach before announcing the reappearance, so the new watcher's
+      // baseline is the file as it is now. Emitting first would leave a window
+      // in which a listener reacts to the event and writes to the file before
+      // the watcher has read its baseline, folding that write into the
+      // baseline instead of reporting it as a change.
       await _watchOrPoll();
+
+      // The underlying watcher cannot report a creation that happened while
+      // the path was absent, so synthesize it here.
+      if (_isListening) {
+        _eventsController.add(w.WatchEvent(w.ChangeType.MODIFY, path));
+      }
     } finally {
       _isCheckingForFile = false;
     }
@@ -230,7 +238,8 @@ class FileWatcher {
   /// [packageConfigPath] and [packageGraphPaths] are the exact pub-artifact
   /// files whose changes map to `packageConfigChanged` / `flutterDependenciesChanged`.
   /// Missing pub artifacts are checked every [missingFilePollingDelay] until
-  /// they appear, then watched natively.
+  /// they appear, then watched directly. The same delay is the polling cadence
+  /// on platforms without native single-file watching.
   FileWatcher({
     required Iterable<String> watchPaths,
     String? packageConfigPath,

--- a/tools/serverpod_cli/test/commands/start/file_watcher_reattach_test.dart
+++ b/tools/serverpod_cli/test/commands/start/file_watcher_reattach_test.dart
@@ -1,0 +1,284 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:async/async.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/commands/start/file_watcher.dart';
+import 'package:test/test.dart';
+import 'package:watcher/watcher.dart' as w;
+
+/// A file watcher that only starts reporting changes after [startupLatency].
+///
+/// `package:watcher` never watches a single file natively on Windows; it falls
+/// back to polling, which recognizes a change only by comparing it against a
+/// baseline read asynchronously once the watcher starts. Substituting this
+/// watcher exercises that shape on every platform, and makes the start-up cost
+/// explicit rather than dependent on how loaded the machine running the test
+/// happens to be.
+class _SlowToStartFileWatcher implements w.FileWatcher {
+  @override
+  final String path;
+
+  final _controller = StreamController<w.WatchEvent>.broadcast();
+  final _readyCompleter = Completer<void>();
+
+  _SlowToStartFileWatcher(
+    this.path, {
+    required Duration startupLatency,
+    Duration? pollingDelay,
+  }) {
+    unawaited(() async {
+      await Future<void>.delayed(startupLatency);
+      final inner = w.PollingFileWatcher(path, pollingDelay: pollingDelay);
+      inner.events.listen(
+        _controller.add,
+        onError: _controller.addError,
+        onDone: _controller.close,
+      );
+      await inner.ready;
+      if (!_readyCompleter.isCompleted) _readyCompleter.complete();
+    }());
+  }
+
+  @override
+  Stream<w.WatchEvent> get events => _controller.stream;
+
+  @override
+  bool get isReady => _readyCompleter.isCompleted;
+
+  @override
+  Future<void> get ready => _readyCompleter.future;
+}
+
+void main() {
+  late Directory tempDir;
+  late File packageGraph;
+  late w.FileWatcher Function(String path, Duration? pollingDelay)
+  createPlatformWatcher;
+
+  // `package:watcher` picks the platform's file watcher for a path. Route that
+  // choice to whatever the running scenario installed. The registration is
+  // global and permanent, so it is made once for the whole file.
+  w.registerCustomWatcher(
+    'scenario-double',
+    null,
+    (path, {pollingDelay}) => createPlatformWatcher(path, pollingDelay),
+  );
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('file_watcher_reattach_');
+    await Directory(p.join(tempDir.path, '.dart_tool')).create();
+
+    packageGraph = File(
+      p.join(tempDir.path, '.dart_tool', 'package_graph.json'),
+    );
+    await packageGraph.writeAsString('{"roots":[],"packages":[]}');
+  });
+
+  tearDown(() async {
+    await tempDir.delete(recursive: true);
+  });
+
+  group(
+    'Given a FileWatcher configured with a 30 ms missing-file polling delay, '
+    'when it starts tracking a pub artifact that already exists,',
+    () {
+      late List<Duration?> requestedPollingDelays;
+      late StreamSubscription<FileChangeEvent> subscription;
+
+      setUp(() async {
+        // The delay is named for a file that is absent, but it governs the
+        // watcher attached to the artifact while it exists too. Without it
+        // that watcher falls back to the watcher package's one second default.
+        requestedPollingDelays = [];
+        createPlatformWatcher = (path, pollingDelay) {
+          requestedPollingDelays.add(pollingDelay);
+          return _SlowToStartFileWatcher(
+            path,
+            startupLatency: Duration.zero,
+            pollingDelay: pollingDelay,
+          );
+        };
+
+        final watcher = FileWatcher(
+          watchPaths: [packageGraph.path],
+          packageGraphPaths: [packageGraph.path],
+          debounceDelay: const Duration(milliseconds: 50),
+          missingFilePollingDelay: const Duration(milliseconds: 30),
+        );
+        subscription = watcher.onFilesChanged.listen((_) {});
+        await watcher.ready;
+      });
+
+      tearDown(() async {
+        await subscription.cancel();
+      });
+
+      test(
+        'then it opens a watcher for the artifact with a 30 ms polling delay.',
+        () {
+          expect(requestedPollingDelays, [const Duration(milliseconds: 30)]);
+        },
+      );
+    },
+  );
+
+  group('Given a FileWatcher tracking an existing pub artifact,', () {
+    late StreamSubscription<FileChangeEvent> subscription;
+    late StreamQueue<FileChangeEvent> events;
+
+    setUp(() async {
+      // The platform watcher takes longer to start than the debounce below,
+      // so an event reaches the test while a watcher announced before it
+      // started would still be blind to further changes.
+      createPlatformWatcher = (path, pollingDelay) => _SlowToStartFileWatcher(
+        path,
+        startupLatency: const Duration(milliseconds: 150),
+        pollingDelay: pollingDelay,
+      );
+
+      final watcher = FileWatcher(
+        watchPaths: [packageGraph.path],
+        packageGraphPaths: [packageGraph.path],
+        debounceDelay: const Duration(milliseconds: 50),
+        missingFilePollingDelay: const Duration(milliseconds: 20),
+      );
+      // Buffer the events, so one emitted before the next read is awaited is
+      // not missed.
+      final received = StreamController<FileChangeEvent>();
+      subscription = watcher.onFilesChanged.listen(received.add);
+      events = StreamQueue(received.stream);
+      await watcher.ready;
+    });
+
+    tearDown(() async {
+      // Cancel immediately: a plain cancel waits for a request still pending
+      // from a failed expectation, which would hang the suite instead of
+      // reporting the failure.
+      await events.cancel(immediate: true);
+      await subscription.cancel();
+    });
+
+    test(
+      'when the artifact is deleted, '
+      'then it emits a Flutter dependency change.',
+      () async {
+        await packageGraph.delete();
+
+        final event = await events.next.timeout(const Duration(seconds: 3));
+        expect(event.flutterDependenciesChanged, isTrue);
+      },
+    );
+  });
+
+  group('Given a FileWatcher tracking a pub artifact that was deleted,', () {
+    late StreamSubscription<FileChangeEvent> subscription;
+    late StreamQueue<FileChangeEvent> events;
+
+    setUp(() async {
+      // The platform watcher takes longer to start than the debounce below,
+      // so an event reaches the test while a watcher announced before it
+      // started would still be blind to further changes.
+      createPlatformWatcher = (path, pollingDelay) => _SlowToStartFileWatcher(
+        path,
+        startupLatency: const Duration(milliseconds: 150),
+        pollingDelay: pollingDelay,
+      );
+
+      final watcher = FileWatcher(
+        watchPaths: [packageGraph.path],
+        packageGraphPaths: [packageGraph.path],
+        debounceDelay: const Duration(milliseconds: 50),
+        missingFilePollingDelay: const Duration(milliseconds: 20),
+      );
+      // Buffer the events, so one emitted before the next read is awaited is
+      // not missed.
+      final received = StreamController<FileChangeEvent>();
+      subscription = watcher.onFilesChanged.listen(received.add);
+      events = StreamQueue(received.stream);
+      await watcher.ready;
+
+      await packageGraph.delete();
+      await events.next.timeout(const Duration(seconds: 3));
+    });
+
+    tearDown(() async {
+      // Cancel immediately: a plain cancel waits for a request still pending
+      // from a failed expectation, which would hang the suite instead of
+      // reporting the failure.
+      await events.cancel(immediate: true);
+      await subscription.cancel();
+    });
+
+    test(
+      'when the artifact is recreated, '
+      'then it emits a Flutter dependency change.',
+      () async {
+        await packageGraph.writeAsString('{"roots":[],"packages":[]}');
+
+        final event = await events.next.timeout(const Duration(seconds: 3));
+        expect(event.flutterDependenciesChanged, isTrue);
+      },
+    );
+  });
+
+  group(
+    'Given a FileWatcher tracking a pub artifact that was deleted and '
+    'recreated,',
+    () {
+      late StreamSubscription<FileChangeEvent> subscription;
+      late StreamQueue<FileChangeEvent> events;
+
+      setUp(() async {
+        // The platform watcher takes longer to start than the debounce below,
+        // so an event reaches the test while a watcher announced before it
+        // started would still be blind to further changes.
+        createPlatformWatcher = (path, pollingDelay) => _SlowToStartFileWatcher(
+          path,
+          startupLatency: const Duration(milliseconds: 150),
+          pollingDelay: pollingDelay,
+        );
+
+        final watcher = FileWatcher(
+          watchPaths: [packageGraph.path],
+          packageGraphPaths: [packageGraph.path],
+          debounceDelay: const Duration(milliseconds: 50),
+          missingFilePollingDelay: const Duration(milliseconds: 20),
+        );
+        // Buffer the events, so one emitted before the next read is awaited is
+        // not missed.
+        final received = StreamController<FileChangeEvent>();
+        subscription = watcher.onFilesChanged.listen(received.add);
+        events = StreamQueue(received.stream);
+        await watcher.ready;
+
+        await packageGraph.delete();
+        await events.next.timeout(const Duration(seconds: 3));
+
+        await packageGraph.writeAsString('{"roots":[],"packages":[]}');
+        await events.next.timeout(const Duration(seconds: 3));
+      });
+
+      tearDown(() async {
+        // Cancel immediately: a plain cancel waits for a request still pending
+        // from a failed expectation, which would hang the suite instead of
+        // reporting the failure.
+        await events.cancel(immediate: true);
+        await subscription.cancel();
+      });
+
+      test(
+        'when the artifact changes again, '
+        'then it emits a Flutter dependency change.',
+        () async {
+          await packageGraph.writeAsString(
+            '{"roots":[],"packages":[{"name":"new_dependency"}]}',
+          );
+
+          final event = await events.next.timeout(const Duration(seconds: 3));
+          expect(event.flutterDependenciesChanged, isTrue);
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
Fixes the flaky `file_watcher_test.dart` failure on Windows CI (`TimeoutException after 0:00:03.000000: Future not completed`), which was a real bug.

### Cause

`package:watcher` never watches a single file natively on Windows because its `FileWatcher` factory always returns a `PollingFileWatcher`, which recognizes a change only by comparing against a baseline it reads asynchronously once started.

`_PersistentFileWatcher` announced a recreated pub artifact *before* reattaching its watcher. A listener therefore learned of the recreation while the new watcher had not read its baseline yet, so a write made in response was folded into that baseline instead of reported, and no further change to `package_graph.json` was ever seen. In `serverpod start`, that means Flutter dependency changes stop being detected after a `pub get` replaces the file.

Compounding it, `w.FileWatcher` was constructed without a `pollingDelay`, so on Windows it polled at the package's 1 s default instead of the configured one.

### Fix

- Reattach the watcher before emitting the synthesized recreation event.
- Forward `missingFilePollingDelay` to the underlying watcher.

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.