### PR TITLE
chore: Support `flutter_secure_storage` 11.x in `serverpod_auth_core_flutter`

### DIFF
--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/lib/src/storage/secure_client_auth_success_storage.dart
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/lib/src/storage/secure_client_auth_success_storage.dart
@@ -31,10 +31,6 @@ class FlutterSecureKeyValueStorage implements KeyValueStorage {
 
   static FlutterSecureStorage _defaultSecureStorage() =>
       const FlutterSecureStorage(
-        aOptions: AndroidOptions(
-          // ignore: deprecated_member_use
-          encryptedSharedPreferences: true,
-        ),
         iOptions: IOSOptions(
           accessibility: KeychainAccessibility.first_unlock,
         ),

--- a/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/pubspec.yaml
+++ b/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   clock: ^1.1.1
   flutter:
     sdk: flutter
-  flutter_secure_storage: '>=9.2.4 <11.0.0'
+  flutter_secure_storage: '>=10.0.0 <12.0.0'
   meta: ^1.15.0
   serverpod_auth_core_client: 4.0.0-rc.1
 

--- a/packages/serverpod/skills/serverpod-upgrading/SKILL.md
+++ b/packages/serverpod/skills/serverpod-upgrading/SKILL.md
@@ -35,7 +35,7 @@ After following the regular upgrade process, address the following breaking chan
 
 **Web server:** The deprecated widget classes and legacy static directory classes are removed. Use `WebWidget`, `TemplateWidget`, `ListWidget`, `JsonWidget`, `RedirectWidget` and `StaticRoute.directory(...)`. `WidgetRoute.build` now returns `Future<WebWidget?>`, where `null` responds with 404.
 
-**Auth:** The `authenticationKeyManager` client parameter is removed; use `authSessionManager` (Flutter) or `authKeyProvider`. The native Google Sign-In web implementation is replaced by OAuth2, and dead email exceptions are removed.
+**Auth:** The `authenticationKeyManager` client parameter is removed; use `authSessionManager` (Flutter) or `authKeyProvider`. The native Google Sign-In web implementation is replaced by OAuth2, and dead email exceptions are removed. `flutter_secure_storage` must be 10.0.0 or newer. On Android, upgrading from 9.x directly to 11.x signs users out; go through 10.x first. 11.x also needs `compileSdk` 37.
 
 **Server:** `SerializationManagerServer` is replaced by `DatabaseSerializationManager`. Generated projects now import `src/generated/serverpod.dart` and create the server with `Serverpod(args)`; the `Serverpod(args, Protocol(), Endpoints())` form still works, but prefer the new simpler form.
 

--- a/templates/pubspecs/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/pubspec.yaml
+++ b/templates/pubspecs/modules/serverpod_auth/serverpod_auth_core/serverpod_auth_core_flutter/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   clock: ^1.1.1
   flutter:
     sdk: flutter
-  flutter_secure_storage: '>=9.2.4 <11.0.0'
+  flutter_secure_storage: '>=10.0.0 <12.0.0'
   meta: ^1.15.0
   serverpod_auth_core_client: SERVERPOD_VERSION
 

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -811,6 +811,8 @@ Future<List<String>> _copyFlutterUpgrade(
           ),
           type: DependencyType.normal,
         ),
+        // 11.x requires compileSdk 37, above Flutter's current default, so new
+        // projects stay on 10.x until Flutter's default catches up.
         (
           name: 'flutter_secure_storage',
           source: DependencySource.version(


### PR DESCRIPTION
`flutter_secure_storage` 11.0.0 removed the deprecated `encryptedSharedPreferences` option from `AndroidOptions`, which `SecureClientAuthSuccessStorage` still passed. This PR drops the option and widens the constraint to `>=10.0.0 <12.0.0`.

The floor moves to 10.0.0 because on 9.x the option selects the Android storage backend, so removing it would sign out existing users. On 10.x the migration runs by default and the option is a no-op.

The `^10.0.0` override that `serverpod create` writes into new projects stays, since 11.x requires `compileSdk` 37 and Flutter stable still defaults to 36. A comment explains this, and the `serverpod-upgrading` skill got a short note.

The workspace still resolves 10.3.1 because `facebook_auth_desktop` pins `^10.3.1`. Verified 11.0.0 locally with a temporary override; `flutter analyze` and `flutter test` pass on both versions.

Docs PR: serverpod/serverpod_docs#780

Closes #5620

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [ ] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes
Raises the minimum `flutter_secure_storage` version to 10.0.0 and allows 11.x. On Android, upgrading directly from 9.x to 11.x signs users out because 11.0.0 dropped the pre-10 migration. Upgrade to 10.x first if that matters to you. Version 11 also requires `compileSdk` 37.