### PR TITLE
feat: Auto-upgrade and relaunch `scloud` when invoked from `serverpod cloud`

### DIFF
--- a/tools/serverpod_cli/lib/src/commands/cloud.dart
+++ b/tools/serverpod_cli/lib/src/commands/cloud.dart
@@ -10,6 +10,39 @@ import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/util/dart_install.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
+/// The exit codes `scloud` uses to hand its self-update over to the launcher.
+abstract final class ScloudExitCode {
+  /// `scloud` needs a breaking update that it could not install itself.
+  static const int updateRequired = 69;
+
+  /// `scloud` installed an update and the command must be run again with
+  /// the new version.
+  static const int updatedRerunRequired = 75;
+}
+
+/// The environment variables `scloud` reads from its launcher.
+abstract final class ScloudEnvironment {
+  /// The command name `scloud` shows in its user-facing text.
+  static const String baseCommand = 'SERVERPOD_CLOUD_BASE_COMMAND';
+
+  /// Makes `scloud` exit with [ScloudExitCode.updatedRerunRequired] after
+  /// updating itself, instead of rerunning the command in a nested process.
+  static const String exitOnUpdated = 'SERVERPOD_CLOUD_EXIT_ON_UPDATED';
+}
+
+/// The command name shown to users who invoke `scloud` through this command.
+const scloudBaseCommand = 'serverpod cloud';
+
+/// Starts `scloud` with [args] and [environment], and returns its exit code.
+typedef ScloudStarter =
+    Future<int> Function(
+      List<String> args, {
+      required Map<String, String> environment,
+    });
+
+/// Installs the latest `scloud`, throwing [ExitException] on failure.
+typedef ScloudInstaller = Future<void> Function();
+
 /// Forwards to the Serverpod Cloud CLI (`scloud`).
 class CloudCommand extends ServerpodCommand {
   CloudCommand() : super(options: []);
@@ -43,34 +76,89 @@ class CloudCommand extends ServerpodCommand {
   Future<void> runWithConfig(Configuration commandConfig) async {
     final scloudArgs = argResults?.rest ?? [];
 
-    final process = await _startScloudProcess(
+    final exitCode = await runScloud(
       scloudArgs,
-      installIfMissing: true,
+      start: _startScloud,
+      install: _installScloud,
     );
 
-    final sigSubscription =
-        StreamGroup.merge(
-          [
-            ProcessSignal.sigint,
-            if (!Platform.isWindows) ProcessSignal.sigterm,
-          ].map((signal) => signal.watch()),
-        ).listen((signal) {
-          process.kill(signal);
-        });
-
-    try {
-      final exitCode = await process.exitCode;
-      if (exitCode != 0) {
-        throw ExitException(exitCode);
-      }
-    } finally {
-      await sigSubscription.cancel();
+    if (exitCode != 0) {
+      throw ExitException(exitCode);
     }
+  }
+}
+
+/// Runs `scloud` with [args] and returns the exit code of its last launch.
+///
+/// The first launch asks `scloud` to exit instead of rerunning itself after
+/// a self-update, so that only one process inherits the terminal at a time.
+/// Exit code [ScloudExitCode.updatedRerunRequired] relaunches the command
+/// once. Exit code [ScloudExitCode.updateRequired] installs the latest
+/// `scloud` with [install] first, then relaunches once.
+Future<int> runScloud(
+  List<String> args, {
+  required ScloudStarter start,
+  required ScloudInstaller install,
+}) async {
+  final exitCode = await start(
+    args,
+    environment: {
+      ScloudEnvironment.baseCommand: scloudBaseCommand,
+      ScloudEnvironment.exitOnUpdated: 'true',
+    },
+  );
+
+  switch (exitCode) {
+    case ScloudExitCode.updatedRerunRequired:
+      log.debug(
+        'Serverpod Cloud CLI updated itself, running the command again.',
+      );
+    case ScloudExitCode.updateRequired:
+      log.debug(
+        'Serverpod Cloud CLI requires an update it could not install itself, '
+        'installing it.',
+      );
+      await install();
+    default:
+      return exitCode;
+  }
+
+  return start(
+    args,
+    environment: {ScloudEnvironment.baseCommand: scloudBaseCommand},
+  );
+}
+
+Future<int> _startScloud(
+  List<String> args, {
+  required Map<String, String> environment,
+}) async {
+  final process = await _startScloudProcess(
+    args,
+    environment: environment,
+    installIfMissing: true,
+  );
+
+  final sigSubscription =
+      StreamGroup.merge(
+        [
+          ProcessSignal.sigint,
+          if (!Platform.isWindows) ProcessSignal.sigterm,
+        ].map((signal) => signal.watch()),
+      ).listen((signal) {
+        process.kill(signal);
+      });
+
+  try {
+    return await process.exitCode;
+  } finally {
+    await sigSubscription.cancel();
   }
 }
 
 Future<Process> _startScloudProcess(
   List<String> args, {
+  required Map<String, String> environment,
   required bool installIfMissing,
 }) async {
   final scloudExecutable = getScloudExecutablePath();
@@ -78,7 +166,11 @@ Future<Process> _startScloudProcess(
   if (!File(scloudExecutable).existsSync()) {
     if (installIfMissing) {
       await _installScloud();
-      return _startScloudProcess(args, installIfMissing: false);
+      return _startScloudProcess(
+        args,
+        environment: environment,
+        installIfMissing: false,
+      );
     }
 
     log.error(
@@ -93,6 +185,7 @@ Future<Process> _startScloudProcess(
       scloudExecutable,
       args,
       workingDirectory: Directory.current.path,
+      environment: environment,
       mode: ProcessStartMode.inheritStdio,
     );
   } on ProcessException catch (exception) {

--- a/tools/serverpod_cli/test/commands/cloud_command_test.dart
+++ b/tools/serverpod_cli/test/commands/cloud_command_test.dart
@@ -1,6 +1,33 @@
+import 'package:cli_tools/cli_tools.dart';
 import 'package:serverpod_cli/src/commands/cloud.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:test/test.dart';
+
+typedef _Launch = ({List<String> args, Map<String, String> environment});
+
+/// Records each launch and exits with the next code from [exitCodes].
+class _FakeScloud {
+  final List<int> exitCodes;
+  final List<_Launch> launches = [];
+  int installs = 0;
+  ExitException? installError;
+
+  _FakeScloud(this.exitCodes);
+
+  Future<int> start(
+    final List<String> args, {
+    required final Map<String, String> environment,
+  }) async {
+    launches.add((args: args, environment: environment));
+    return exitCodes[launches.length - 1];
+  }
+
+  Future<void> install() async {
+    installs++;
+    final error = installError;
+    if (error != null) throw error;
+  }
+}
 
 void main() {
   group('Given a CloudCommand', () {
@@ -41,4 +68,278 @@ void main() {
       });
     });
   });
+
+  group('Given scloud that exits successfully when run', () {
+    late _FakeScloud scloud;
+    late int exitCode;
+
+    setUp(() async {
+      scloud = _FakeScloud([0]);
+      exitCode = await runScloud(
+        ['deploy', '--project', 'my-project'],
+        start: scloud.start,
+        install: scloud.install,
+      );
+    });
+
+    test('then the exit code is returned', () {
+      expect(exitCode, 0);
+    });
+
+    test('then scloud is launched once', () {
+      expect(scloud.launches, hasLength(1));
+    });
+
+    test('then the args are forwarded unchanged', () {
+      expect(scloud.launches.single.args, [
+        'deploy',
+        '--project',
+        'my-project',
+      ]);
+    });
+
+    test('then the base command is set to serverpod cloud', () {
+      expect(
+        scloud.launches.single.environment[ScloudEnvironment.baseCommand],
+        'serverpod cloud',
+      );
+    });
+
+    test('then scloud is asked to exit on updated', () {
+      expect(
+        scloud.launches.single.environment[ScloudEnvironment.exitOnUpdated],
+        'true',
+      );
+    });
+
+    test('then scloud is not installed', () {
+      expect(scloud.installs, 0);
+    });
+  });
+
+  group('Given scloud that exits with an unrelated error when run', () {
+    late _FakeScloud scloud;
+    late int exitCode;
+
+    setUp(() async {
+      scloud = _FakeScloud([1]);
+      exitCode = await runScloud(
+        ['deploy'],
+        start: scloud.start,
+        install: scloud.install,
+      );
+    });
+
+    test('then the exit code is returned', () {
+      expect(exitCode, 1);
+    });
+
+    test('then scloud is not relaunched', () {
+      expect(scloud.launches, hasLength(1));
+    });
+
+    test('then scloud is not installed', () {
+      expect(scloud.installs, 0);
+    });
+  });
+
+  group(
+    'Given scloud that updated itself and succeeds on relaunch when run',
+    () {
+      late _FakeScloud scloud;
+      late int exitCode;
+
+      setUp(() async {
+        scloud = _FakeScloud([ScloudExitCode.updatedRerunRequired, 0]);
+        exitCode = await runScloud(
+          ['deploy', '--project', 'my-project'],
+          start: scloud.start,
+          install: scloud.install,
+        );
+      });
+
+      test('then the relaunch exit code is returned', () {
+        expect(exitCode, 0);
+      });
+
+      test('then scloud is relaunched once', () {
+        expect(scloud.launches, hasLength(2));
+      });
+
+      test('then scloud is not installed', () {
+        expect(scloud.installs, 0);
+      });
+
+      test('then the relaunch forwards the same args', () {
+        expect(scloud.launches[1].args, ['deploy', '--project', 'my-project']);
+      });
+
+      test('then the relaunch keeps the base command', () {
+        expect(
+          scloud.launches[1].environment[ScloudEnvironment.baseCommand],
+          'serverpod cloud',
+        );
+      });
+
+      test('then the relaunch is not asked to exit on updated', () {
+        expect(
+          scloud.launches[1].environment,
+          isNot(contains(ScloudEnvironment.exitOnUpdated)),
+        );
+      });
+    },
+  );
+
+  group('Given scloud that updated itself and fails on relaunch when run', () {
+    late _FakeScloud scloud;
+    late int exitCode;
+
+    setUp(() async {
+      scloud = _FakeScloud([ScloudExitCode.updatedRerunRequired, 1]);
+      exitCode = await runScloud(
+        ['deploy'],
+        start: scloud.start,
+        install: scloud.install,
+      );
+    });
+
+    test('then the relaunch exit code is returned', () {
+      expect(exitCode, 1);
+    });
+
+    test('then scloud is relaunched once', () {
+      expect(scloud.launches, hasLength(2));
+    });
+  });
+
+  group('Given scloud that updated itself and updates again on relaunch '
+      'when run', () {
+    late _FakeScloud scloud;
+    late int exitCode;
+
+    setUp(() async {
+      scloud = _FakeScloud([
+        ScloudExitCode.updatedRerunRequired,
+        ScloudExitCode.updatedRerunRequired,
+      ]);
+      exitCode = await runScloud(
+        ['deploy'],
+        start: scloud.start,
+        install: scloud.install,
+      );
+    });
+
+    test('then the relaunch exit code is returned', () {
+      expect(exitCode, ScloudExitCode.updatedRerunRequired);
+    });
+
+    test('then scloud is not relaunched again', () {
+      expect(scloud.launches, hasLength(2));
+    });
+  });
+
+  group('Given scloud that could not update itself and a successful install '
+      'when run', () {
+    late _FakeScloud scloud;
+    late int exitCode;
+
+    setUp(() async {
+      scloud = _FakeScloud([ScloudExitCode.updateRequired, 0]);
+      exitCode = await runScloud(
+        ['deploy', '--project', 'my-project'],
+        start: scloud.start,
+        install: scloud.install,
+      );
+    });
+
+    test('then the relaunch exit code is returned', () {
+      expect(exitCode, 0);
+    });
+
+    test('then scloud is installed once', () {
+      expect(scloud.installs, 1);
+    });
+
+    test('then scloud is relaunched once', () {
+      expect(scloud.launches, hasLength(2));
+    });
+
+    test('then the relaunch forwards the same args', () {
+      expect(scloud.launches[1].args, ['deploy', '--project', 'my-project']);
+    });
+
+    test('then the relaunch keeps the base command', () {
+      expect(
+        scloud.launches[1].environment[ScloudEnvironment.baseCommand],
+        'serverpod cloud',
+      );
+    });
+
+    test('then the relaunch is not asked to exit on updated', () {
+      expect(
+        scloud.launches[1].environment,
+        isNot(contains(ScloudEnvironment.exitOnUpdated)),
+      );
+    });
+  });
+
+  group('Given scloud that could not update itself and a failing install', () {
+    late _FakeScloud scloud;
+
+    setUp(() {
+      scloud = _FakeScloud([ScloudExitCode.updateRequired, 0]);
+      scloud.installError = ExitException(126);
+    });
+
+    test('when run then the install error is thrown', () async {
+      await expectLater(
+        runScloud(['deploy'], start: scloud.start, install: scloud.install),
+        throwsA(
+          isA<ExitException>().having((e) => e.exitCode, 'exitCode', 126),
+        ),
+      );
+    });
+
+    test('when run then scloud is not relaunched', () async {
+      await runScloud(
+        ['deploy'],
+        start: scloud.start,
+        install: scloud.install,
+      ).catchError((_) => 0);
+
+      expect(scloud.launches, hasLength(1));
+    });
+  });
+
+  group(
+    'Given scloud that still needs an update after the install when run',
+    () {
+      late _FakeScloud scloud;
+      late int exitCode;
+
+      setUp(() async {
+        scloud = _FakeScloud([
+          ScloudExitCode.updateRequired,
+          ScloudExitCode.updateRequired,
+        ]);
+        exitCode = await runScloud(
+          ['deploy'],
+          start: scloud.start,
+          install: scloud.install,
+        );
+      });
+
+      test('then the relaunch exit code is returned', () {
+        expect(exitCode, ScloudExitCode.updateRequired);
+      });
+
+      test('then scloud is installed once', () {
+        expect(scloud.installs, 1);
+      });
+
+      test('then scloud is not relaunched again', () {
+        expect(scloud.launches, hasLength(2));
+      });
+    },
+  );
 }


### PR DESCRIPTION
Since `scloud` 0.38.0, the Cloud CLI installs required updates itself and reruns the command with inherited stdio. Under `serverpod cloud` that nested two inherit-stdio processes.

`serverpod cloud` now:
- Launches `scloud` with `SERVERPOD_CLOUD_EXIT_ON_UPDATED`, so it exits with 75 after updating itself. The wrapper then relaunches the command once.
- On exit 69 (update required but `scloud` could not install it), the wrapper installs the latest `scloud` and relaunches once.
- The relaunch drops `SERVERPOD_CLOUD_EXIT_ON_UPDATED`, so `scloud` never runs more than twice. Other exit codes propagate unchanged.
- Sets `SERVERPOD_CLOUD_BASE_COMMAND=serverpod cloud` so `scloud` reports the command the user actually typed.

The launch policy is extracted into `runScloud` with an injected starter and installer, and unit-tested for every exit-code path.

Fixes #5649

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
None