### PR TITLE
feat: Implements CTRL+Click to go to model definitions

### DIFF
--- a/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
@@ -80,6 +80,58 @@ class StatefulAnalyzer {
     return _modelStates.containsKey(_modelStateKey(uri));
   }
 
+  /// Returns the [ModelSource] for the registered model with [uri].
+  ModelSource? getModelSource(Uri uri) {
+    return _modelStates[_modelStateKey(uri)]?.source;
+  }
+
+  /// Returns the [SerializableModelDefinition] for the registered model with [uri].
+  SerializableModelDefinition? getModel(Uri uri) {
+    return _modelStates[_modelStateKey(uri)]?.model;
+  }
+
+  /// Returns the [ModelSource] for the given [model].
+  ModelSource? getModelSourceForModel(SerializableModelDefinition model) {
+    for (var state in _modelStates.values) {
+      if (state.model == model) return state.source;
+      if (state.model?.className == model.className &&
+          state.model?.type.moduleAlias == model.type.moduleAlias) {
+        return state.source;
+      }
+    }
+    return null;
+  }
+
+  /// Finds a registered model by [className], optionally qualified with [moduleAlias].
+  SerializableModelDefinition? findModelByName(
+    String className, {
+    String? moduleAlias,
+  }) {
+    if (moduleAlias != null && moduleAlias.isNotEmpty) {
+      return models
+          .where((m) =>
+              m.className == className && m.type.moduleAlias == moduleAlias)
+          .firstOrNull;
+    }
+
+    var projectModel = models
+        .where((m) =>
+            m.className == className &&
+            m.type.moduleAlias == defaultModuleAlias)
+        .firstOrNull;
+    if (projectModel != null) return projectModel;
+
+    return models.where((m) => m.className == className).firstOrNull;
+  }
+
+  /// Finds a registered model by its database [tableName].
+  SerializableModelDefinition? findModelByTableName(String tableName) {
+    return models
+        .whereType<ModelClassDefinition>()
+        .where((m) => m.tableName == tableName)
+        .firstOrNull;
+  }
+
   /// Removes a model from the state but leaves the responsibility of validating
   /// the new state to the caller. Please note that [validateAll] should be called to
   /// guarantee that all related errors are cleared.

--- a/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
@@ -97,11 +97,7 @@ class StatefulAnalyzer {
   /// Returns the [ModelSource] for the given [model].
   ModelSource? getModelSourceForModel(SerializableModelDefinition model) {
     for (var state in _modelStates.values) {
-      if (state.model == model) return state.source;
-      if (state.model?.className == model.className &&
-          state.model?.type.moduleAlias == model.type.moduleAlias) {
-        return state.source;
-      }
+      if (identical(state.model, model)) return state.source;
     }
     return null;
   }

--- a/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
+++ b/tools/serverpod_cli/lib/src/analyzer/models/stateful_analyzer.dart
@@ -64,6 +64,10 @@ class StatefulAnalyzer {
       .map((state) => state.source.yamlSourceUri)
       .toList(growable: false);
 
+  /// The sources of all models currently registered in the state.
+  List<ModelSource> get registeredModelSources =>
+      _modelStates.values.map((state) => state.source).toList(growable: false);
+
   /// Adds a new model to the state but leaves the responsibility of validating
   /// it to the caller. Please note that [validateAll] should be called to
   /// guarantee that all errors are found.
@@ -109,15 +113,19 @@ class StatefulAnalyzer {
   }) {
     if (moduleAlias != null && moduleAlias.isNotEmpty) {
       return models
-          .where((m) =>
-              m.className == className && m.type.moduleAlias == moduleAlias)
+          .where(
+            (m) =>
+                m.className == className && m.type.moduleAlias == moduleAlias,
+          )
           .firstOrNull;
     }
 
     var projectModel = models
-        .where((m) =>
-            m.className == className &&
-            m.type.moduleAlias == defaultModuleAlias)
+        .where(
+          (m) =>
+              m.className == className &&
+              m.type.moduleAlias == defaultModuleAlias,
+        )
         .firstOrNull;
     if (projectModel != null) return projectModel;
 

--- a/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
@@ -23,6 +23,12 @@ class DefinitionProvider {
     var wordMatch = extractWordAt(line, position.character);
     if (wordMatch == null) return null;
 
+    // Quoted values and comments are plain text and never reference a model
+    // or a field of one.
+    if (lineContextAt(line, wordMatch.startColumn) != LineContext.code) {
+      return null;
+    }
+
     var token = wordMatch.word;
 
     var originSelectionRange = Range(

--- a/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
@@ -143,13 +143,19 @@ class DefinitionProvider {
   /// optionally qualified with [moduleAlias].
   ///
   /// Backs the `serverpod/modelDefinition` custom request, which lets the
-  /// editor navigate from generated Dart code back to the model file.
+  /// editor navigate from generated Dart code back to the model file. The
+  /// editor derives [moduleAlias] from the import prefix of the Dart
+  /// reference, which is picked at the import site and need not match the
+  /// alias of the module, so an alias that names no model falls back to the
+  /// unqualified lookup.
   static Location? resolveModelByName({
     required StatefulAnalyzer analyzer,
     required String className,
     String? moduleAlias,
   }) {
-    var model = analyzer.findModelByName(className, moduleAlias: moduleAlias);
+    var model =
+        analyzer.findModelByName(className, moduleAlias: moduleAlias) ??
+        (moduleAlias == null ? null : analyzer.findModelByName(className));
     if (model == null) return null;
 
     var source = analyzer.getModelSourceForModel(model);

--- a/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
@@ -1,0 +1,337 @@
+import 'package:lsp_server/lsp_server.dart';
+import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+
+/// Provides Go to Definition (CTRL+Click) resolution for Serverpod model files.
+class DefinitionProvider {
+  static const Set<String> _primitiveTypes = {
+    'int',
+    'double',
+    'String',
+    'bool',
+    'DateTime',
+    'ByteData',
+    'Duration',
+    'UuidValue',
+    'BigInt',
+    'num',
+    'dynamic',
+    'void',
+    'List',
+    'Map',
+    'Set',
+  };
+
+  static const Set<String> _ignoredKeywords = {
+    'class',
+    'enum',
+    'exception',
+    'table',
+    'fields',
+    'indexes',
+    'relation',
+    'name',
+    'onDelete',
+    'onUpdate',
+    'unique',
+    'true',
+    'false',
+    'null',
+    'serverOnly',
+    'database',
+    'all',
+    'client',
+    'server',
+    'none',
+    'optional',
+    'order',
+    'persist',
+    'default',
+    'defaultModel',
+    'defaultPersist',
+    'cascade',
+    'noAction',
+    'restrict',
+    'setNull',
+    'setDefault',
+  };
+
+  /// Resolves the definition location for a symbol at [position] in the document at [documentUri].
+  static Either3<Location, List<Location>, List<LocationLink>>? resolveDefinition({
+    required StatefulAnalyzer analyzer,
+    required Uri documentUri,
+    required Position position,
+    required bool linkSupport,
+  }) {
+    var source = analyzer.getModelSource(documentUri);
+    if (source == null) return null;
+
+    var lines = source.yaml.split('\n');
+    if (position.line < 0 || position.line >= lines.length) return null;
+
+    var line = lines[position.line];
+    var wordMatch = _extractWordAt(line, position.character);
+    if (wordMatch == null) return null;
+
+    var token = wordMatch.word;
+
+    // Skip primitive types and common keywords
+    if (_primitiveTypes.contains(token) || _ignoredKeywords.contains(token)) {
+      return null;
+    }
+
+    var originSelectionRange = Range(
+      start: Position(line: position.line, character: wordMatch.startColumn),
+      end: Position(line: position.line, character: wordMatch.endColumn),
+    );
+
+    // 1. Check if token is a reference to a field in the current model
+    // e.g. relation(field=authorId) or fields: authorId in index
+    var currentModel = analyzer.getModel(documentUri);
+    if (currentModel is ClassDefinition && _isFieldReferenceContext(line, wordMatch)) {
+      var field = currentModel.findField(token);
+      if (field != null) {
+        var fieldLocation = _findFieldDefinitionRange(lines, token);
+        if (fieldLocation != null) {
+          return _buildResult(
+            targetUri: documentUri,
+            targetSelectionRange: fieldLocation,
+            targetRange: Range(
+              start: Position(line: fieldLocation.start.line, character: 0),
+              end: Position(
+                line: fieldLocation.start.line,
+                character: lines[fieldLocation.start.line].length,
+              ),
+            ),
+            originSelectionRange: originSelectionRange,
+            linkSupport: linkSupport,
+          );
+        }
+      }
+    }
+
+    // 2. Parse potential model / class target from token
+    String? moduleAlias;
+    String className = token;
+
+    if (token.startsWith('module:')) {
+      var parts = token.split(':');
+      if (parts.length >= 3) {
+        moduleAlias = parts[1];
+        className = parts.sublist(2).join(':');
+      }
+    } else if (token.startsWith('project:')) {
+      var parts = token.split(':');
+      if (parts.length >= 3) {
+        moduleAlias = parts[1];
+        className = parts.sublist(2).join(':');
+      }
+    } else if (token.contains(':')) {
+      var parts = token.split(':');
+      if (parts.length == 2) {
+        moduleAlias = parts[0];
+        className = parts[1];
+      }
+    }
+
+    // 3. Search model by className and moduleAlias
+    var targetModel = analyzer.findModelByName(className, moduleAlias: moduleAlias);
+
+    // 4. If not found by class name, try searching by database table name
+    // e.g. parentTable=citizen
+    targetModel ??= analyzer.findModelByTableName(token);
+
+    if (targetModel == null) return null;
+
+    var targetSource = analyzer.getModelSourceForModel(targetModel);
+    if (targetSource == null) return null;
+
+    var targetLines = targetSource.yaml.split('\n');
+    var targetSelectionRange = _findModelDefinitionRange(
+      targetLines,
+      targetModel.className,
+    );
+
+    var targetRange = Range(
+      start: Position(line: targetSelectionRange.start.line, character: 0),
+      end: Position(
+        line: targetSelectionRange.start.line,
+        character: targetLines[targetSelectionRange.start.line].length,
+      ),
+    );
+
+    return _buildResult(
+      targetUri: targetSource.yamlSourceUri,
+      targetSelectionRange: targetSelectionRange,
+      targetRange: targetRange,
+      originSelectionRange: originSelectionRange,
+      linkSupport: linkSupport,
+    );
+  }
+
+  static Either3<Location, List<Location>, List<LocationLink>> _buildResult({
+    required Uri targetUri,
+    required Range targetSelectionRange,
+    required Range targetRange,
+    required Range originSelectionRange,
+    required bool linkSupport,
+  }) {
+    if (linkSupport) {
+      return Either3.t3([
+        LocationLink(
+          originSelectionRange: originSelectionRange,
+          targetUri: targetUri,
+          targetRange: targetRange,
+          targetSelectionRange: targetSelectionRange,
+        ),
+      ]);
+    }
+
+    return Either3.t1(
+      Location(
+        uri: targetUri,
+        range: targetSelectionRange,
+      ),
+    );
+  }
+
+  /// Extracts the word / identifier at the given column position in [line].
+  static _WordMatch? _extractWordAt(String line, int column) {
+    if (line.isEmpty || column < 0) return null;
+
+    // Adjust column if at end of line or right after a word character
+    int col = column;
+    if (col >= line.length) {
+      if (col > 0 && _isWordChar(line, col - 1)) {
+        col = col - 1;
+      } else {
+        return null;
+      }
+    }
+
+    if (!_isWordChar(line, col)) {
+      if (col > 0 && _isWordChar(line, col - 1)) {
+        col = col - 1;
+      } else {
+        return null;
+      }
+    }
+
+    int start = col;
+    while (start > 0 && _isWordChar(line, start - 1)) {
+      start--;
+    }
+
+    int end = col;
+    while (end < line.length && _isWordChar(line, end)) {
+      end++;
+    }
+
+    var word = line.substring(start, end);
+    if (word.isEmpty) return null;
+
+    return _WordMatch(
+      word: word,
+      startColumn: start,
+      endColumn: end,
+    );
+  }
+
+  static bool _isWordChar(String line, int index) {
+    var char = line[index];
+    var code = char.codeUnitAt(0);
+
+    // A-Z, a-z, 0-9, _
+    if ((code >= 65 && code <= 90) ||
+        (code >= 97 && code <= 122) ||
+        (code >= 48 && code <= 57) ||
+        code == 95) {
+      return true;
+    }
+
+    // Allow ':' only if it connects identifier parts (like module:auth:User)
+    if (char == ':') {
+      var hasPrev = index > 0 && _isIdentifierChar(line[index - 1]);
+      var hasNext = index + 1 < line.length && _isIdentifierChar(line[index + 1]);
+      return hasPrev && hasNext;
+    }
+
+    return false;
+  }
+
+  static bool _isIdentifierChar(String char) {
+    var code = char.codeUnitAt(0);
+    return (code >= 65 && code <= 90) ||
+        (code >= 97 && code <= 122) ||
+        (code >= 48 && code <= 57) ||
+        code == 95;
+  }
+
+  static bool _isFieldReferenceContext(String line, _WordMatch wordMatch) {
+    var beforeWord = line.substring(0, wordMatch.startColumn);
+    if (beforeWord.contains('field=') ||
+        beforeWord.contains('field:') ||
+        beforeWord.contains('fields:')) {
+      return true;
+    }
+    return false;
+  }
+
+  static Range? _findFieldDefinitionRange(List<String> lines, String fieldName) {
+    var fieldRegex = RegExp(r'^\s*' + RegExp.escape(fieldName) + r'\s*:');
+    for (var i = 0; i < lines.length; i++) {
+      var l = lines[i];
+      if (fieldRegex.hasMatch(l)) {
+        var col = l.indexOf(fieldName);
+        return Range(
+          start: Position(line: i, character: col >= 0 ? col : 0),
+          end: Position(
+            line: i,
+            character: col >= 0 ? col + fieldName.length : l.length,
+          ),
+        );
+      }
+    }
+    return null;
+  }
+
+  static Range _findModelDefinitionRange(
+    List<String> targetLines,
+    String targetClassName,
+  ) {
+    var defRegex = RegExp(
+      r'^(class|enum|exception)\s*:\s*' +
+          RegExp.escape(targetClassName) +
+          r'\b',
+    );
+    for (var i = 0; i < targetLines.length; i++) {
+      var l = targetLines[i];
+      if (defRegex.hasMatch(l)) {
+        var col = l.indexOf(targetClassName);
+        return Range(
+          start: Position(line: i, character: col >= 0 ? col : 0),
+          end: Position(
+            line: i,
+            character: col >= 0 ? col + targetClassName.length : l.length,
+          ),
+        );
+      }
+    }
+    return Range(
+      start: Position(line: 0, character: 0),
+      end: Position(line: 0, character: 0),
+    );
+  }
+}
+
+class _WordMatch {
+  final String word;
+  final int startColumn;
+  final int endColumn;
+
+  _WordMatch({
+    required this.word,
+    required this.startColumn,
+    required this.endColumn,
+  });
+}

--- a/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
@@ -1,63 +1,78 @@
 import 'package:lsp_server/lsp_server.dart';
-import 'package:serverpod_cli/analyzer.dart';
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/analyzer/models/validation/keywords.dart';
+import 'package:serverpod_database/serverpod_database.dart';
+import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Provides Go to Definition (CTRL+Click) resolution for Serverpod model files.
 class DefinitionProvider {
-  static const Set<String> _primitiveTypes = {
-    'int',
-    'double',
-    'String',
-    'bool',
-    'DateTime',
-    'ByteData',
-    'Duration',
-    'UuidValue',
-    'BigInt',
-    'num',
+  static final Set<String> _primitiveTypes = {
+    ...autoSerializedTypes,
+    ...extensionSerializedTypes,
     'dynamic',
     'void',
-    'List',
-    'Map',
-    'Set',
+    'num',
   };
 
-  static const Set<String> _ignoredKeywords = {
-    'class',
-    'enum',
-    'exception',
-    'table',
-    'fields',
-    'indexes',
-    'relation',
-    'name',
-    'onDelete',
-    'onUpdate',
-    'unique',
-    'true',
-    'false',
+  static final Set<String> _ignoredKeywords = {
+    /// All valid YAML keywords defined for model files.
+    Keyword.classType,
+    Keyword.exceptionType,
+    Keyword.enumType,
+    Keyword.serializationDataType,
+    Keyword.serialized,
+    Keyword.isSealed,
+    Keyword.isImmutable,
+    Keyword.extendsClass,
+    Keyword.serverOnly,
+    Keyword.table,
+    Keyword.managedMigration,
+    Keyword.fields,
+    Keyword.indexes,
+    Keyword.properties,
+    Keyword.values,
+    Keyword.type,
+    Keyword.unique,
+    Keyword.nullsDistinct,
+    Keyword.per,
+    Keyword.operatorClass,
+    Keyword.distanceFunction,
+    Keyword.parameters,
+    Keyword.parent,
+    Keyword.relation,
+    Keyword.field,
+    Keyword.onUpdate,
+    Keyword.onDelete,
+    Keyword.deferrable,
+    Keyword.deferred,
+    Keyword.name,
+    Keyword.api,
+    Keyword.database,
+    Keyword.optional,
+    Keyword.fk,
+    Keyword.scope,
+    Keyword.persist,
+    Keyword.requiredKey,
+    Keyword.tail,
+    Keyword.defaultKey,
+    Keyword.defaultModelKey,
+    Keyword.defaultPersistKey,
+    Keyword.columnKey,
+    Keyword.jsonKey,
+    ...ForeignKeyAction.values.expand(
+      (e) => [e.name, '${e.name[0].toUpperCase()}${e.name.substring(1)}'],
+    ),
+    ...ModelDatabaseDefinition.values.map((e) => e.name),
+    ...ModelFieldScopeDefinition.values.map((e) => e.name),
+    defaultBooleanTrue,
+    defaultBooleanFalse,
     'null',
-    'serverOnly',
-    'database',
-    'all',
-    'client',
-    'server',
-    'none',
-    'optional',
-    'order',
-    'persist',
-    'default',
-    'defaultModel',
-    'defaultPersist',
-    'cascade',
-    'noAction',
-    'restrict',
-    'setNull',
-    'setDefault',
   };
 
   /// Resolves the definition location for a symbol at [position] in the document at [documentUri].
-  static Either3<Location, List<Location>, List<LocationLink>>? resolveDefinition({
+  static Either3<Location, List<Location>, List<LocationLink>>?
+  resolveDefinition({
     required StatefulAnalyzer analyzer,
     required Uri documentUri,
     required Position position,
@@ -88,7 +103,8 @@ class DefinitionProvider {
     // 1. Check if token is a reference to a field in the current model
     // e.g. relation(field=authorId) or fields: authorId in index
     var currentModel = analyzer.getModel(documentUri);
-    if (currentModel is ClassDefinition && _isFieldReferenceContext(line, wordMatch)) {
+    if (currentModel is ClassDefinition &&
+        _isFieldReferenceContext(line, wordMatch)) {
       var field = currentModel.findField(token);
       if (field != null) {
         var fieldLocation = _findFieldDefinitionRange(lines, token);
@@ -135,7 +151,10 @@ class DefinitionProvider {
     }
 
     // 3. Search model by className and moduleAlias
-    var targetModel = analyzer.findModelByName(className, moduleAlias: moduleAlias);
+    var targetModel = analyzer.findModelByName(
+      className,
+      moduleAlias: moduleAlias,
+    );
 
     // 4. If not found by class name, try searching by database table name
     // e.g. parentTable=citizen
@@ -252,7 +271,8 @@ class DefinitionProvider {
     // Allow ':' only if it connects identifier parts (like module:auth:User)
     if (char == ':') {
       var hasPrev = index > 0 && _isIdentifierChar(line[index - 1]);
-      var hasNext = index + 1 < line.length && _isIdentifierChar(line[index + 1]);
+      var hasNext =
+          index + 1 < line.length && _isIdentifierChar(line[index + 1]);
       return hasPrev && hasNext;
     }
 
@@ -277,7 +297,10 @@ class DefinitionProvider {
     return false;
   }
 
-  static Range? _findFieldDefinitionRange(List<String> lines, String fieldName) {
+  static Range? _findFieldDefinitionRange(
+    List<String> lines,
+    String fieldName,
+  ) {
     var fieldRegex = RegExp(r'^\s*' + RegExp.escape(fieldName) + r'\s*:');
     for (var i = 0; i < lines.length; i++) {
       var l = lines[i];

--- a/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
@@ -107,6 +107,29 @@ class DefinitionProvider {
     );
   }
 
+  /// Resolves the location of the model declaration for [className],
+  /// optionally qualified with [moduleAlias].
+  ///
+  /// Backs the `serverpod/modelDefinition` custom request, which lets the
+  /// editor navigate from generated Dart code back to the model file.
+  static Location? resolveModelByName({
+    required StatefulAnalyzer analyzer,
+    required String className,
+    String? moduleAlias,
+  }) {
+    var model = analyzer.findModelByName(className, moduleAlias: moduleAlias);
+    if (model == null) return null;
+
+    var source = analyzer.getModelSourceForModel(model);
+    if (source == null) return null;
+
+    var range = findModelDefinitionRange(
+      source.yaml.split('\n'),
+      model.className,
+    );
+    return Location(uri: source.yamlSourceUri, range: range);
+  }
+
   static Either3<Location, List<Location>, List<LocationLink>> _buildResult({
     required Uri targetUri,
     required Range targetSelectionRange,

--- a/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
@@ -1,75 +1,10 @@
 import 'package:lsp_server/lsp_server.dart';
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
-import 'package:serverpod_cli/src/analyzer/models/validation/keywords.dart';
-import 'package:serverpod_database/serverpod_database.dart';
-import 'package:serverpod_serialization/serverpod_serialization.dart';
+import 'package:serverpod_cli/src/language_server/model_navigation_utils.dart';
 
 /// Provides Go to Definition (CTRL+Click) resolution for Serverpod model files.
 class DefinitionProvider {
-  static final Set<String> primitiveTypes = {
-    ...autoSerializedTypes,
-    ...extensionSerializedTypes,
-    'dynamic',
-    'void',
-    'num',
-  };
-
-  static final Set<String> ignoredKeywords = {
-    /// All valid YAML keywords defined for model files.
-    Keyword.classType,
-    Keyword.exceptionType,
-    Keyword.enumType,
-    Keyword.serializationDataType,
-    Keyword.serialized,
-    Keyword.isSealed,
-    Keyword.isImmutable,
-    Keyword.extendsClass,
-    Keyword.serverOnly,
-    Keyword.table,
-    Keyword.managedMigration,
-    Keyword.fields,
-    Keyword.indexes,
-    Keyword.properties,
-    Keyword.values,
-    Keyword.type,
-    Keyword.unique,
-    Keyword.nullsDistinct,
-    Keyword.per,
-    Keyword.operatorClass,
-    Keyword.distanceFunction,
-    Keyword.parameters,
-    Keyword.parent,
-    Keyword.relation,
-    Keyword.field,
-    Keyword.onUpdate,
-    Keyword.onDelete,
-    Keyword.deferrable,
-    Keyword.deferred,
-    Keyword.name,
-    Keyword.api,
-    Keyword.database,
-    Keyword.optional,
-    Keyword.fk,
-    Keyword.scope,
-    Keyword.persist,
-    Keyword.requiredKey,
-    Keyword.tail,
-    Keyword.defaultKey,
-    Keyword.defaultModelKey,
-    Keyword.defaultPersistKey,
-    Keyword.columnKey,
-    Keyword.jsonKey,
-    ...ForeignKeyAction.values.expand(
-      (e) => [e.name, '${e.name[0].toUpperCase()}${e.name.substring(1)}'],
-    ),
-    ...ModelDatabaseDefinition.values.map((e) => e.name),
-    ...ModelFieldScopeDefinition.values.map((e) => e.name),
-    defaultBooleanTrue,
-    defaultBooleanFalse,
-    'null',
-  };
-
   /// Resolves the definition location for a symbol at [position] in the document at [documentUri].
   static Either3<Location, List<Location>, List<LocationLink>>?
   resolveDefinition({
@@ -90,21 +25,18 @@ class DefinitionProvider {
 
     var token = wordMatch.word;
 
-    // Skip primitive types and common keywords
-    if (primitiveTypes.contains(token) || ignoredKeywords.contains(token)) {
-      return null;
-    }
-
     var originSelectionRange = Range(
       start: Position(line: position.line, character: wordMatch.startColumn),
       end: Position(line: position.line, character: wordMatch.endColumn),
     );
 
     // 1. Check if token is a reference to a field in the current model
-    // e.g. relation(field=authorId) or fields: authorId in index
+    // e.g. relation(field=authorId) or fields: authorId in index.
+    // This runs before the keyword skip so that fields named like keywords
+    // (e.g. `name`) stay navigable.
     var currentModel = analyzer.getModel(documentUri);
     if (currentModel is ClassDefinition &&
-        isFieldReferenceContext(line, wordMatch)) {
+        isFieldReferenceContext(line, wordMatch.startColumn)) {
       var field = currentModel.findField(token);
       if (field != null) {
         var fieldLocation = findFieldDefinitionRange(lines, token);
@@ -126,37 +58,24 @@ class DefinitionProvider {
       }
     }
 
-    // 2. Parse potential model / class target from token
-    String? moduleAlias;
-    String className = token;
-
-    if (token.startsWith('module:')) {
-      var parts = token.split(':');
-      if (parts.length >= 3) {
-        moduleAlias = parts[1];
-        className = parts.sublist(2).join(':');
-      }
-    } else if (token.startsWith('project:')) {
-      var parts = token.split(':');
-      if (parts.length >= 3) {
-        moduleAlias = parts[1];
-        className = parts.sublist(2).join(':');
-      }
-    } else if (token.contains(':')) {
-      var parts = token.split(':');
-      if (parts.length == 2) {
-        moduleAlias = parts[0];
-        className = parts[1];
-      }
+    // 2. Skip primitive types and common keywords
+    if (primitiveTypes.contains(token) || ignoredKeywords.contains(token)) {
+      return null;
     }
 
-    // 3. Search model by className and moduleAlias
+    // 3. Parse potential model / class target from token.
+    // `project:` and `package:` tokens denote plain Dart classes and can
+    // never resolve to a model.
+    var modelToken = parseModelToken(token);
+    if (modelToken == null) return null;
+
+    // 4. Search model by className and moduleAlias
     var targetModel = analyzer.findModelByName(
-      className,
-      moduleAlias: moduleAlias,
+      modelToken.className,
+      moduleAlias: modelToken.moduleAlias,
     );
 
-    // 4. If not found by class name, try searching by database table name
+    // 5. If not found by class name, try searching by database table name
     // e.g. parentTable=citizen
     targetModel ??= analyzer.findModelByTableName(token);
 
@@ -213,148 +132,4 @@ class DefinitionProvider {
       ),
     );
   }
-
-  /// Extracts the word / identifier at the given column position in [line].
-  static WordMatch? extractWordAt(String line, int column) {
-    if (line.isEmpty || column < 0) return null;
-
-    // Adjust column if at end of line or right after a word character
-    int col = column;
-    if (col >= line.length) {
-      if (col > 0 && _isWordChar(line, col - 1)) {
-        col = col - 1;
-      } else {
-        return null;
-      }
-    }
-
-    if (!_isWordChar(line, col)) {
-      if (col > 0 && _isWordChar(line, col - 1)) {
-        col = col - 1;
-      } else {
-        return null;
-      }
-    }
-
-    int start = col;
-    while (start > 0 && _isWordChar(line, start - 1)) {
-      start--;
-    }
-
-    int end = col;
-    while (end < line.length && _isWordChar(line, end)) {
-      end++;
-    }
-
-    var word = line.substring(start, end);
-    if (word.isEmpty) return null;
-
-    return WordMatch(
-      word: word,
-      startColumn: start,
-      endColumn: end,
-    );
-  }
-
-  static bool _isWordChar(String line, int index) {
-    var char = line[index];
-    var code = char.codeUnitAt(0);
-
-    // A-Z, a-z, 0-9, _
-    if ((code >= 65 && code <= 90) ||
-        (code >= 97 && code <= 122) ||
-        (code >= 48 && code <= 57) ||
-        code == 95) {
-      return true;
-    }
-
-    // Allow ':' only if it connects identifier parts (like module:auth:User)
-    if (char == ':') {
-      var hasPrev = index > 0 && _isIdentifierChar(line[index - 1]);
-      var hasNext =
-          index + 1 < line.length && _isIdentifierChar(line[index + 1]);
-      return hasPrev && hasNext;
-    }
-
-    return false;
-  }
-
-  static bool _isIdentifierChar(String char) {
-    var code = char.codeUnitAt(0);
-    return (code >= 65 && code <= 90) ||
-        (code >= 97 && code <= 122) ||
-        (code >= 48 && code <= 57) ||
-        code == 95;
-  }
-
-  static bool isFieldReferenceContext(String line, WordMatch wordMatch) {
-    var beforeWord = line.substring(0, wordMatch.startColumn);
-    if (beforeWord.contains('field=') ||
-        beforeWord.contains('field:') ||
-        beforeWord.contains('fields:')) {
-      return true;
-    }
-    return false;
-  }
-
-  static Range? findFieldDefinitionRange(
-    List<String> lines,
-    String fieldName,
-  ) {
-    var fieldRegex = RegExp(r'^\s*' + RegExp.escape(fieldName) + r'\s*:');
-    for (var i = 0; i < lines.length; i++) {
-      var l = lines[i];
-      if (fieldRegex.hasMatch(l)) {
-        var col = l.indexOf(fieldName);
-        return Range(
-          start: Position(line: i, character: col >= 0 ? col : 0),
-          end: Position(
-            line: i,
-            character: col >= 0 ? col + fieldName.length : l.length,
-          ),
-        );
-      }
-    }
-    return null;
-  }
-
-  static Range findModelDefinitionRange(
-    List<String> targetLines,
-    String targetClassName,
-  ) {
-    var defRegex = RegExp(
-      r'^(class|enum|exception)\s*:\s*' +
-          RegExp.escape(targetClassName) +
-          r'\b',
-    );
-    for (var i = 0; i < targetLines.length; i++) {
-      var l = targetLines[i];
-      if (defRegex.hasMatch(l)) {
-        var col = l.indexOf(targetClassName);
-        return Range(
-          start: Position(line: i, character: col >= 0 ? col : 0),
-          end: Position(
-            line: i,
-            character: col >= 0 ? col + targetClassName.length : l.length,
-          ),
-        );
-      }
-    }
-    return Range(
-      start: Position(line: 0, character: 0),
-      end: Position(line: 0, character: 0),
-    );
-  }
-}
-
-class WordMatch {
-  final String word;
-  final int startColumn;
-  final int endColumn;
-
-  WordMatch({
-    required this.word,
-    required this.startColumn,
-    required this.endColumn,
-  });
 }

--- a/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
@@ -7,7 +7,7 @@ import 'package:serverpod_serialization/serverpod_serialization.dart';
 
 /// Provides Go to Definition (CTRL+Click) resolution for Serverpod model files.
 class DefinitionProvider {
-  static final Set<String> _primitiveTypes = {
+  static final Set<String> primitiveTypes = {
     ...autoSerializedTypes,
     ...extensionSerializedTypes,
     'dynamic',
@@ -15,7 +15,7 @@ class DefinitionProvider {
     'num',
   };
 
-  static final Set<String> _ignoredKeywords = {
+  static final Set<String> ignoredKeywords = {
     /// All valid YAML keywords defined for model files.
     Keyword.classType,
     Keyword.exceptionType,
@@ -85,13 +85,13 @@ class DefinitionProvider {
     if (position.line < 0 || position.line >= lines.length) return null;
 
     var line = lines[position.line];
-    var wordMatch = _extractWordAt(line, position.character);
+    var wordMatch = extractWordAt(line, position.character);
     if (wordMatch == null) return null;
 
     var token = wordMatch.word;
 
     // Skip primitive types and common keywords
-    if (_primitiveTypes.contains(token) || _ignoredKeywords.contains(token)) {
+    if (primitiveTypes.contains(token) || ignoredKeywords.contains(token)) {
       return null;
     }
 
@@ -104,10 +104,10 @@ class DefinitionProvider {
     // e.g. relation(field=authorId) or fields: authorId in index
     var currentModel = analyzer.getModel(documentUri);
     if (currentModel is ClassDefinition &&
-        _isFieldReferenceContext(line, wordMatch)) {
+        isFieldReferenceContext(line, wordMatch)) {
       var field = currentModel.findField(token);
       if (field != null) {
-        var fieldLocation = _findFieldDefinitionRange(lines, token);
+        var fieldLocation = findFieldDefinitionRange(lines, token);
         if (fieldLocation != null) {
           return _buildResult(
             targetUri: documentUri,
@@ -166,7 +166,7 @@ class DefinitionProvider {
     if (targetSource == null) return null;
 
     var targetLines = targetSource.yaml.split('\n');
-    var targetSelectionRange = _findModelDefinitionRange(
+    var targetSelectionRange = findModelDefinitionRange(
       targetLines,
       targetModel.className,
     );
@@ -215,7 +215,7 @@ class DefinitionProvider {
   }
 
   /// Extracts the word / identifier at the given column position in [line].
-  static _WordMatch? _extractWordAt(String line, int column) {
+  static WordMatch? extractWordAt(String line, int column) {
     if (line.isEmpty || column < 0) return null;
 
     // Adjust column if at end of line or right after a word character
@@ -249,7 +249,7 @@ class DefinitionProvider {
     var word = line.substring(start, end);
     if (word.isEmpty) return null;
 
-    return _WordMatch(
+    return WordMatch(
       word: word,
       startColumn: start,
       endColumn: end,
@@ -287,7 +287,7 @@ class DefinitionProvider {
         code == 95;
   }
 
-  static bool _isFieldReferenceContext(String line, _WordMatch wordMatch) {
+  static bool isFieldReferenceContext(String line, WordMatch wordMatch) {
     var beforeWord = line.substring(0, wordMatch.startColumn);
     if (beforeWord.contains('field=') ||
         beforeWord.contains('field:') ||
@@ -297,7 +297,7 @@ class DefinitionProvider {
     return false;
   }
 
-  static Range? _findFieldDefinitionRange(
+  static Range? findFieldDefinitionRange(
     List<String> lines,
     String fieldName,
   ) {
@@ -318,7 +318,7 @@ class DefinitionProvider {
     return null;
   }
 
-  static Range _findModelDefinitionRange(
+  static Range findModelDefinitionRange(
     List<String> targetLines,
     String targetClassName,
   ) {
@@ -347,12 +347,12 @@ class DefinitionProvider {
   }
 }
 
-class _WordMatch {
+class WordMatch {
   final String word;
   final int startColumn;
   final int endColumn;
 
-  _WordMatch({
+  WordMatch({
     required this.word,
     required this.startColumn,
     required this.endColumn,

--- a/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
@@ -58,24 +58,28 @@ class DefinitionProvider {
       }
     }
 
-    // 2. Skip primitive types and common keywords
+    // 2. Only values reference models. Keys name the model syntax itself and
+    // sequence entries only ever hold enum values or index field names.
+    if (!isValuePosition(line, wordMatch.startColumn)) return null;
+
+    // 3. Skip primitive types and common keywords
     if (primitiveTypes.contains(token) || ignoredKeywords.contains(token)) {
       return null;
     }
 
-    // 3. Parse potential model / class target from token.
+    // 4. Parse potential model / class target from token.
     // `project:` and `package:` tokens denote plain Dart classes and can
     // never resolve to a model.
     var modelToken = parseModelToken(token);
     if (modelToken == null) return null;
 
-    // 4. Search model by className and moduleAlias
+    // 5. Search model by className and moduleAlias
     var targetModel = analyzer.findModelByName(
       modelToken.className,
       moduleAlias: modelToken.moduleAlias,
     );
 
-    // 5. If not found by class name, try searching by database table name
+    // 6. If not found by class name, try searching by database table name
     // e.g. parentTable=citizen
     targetModel ??= analyzer.findModelByTableName(token);
 

--- a/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/definition_provider.dart
@@ -32,7 +32,7 @@ class DefinitionProvider {
 
     // 1. Check if token is a reference to a field in the current model
     // e.g. relation(field=authorId) or fields: authorId in index.
-    // This runs before the keyword skip so that fields named like keywords
+    // This runs before the value checks so that fields named like keys
     // (e.g. `name`) stay navigable.
     var currentModel = analyzer.getModel(documentUri);
     if (currentModel is ClassDefinition &&
@@ -58,31 +58,55 @@ class DefinitionProvider {
       }
     }
 
-    // 2. Only values reference models. Keys name the model syntax itself and
+    // 2. A token in table reference position, e.g. relation(parent=citizen),
+    // names a database table. It is resolved before the checks below since
+    // table names may collide with the literal values of the model syntax.
+    if (isTableReferenceContext(line, wordMatch.startColumn)) {
+      return _buildModelResult(
+        analyzer: analyzer,
+        targetModel: analyzer.findModelByTableName(token),
+        originSelectionRange: originSelectionRange,
+        linkSupport: linkSupport,
+      );
+    }
+
+    // 3. Only values reference models. Keys name the model syntax itself and
     // sequence entries only ever hold enum values or index field names.
     if (!isValuePosition(line, wordMatch.startColumn)) return null;
 
-    // 3. Skip primitive types and common keywords
-    if (primitiveTypes.contains(token) || ignoredKeywords.contains(token)) {
-      return null;
-    }
+    // 4. Skip primitive types and literal values of the model syntax.
+    if (primitiveTypes.contains(token) || isLiteralValue(token)) return null;
 
-    // 4. Parse potential model / class target from token.
+    // 5. Parse potential model / class target from token.
     // `project:` and `package:` tokens denote plain Dart classes and can
     // never resolve to a model.
     var modelToken = parseModelToken(token);
     if (modelToken == null) return null;
 
-    // 5. Search model by className and moduleAlias
-    var targetModel = analyzer.findModelByName(
-      modelToken.className,
-      moduleAlias: modelToken.moduleAlias,
+    // 6. Search model by className and moduleAlias, falling back to the
+    // database table name, e.g. `table: citizen`.
+    var targetModel =
+        analyzer.findModelByName(
+          modelToken.className,
+          moduleAlias: modelToken.moduleAlias,
+        ) ??
+        analyzer.findModelByTableName(token);
+
+    return _buildModelResult(
+      analyzer: analyzer,
+      targetModel: targetModel,
+      originSelectionRange: originSelectionRange,
+      linkSupport: linkSupport,
     );
+  }
 
-    // 6. If not found by class name, try searching by database table name
-    // e.g. parentTable=citizen
-    targetModel ??= analyzer.findModelByTableName(token);
-
+  static Either3<Location, List<Location>, List<LocationLink>>?
+  _buildModelResult({
+    required StatefulAnalyzer analyzer,
+    required SerializableModelDefinition? targetModel,
+    required Range originSelectionRange,
+    required bool linkSupport,
+  }) {
     if (targetModel == null) return null;
 
     var targetSource = analyzer.getModelSourceForModel(targetModel);
@@ -94,18 +118,16 @@ class DefinitionProvider {
       targetModel.className,
     );
 
-    var targetRange = Range(
-      start: Position(line: targetSelectionRange.start.line, character: 0),
-      end: Position(
-        line: targetSelectionRange.start.line,
-        character: targetLines[targetSelectionRange.start.line].length,
-      ),
-    );
-
     return _buildResult(
       targetUri: targetSource.yamlSourceUri,
       targetSelectionRange: targetSelectionRange,
-      targetRange: targetRange,
+      targetRange: Range(
+        start: Position(line: targetSelectionRange.start.line, character: 0),
+        end: Position(
+          line: targetSelectionRange.start.line,
+          character: targetLines[targetSelectionRange.start.line].length,
+        ),
+      ),
       originSelectionRange: originSelectionRange,
       linkSupport: linkSupport,
     );

--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -207,24 +207,22 @@ Future<void> runLanguageServer({
 
   // Custom request used by the editor extension to navigate from generated
   // Dart code back to the model definition.
-  unawaited(
-    conn.onRequest('serverpod/modelDefinition', (params) async {
-      var project = serverProject;
-      if (project == null) return null;
+  await conn.onRequest('serverpod/modelDefinition', (params) async {
+    var project = serverProject;
+    if (project == null) return null;
 
-      var map = params.value;
-      if (map is! Map) return null;
-      var className = map['className'];
-      if (className is! String) return null;
-      var moduleAlias = map['moduleAlias'];
+    var map = params.value;
+    if (map is! Map) return null;
+    var className = map['className'];
+    if (className is! String) return null;
+    var moduleAlias = map['moduleAlias'];
 
-      return DefinitionProvider.resolveModelByName(
-        analyzer: project.analyzer,
-        className: className,
-        moduleAlias: moduleAlias is String ? moduleAlias : null,
-      )?.toJson();
-    }),
-  );
+    return DefinitionProvider.resolveModelByName(
+      analyzer: project.analyzer,
+      className: className,
+      moduleAlias: moduleAlias is String ? moduleAlias : null,
+    )?.toJson();
+  });
 
   await conn.listen();
 }

--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -9,6 +9,7 @@ import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
 import 'package:serverpod_cli/src/language_server/definition_provider.dart';
 import 'package:serverpod_cli/src/language_server/diagnostics_source.dart';
+import 'package:serverpod_cli/src/language_server/reference_provider.dart';
 import 'package:serverpod_cli/src/util/directory.dart';
 import 'package:serverpod_cli/src/util/model_helper.dart';
 
@@ -72,6 +73,7 @@ Future<void> runLanguageServer({
       capabilities: ServerCapabilities(
         textDocumentSync: const Either2.t1(TextDocumentSyncKind.Full),
         definitionProvider: const Either2.t1(true),
+        referencesProvider: const Either2.t1(true),
       ),
     );
   });
@@ -188,6 +190,18 @@ Future<void> runLanguageServer({
       documentUri: params.textDocument.uri,
       position: params.position,
       linkSupport: clientSupportsDefinitionLink,
+    );
+  });
+
+  conn.onReferences((params) async {
+    var project = serverProject;
+    if (project == null) return [];
+
+    return ReferenceProvider.findReferences(
+      analyzer: project.analyzer,
+      documentUri: params.textDocument.uri,
+      position: params.position,
+      context: params.context,
     );
   });
 

--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -205,6 +205,27 @@ Future<void> runLanguageServer({
     );
   });
 
+  // Custom request used by the editor extension to navigate from generated
+  // Dart code back to the model definition.
+  unawaited(
+    conn.onRequest('serverpod/modelDefinition', (params) async {
+      var project = serverProject;
+      if (project == null) return null;
+
+      var map = params.value;
+      if (map is! Map) return null;
+      var className = map['className'];
+      if (className is! String) return null;
+      var moduleAlias = map['moduleAlias'];
+
+      return DefinitionProvider.resolveModelByName(
+        analyzer: project.analyzer,
+        className: className,
+        moduleAlias: moduleAlias is String ? moduleAlias : null,
+      )?.toJson();
+    }),
+  );
+
   await conn.listen();
 }
 

--- a/tools/serverpod_cli/lib/src/language_server/language_server.dart
+++ b/tools/serverpod_cli/lib/src/language_server/language_server.dart
@@ -7,6 +7,7 @@ import 'package:serverpod_cli/src/analyzer/code_analysis_collector.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/config/config.dart';
 import 'package:serverpod_cli/src/generator/code_generation_collector.dart';
+import 'package:serverpod_cli/src/language_server/definition_provider.dart';
 import 'package:serverpod_cli/src/language_server/diagnostics_source.dart';
 import 'package:serverpod_cli/src/util/directory.dart';
 import 'package:serverpod_cli/src/util/model_helper.dart';
@@ -32,6 +33,7 @@ Future<void> runLanguageServer({
   ServerProject? serverProject;
   Exception? exception;
   var clientSupportsWatchedFilesRegistration = false;
+  var clientSupportsDefinitionLink = false;
 
   // The editor buffer is authoritative for open documents; rescans from disk
   // must not replace or remove them.
@@ -52,6 +54,9 @@ Future<void> runLanguageServer({
             ?.dynamicRegistration ??
         false;
 
+    clientSupportsDefinitionLink =
+        params.capabilities.textDocument?.definition?.linkSupport ?? false;
+
     var rootUri = params.rootUri;
     if (rootUri != null) {
       try {
@@ -66,6 +71,7 @@ Future<void> runLanguageServer({
     return InitializeResult(
       capabilities: ServerCapabilities(
         textDocumentSync: const Either2.t1(TextDocumentSyncKind.Full),
+        definitionProvider: const Either2.t1(true),
       ),
     );
   });
@@ -170,6 +176,18 @@ Future<void> runLanguageServer({
     serverProject?.analyzer.validateModel(
       contentChanges.first.text,
       params.textDocument.uri,
+    );
+  });
+
+  conn.onDefinition((params) async {
+    var project = serverProject;
+    if (project == null) return null;
+
+    return DefinitionProvider.resolveDefinition(
+      analyzer: project.analyzer,
+      documentUri: params.textDocument.uri,
+      position: params.position,
+      linkSupport: clientSupportsDefinitionLink,
     );
   });
 

--- a/tools/serverpod_cli/lib/src/language_server/model_navigation_utils.dart
+++ b/tools/serverpod_cli/lib/src/language_server/model_navigation_utils.dart
@@ -70,6 +70,24 @@ final ignoredKeywords = {
   'null',
 };
 
+final _keyRegex = RegExp(r'^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:');
+
+/// Returns the mapping key declared on [line], or null when [line] is not a
+/// mapping entry (a sequence entry such as `- alpha`, for instance).
+String? lineKey(String line) => _keyRegex.firstMatch(line)?.group(1);
+
+/// Returns true when [column] in [line] sits in the value of a mapping entry.
+///
+/// Sequence entries are deliberately excluded: only enum values and index
+/// field lists live there, and neither references a model. Values of the
+/// `values` key are excluded for the same reason.
+bool isValuePosition(String line, int column) {
+  var keyMatch = _keyRegex.firstMatch(line);
+  if (keyMatch == null) return false;
+  if (column < keyMatch.end) return false;
+  return keyMatch.group(1) != Keyword.values;
+}
+
 /// A word extracted from a line of text, with its column span.
 class WordMatch {
   /// Creates a [WordMatch].

--- a/tools/serverpod_cli/lib/src/language_server/model_navigation_utils.dart
+++ b/tools/serverpod_cli/lib/src/language_server/model_navigation_utils.dart
@@ -184,9 +184,12 @@ Range? findFieldDefinitionRange(List<String> lines, String fieldName) {
   int? fieldsIndent;
   for (var i = 0; i < lines.length; i++) {
     var line = lines[i];
-    if (line.trim().isEmpty) continue;
+    // Blank and comment only lines carry no structure, so their indentation
+    // never closes the fields block.
+    var trimmed = line.trimLeft();
+    if (trimmed.isEmpty || trimmed.startsWith('#')) continue;
 
-    var indent = line.length - line.trimLeft().length;
+    var indent = line.length - trimmed.length;
     if (fieldsIndent != null && indent <= fieldsIndent) fieldsIndent = null;
 
     if (fieldsIndent == null) {

--- a/tools/serverpod_cli/lib/src/language_server/model_navigation_utils.dart
+++ b/tools/serverpod_cli/lib/src/language_server/model_navigation_utils.dart
@@ -33,6 +33,39 @@ final _literalValues = {
 bool isLiteralValue(String token) =>
     _literalValues.contains(token.toLowerCase());
 
+/// Where a column of a model file line sits with respect to quoting and
+/// comments.
+enum LineContext {
+  /// Model file syntax, the only place a model or a field is referenced.
+  code,
+
+  /// Inside a quoted string, such as the `user` of `default='user'`. Quoted
+  /// values are plain text, never a reference.
+  quoted,
+
+  /// Inside a `#` comment.
+  comment,
+}
+
+/// Classifies the character at [column] of [line].
+LineContext lineContextAt(String line, int column) {
+  var inSingleQuote = false;
+  var inDoubleQuote = false;
+  for (var i = 0; i < line.length && i <= column; i++) {
+    var char = line[i];
+    if (char == "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+    } else if (char == '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+    } else if (char == '#' && !inSingleQuote && !inDoubleQuote) {
+      return LineContext.comment;
+    }
+  }
+
+  if (inSingleQuote || inDoubleQuote) return LineContext.quoted;
+  return LineContext.code;
+}
+
 final _keyRegex = RegExp(r'^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:');
 
 /// Returns the mapping key declared on [line], or null when [line] is not a

--- a/tools/serverpod_cli/lib/src/language_server/model_navigation_utils.dart
+++ b/tools/serverpod_cli/lib/src/language_server/model_navigation_utils.dart
@@ -14,61 +14,24 @@ final primitiveTypes = {
   'num',
 };
 
-/// All valid YAML keywords and literal values defined for model files.
-/// These can never resolve to a model or field definition.
-final ignoredKeywords = {
-  Keyword.classType,
-  Keyword.exceptionType,
-  Keyword.enumType,
-  Keyword.serializationDataType,
-  Keyword.serialized,
-  Keyword.isSealed,
-  Keyword.isImmutable,
-  Keyword.extendsClass,
-  Keyword.serverOnly,
-  Keyword.table,
-  Keyword.managedMigration,
-  Keyword.fields,
-  Keyword.indexes,
-  Keyword.properties,
-  Keyword.values,
-  Keyword.type,
-  Keyword.unique,
-  Keyword.nullsDistinct,
-  Keyword.per,
-  Keyword.operatorClass,
-  Keyword.distanceFunction,
-  Keyword.parameters,
-  Keyword.parent,
-  Keyword.relation,
-  Keyword.field,
-  Keyword.onUpdate,
-  Keyword.onDelete,
-  Keyword.deferrable,
-  Keyword.deferred,
-  Keyword.name,
-  Keyword.api,
-  Keyword.database,
-  Keyword.optional,
-  Keyword.fk,
-  Keyword.scope,
-  Keyword.persist,
-  Keyword.requiredKey,
-  Keyword.tail,
-  Keyword.defaultKey,
-  Keyword.defaultModelKey,
-  Keyword.defaultPersistKey,
-  Keyword.columnKey,
-  Keyword.jsonKey,
-  ...ForeignKeyAction.values.expand(
-    (e) => [e.name, '${e.name[0].toUpperCase()}${e.name.substring(1)}'],
-  ),
-  ...ModelDatabaseDefinition.values.map((e) => e.name),
-  ...ModelFieldScopeDefinition.values.map((e) => e.name),
-  defaultBooleanTrue,
-  defaultBooleanFalse,
+/// The literal values a model file may hold in a value position, lowercased.
+///
+/// The analyzer matches these case insensitively, so `onDelete: CASCADE` and
+/// `onDelete: cascade` are equally valid. They can never resolve to a model,
+/// even when a model shares their name.
+final _literalValues = {
+  for (var value in ForeignKeyAction.values) value.name.toLowerCase(),
+  for (var value in ModelDatabaseDefinition.values) value.name.toLowerCase(),
+  for (var value in ModelFieldScopeDefinition.values) value.name.toLowerCase(),
+  defaultBooleanTrue.toLowerCase(),
+  defaultBooleanFalse.toLowerCase(),
   'null',
 };
+
+/// Returns true if [token] is a literal value of the model file syntax, such
+/// as `cascade` or `serverOnly`, rather than a reference to a model.
+bool isLiteralValue(String token) =>
+    _literalValues.contains(token.toLowerCase());
 
 final _keyRegex = RegExp(r'^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:');
 
@@ -184,6 +147,14 @@ bool isFieldReferenceContext(String line, int column) {
   return beforeWord.endsWith('field=') ||
       beforeWord.contains(RegExp(r'\bfield:\s*$')) ||
       beforeWord.contains(RegExp(r'\bfields:'));
+}
+
+/// Returns true if the word at [column] in [line] is positioned where a
+/// database table is referenced, e.g. `relation(parent=citizen)`.
+bool isTableReferenceContext(String line, int column) {
+  var beforeWord = line.substring(0, column);
+  return beforeWord.endsWith('${Keyword.parent}=') ||
+      beforeWord.contains(RegExp('\\b${Keyword.parent}:\\s*\$'));
 }
 
 /// Returns the column at which [fieldName] is declared on [line]

--- a/tools/serverpod_cli/lib/src/language_server/model_navigation_utils.dart
+++ b/tools/serverpod_cli/lib/src/language_server/model_navigation_utils.dart
@@ -160,8 +160,7 @@ bool isTableReferenceContext(String line, int column) {
 /// Returns the column at which [fieldName] is declared on [line]
 /// (i.e. the line has the shape `<indent><fieldName>:`), or null.
 int? fieldDeclarationColumn(String line, String fieldName) {
-  var declRegex = RegExp(r'^\s*' + RegExp.escape(fieldName) + r'\s*:');
-  if (!declRegex.hasMatch(line)) return null;
+  if (lineKey(line) != fieldName) return null;
   return line.indexOf(fieldName);
 }
 
@@ -177,9 +176,25 @@ int? modelDeclarationColumn(String line, String className) {
 
 /// Finds the range of the declaration of the field [fieldName] in [lines],
 /// or null if the field is not declared.
+///
+/// Only entries nested under the `fields` key are considered, so a field
+/// named like a top level key (`table`, for instance) resolves to its own
+/// declaration rather than to that key.
 Range? findFieldDefinitionRange(List<String> lines, String fieldName) {
+  int? fieldsIndent;
   for (var i = 0; i < lines.length; i++) {
-    var col = fieldDeclarationColumn(lines[i], fieldName);
+    var line = lines[i];
+    if (line.trim().isEmpty) continue;
+
+    var indent = line.length - line.trimLeft().length;
+    if (fieldsIndent != null && indent <= fieldsIndent) fieldsIndent = null;
+
+    if (fieldsIndent == null) {
+      if (lineKey(line) == Keyword.fields) fieldsIndent = indent;
+      continue;
+    }
+
+    var col = fieldDeclarationColumn(line, fieldName);
     if (col == null) continue;
     return Range(
       start: Position(line: i, character: col),

--- a/tools/serverpod_cli/lib/src/language_server/model_navigation_utils.dart
+++ b/tools/serverpod_cli/lib/src/language_server/model_navigation_utils.dart
@@ -1,0 +1,233 @@
+import 'package:lsp_server/lsp_server.dart';
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/models/validation/keywords.dart';
+import 'package:serverpod_cli/src/generator/types.dart';
+import 'package:serverpod_database/serverpod_database.dart';
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+
+/// Types that can never resolve to a Serverpod model definition.
+final primitiveTypes = {
+  ...autoSerializedTypes,
+  ...extensionSerializedTypes,
+  'dynamic',
+  'void',
+  'num',
+};
+
+/// All valid YAML keywords and literal values defined for model files.
+/// These can never resolve to a model or field definition.
+final ignoredKeywords = {
+  Keyword.classType,
+  Keyword.exceptionType,
+  Keyword.enumType,
+  Keyword.serializationDataType,
+  Keyword.serialized,
+  Keyword.isSealed,
+  Keyword.isImmutable,
+  Keyword.extendsClass,
+  Keyword.serverOnly,
+  Keyword.table,
+  Keyword.managedMigration,
+  Keyword.fields,
+  Keyword.indexes,
+  Keyword.properties,
+  Keyword.values,
+  Keyword.type,
+  Keyword.unique,
+  Keyword.nullsDistinct,
+  Keyword.per,
+  Keyword.operatorClass,
+  Keyword.distanceFunction,
+  Keyword.parameters,
+  Keyword.parent,
+  Keyword.relation,
+  Keyword.field,
+  Keyword.onUpdate,
+  Keyword.onDelete,
+  Keyword.deferrable,
+  Keyword.deferred,
+  Keyword.name,
+  Keyword.api,
+  Keyword.database,
+  Keyword.optional,
+  Keyword.fk,
+  Keyword.scope,
+  Keyword.persist,
+  Keyword.requiredKey,
+  Keyword.tail,
+  Keyword.defaultKey,
+  Keyword.defaultModelKey,
+  Keyword.defaultPersistKey,
+  Keyword.columnKey,
+  Keyword.jsonKey,
+  ...ForeignKeyAction.values.expand(
+    (e) => [e.name, '${e.name[0].toUpperCase()}${e.name.substring(1)}'],
+  ),
+  ...ModelDatabaseDefinition.values.map((e) => e.name),
+  ...ModelFieldScopeDefinition.values.map((e) => e.name),
+  defaultBooleanTrue,
+  defaultBooleanFalse,
+  'null',
+};
+
+/// A word extracted from a line of text, with its column span.
+class WordMatch {
+  /// Creates a [WordMatch].
+  WordMatch({
+    required this.word,
+    required this.startColumn,
+    required this.endColumn,
+  });
+
+  /// The extracted word.
+  final String word;
+
+  /// The column where the word starts (inclusive).
+  final int startColumn;
+
+  /// The column where the word ends (exclusive).
+  final int endColumn;
+}
+
+/// Extracts the word / identifier at the given column position in [line].
+///
+/// Colons are considered word characters when they connect identifier parts,
+/// so qualified references such as `module:auth:User` are extracted as a
+/// single word.
+WordMatch? extractWordAt(String line, int column) {
+  if (line.isEmpty || column < 0) return null;
+
+  // Adjust column if at end of line or right after a word character.
+  var col = column;
+  if (col >= line.length) {
+    if (col > 0 && _isWordChar(line, col - 1)) {
+      col = col - 1;
+    } else {
+      return null;
+    }
+  }
+
+  if (!_isWordChar(line, col)) {
+    if (col > 0 && _isWordChar(line, col - 1)) {
+      col = col - 1;
+    } else {
+      return null;
+    }
+  }
+
+  var start = col;
+  while (start > 0 && _isWordChar(line, start - 1)) {
+    start--;
+  }
+
+  var end = col;
+  while (end < line.length && _isWordChar(line, end)) {
+    end++;
+  }
+
+  var word = line.substring(start, end);
+  if (word.isEmpty) return null;
+
+  return WordMatch(
+    word: word,
+    startColumn: start,
+    endColumn: end,
+  );
+}
+
+bool _isWordChar(String line, int index) {
+  var char = line[index];
+  if (_isIdentifierChar(char)) return true;
+
+  // Allow ':' only if it connects identifier parts (like module:auth:User).
+  if (char == ':') {
+    var hasPrev = index > 0 && _isIdentifierChar(line[index - 1]);
+    var hasNext = index + 1 < line.length && _isIdentifierChar(line[index + 1]);
+    return hasPrev && hasNext;
+  }
+
+  return false;
+}
+
+bool _isIdentifierChar(String char) {
+  var code = char.codeUnitAt(0);
+  // A-Z, a-z, 0-9, _
+  return (code >= 65 && code <= 90) ||
+      (code >= 97 && code <= 122) ||
+      (code >= 48 && code <= 57) ||
+      code == 95;
+}
+
+/// Returns true if the word at [column] in [line] is positioned where a field
+/// of the current model is referenced, e.g. `relation(field=authorId)`,
+/// `field: authorId`, or `fields: authorId` in an index.
+bool isFieldReferenceContext(String line, int column) {
+  var beforeWord = line.substring(0, column);
+  return beforeWord.endsWith('field=') ||
+      beforeWord.contains(RegExp(r'\bfield:\s*$')) ||
+      beforeWord.contains(RegExp(r'\bfields:'));
+}
+
+/// Returns the column at which [fieldName] is declared on [line]
+/// (i.e. the line has the shape `<indent><fieldName>:`), or null.
+int? fieldDeclarationColumn(String line, String fieldName) {
+  var declRegex = RegExp(r'^\s*' + RegExp.escape(fieldName) + r'\s*:');
+  if (!declRegex.hasMatch(line)) return null;
+  return line.indexOf(fieldName);
+}
+
+/// Returns the column at which [className] is declared on [line]
+/// (i.e. the line has the shape `class|enum|exception: <className>`), or null.
+int? modelDeclarationColumn(String line, String className) {
+  var declRegex = RegExp(
+    r'^\s*(?:class|enum|exception)\s*:\s*' + RegExp.escape(className) + r'\b',
+  );
+  if (!declRegex.hasMatch(line)) return null;
+  return line.indexOf(className);
+}
+
+/// Finds the range of the declaration of the field [fieldName] in [lines],
+/// or null if the field is not declared.
+Range? findFieldDefinitionRange(List<String> lines, String fieldName) {
+  for (var i = 0; i < lines.length; i++) {
+    var col = fieldDeclarationColumn(lines[i], fieldName);
+    if (col == null) continue;
+    return Range(
+      start: Position(line: i, character: col),
+      end: Position(line: i, character: col + fieldName.length),
+    );
+  }
+  return null;
+}
+
+/// Finds the range of the declaration of the model [className] in [lines].
+/// Falls back to the start of the document if no declaration is found.
+Range findModelDefinitionRange(List<String> lines, String className) {
+  for (var i = 0; i < lines.length; i++) {
+    var col = modelDeclarationColumn(lines[i], className);
+    if (col == null) continue;
+    return Range(
+      start: Position(line: i, character: col),
+      end: Position(line: i, character: col + className.length),
+    );
+  }
+  return Range(
+    start: Position(line: 0, character: 0),
+    end: Position(line: 0, character: 0),
+  );
+}
+
+/// Parses a navigation [token] (e.g. `User`, `module:auth:User`) into its
+/// optional module alias and class name, reusing the analyzer's type parser.
+///
+/// Returns null for `project:` and `package:` tokens, which denote plain
+/// Dart classes and can never resolve to a Serverpod model.
+({String? moduleAlias, String className})? parseModelToken(String token) {
+  var type = parseType(token, extraClasses: null);
+  var url = type.url;
+  if (url != null &&
+      (url.startsWith('project:') || url.startsWith('package:'))) {
+    return null;
+  }
+  return (moduleAlias: type.moduleAlias, className: type.className);
+}

--- a/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
@@ -180,26 +180,15 @@ class ReferenceProvider {
     required bool includeDeclaration,
   }) {
     var locations = <Location>[];
+    var declarationRange = findFieldDefinitionRange(lines, fieldName);
     var fieldRegex = RegExp(r'\b' + RegExp.escape(fieldName) + r'\b');
 
     for (var i = 0; i < lines.length; i++) {
       var line = lines[i];
-      var declColumn = fieldDeclarationColumn(line, fieldName);
 
-      if (declColumn != null) {
+      if (i == declarationRange?.start.line) {
         if (includeDeclaration) {
-          locations.add(
-            Location(
-              uri: documentUri,
-              range: Range(
-                start: Position(line: i, character: declColumn),
-                end: Position(
-                  line: i,
-                  character: declColumn + fieldName.length,
-                ),
-              ),
-            ),
-          );
+          locations.add(Location(uri: documentUri, range: declarationRange!));
         }
         continue;
       }

--- a/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
@@ -103,6 +103,15 @@ class ReferenceProvider {
     var className = targetModel.className;
     var classRegex = RegExp(r'\b' + RegExp.escape(className) + r'\b');
 
+    // A table backed model is also referenced by its table name, e.g. in
+    // relation(parent=citizen).
+    var tableName = targetModel is ModelClassDefinition
+        ? targetModel.tableName
+        : null;
+    var tableRegex = tableName == null
+        ? null
+        : RegExp(r'\b' + RegExp.escape(tableName) + r'\b');
+
     // 2. Search all registered models
     for (var source in analyzer.registeredModelSources) {
       var modelUri = source.yamlSourceUri;
@@ -122,6 +131,8 @@ class ReferenceProvider {
           continue;
         }
 
+        var columns = <int, int>{};
+
         for (var match in classRegex.allMatches(rawLine)) {
           // Ignore matches inside comments
           if (_isCommentIndex(rawLine, match.start)) continue;
@@ -135,12 +146,23 @@ class ReferenceProvider {
           // Not a relation name= parameter
           if (_isRelationNameParam(rawLine, match.start)) continue;
 
+          columns[match.start] = match.end;
+        }
+
+        for (var match in tableRegex?.allMatches(rawLine) ?? <RegExpMatch>[]) {
+          if (_isCommentIndex(rawLine, match.start)) continue;
+          if (!isTableReferenceContext(rawLine, match.start)) continue;
+
+          columns[match.start] = match.end;
+        }
+
+        for (var startCol in columns.keys.toList()..sort()) {
           locations.add(
             Location(
               uri: modelUri,
               range: Range(
-                start: Position(line: lineIdx, character: match.start),
-                end: Position(line: lineIdx, character: match.end),
+                start: Position(line: lineIdx, character: startCol),
+                end: Position(line: lineIdx, character: columns[startCol]!),
               ),
             ),
           );

--- a/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
@@ -35,12 +35,15 @@ class ReferenceProvider {
 
     var token = wordMatch.word;
 
-    // 1. Check if token is a field of the current model. This runs before
+    // 1. Check if token names a field of the current model. This runs before
     // the value checks so that fields named like keys (e.g. `name`)
-    // stay searchable.
+    // stay searchable. The position matters: a token that merely spells out
+    // a field name, such as the table of relation(parent=record), refers to
+    // whatever its own position names.
     var currentModel = analyzer.getModel(documentUri);
     if (currentModel is ClassDefinition &&
-        currentModel.findField(token) != null) {
+        currentModel.findField(token) != null &&
+        _namesField(lines, position, wordMatch, token)) {
       return _findFieldReferences(
         lines: lines,
         documentUri: documentUri,
@@ -87,6 +90,24 @@ class ReferenceProvider {
       targetModel: targetModel,
       includeDeclaration: context.includeDeclaration,
     );
+  }
+
+  /// Whether [wordMatch] names the field [fieldName], either at the field
+  /// declaration itself or in a reference to it such as
+  /// `relation(field=authorId)`.
+  static bool _namesField(
+    List<String> lines,
+    Position position,
+    WordMatch wordMatch,
+    String fieldName,
+  ) {
+    var line = lines[position.line];
+    if (isFieldReferenceContext(line, wordMatch.startColumn)) return true;
+
+    var declaration = findFieldDefinitionRange(lines, fieldName);
+    return declaration != null &&
+        declaration.start.line == position.line &&
+        declaration.start.character == wordMatch.startColumn;
   }
 
   static List<Location> _findModelReferences({

--- a/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
@@ -39,24 +39,28 @@ class ReferenceProvider {
       );
     }
 
-    // 2. Skip primitive types and common keywords
+    // 2. Only values reference models. Keys name the model syntax itself and
+    // sequence entries only ever hold enum values or index field names.
+    if (!isValuePosition(line, wordMatch.startColumn)) return [];
+
+    // 3. Skip primitive types and common keywords
     if (primitiveTypes.contains(token) || ignoredKeywords.contains(token)) {
       return [];
     }
 
-    // 3. Parse potential model / class target from token.
+    // 4. Parse potential model / class target from token.
     // `project:` and `package:` tokens denote plain Dart classes and can
     // never resolve to a model.
     var modelToken = parseModelToken(token);
     if (modelToken == null) return [];
 
-    // 4. Search model by className and moduleAlias
+    // 5. Search model by className and moduleAlias
     var targetModel = analyzer.findModelByName(
       modelToken.className,
       moduleAlias: modelToken.moduleAlias,
     );
 
-    // 5. If not found by class name, try searching by database table name
+    // 6. If not found by class name, try searching by database table name
     targetModel ??= analyzer.findModelByTableName(token);
 
     if (targetModel == null) return [];
@@ -116,8 +120,8 @@ class ReferenceProvider {
           // Ignore matches inside comments
           if (_isCommentIndex(rawLine, startCol)) continue;
 
-          // Must be in a value position (after `:` or `-`)
-          if (!_isValuePosition(rawLine, startCol)) continue;
+          // Must be in a value position, never a key or a sequence entry
+          if (!isValuePosition(rawLine, startCol)) continue;
 
           // Check for module qualification mismatch
           if (!_matchesModule(rawLine, startCol, targetModel)) continue;
@@ -206,14 +210,6 @@ class ReferenceProvider {
         return index >= i;
       }
     }
-    return false;
-  }
-
-  static bool _isValuePosition(String line, int index) {
-    var colonIdx = line.indexOf(':');
-    if (colonIdx >= 0 && index > colonIdx) return true;
-    var dashIdx = line.indexOf('-');
-    if (dashIdx >= 0 && index > dashIdx) return true;
     return false;
   }
 

--- a/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
@@ -26,7 +26,7 @@ class ReferenceProvider {
     var token = wordMatch.word;
 
     // 1. Check if token is a field of the current model. This runs before
-    // the keyword skip so that fields named like keywords (e.g. `name`)
+    // the value checks so that fields named like keys (e.g. `name`)
     // stay searchable.
     var currentModel = analyzer.getModel(documentUri);
     if (currentModel is ClassDefinition &&
@@ -39,31 +39,38 @@ class ReferenceProvider {
       );
     }
 
-    // 2. Only values reference models. Keys name the model syntax itself and
+    // 2. A token in table reference position, e.g. relation(parent=citizen),
+    // names a database table. It is resolved before the checks below since
+    // table names may collide with the literal values of the model syntax.
+    if (isTableReferenceContext(line, wordMatch.startColumn)) {
+      return _findModelReferences(
+        analyzer: analyzer,
+        targetModel: analyzer.findModelByTableName(token),
+        includeDeclaration: context.includeDeclaration,
+      );
+    }
+
+    // 3. Only values reference models. Keys name the model syntax itself and
     // sequence entries only ever hold enum values or index field names.
     if (!isValuePosition(line, wordMatch.startColumn)) return [];
 
-    // 3. Skip primitive types and common keywords
-    if (primitiveTypes.contains(token) || ignoredKeywords.contains(token)) {
-      return [];
-    }
+    // 4. Skip primitive types and literal values of the model syntax.
+    if (primitiveTypes.contains(token) || isLiteralValue(token)) return [];
 
-    // 4. Parse potential model / class target from token.
+    // 5. Parse potential model / class target from token.
     // `project:` and `package:` tokens denote plain Dart classes and can
     // never resolve to a model.
     var modelToken = parseModelToken(token);
     if (modelToken == null) return [];
 
-    // 5. Search model by className and moduleAlias
-    var targetModel = analyzer.findModelByName(
-      modelToken.className,
-      moduleAlias: modelToken.moduleAlias,
-    );
-
-    // 6. If not found by class name, try searching by database table name
-    targetModel ??= analyzer.findModelByTableName(token);
-
-    if (targetModel == null) return [];
+    // 6. Search model by className and moduleAlias, falling back to the
+    // database table name.
+    var targetModel =
+        analyzer.findModelByName(
+          modelToken.className,
+          moduleAlias: modelToken.moduleAlias,
+        ) ??
+        analyzer.findModelByTableName(token);
 
     return _findModelReferences(
       analyzer: analyzer,
@@ -74,9 +81,11 @@ class ReferenceProvider {
 
   static List<Location> _findModelReferences({
     required StatefulAnalyzer analyzer,
-    required SerializableModelDefinition targetModel,
+    required SerializableModelDefinition? targetModel,
     required bool includeDeclaration,
   }) {
+    if (targetModel == null) return [];
+
     var locations = <Location>[];
     var targetSource = analyzer.getModelSourceForModel(targetModel);
     var targetUri = targetSource?.yamlSourceUri;
@@ -106,35 +115,32 @@ class ReferenceProvider {
       for (var lineIdx = 0; lineIdx < modelLines.length; lineIdx++) {
         var rawLine = modelLines[lineIdx];
 
-        // Skip the declaration line itself in the declaration file (already handled above if includeDeclaration is true)
+        // Skip the declaration line itself in the declaration file (already
+        // handled above if includeDeclaration is true)
         if (isDeclarationFile &&
             modelDeclarationColumn(rawLine, className) != null) {
           continue;
         }
 
-        var matches = classRegex.allMatches(rawLine);
-        for (var match in matches) {
-          var startCol = match.start;
-          var endCol = match.end;
-
+        for (var match in classRegex.allMatches(rawLine)) {
           // Ignore matches inside comments
-          if (_isCommentIndex(rawLine, startCol)) continue;
+          if (_isCommentIndex(rawLine, match.start)) continue;
 
           // Must be in a value position, never a key or a sequence entry
-          if (!isValuePosition(rawLine, startCol)) continue;
+          if (!isValuePosition(rawLine, match.start)) continue;
 
           // Check for module qualification mismatch
-          if (!_matchesModule(rawLine, startCol, targetModel)) continue;
+          if (!_matchesModule(rawLine, match.start, targetModel)) continue;
 
           // Not a relation name= parameter
-          if (_isRelationNameParam(rawLine, startCol)) continue;
+          if (_isRelationNameParam(rawLine, match.start)) continue;
 
           locations.add(
             Location(
               uri: modelUri,
               range: Range(
-                start: Position(line: lineIdx, character: startCol),
-                end: Position(line: lineIdx, character: endCol),
+                start: Position(line: lineIdx, character: match.start),
+                end: Position(line: lineIdx, character: match.end),
               ),
             ),
           );

--- a/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
@@ -1,0 +1,283 @@
+import 'package:lsp_server/lsp_server.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
+import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
+import 'package:serverpod_cli/src/language_server/definition_provider.dart';
+
+/// Provides Find References resolution for Serverpod model files.
+class ReferenceProvider {
+  /// Finds all references to the symbol at [position] in [documentUri].
+  static List<Location> findReferences({
+    required StatefulAnalyzer analyzer,
+    required Uri documentUri,
+    required Position position,
+    required ReferenceContext context,
+  }) {
+    var source = analyzer.getModelSource(documentUri);
+    if (source == null) return [];
+
+    var lines = source.yaml.split('\n');
+    if (position.line < 0 || position.line >= lines.length) return [];
+
+    var line = lines[position.line];
+    var wordMatch = DefinitionProvider.extractWordAt(line, position.character);
+    if (wordMatch == null) return [];
+
+    var token = wordMatch.word;
+
+    // Skip primitive types and common keywords
+    if (DefinitionProvider.primitiveTypes.contains(token) ||
+        DefinitionProvider.ignoredKeywords.contains(token)) {
+      return [];
+    }
+
+    // 1. Check if token is a reference to a field in the current model
+    var currentModel = analyzer.getModel(documentUri);
+    if (currentModel is ClassDefinition) {
+      var isField =
+          currentModel.findField(token) != null ||
+          DefinitionProvider.isFieldReferenceContext(line, wordMatch);
+      if (isField && currentModel.findField(token) != null) {
+        return _findFieldReferences(
+          lines: lines,
+          documentUri: documentUri,
+          fieldName: token,
+          includeDeclaration: context.includeDeclaration,
+        );
+      }
+    }
+
+    // 2. Parse potential model / class target from token
+    String? moduleAlias;
+    String className = token;
+
+    if (token.startsWith('module:')) {
+      var parts = token.split(':');
+      if (parts.length >= 3) {
+        moduleAlias = parts[1];
+        className = parts.sublist(2).join(':');
+      }
+    } else if (token.startsWith('project:')) {
+      var parts = token.split(':');
+      if (parts.length >= 3) {
+        moduleAlias = parts[1];
+        className = parts.sublist(2).join(':');
+      }
+    } else if (token.contains(':')) {
+      var parts = token.split(':');
+      if (parts.length == 2) {
+        moduleAlias = parts[0];
+        className = parts[1];
+      }
+    }
+
+    // 3. Search model by className and moduleAlias
+    var targetModel = analyzer.findModelByName(
+      className,
+      moduleAlias: moduleAlias,
+    );
+
+    // 4. If not found by class name, try searching by database table name
+    targetModel ??= analyzer.findModelByTableName(token);
+
+    if (targetModel == null) return [];
+
+    return _findModelReferences(
+      analyzer: analyzer,
+      targetModel: targetModel,
+      includeDeclaration: context.includeDeclaration,
+    );
+  }
+
+  static List<Location> _findModelReferences({
+    required StatefulAnalyzer analyzer,
+    required SerializableModelDefinition targetModel,
+    required bool includeDeclaration,
+  }) {
+    var locations = <Location>[];
+    var targetSource = analyzer.getModelSourceForModel(targetModel);
+    var targetUri = targetSource?.yamlSourceUri;
+
+    // 1. Declaration site
+    if (includeDeclaration && targetSource != null && targetUri != null) {
+      var targetLines = targetSource.yaml.split('\n');
+      var declRange = DefinitionProvider.findModelDefinitionRange(
+        targetLines,
+        targetModel.className,
+      );
+      locations.add(Location(uri: targetUri, range: declRange));
+    }
+
+    var className = targetModel.className;
+    var classRegex = RegExp(r'\b' + RegExp.escape(className) + r'\b');
+
+    // 2. Search all registered models
+    for (var source in analyzer.registeredModelSources) {
+      var modelUri = source.yamlSourceUri;
+      var isDeclarationFile =
+          targetUri != null &&
+          p.canonicalize(modelUri.toFilePath()) ==
+              p.canonicalize(targetUri.toFilePath());
+
+      var modelLines = source.yaml.split('\n');
+      for (var lineIdx = 0; lineIdx < modelLines.length; lineIdx++) {
+        var rawLine = modelLines[lineIdx];
+
+        // Skip the declaration line itself in the declaration file (already handled above if includeDeclaration is true)
+        if (isDeclarationFile && _isDeclarationLine(rawLine, className)) {
+          continue;
+        }
+
+        var matches = classRegex.allMatches(rawLine);
+        for (var match in matches) {
+          var startCol = match.start;
+          var endCol = match.end;
+
+          // Ignore matches inside comments
+          if (_isCommentIndex(rawLine, startCol)) continue;
+
+          // Must be in a value position (after `:` or `-`)
+          if (!_isValuePosition(rawLine, startCol)) continue;
+
+          // Check for module qualification mismatch
+          if (!_matchesModule(rawLine, startCol, targetModel)) continue;
+
+          // Not a relation name= parameter
+          if (_isRelationNameParam(rawLine, startCol)) continue;
+
+          locations.add(
+            Location(
+              uri: modelUri,
+              range: Range(
+                start: Position(line: lineIdx, character: startCol),
+                end: Position(line: lineIdx, character: endCol),
+              ),
+            ),
+          );
+        }
+      }
+    }
+
+    return locations;
+  }
+
+  static List<Location> _findFieldReferences({
+    required List<String> lines,
+    required Uri documentUri,
+    required String fieldName,
+    required bool includeDeclaration,
+  }) {
+    var locations = <Location>[];
+    var fieldRegex = RegExp(r'\b' + RegExp.escape(fieldName) + r'\b');
+
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      var isDecl = RegExp(
+        r'^\s*' + RegExp.escape(fieldName) + r'\s*:',
+      ).hasMatch(line);
+
+      if (isDecl) {
+        if (includeDeclaration) {
+          var col = line.indexOf(fieldName);
+          locations.add(
+            Location(
+              uri: documentUri,
+              range: Range(
+                start: Position(line: i, character: col >= 0 ? col : 0),
+                end: Position(
+                  line: i,
+                  character: col >= 0 ? col + fieldName.length : line.length,
+                ),
+              ),
+            ),
+          );
+        }
+        continue;
+      }
+
+      var matches = fieldRegex.allMatches(line);
+      for (var match in matches) {
+        if (_isCommentIndex(line, match.start)) continue;
+
+        var before = line.substring(0, match.start);
+        var isRef =
+            before.contains('field=') ||
+            before.contains('fields:') ||
+            before.contains('field:') ||
+            before.contains('fields=[');
+
+        if (isRef) {
+          locations.add(
+            Location(
+              uri: documentUri,
+              range: Range(
+                start: Position(line: i, character: match.start),
+                end: Position(line: i, character: match.end),
+              ),
+            ),
+          );
+        }
+      }
+    }
+
+    return locations;
+  }
+
+  static bool _isDeclarationLine(String line, String className) {
+    var defRegex = RegExp(
+      r'^\s*(class|enum|exception)\s*:\s*' + RegExp.escape(className) + r'\b',
+    );
+    return defRegex.hasMatch(line);
+  }
+
+  static bool _isCommentIndex(String line, int index) {
+    var inSingleQuote = false;
+    var inDoubleQuote = false;
+    for (var i = 0; i < line.length && i <= index; i++) {
+      var char = line[i];
+      if (char == "'" && !inDoubleQuote) {
+        inSingleQuote = !inSingleQuote;
+      } else if (char == '"' && !inSingleQuote) {
+        inDoubleQuote = !inDoubleQuote;
+      } else if (char == '#' && !inSingleQuote && !inDoubleQuote) {
+        return index >= i;
+      }
+    }
+    return false;
+  }
+
+  static bool _isValuePosition(String line, int index) {
+    var colonIdx = line.indexOf(':');
+    if (colonIdx >= 0 && index > colonIdx) return true;
+    var dashIdx = line.indexOf('-');
+    if (dashIdx >= 0 && index > dashIdx) return true;
+    return false;
+  }
+
+  static bool _matchesModule(
+    String line,
+    int startCol,
+    SerializableModelDefinition targetModel,
+  ) {
+    if (startCol > 0 && line[startCol - 1] == ':') {
+      var prefix = line.substring(0, startCol - 1);
+      var delimiterIdx = prefix.lastIndexOf(RegExp(r'[\s,<(?:]'));
+      var word = delimiterIdx >= 0
+          ? prefix.substring(delimiterIdx + 1)
+          : prefix;
+      var parts = word.split(':');
+      var alias = parts.length >= 2 && parts[0] == 'module'
+          ? parts[1]
+          : parts.last;
+      if (alias.isNotEmpty && targetModel.type.moduleAlias != alias) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static bool _isRelationNameParam(String line, int startCol) {
+    var before = line.substring(0, startCol);
+    return before.endsWith('name=') || before.endsWith('name: ');
+  }
+}

--- a/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
@@ -5,6 +5,10 @@ import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
 import 'package:serverpod_cli/src/language_server/model_navigation_utils.dart';
 
 /// Provides Find References resolution for Serverpod model files.
+///
+/// References are resolved across model files only. Usages in Dart code, such
+/// as endpoints and business logic, are outside the scope of this analyzer and
+/// are left to the Dart language server.
 class ReferenceProvider {
   /// Finds all references to the symbol at [position] in [documentUri].
   static List<Location> findReferences({

--- a/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
@@ -2,7 +2,7 @@ import 'package:lsp_server/lsp_server.dart';
 import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/analyzer/models/definitions.dart';
 import 'package:serverpod_cli/src/analyzer/models/stateful_analyzer.dart';
-import 'package:serverpod_cli/src/language_server/definition_provider.dart';
+import 'package:serverpod_cli/src/language_server/model_navigation_utils.dart';
 
 /// Provides Find References resolution for Serverpod model files.
 class ReferenceProvider {
@@ -20,64 +20,43 @@ class ReferenceProvider {
     if (position.line < 0 || position.line >= lines.length) return [];
 
     var line = lines[position.line];
-    var wordMatch = DefinitionProvider.extractWordAt(line, position.character);
+    var wordMatch = extractWordAt(line, position.character);
     if (wordMatch == null) return [];
 
     var token = wordMatch.word;
 
-    // Skip primitive types and common keywords
-    if (DefinitionProvider.primitiveTypes.contains(token) ||
-        DefinitionProvider.ignoredKeywords.contains(token)) {
+    // 1. Check if token is a field of the current model. This runs before
+    // the keyword skip so that fields named like keywords (e.g. `name`)
+    // stay searchable.
+    var currentModel = analyzer.getModel(documentUri);
+    if (currentModel is ClassDefinition &&
+        currentModel.findField(token) != null) {
+      return _findFieldReferences(
+        lines: lines,
+        documentUri: documentUri,
+        fieldName: token,
+        includeDeclaration: context.includeDeclaration,
+      );
+    }
+
+    // 2. Skip primitive types and common keywords
+    if (primitiveTypes.contains(token) || ignoredKeywords.contains(token)) {
       return [];
     }
 
-    // 1. Check if token is a reference to a field in the current model
-    var currentModel = analyzer.getModel(documentUri);
-    if (currentModel is ClassDefinition) {
-      var isField =
-          currentModel.findField(token) != null ||
-          DefinitionProvider.isFieldReferenceContext(line, wordMatch);
-      if (isField && currentModel.findField(token) != null) {
-        return _findFieldReferences(
-          lines: lines,
-          documentUri: documentUri,
-          fieldName: token,
-          includeDeclaration: context.includeDeclaration,
-        );
-      }
-    }
+    // 3. Parse potential model / class target from token.
+    // `project:` and `package:` tokens denote plain Dart classes and can
+    // never resolve to a model.
+    var modelToken = parseModelToken(token);
+    if (modelToken == null) return [];
 
-    // 2. Parse potential model / class target from token
-    String? moduleAlias;
-    String className = token;
-
-    if (token.startsWith('module:')) {
-      var parts = token.split(':');
-      if (parts.length >= 3) {
-        moduleAlias = parts[1];
-        className = parts.sublist(2).join(':');
-      }
-    } else if (token.startsWith('project:')) {
-      var parts = token.split(':');
-      if (parts.length >= 3) {
-        moduleAlias = parts[1];
-        className = parts.sublist(2).join(':');
-      }
-    } else if (token.contains(':')) {
-      var parts = token.split(':');
-      if (parts.length == 2) {
-        moduleAlias = parts[0];
-        className = parts[1];
-      }
-    }
-
-    // 3. Search model by className and moduleAlias
+    // 4. Search model by className and moduleAlias
     var targetModel = analyzer.findModelByName(
-      className,
-      moduleAlias: moduleAlias,
+      modelToken.className,
+      moduleAlias: modelToken.moduleAlias,
     );
 
-    // 4. If not found by class name, try searching by database table name
+    // 5. If not found by class name, try searching by database table name
     targetModel ??= analyzer.findModelByTableName(token);
 
     if (targetModel == null) return [];
@@ -101,7 +80,7 @@ class ReferenceProvider {
     // 1. Declaration site
     if (includeDeclaration && targetSource != null && targetUri != null) {
       var targetLines = targetSource.yaml.split('\n');
-      var declRange = DefinitionProvider.findModelDefinitionRange(
+      var declRange = findModelDefinitionRange(
         targetLines,
         targetModel.className,
       );
@@ -124,7 +103,8 @@ class ReferenceProvider {
         var rawLine = modelLines[lineIdx];
 
         // Skip the declaration line itself in the declaration file (already handled above if includeDeclaration is true)
-        if (isDeclarationFile && _isDeclarationLine(rawLine, className)) {
+        if (isDeclarationFile &&
+            modelDeclarationColumn(rawLine, className) != null) {
           continue;
         }
 
@@ -172,21 +152,18 @@ class ReferenceProvider {
 
     for (var i = 0; i < lines.length; i++) {
       var line = lines[i];
-      var isDecl = RegExp(
-        r'^\s*' + RegExp.escape(fieldName) + r'\s*:',
-      ).hasMatch(line);
+      var declColumn = fieldDeclarationColumn(line, fieldName);
 
-      if (isDecl) {
+      if (declColumn != null) {
         if (includeDeclaration) {
-          var col = line.indexOf(fieldName);
           locations.add(
             Location(
               uri: documentUri,
               range: Range(
-                start: Position(line: i, character: col >= 0 ? col : 0),
+                start: Position(line: i, character: declColumn),
                 end: Position(
                   line: i,
-                  character: col >= 0 ? col + fieldName.length : line.length,
+                  character: declColumn + fieldName.length,
                 ),
               ),
             ),
@@ -199,35 +176,21 @@ class ReferenceProvider {
       for (var match in matches) {
         if (_isCommentIndex(line, match.start)) continue;
 
-        var before = line.substring(0, match.start);
-        var isRef =
-            before.contains('field=') ||
-            before.contains('fields:') ||
-            before.contains('field:') ||
-            before.contains('fields=[');
+        if (!isFieldReferenceContext(line, match.start)) continue;
 
-        if (isRef) {
-          locations.add(
-            Location(
-              uri: documentUri,
-              range: Range(
-                start: Position(line: i, character: match.start),
-                end: Position(line: i, character: match.end),
-              ),
+        locations.add(
+          Location(
+            uri: documentUri,
+            range: Range(
+              start: Position(line: i, character: match.start),
+              end: Position(line: i, character: match.end),
             ),
-          );
-        }
+          ),
+        );
       }
     }
 
     return locations;
-  }
-
-  static bool _isDeclarationLine(String line, String className) {
-    var defRegex = RegExp(
-      r'^\s*(class|enum|exception)\s*:\s*' + RegExp.escape(className) + r'\b',
-    );
-    return defRegex.hasMatch(line);
   }
 
   static bool _isCommentIndex(String line, int index) {
@@ -262,13 +225,9 @@ class ReferenceProvider {
     if (startCol > 0 && line[startCol - 1] == ':') {
       var prefix = line.substring(0, startCol - 1);
       var delimiterIdx = prefix.lastIndexOf(RegExp(r'[\s,<(?:]'));
-      var word = delimiterIdx >= 0
+      var alias = delimiterIdx >= 0
           ? prefix.substring(delimiterIdx + 1)
           : prefix;
-      var parts = word.split(':');
-      var alias = parts.length >= 2 && parts[0] == 'module'
-          ? parts[1]
-          : parts.last;
       if (alias.isNotEmpty && targetModel.type.moduleAlias != alias) {
         return false;
       }

--- a/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
+++ b/tools/serverpod_cli/lib/src/language_server/reference_provider.dart
@@ -27,6 +27,12 @@ class ReferenceProvider {
     var wordMatch = extractWordAt(line, position.character);
     if (wordMatch == null) return [];
 
+    // Quoted values and comments are plain text and never reference a model
+    // or a field of one.
+    if (lineContextAt(line, wordMatch.startColumn) != LineContext.code) {
+      return [];
+    }
+
     var token = wordMatch.word;
 
     // 1. Check if token is a field of the current model. This runs before
@@ -138,8 +144,8 @@ class ReferenceProvider {
         var columns = <int, int>{};
 
         for (var match in classRegex.allMatches(rawLine)) {
-          // Ignore matches inside comments
-          if (_isCommentIndex(rawLine, match.start)) continue;
+          // Ignore matches inside comments and quoted values
+          if (lineContextAt(rawLine, match.start) != LineContext.code) continue;
 
           // Must be in a value position, never a key or a sequence entry
           if (!isValuePosition(rawLine, match.start)) continue;
@@ -154,7 +160,7 @@ class ReferenceProvider {
         }
 
         for (var match in tableRegex?.allMatches(rawLine) ?? <RegExpMatch>[]) {
-          if (_isCommentIndex(rawLine, match.start)) continue;
+          if (lineContextAt(rawLine, match.start) != LineContext.code) continue;
           if (!isTableReferenceContext(rawLine, match.start)) continue;
 
           columns[match.start] = match.end;
@@ -199,7 +205,7 @@ class ReferenceProvider {
 
       var matches = fieldRegex.allMatches(line);
       for (var match in matches) {
-        if (_isCommentIndex(line, match.start)) continue;
+        if (lineContextAt(line, match.start) != LineContext.code) continue;
 
         if (!isFieldReferenceContext(line, match.start)) continue;
 
@@ -216,22 +222,6 @@ class ReferenceProvider {
     }
 
     return locations;
-  }
-
-  static bool _isCommentIndex(String line, int index) {
-    var inSingleQuote = false;
-    var inDoubleQuote = false;
-    for (var i = 0; i < line.length && i <= index; i++) {
-      var char = line[i];
-      if (char == "'" && !inDoubleQuote) {
-        inSingleQuote = !inSingleQuote;
-      } else if (char == '"' && !inSingleQuote) {
-        inDoubleQuote = !inDoubleQuote;
-      } else if (char == '#' && !inSingleQuote && !inDoubleQuote) {
-        return index >= i;
-      }
-    }
-    return false;
   }
 
   static bool _matchesModule(

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -1156,6 +1156,7 @@ fields:
       setUp(() async {
         await ProjectDirectoryBuilder()
             .withModelDirContents([
+              // The table name is also a key of the model file syntax.
               d.file('parameter.spy.yaml', '''
 class: Parameter
 table: parameters

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -335,6 +335,10 @@ void main() {
     late String modelsDir;
     late String userModelPath;
     late String postModelPath;
+    late String indexedModelPath;
+    late String configModelPath;
+    late String enumModelPath;
+    late String jobModelPath;
 
     setUp(() async {
       await ProjectDirectoryBuilder().build().create();
@@ -350,6 +354,10 @@ void main() {
 
       userModelPath = p.join(modelsDir, 'user.spy.yaml');
       postModelPath = p.join(modelsDir, 'post.spy.yaml');
+      indexedModelPath = p.join(modelsDir, 'indexed.spy.yaml');
+      configModelPath = p.join(modelsDir, 'app_config.spy.yaml');
+      enumModelPath = p.join(modelsDir, 'stage_family.spy.yaml');
+      jobModelPath = p.join(modelsDir, 'job.spy.yaml');
 
       File(userModelPath).writeAsStringSync('''
 class: User
@@ -365,6 +373,38 @@ fields:
   title: String
   authorId: int
   author: User?, relation(field=authorId)
+''');
+
+      File(indexedModelPath).writeAsStringSync('''
+class: Indexed
+table: indexed
+fields:
+  title: String
+  authorId: int
+indexes:
+  indexed_title_idx:
+    fields: title, authorId
+''');
+
+      File(configModelPath).writeAsStringSync('''
+class: AppConfig
+fields:
+  data: project:my_project:ConfigData
+''');
+
+      File(enumModelPath).writeAsStringSync('''
+enum: IngestionStageFamily
+serialized: byName
+values:
+  - alpha
+  - beta
+''');
+
+      File(jobModelPath).writeAsStringSync('''
+class: Job
+table: job
+fields:
+  stage: IngestionStageFamily
 ''');
 
       session = LanguageServerTestSession();
@@ -534,29 +574,10 @@ fields:
       'when references are requested for an enum on its declaration line, '
       'then it returns references across other model files.',
       () async {
-        var enumPath = p.join(modelsDir, 'stage_family.spy.yaml');
-        var jobPath = p.join(modelsDir, 'job.spy.yaml');
-
-        File(enumPath).writeAsStringSync('''
-enum: IngestionStageFamily
-serialized: byName
-values:
-  - alpha
-  - beta
-''');
-
-        File(jobPath).writeAsStringSync('''
-class: Job
-table: job
-fields:
-  stage: IngestionStageFamily
-''');
-
-        session.openDocument(enumPath, File(enumPath).readAsStringSync());
-        session.openDocument(jobPath, File(jobPath).readAsStringSync());
-
+        // Line 0 in stage_family.spy.yaml: "enum: IngestionStageFamily" ->
+        // "IngestionStageFamily" is at column 6
         var result = await session.requestReferences(
-          enumPath,
+          enumModelPath,
           line: 0,
           character: 8,
           includeDeclaration: false,
@@ -567,7 +588,7 @@ fields:
         expect(locations, hasLength(1));
 
         var loc = locations.first;
-        expect(loc['uri'], Uri.file(jobPath).toString());
+        expect(loc['uri'], Uri.file(jobModelPath).toString());
         var start = (loc['range'] as Map)['start'] as Map;
         // In job.spy.yaml: "  stage: IngestionStageFamily" -> line 3, col 9
         expect(start['line'], 3);
@@ -589,7 +610,413 @@ fields:
         expect(result as List, isEmpty);
       },
     );
+
+    test(
+      'when definition is requested on a word that resolves to nothing, '
+      'then it returns null.',
+      () async {
+        // Line 3 in post.spy.yaml: "  title: String" -> "title" is a field
+        // declaration, not a reference, and matches no model or table name.
+        var result = await session.requestDefinition(
+          postModelPath,
+          line: 3,
+          character: 3,
+        );
+
+        expect(result, isNull);
+      },
+    );
+
+    test(
+      'when definition is requested on a database table name, '
+      'then it returns the location of the model definition.',
+      () async {
+        // Line 1 in user.spy.yaml: "table: user" -> "user" is at column 7
+        var result = await session.requestDefinition(
+          userModelPath,
+          line: 1,
+          character: 8,
+        );
+
+        expect(result, isNotNull);
+        var location = result as Map<String, dynamic>;
+        var range = location['range'] as Map<String, dynamic>;
+        var start = range['start'] as Map<String, dynamic>;
+        expect(location['uri'], Uri.file(userModelPath).toString());
+        expect(start['line'], 0);
+        expect(start['character'], 7);
+      },
+    );
+
+    test(
+      'when definition is requested on a field in an index, '
+      'then it returns the location of the field declaration.',
+      () async {
+        // Line 7 in indexed.spy.yaml: "    fields: title, authorId" ->
+        // "authorId" is at column 19
+        var result = await session.requestDefinition(
+          indexedModelPath,
+          line: 7,
+          character: 20,
+        );
+
+        expect(result, isNotNull);
+        var location = result as Map<String, dynamic>;
+        var range = location['range'] as Map<String, dynamic>;
+        var start = range['start'] as Map<String, dynamic>;
+        expect(location['uri'], Uri.file(indexedModelPath).toString());
+        // authorId is declared at line 4: "  authorId: int"
+        expect(start['line'], 4);
+        expect(start['character'], 2);
+      },
+    );
+
+    test(
+      'when definition is requested on a project: type reference, '
+      'then it returns null.',
+      () async {
+        // Line 2 in app_config.spy.yaml: "  data: project:my_project:ConfigData"
+        // -> "ConfigData" is at column 27
+        var result = await session.requestDefinition(
+          configModelPath,
+          line: 2,
+          character: 30,
+        );
+
+        expect(result, isNull);
+      },
+    );
+
+    test(
+      'when references are requested on a project: type reference, '
+      'then it returns an empty list.',
+      () async {
+        var result = await session.requestReferences(
+          configModelPath,
+          line: 2,
+          character: 30,
+        );
+
+        expect(result, isA<List>());
+        expect(result as List, isEmpty);
+      },
+    );
+
+    test(
+      'when references are requested for a field with includeDeclaration false, '
+      'then only the references are returned.',
+      () async {
+        // Line 4 in post.spy.yaml: "  authorId: int" -> "authorId" is at
+        // column 2
+        var result = await session.requestReferences(
+          postModelPath,
+          line: 4,
+          character: 5,
+          includeDeclaration: false,
+        );
+
+        expect(result, isNotNull);
+        var locations = (result as List).cast<Map<String, dynamic>>();
+        expect(locations, hasLength(1));
+
+        var ref = locations.first;
+        expect(ref['uri'], Uri.file(postModelPath).toString());
+        var start = (ref['range'] as Map)['start'] as Map;
+        expect(start['line'], 5);
+        expect(start['character'], 32);
+      },
+    );
   });
+
+  group(
+    'Given an initialized language server with a model that has a field named like a YAML keyword,',
+    () {
+      late LanguageServerTestSession session;
+      late String profileModelPath;
+
+      setUp(() async {
+        await ProjectDirectoryBuilder()
+            .withModelDirContents([
+              d.file('user.spy.yaml', '''
+class: User
+table: user
+fields:
+  name: String
+'''),
+              d.file('profile.spy.yaml', '''
+class: Profile
+table: profile
+fields:
+  name: String
+  user: User?, relation(field=name)
+'''),
+            ])
+            .build()
+            .create();
+
+        profileModelPath = p.join(
+          d.sandbox,
+          'project',
+          'my_project_server',
+          'lib',
+          'src',
+          'models',
+          'profile.spy.yaml',
+        );
+
+        session = LanguageServerTestSession();
+        await session.initialize(Uri.directory(p.join(d.sandbox, 'project')));
+        session.sendInitialized();
+      });
+
+      tearDown(() async {
+        await session.dispose();
+      });
+
+      test(
+        'when definition is requested on a relation reference to that field, '
+        'then it returns the location of the field declaration.',
+        () async {
+          // Line 4 in profile.spy.yaml: "  user: User?, relation(field=name)"
+          // -> the referenced "name" is at column 30
+          var result = await session.requestDefinition(
+            profileModelPath,
+            line: 4,
+            character: 31,
+          );
+
+          expect(result, isNotNull);
+          var location = result as Map<String, dynamic>;
+          var range = location['range'] as Map<String, dynamic>;
+          var start = range['start'] as Map<String, dynamic>;
+          expect(location['uri'], Uri.file(profileModelPath).toString());
+          // name is declared at line 3: "  name: String"
+          expect(start['line'], 3);
+          expect(start['character'], 2);
+        },
+      );
+
+      test(
+        'when references are requested for that field, '
+        'then it returns occurrences in relations and declarations.',
+        () async {
+          // Line 3 in profile.spy.yaml: "  name: String" -> "name" is at
+          // column 2
+          var result = await session.requestReferences(
+            profileModelPath,
+            line: 3,
+            character: 3,
+            includeDeclaration: true,
+          );
+
+          expect(result, isNotNull);
+          var locations = (result as List).cast<Map<String, dynamic>>();
+          expect(locations, hasLength(2));
+
+          // Declaration at line 3
+          var decl = locations.firstWhere(
+            (l) => ((l['range'] as Map)['start'] as Map)['line'] == 3,
+          );
+          expect(decl['uri'], Uri.file(profileModelPath).toString());
+
+          // Relation reference at line 4, column 30
+          var rel = locations.firstWhere(
+            (l) => ((l['range'] as Map)['start'] as Map)['line'] == 4,
+          );
+          var relStart = (rel['range'] as Map)['start'] as Map;
+          expect(rel['uri'], Uri.file(profileModelPath).toString());
+          expect(relStart['character'], 30);
+        },
+      );
+    },
+  );
+
+  group(
+    'Given an initialized language server with a model that mentions another model in a comment,',
+    () {
+      late LanguageServerTestSession session;
+      late String userModelPath;
+      late String commentModelPath;
+
+      setUp(() async {
+        await ProjectDirectoryBuilder()
+            .withModelDirContents([
+              d.file('user.spy.yaml', '''
+class: User
+table: user
+fields:
+  name: String
+'''),
+              d.file('comment.spy.yaml', '''
+class: Comment
+table: comment
+# The User class should not be matched inside comments
+fields:
+  text: String
+  author: User
+'''),
+            ])
+            .build()
+            .create();
+
+        var modelsDir = p.join(
+          d.sandbox,
+          'project',
+          'my_project_server',
+          'lib',
+          'src',
+          'models',
+        );
+        userModelPath = p.join(modelsDir, 'user.spy.yaml');
+        commentModelPath = p.join(modelsDir, 'comment.spy.yaml');
+
+        session = LanguageServerTestSession();
+        await session.initialize(Uri.directory(p.join(d.sandbox, 'project')));
+        session.sendInitialized();
+      });
+
+      tearDown(() async {
+        await session.dispose();
+      });
+
+      test(
+        'when references are requested for the mentioned model, '
+        'then it returns the reference in the model file and excludes the match inside the comment.',
+        () async {
+          // Line 0 in user.spy.yaml: "class: User" -> "User" is at column 7
+          var result = await session.requestReferences(
+            userModelPath,
+            line: 0,
+            character: 8,
+            includeDeclaration: false,
+          );
+
+          expect(result, isNotNull);
+          var locations = (result as List).cast<Map<String, dynamic>>();
+          expect(locations, hasLength(1));
+
+          var ref = locations.first;
+          expect(ref['uri'], Uri.file(commentModelPath).toString());
+          var start = (ref['range'] as Map)['start'] as Map;
+          // Line 5 in comment.spy.yaml: "  author: User" -> "User" is at
+          // column 10; the mention in the comment at line 2 is excluded.
+          expect(start['line'], 5);
+          expect(start['character'], 10);
+        },
+      );
+    },
+  );
+
+  group(
+    'Given an initialized language server for a project with a module dependency,',
+    () {
+      late LanguageServerTestSession session;
+      late String orderModelPath;
+      late String moduleModelPath;
+
+      setUp(() async {
+        await ProjectDirectoryBuilder()
+            .withModelDirContents([
+              d.file('order.spy.yaml', '''
+class: Order
+table: order
+fields:
+  user: module:auth:UserInfo
+'''),
+            ])
+            .withModule(
+              'auth',
+              modelDirContents: [
+                d.file('user_info.spy.yaml', '''
+class: UserInfo
+table: user_info
+fields:
+  name: String
+'''),
+              ],
+            )
+            .build()
+            .create();
+
+        orderModelPath = p.join(
+          d.sandbox,
+          'project',
+          'my_project_server',
+          'lib',
+          'src',
+          'models',
+          'order.spy.yaml',
+        );
+        moduleModelPath = p.join(
+          d.sandbox,
+          'project',
+          'auth_server',
+          'lib',
+          'src',
+          'models',
+          'user_info.spy.yaml',
+        );
+
+        session = LanguageServerTestSession();
+        await session.initialize(Uri.directory(p.join(d.sandbox, 'project')));
+        session.sendInitialized();
+      });
+
+      tearDown(() async {
+        await session.dispose();
+      });
+
+      test(
+        'when definition is requested on a module-qualified model name, '
+        'then it returns the location of the module model definition.',
+        () async {
+          // Line 3 in order.spy.yaml: "  user: module:auth:UserInfo"
+          // "UserInfo" is at column 20
+          var result = await session.requestDefinition(
+            orderModelPath,
+            line: 3,
+            character: 21,
+          );
+
+          expect(result, isNotNull);
+          var location = result as Map<String, dynamic>;
+          var range = location['range'] as Map<String, dynamic>;
+          var start = range['start'] as Map<String, dynamic>;
+          expect(location['uri'], Uri.file(moduleModelPath).toString());
+          expect(start['line'], 0);
+          expect(start['character'], 7);
+        },
+      );
+
+      test(
+        'when references are requested for a module model on its declaration line, '
+        'then it returns module-qualified references in project model files.',
+        () async {
+          // Line 0 in user_info.spy.yaml: "class: UserInfo" -> "UserInfo" is
+          // at column 7
+          var result = await session.requestReferences(
+            moduleModelPath,
+            line: 0,
+            character: 8,
+            includeDeclaration: false,
+          );
+
+          expect(result, isNotNull);
+          var locations = (result as List).cast<Map<String, dynamic>>();
+          expect(locations, hasLength(1));
+
+          var loc = locations.first;
+          expect(loc['uri'], Uri.file(orderModelPath).toString());
+          var range = loc['range'] as Map<String, dynamic>;
+          var start = range['start'] as Map<String, dynamic>;
+          var end = range['end'] as Map<String, dynamic>;
+          expect(start['line'], 3);
+          expect(start['character'], 20);
+          expect(end['character'], 28);
+        },
+      );
+    },
+  );
 
   group('Given an initialized language server with linkSupport enabled,', () {
     late LanguageServerTestSession session;

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -1150,6 +1150,7 @@ fields:
       late LanguageServerTestSession session;
       late String parameterModelPath;
       late String holderModelPath;
+      late String recordModelPath;
       late String ownerModelPath;
 
       setUp(() async {
@@ -1174,6 +1175,16 @@ serialized: byName
 values:
   - Parameter
   - guest
+'''),
+              // A field that is named like a top level key.
+              d.file('record.spy.yaml', '''
+class: Record
+table: record
+fields:
+  table: String
+indexes:
+  record_table_idx:
+    fields: table
 '''),
               // A model that shares the name of a foreign key action.
               d.file('cascade.spy.yaml', '''
@@ -1202,6 +1213,7 @@ fields:
         );
         parameterModelPath = p.join(modelsDir, 'parameter.spy.yaml');
         holderModelPath = p.join(modelsDir, 'holder.spy.yaml');
+        recordModelPath = p.join(modelsDir, 'record.spy.yaml');
         ownerModelPath = p.join(modelsDir, 'owner.spy.yaml');
 
         session = LanguageServerTestSession();
@@ -1233,6 +1245,29 @@ fields:
           expect(location['uri'], Uri.file(parameterModelPath).toString());
           expect(start['line'], 0);
           expect(start['character'], 7);
+        },
+      );
+
+      test(
+        'when definition is requested on a field that is named like a top '
+        'level key, '
+        'then it returns the location of the field declaration.',
+        () async {
+          // Line 6 in record.spy.yaml: "    fields: table"
+          // -> the referenced "table" is at column 12
+          var result = await session.requestDefinition(
+            recordModelPath,
+            line: 6,
+            character: 14,
+          );
+
+          expect(result, isNotNull);
+          var location = result as Map<String, dynamic>;
+          var start = (location['range'] as Map)['start'] as Map;
+          expect(location['uri'], Uri.file(recordModelPath).toString());
+          // The field is declared at line 3, not at the "table:" key on line 1
+          expect(start['line'], 3);
+          expect(start['character'], 2);
         },
       );
 

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -1142,4 +1142,86 @@ fields:
       },
     );
   });
+
+  group(
+    'Given an initialized language server with models whose table names and '
+    'fields collide with the model file syntax,',
+    () {
+      late LanguageServerTestSession session;
+      late String parameterModelPath;
+      late String holderModelPath;
+
+      setUp(() async {
+        await ProjectDirectoryBuilder()
+            .withModelDirContents([
+              d.file('parameter.spy.yaml', '''
+class: Parameter
+table: parameters
+fields:
+  name: String
+'''),
+              d.file('holder.spy.yaml', '''
+class: Holder
+table: holder
+fields:
+  param: Parameter?, relation(parent=parameters)
+'''),
+              // An enum value that shares the name of a model.
+              d.file('role.spy.yaml', '''
+enum: Role
+serialized: byName
+values:
+  - Parameter
+  - guest
+'''),
+            ])
+            .build()
+            .create();
+
+        var modelsDir = p.join(
+          d.sandbox,
+          'project',
+          'my_project_server',
+          'lib',
+          'src',
+          'models',
+        );
+        parameterModelPath = p.join(modelsDir, 'parameter.spy.yaml');
+        holderModelPath = p.join(modelsDir, 'holder.spy.yaml');
+
+        session = LanguageServerTestSession();
+        await session.initialize(Uri.directory(p.join(d.sandbox, 'project')));
+        session.sendInitialized();
+      });
+
+      tearDown(() async {
+        await session.dispose();
+      });
+
+      test(
+        'when references are requested for a model that shares its name with '
+        'an enum value, '
+        'then the enum value is not reported as a reference.',
+        () async {
+          // Line 0 in parameter.spy.yaml: "class: Parameter"
+          var result = await session.requestReferences(
+            parameterModelPath,
+            line: 0,
+            character: 8,
+            includeDeclaration: false,
+          );
+
+          var locations = (result as List).cast<Map<String, dynamic>>();
+          expect(
+            locations.map((loc) => loc['uri']),
+            isNot(contains(contains('role.spy.yaml'))),
+          );
+          expect(
+            locations.map((loc) => loc['uri']),
+            everyElement(Uri.file(holderModelPath).toString()),
+          );
+        },
+      );
+    },
+  );
 }

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -1152,6 +1152,7 @@ fields:
       late String holderModelPath;
       late String recordModelPath;
       late String ownerModelPath;
+      late String noteModelPath;
 
       setUp(() async {
         await ProjectDirectoryBuilder()
@@ -1200,6 +1201,16 @@ table: owner
 fields:
   item: Cascade?, relation(onDelete=CASCADE)
 '''),
+              // A comment dedented below the entries of the fields block.
+              d.file('note.spy.yaml', '''
+class: Note
+table: note
+fields:
+  title: String
+# foreign key
+  authorId: int
+  author: Cascade?, relation(field=authorId)
+'''),
             ])
             .build()
             .create();
@@ -1216,6 +1227,7 @@ fields:
         holderModelPath = p.join(modelsDir, 'holder.spy.yaml');
         recordModelPath = p.join(modelsDir, 'record.spy.yaml');
         ownerModelPath = p.join(modelsDir, 'owner.spy.yaml');
+        noteModelPath = p.join(modelsDir, 'note.spy.yaml');
 
         session = LanguageServerTestSession();
         await session.initialize(Uri.directory(p.join(d.sandbox, 'project')));
@@ -1343,6 +1355,58 @@ fields:
             locations.map((loc) => loc['uri']),
             everyElement(Uri.file(holderModelPath).toString()),
           );
+        },
+      );
+
+      test(
+        'when definition is requested on a field of a fields block that holds '
+        'a dedented comment, '
+        'then it returns the location of the field declaration.',
+        () async {
+          // Line 6 in note.spy.yaml:
+          // "  author: Cascade?, relation(field=authorId)"
+          // -> the referenced "authorId" is at column 35
+          var result = await session.requestDefinition(
+            noteModelPath,
+            line: 6,
+            character: 37,
+          );
+
+          expect(result, isNotNull);
+          var location = result as Map<String, dynamic>;
+          var start = (location['range'] as Map)['start'] as Map;
+          expect(location['uri'], Uri.file(noteModelPath).toString());
+          // authorId is declared at line 5, below the comment on line 4
+          expect(start['line'], 5);
+          expect(start['character'], 2);
+        },
+      );
+
+      test(
+        'when references are requested for a field of a fields block that '
+        'holds a dedented comment, '
+        'then the declaration is reported alongside the relation usage.',
+        () async {
+          // Line 5 in note.spy.yaml: "  authorId: int"
+          var result = await session.requestReferences(
+            noteModelPath,
+            line: 5,
+            character: 4,
+            includeDeclaration: true,
+          );
+
+          var locations = (result as List).cast<Map<String, dynamic>>();
+          expect(locations, hasLength(2));
+
+          var starts = locations
+              .map((loc) => (loc['range'] as Map)['start'] as Map)
+              .toList();
+          expect(
+            locations.map((loc) => loc['uri']),
+            everyElement(Uri.file(noteModelPath).toString()),
+          );
+          expect(starts.map((start) => start['line']), [5, 6]);
+          expect(starts.map((start) => start['character']), [2, 35]);
         },
       );
     },

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -672,6 +672,32 @@ fields:
     );
 
     test(
+      'when a model definition is requested by class name, '
+      'then it returns the location of the model definition.',
+      () async {
+        var result = await session.requestModelDefinition('User');
+
+        expect(result, isNotNull);
+        var location = result as Map<String, dynamic>;
+        var range = location['range'] as Map<String, dynamic>;
+        var start = range['start'] as Map<String, dynamic>;
+        expect(location['uri'], Uri.file(userModelPath).toString());
+        expect(start['line'], 0);
+        expect(start['character'], 7);
+      },
+    );
+
+    test(
+      'when a model definition is requested by an unknown class name, '
+      'then it returns null.',
+      () async {
+        var result = await session.requestModelDefinition('NonExistent');
+
+        expect(result, isNull);
+      },
+    );
+
+    test(
       'when definition is requested on a project: type reference, '
       'then it returns null.',
       () async {
@@ -976,6 +1002,25 @@ fields:
             orderModelPath,
             line: 3,
             character: 21,
+          );
+
+          expect(result, isNotNull);
+          var location = result as Map<String, dynamic>;
+          var range = location['range'] as Map<String, dynamic>;
+          var start = range['start'] as Map<String, dynamic>;
+          expect(location['uri'], Uri.file(moduleModelPath).toString());
+          expect(start['line'], 0);
+          expect(start['character'], 7);
+        },
+      );
+
+      test(
+        'when a model definition is requested by module-qualified class name, '
+        'then it returns the location of the module model definition.',
+        () async {
+          var result = await session.requestModelDefinition(
+            'UserInfo',
+            moduleAlias: 'auth',
           );
 
           expect(result, isNotNull);

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -1034,6 +1034,24 @@ fields:
       );
 
       test(
+        'when a model definition is requested with an import prefix that '
+        'names no module, '
+        'then it falls back to the unqualified model definition.',
+        () async {
+          // Generated Dart code imports modules under prefixes such as _i2,
+          // which say nothing about the module alias.
+          var result = await session.requestModelDefinition(
+            'UserInfo',
+            moduleAlias: '_i2',
+          );
+
+          expect(result, isNotNull);
+          var location = result as Map<String, dynamic>;
+          expect(location['uri'], Uri.file(moduleModelPath).toString());
+        },
+      );
+
+      test(
         'when references are requested for a module model on its declaration line, '
         'then it returns module-qualified references in project model files.',
         () async {

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -1154,6 +1154,7 @@ fields:
       late String ownerModelPath;
       late String noteModelPath;
       late String labelModelPath;
+      late String ticketModelPath;
 
       setUp(() async {
         await ProjectDirectoryBuilder()
@@ -1202,6 +1203,14 @@ table: owner
 fields:
   item: Cascade?, relation(onDelete=CASCADE)
 '''),
+              // A field named after the table it points at.
+              d.file('ticket.spy.yaml', '''
+class: Ticket
+table: ticket
+fields:
+  recordId: int, relation(parent=record)
+  record: Record?, relation(field=recordId)
+'''),
               // Quoted defaults that spell out a model and a table name.
               d.file('label.spy.yaml', '''
 class: Label
@@ -1238,6 +1247,7 @@ fields:
         ownerModelPath = p.join(modelsDir, 'owner.spy.yaml');
         noteModelPath = p.join(modelsDir, 'note.spy.yaml');
         labelModelPath = p.join(modelsDir, 'label.spy.yaml');
+        ticketModelPath = p.join(modelsDir, 'ticket.spy.yaml');
 
         session = LanguageServerTestSession();
         await session.initialize(Uri.directory(p.join(d.sandbox, 'project')));
@@ -1474,6 +1484,38 @@ fields:
             locations.map((loc) => loc['uri']),
             isNot(contains(Uri.file(labelModelPath).toString())),
           );
+        },
+      );
+
+      test(
+        'when references are requested on a parent table that is also the '
+        'name of a field of the same model, '
+        'then it returns the usages of the model behind that table.',
+        () async {
+          // Line 3 in ticket.spy.yaml:
+          // "  recordId: int, relation(parent=record)"
+          // -> "record" is at column 33
+          var result = await session.requestReferences(
+            ticketModelPath,
+            line: 3,
+            character: 35,
+            includeDeclaration: false,
+          );
+
+          var locations = (result as List).cast<Map<String, dynamic>>();
+          expect(locations, hasLength(2));
+          expect(
+            locations.map((loc) => loc['uri']),
+            everyElement(Uri.file(ticketModelPath).toString()),
+          );
+
+          // The table usage on line 3 and the class name on line 4, never the
+          // "record:" field declaration.
+          var starts = locations
+              .map((loc) => (loc['range'] as Map)['start'] as Map)
+              .toList();
+          expect(starts.map((start) => start['line']), [3, 4]);
+          expect(starts.map((start) => start['character']), [33, 10]);
         },
       );
     },

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -1034,8 +1034,7 @@ fields:
       );
 
       test(
-        'when a model definition is requested with an import prefix that '
-        'names no module, '
+        'when a model definition is requested with an import prefix that names no module, '
         'then it falls back to the unqualified model definition.',
         () async {
           // Generated Dart code imports modules under prefixes such as _i2,
@@ -1277,8 +1276,7 @@ fields:
       });
 
       test(
-        'when definition is requested on a parent table name that is also a '
-        'key of the model file syntax, '
+        'when definition is requested on a parent table name that is also a key of the model file syntax, '
         'then it returns the location of the model definition.',
         () async {
           // Line 3 in holder.spy.yaml:
@@ -1300,8 +1298,7 @@ fields:
       );
 
       test(
-        'when definition is requested on a field that is named like a top '
-        'level key, '
+        'when definition is requested on a field that is named like a top level key, '
         'then it returns the location of the field declaration.',
         () async {
           // Line 6 in record.spy.yaml: "    fields: table"
@@ -1323,8 +1320,7 @@ fields:
       );
 
       test(
-        'when definition is requested on a foreign key action written in a '
-        'different casing than a model that shares its name, '
+        'when definition is requested on a foreign key action written in a different casing than a model that shares its name, '
         'then it returns null.',
         () async {
           // Line 3 in owner.spy.yaml:
@@ -1372,8 +1368,7 @@ fields:
       );
 
       test(
-        'when references are requested for a model that shares its name with '
-        'an enum value, '
+        'when references are requested for a model that shares its name with an enum value, '
         'then the enum value is not reported as a reference.',
         () async {
           // Line 0 in parameter.spy.yaml: "class: Parameter"
@@ -1397,8 +1392,7 @@ fields:
       );
 
       test(
-        'when definition is requested on a field of a fields block that holds '
-        'a dedented comment, '
+        'when definition is requested on a field of a fields block that holds a dedented comment, '
         'then it returns the location of the field declaration.',
         () async {
           // Line 6 in note.spy.yaml:
@@ -1421,8 +1415,7 @@ fields:
       );
 
       test(
-        'when references are requested for a field of a fields block that '
-        'holds a dedented comment, '
+        'when references are requested for a field of a fields block that holds a dedented comment, '
         'then the declaration is reported alongside the relation usage.',
         () async {
           // Line 5 in note.spy.yaml: "  authorId: int"
@@ -1449,8 +1442,7 @@ fields:
       );
 
       test(
-        'when definition is requested on a quoted default that spells out a '
-        'model name, '
+        'when definition is requested on a quoted default that spells out a model name, '
         'then it returns null.',
         () async {
           // Line 3 in label.spy.yaml:
@@ -1467,8 +1459,7 @@ fields:
       );
 
       test(
-        'when definition is requested on a quoted default that spells out a '
-        'table name, '
+        'when definition is requested on a quoted default that spells out a table name, '
         'then it returns null.',
         () async {
           // Line 4 in label.spy.yaml:
@@ -1485,8 +1476,7 @@ fields:
       );
 
       test(
-        'when references are requested for a model whose name is spelled out '
-        'by a quoted default, '
+        'when references are requested for a model whose name is spelled out by a quoted default, '
         'then the quoted default is not reported as a reference.',
         () async {
           // Line 0 in parameter.spy.yaml: "class: Parameter"
@@ -1506,8 +1496,7 @@ fields:
       );
 
       test(
-        'when references are requested on a parent table that is also the '
-        'name of a field of the same model, '
+        'when references are requested on a parent table that is also the name of a field of the same model, '
         'then it returns the usages of the model behind that table.',
         () async {
           // Line 3 in ticket.spy.yaml:

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -437,6 +437,158 @@ fields:
         expect(result, isNull);
       },
     );
+
+    test(
+      'when references are requested for a class on its declaration line with includeDeclaration false, '
+      'then it returns references across other model files.',
+      () async {
+        // Line 0 in user.spy.yaml: "class: User" -> "User" is at column 7
+        var result = await session.requestReferences(
+          userModelPath,
+          line: 0,
+          character: 8,
+          includeDeclaration: false,
+        );
+
+        expect(result, isNotNull);
+        expect(result, isA<List>());
+        var locations = (result as List).cast<Map<String, dynamic>>();
+        expect(locations, hasLength(1));
+
+        var loc = locations.first;
+        expect(loc['uri'], Uri.file(postModelPath).toString());
+        var range = loc['range'] as Map<String, dynamic>;
+        var start = range['start'] as Map<String, dynamic>;
+        var end = range['end'] as Map<String, dynamic>;
+        // In post.spy.yaml: "  author: User?, relation(field=authorId)" -> line 5, col 10..14
+        expect(start['line'], 5);
+        expect(start['character'], 10);
+        expect(end['character'], 14);
+      },
+    );
+
+    test(
+      'when references are requested for a class on its declaration line with includeDeclaration true, '
+      'then it returns the declaration and all references.',
+      () async {
+        var result = await session.requestReferences(
+          userModelPath,
+          line: 0,
+          character: 8,
+          includeDeclaration: true,
+        );
+
+        expect(result, isNotNull);
+        expect(result, isA<List>());
+        var locations = (result as List).cast<Map<String, dynamic>>();
+        expect(locations, hasLength(2));
+
+        var declLoc = locations.firstWhere(
+          (loc) => loc['uri'] == Uri.file(userModelPath).toString(),
+        );
+        var declStart = (declLoc['range'] as Map)['start'] as Map;
+        expect(declStart['line'], 0);
+        expect(declStart['character'], 7);
+
+        var refLoc = locations.firstWhere(
+          (loc) => loc['uri'] == Uri.file(postModelPath).toString(),
+        );
+        var refStart = (refLoc['range'] as Map)['start'] as Map;
+        expect(refStart['line'], 5);
+        expect(refStart['character'], 10);
+      },
+    );
+
+    test(
+      'when references are requested for a field, '
+      'then it returns occurrences in relations and declarations.',
+      () async {
+        // Line 4 in post.spy.yaml: "  authorId: int" -> "authorId" is at column 4
+        var result = await session.requestReferences(
+          postModelPath,
+          line: 4,
+          character: 5,
+          includeDeclaration: true,
+        );
+
+        expect(result, isNotNull);
+        expect(result, isA<List>());
+        var locations = (result as List).cast<Map<String, dynamic>>();
+        expect(locations, hasLength(2));
+
+        // Declaration at line 4
+        var decl = locations.firstWhere(
+          (l) => ((l['range'] as Map)['start'] as Map)['line'] == 4,
+        );
+        expect(decl['uri'], Uri.file(postModelPath).toString());
+
+        // Relation reference at line 5
+        var rel = locations.firstWhere(
+          (l) => ((l['range'] as Map)['start'] as Map)['line'] == 5,
+        );
+        expect(rel['uri'], Uri.file(postModelPath).toString());
+      },
+    );
+
+    test(
+      'when references are requested for an enum on its declaration line, '
+      'then it returns references across other model files.',
+      () async {
+        var enumPath = p.join(modelsDir, 'stage_family.spy.yaml');
+        var jobPath = p.join(modelsDir, 'job.spy.yaml');
+
+        File(enumPath).writeAsStringSync('''
+enum: IngestionStageFamily
+serialized: byName
+values:
+  - alpha
+  - beta
+''');
+
+        File(jobPath).writeAsStringSync('''
+class: Job
+table: job
+fields:
+  stage: IngestionStageFamily
+''');
+
+        session.openDocument(enumPath, File(enumPath).readAsStringSync());
+        session.openDocument(jobPath, File(jobPath).readAsStringSync());
+
+        var result = await session.requestReferences(
+          enumPath,
+          line: 0,
+          character: 8,
+          includeDeclaration: false,
+        );
+
+        expect(result, isNotNull);
+        var locations = (result as List).cast<Map<String, dynamic>>();
+        expect(locations, hasLength(1));
+
+        var loc = locations.first;
+        expect(loc['uri'], Uri.file(jobPath).toString());
+        var start = (loc['range'] as Map)['start'] as Map;
+        // In job.spy.yaml: "  stage: IngestionStageFamily" -> line 3, col 9
+        expect(start['line'], 3);
+        expect(start['character'], 9);
+      },
+    );
+
+    test(
+      'when references are requested for a primitive type, '
+      'then it returns an empty list.',
+      () async {
+        var result = await session.requestReferences(
+          postModelPath,
+          line: 3,
+          character: 10,
+        );
+
+        expect(result, isA<List>());
+        expect(result as List, isEmpty);
+      },
+    );
   });
 
   group('Given an initialized language server with linkSupport enabled,', () {

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -1255,6 +1255,37 @@ fields:
       );
 
       test(
+        'when references are requested for a table backed model, '
+        'then it returns both the class name and the parent table usages.',
+        () async {
+          // Line 0 in parameter.spy.yaml: "class: Parameter"
+          var result = await session.requestReferences(
+            parameterModelPath,
+            line: 0,
+            character: 8,
+            includeDeclaration: false,
+          );
+
+          var locations = (result as List).cast<Map<String, dynamic>>();
+          expect(locations, hasLength(2));
+          expect(
+            locations.every(
+              (loc) => loc['uri'] == Uri.file(holderModelPath).toString(),
+            ),
+            isTrue,
+          );
+
+          // "  param: Parameter?, relation(parent=parameters)"
+          // -> "Parameter" at column 9, "parameters" at column 37
+          var starts = locations
+              .map((loc) => (loc['range'] as Map)['start'] as Map)
+              .toList();
+          expect(starts.map((start) => start['line']), everyElement(3));
+          expect(starts.map((start) => start['character']), [9, 37]);
+        },
+      );
+
+      test(
         'when references are requested for a model that shares its name with '
         'an enum value, '
         'then the enum value is not reported as a reference.',

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -329,4 +329,193 @@ void main() {
       expect(session.registrations, isEmpty);
     },
   );
+
+  group('Given an initialized language server with registered models,', () {
+    late LanguageServerTestSession session;
+    late String modelsDir;
+    late String userModelPath;
+    late String postModelPath;
+
+    setUp(() async {
+      await ProjectDirectoryBuilder().build().create();
+
+      modelsDir = p.join(
+        d.sandbox,
+        'project',
+        'my_project_server',
+        'lib',
+        'src',
+        'models',
+      );
+
+      userModelPath = p.join(modelsDir, 'user.spy.yaml');
+      postModelPath = p.join(modelsDir, 'post.spy.yaml');
+
+      File(userModelPath).writeAsStringSync('''
+class: User
+table: user
+fields:
+  name: String
+''');
+
+      File(postModelPath).writeAsStringSync('''
+class: Post
+table: post
+fields:
+  title: String
+  authorId: int
+  author: User?, relation(field=authorId)
+''');
+
+      session = LanguageServerTestSession();
+      await session.initialize(
+        Uri.directory(p.join(d.sandbox, 'project')),
+        linkSupport: false,
+      );
+      session.sendInitialized();
+    });
+
+    tearDown(() async {
+      await session.dispose();
+    });
+
+    test(
+      'when definition is requested on a model type name, '
+      'then it returns the location of the model definition.',
+      () async {
+        // Line 5 in post.spy.yaml is: "  author: User?, relation(field=authorId)"
+        // "User" is at column 10
+        var result = await session.requestDefinition(
+          postModelPath,
+          line: 5,
+          character: 11,
+        );
+
+        expect(result, isNotNull);
+        var location = result as Map<String, dynamic>;
+        var range = location['range'] as Map<String, dynamic>;
+        var start = range['start'] as Map<String, dynamic>;
+        expect(location['uri'], Uri.file(userModelPath).toString());
+        expect(start['line'], 0);
+        expect(start['character'], 7);
+      },
+    );
+
+    test(
+      'when definition is requested on a relation field reference, '
+      'then it returns the location of that field in the current file.',
+      () async {
+        // Line 5 in post.spy.yaml is: "  author: User?, relation(field=authorId)"
+        // "authorId" is at column 32
+        var result = await session.requestDefinition(
+          postModelPath,
+          line: 5,
+          character: 34,
+        );
+
+        expect(result, isNotNull);
+        var location = result as Map<String, dynamic>;
+        var range = location['range'] as Map<String, dynamic>;
+        var start = range['start'] as Map<String, dynamic>;
+        expect(location['uri'], Uri.file(postModelPath).toString());
+        // authorId is defined at line 4: "  authorId: int"
+        expect(start['line'], 4);
+      },
+    );
+
+    test(
+      'when definition is requested on a primitive type, '
+      'then it returns null.',
+      () async {
+        // Line 3 in post.spy.yaml: "  title: String" -> "String" is at column 9
+        var result = await session.requestDefinition(
+          postModelPath,
+          line: 3,
+          character: 10,
+        );
+
+        expect(result, isNull);
+      },
+    );
+  });
+
+  group('Given an initialized language server with linkSupport enabled,', () {
+    late LanguageServerTestSession session;
+    late String modelsDir;
+    late String userModelPath;
+    late String postModelPath;
+
+    setUp(() async {
+      await ProjectDirectoryBuilder().build().create();
+
+      modelsDir = p.join(
+        d.sandbox,
+        'project',
+        'my_project_server',
+        'lib',
+        'src',
+        'models',
+      );
+
+      userModelPath = p.join(modelsDir, 'user.spy.yaml');
+      postModelPath = p.join(modelsDir, 'post.spy.yaml');
+
+      File(userModelPath).writeAsStringSync('''
+class: User
+table: user
+fields:
+  name: String
+''');
+
+      File(postModelPath).writeAsStringSync('''
+class: Post
+table: post
+fields:
+  title: String
+  author: User?
+''');
+
+      session = LanguageServerTestSession();
+      await session.initialize(
+        Uri.directory(p.join(d.sandbox, 'project')),
+        linkSupport: true,
+      );
+      session.sendInitialized();
+    });
+
+    tearDown(() async {
+      await session.dispose();
+    });
+
+    test(
+      'when definition is requested with linkSupport, '
+      'then it returns a list containing LocationLink.',
+      () async {
+        // Line 4 in post.spy.yaml is: "  author: User?" -> "User" is at column 10
+        var result = await session.requestDefinition(
+          postModelPath,
+          line: 4,
+          character: 11,
+        );
+
+        expect(result, isNotNull);
+        expect(result, isA<List>());
+        var link = (result as List).first as Map<String, dynamic>;
+        var targetSelectionRange =
+            link['targetSelectionRange'] as Map<String, dynamic>;
+        var targetStart = targetSelectionRange['start'] as Map<String, dynamic>;
+        var originSelectionRange =
+            link['originSelectionRange'] as Map<String, dynamic>;
+        var originStart = originSelectionRange['start'] as Map<String, dynamic>;
+        var originEnd = originSelectionRange['end'] as Map<String, dynamic>;
+
+        expect(link['targetUri'], Uri.file(userModelPath).toString());
+        expect(targetStart['line'], 0);
+        expect(targetStart['character'], 7);
+        expect(originStart['line'], 4);
+        expect(originStart['character'], 10);
+        expect(originEnd['character'], 14);
+      },
+    );
+  });
 }

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -1150,6 +1150,7 @@ fields:
       late LanguageServerTestSession session;
       late String parameterModelPath;
       late String holderModelPath;
+      late String ownerModelPath;
 
       setUp(() async {
         await ProjectDirectoryBuilder()
@@ -1174,6 +1175,19 @@ values:
   - Parameter
   - guest
 '''),
+              // A model that shares the name of a foreign key action.
+              d.file('cascade.spy.yaml', '''
+class: Cascade
+table: cascade
+fields:
+  name: String
+'''),
+              d.file('owner.spy.yaml', '''
+class: Owner
+table: owner
+fields:
+  item: Cascade?, relation(onDelete=CASCADE)
+'''),
             ])
             .build()
             .create();
@@ -1188,6 +1202,7 @@ values:
         );
         parameterModelPath = p.join(modelsDir, 'parameter.spy.yaml');
         holderModelPath = p.join(modelsDir, 'holder.spy.yaml');
+        ownerModelPath = p.join(modelsDir, 'owner.spy.yaml');
 
         session = LanguageServerTestSession();
         await session.initialize(Uri.directory(p.join(d.sandbox, 'project')));
@@ -1197,6 +1212,47 @@ values:
       tearDown(() async {
         await session.dispose();
       });
+
+      test(
+        'when definition is requested on a parent table name that is also a '
+        'key of the model file syntax, '
+        'then it returns the location of the model definition.',
+        () async {
+          // Line 3 in holder.spy.yaml:
+          // "  param: Parameter?, relation(parent=parameters)"
+          // -> "parameters" is at column 37
+          var result = await session.requestDefinition(
+            holderModelPath,
+            line: 3,
+            character: 40,
+          );
+
+          expect(result, isNotNull);
+          var location = result as Map<String, dynamic>;
+          var start = (location['range'] as Map)['start'] as Map;
+          expect(location['uri'], Uri.file(parameterModelPath).toString());
+          expect(start['line'], 0);
+          expect(start['character'], 7);
+        },
+      );
+
+      test(
+        'when definition is requested on a foreign key action written in a '
+        'different casing than a model that shares its name, '
+        'then it returns null.',
+        () async {
+          // Line 3 in owner.spy.yaml:
+          // "  item: Cascade?, relation(onDelete=CASCADE)"
+          // -> "CASCADE" is at column 36
+          var result = await session.requestDefinition(
+            ownerModelPath,
+            line: 3,
+            character: 38,
+          );
+
+          expect(result, isNull);
+        },
+      );
 
       test(
         'when references are requested for a model that shares its name with '

--- a/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
+++ b/tools/serverpod_cli/test/integration/language_server/language_server_test.dart
@@ -1153,6 +1153,7 @@ fields:
       late String recordModelPath;
       late String ownerModelPath;
       late String noteModelPath;
+      late String labelModelPath;
 
       setUp(() async {
         await ProjectDirectoryBuilder()
@@ -1201,6 +1202,14 @@ table: owner
 fields:
   item: Cascade?, relation(onDelete=CASCADE)
 '''),
+              // Quoted defaults that spell out a model and a table name.
+              d.file('label.spy.yaml', '''
+class: Label
+table: label
+fields:
+  name: String, default='Parameter'
+  code: String, default='parameters'
+'''),
               // A comment dedented below the entries of the fields block.
               d.file('note.spy.yaml', '''
 class: Note
@@ -1228,6 +1237,7 @@ fields:
         recordModelPath = p.join(modelsDir, 'record.spy.yaml');
         ownerModelPath = p.join(modelsDir, 'owner.spy.yaml');
         noteModelPath = p.join(modelsDir, 'note.spy.yaml');
+        labelModelPath = p.join(modelsDir, 'label.spy.yaml');
 
         session = LanguageServerTestSession();
         await session.initialize(Uri.directory(p.join(d.sandbox, 'project')));
@@ -1407,6 +1417,63 @@ fields:
           );
           expect(starts.map((start) => start['line']), [5, 6]);
           expect(starts.map((start) => start['character']), [2, 35]);
+        },
+      );
+
+      test(
+        'when definition is requested on a quoted default that spells out a '
+        'model name, '
+        'then it returns null.',
+        () async {
+          // Line 3 in label.spy.yaml:
+          // "  name: String, default='Parameter'"
+          // -> "Parameter" is at column 25
+          var result = await session.requestDefinition(
+            labelModelPath,
+            line: 3,
+            character: 27,
+          );
+
+          expect(result, isNull);
+        },
+      );
+
+      test(
+        'when definition is requested on a quoted default that spells out a '
+        'table name, '
+        'then it returns null.',
+        () async {
+          // Line 4 in label.spy.yaml:
+          // "  code: String, default='parameters'"
+          // -> "parameters" is at column 25
+          var result = await session.requestDefinition(
+            labelModelPath,
+            line: 4,
+            character: 27,
+          );
+
+          expect(result, isNull);
+        },
+      );
+
+      test(
+        'when references are requested for a model whose name is spelled out '
+        'by a quoted default, '
+        'then the quoted default is not reported as a reference.',
+        () async {
+          // Line 0 in parameter.spy.yaml: "class: Parameter"
+          var result = await session.requestReferences(
+            parameterModelPath,
+            line: 0,
+            character: 8,
+            includeDeclaration: false,
+          );
+
+          var locations = (result as List).cast<Map<String, dynamic>>();
+          expect(
+            locations.map((loc) => loc['uri']),
+            isNot(contains(Uri.file(labelModelPath).toString())),
+          );
         },
       );
     },

--- a/tools/serverpod_cli/test/test_util/builders/project_directory_builder.dart
+++ b/tools/serverpod_cli/test/test_util/builders/project_directory_builder.dart
@@ -6,6 +6,7 @@ class ProjectDirectoryBuilder {
   String _projectName = 'my_project';
   String _generatorYaml = 'type: server';
   List<d.Descriptor> _modelDirContents = [];
+  final Map<String, List<d.Descriptor>> _modules = {};
 
   ProjectDirectoryBuilder withProjectName(String projectName) {
     _projectName = projectName;
@@ -23,14 +24,54 @@ class ProjectDirectoryBuilder {
     return this;
   }
 
+  /// Adds a Serverpod module dependency named `<moduleName>_server` with
+  /// [modelDirContents] in its lib/src/models directory. The module is
+  /// placed next to the server package and gets the default nickname (the
+  /// module name).
+  ProjectDirectoryBuilder withModule(
+    String moduleName, {
+    List<d.Descriptor> modelDirContents = const [],
+  }) {
+    _modules[moduleName] = modelDirContents;
+    return this;
+  }
+
+  String get _serverPubspecDependencies => [
+    '  serverpod: ^2.0.0',
+    for (var module in _modules.keys) '  ${module}_server: ^1.0.0',
+  ].join('\n');
+
+  String get _packageConfigEntries => [
+    '''
+    {
+      "name": "${_projectName}_server",
+      "rootUri": "../",
+      "packageUri": "lib/"
+    }''',
+    '''
+    {
+      "name": "serverpod",
+      "rootUri": "../.pub-cache/hosted/pub.dev/serverpod-2.0.0",
+      "packageUri": "lib/"
+    }''',
+    for (var module in _modules.keys)
+      '''
+    {
+      "name": "${module}_server",
+      "rootUri": "../../${module}_server",
+      "packageUri": "lib/"
+    }''',
+  ].join(',\n');
+
   /// Returns a descriptor rooted at 'project', holding
-  /// `project/<name>_server` and `project/<name>_client`.
+  /// `project/<name>_server`, `project/<name>_client` and one
+  /// `project/<module>_server` directory per added module.
   d.DirectoryDescriptor build() {
     var serverDir = d.dir('${_projectName}_server', [
       d.file('pubspec.yaml', '''
 name: ${_projectName}_server
 dependencies:
-  serverpod: ^2.0.0
+$_serverPubspecDependencies
 '''),
       d.dir('lib', [
         d.dir('src', [
@@ -43,16 +84,7 @@ dependencies:
 {
   "configVersion": 2,
   "packages": [
-    {
-      "name": "${_projectName}_server",
-      "rootUri": "../",
-      "packageUri": "lib/"
-    },
-    {
-      "name": "serverpod",
-      "rootUri": "../.pub-cache/hosted/pub.dev/serverpod-2.0.0",
-      "packageUri": "lib/"
-    }
+$_packageConfigEntries
   ]
 }
 '''),
@@ -75,6 +107,24 @@ dependencies:
       ]),
     ]);
 
-    return d.dir('project', [serverDir, clientDir]);
+    var moduleDirs = _modules.entries.map((entry) {
+      var modulePackageName = '${entry.key}_server';
+      return d.dir(modulePackageName, [
+        d.file('pubspec.yaml', '''
+name: $modulePackageName
+'''),
+        d.dir('config', [
+          d.file('generator.yaml', 'type: module\n'),
+        ]),
+        d.dir('lib', [
+          d.dir('src', [
+            d.dir('protocol', []),
+            d.dir('models', entry.value),
+          ]),
+        ]),
+      ]);
+    });
+
+    return d.dir('project', [serverDir, clientDir, ...moduleDirs]);
   }
 }

--- a/tools/serverpod_cli/test/test_util/language_server_test_session.dart
+++ b/tools/serverpod_cli/test/test_util/language_server_test_session.dart
@@ -47,6 +47,7 @@ class LanguageServerTestSession {
   Future<void> initialize(
     Uri rootUri, {
     bool supportsWatchedFilesRegistration = true,
+    bool linkSupport = false,
   }) async {
     await client.sendRequest('initialize', {
       'processId': null,
@@ -55,6 +56,10 @@ class LanguageServerTestSession {
         if (supportsWatchedFilesRegistration)
           'workspace': {
             'didChangeWatchedFiles': {'dynamicRegistration': true},
+          },
+        if (linkSupport)
+          'textDocument': {
+            'definition': {'linkSupport': true},
           },
       },
     });
@@ -108,6 +113,17 @@ class LanguageServerTestSession {
   /// Completes with the next capability registration requested by the server.
   Future<Registration> nextRegistration() {
     return _registrations.stream.first.timeout(const Duration(seconds: 10));
+  }
+
+  Future<dynamic> requestDefinition(
+    String filePath, {
+    required int line,
+    required int character,
+  }) {
+    return client.sendRequest('textDocument/definition', {
+      'textDocument': {'uri': Uri.file(filePath).toString()},
+      'position': {'line': line, 'character': character},
+    });
   }
 
   Future<void> dispose() async {

--- a/tools/serverpod_cli/test/test_util/language_server_test_session.dart
+++ b/tools/serverpod_cli/test/test_util/language_server_test_session.dart
@@ -126,6 +126,19 @@ class LanguageServerTestSession {
     });
   }
 
+  Future<dynamic> requestReferences(
+    String filePath, {
+    required int line,
+    required int character,
+    bool includeDeclaration = true,
+  }) {
+    return client.sendRequest('textDocument/references', {
+      'textDocument': {'uri': Uri.file(filePath).toString()},
+      'position': {'line': line, 'character': character},
+      'context': {'includeDeclaration': includeDeclaration},
+    });
+  }
+
   Future<void> dispose() async {
     await _clientToServer.close();
     await _serverToClient.close();

--- a/tools/serverpod_cli/test/test_util/language_server_test_session.dart
+++ b/tools/serverpod_cli/test/test_util/language_server_test_session.dart
@@ -126,6 +126,18 @@ class LanguageServerTestSession {
     });
   }
 
+  /// Sends the custom `serverpod/modelDefinition` request used to navigate
+  /// from generated Dart code back to a model definition.
+  Future<dynamic> requestModelDefinition(
+    String className, {
+    String? moduleAlias,
+  }) {
+    return client.sendRequest('serverpod/modelDefinition', {
+      'className': className,
+      'moduleAlias': ?moduleAlias,
+    });
+  }
+
   Future<dynamic> requestReferences(
     String filePath, {
     required int line,

--- a/tools/serverpod_vscode_extension/CHANGELOG.md
+++ b/tools/serverpod_vscode_extension/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.0
+
+- feat: Implement go to definition for model names in language server to allow easy navigation from models or Dart code.
+
 ## 1.5.0
 
 - refactor: BREAKING. Drops support for bare `.yaml`/`.yml` model files. The language server is only attached to `.spy.yaml`, `.spy.yml` and `.spy` files, and the extension no longer activates for every yaml file.

--- a/tools/serverpod_vscode_extension/README.md
+++ b/tools/serverpod_vscode_extension/README.md
@@ -12,6 +12,12 @@ Real-time diagnostics show errors in model files as you type.
 
 ![Diagnostics](https://github.com/serverpod/serverpod/blob/main/tools/serverpod_vscode_extension/assets/videos/diagnostics.gif?raw=true)
 
+Go to definition (CTRL+Click) in model files navigates to the model, enum or field a name refers to, including models from modules and tables referenced through `relation(parent=...)`.
+
+Find references in model files lists where a model, table or field is used. Only model files are searched; usages in Dart code are reported by the Dart language server.
+
+Go to definition on a model class in Dart code also offers its model file. The `Serverpod: Go to Model Definition` command (CTRL+ALT+F12, CMD+ALT+F12 on macOS) jumps straight to it.
+
 ## Requirements
 
 You need the Serverpod (^1.2.0) CLI installed in your path for this extension to work. Run the following command in your terminal to install it:

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -67,10 +67,16 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "serverpod.goToModelDefinition",
+          "when": "serverpod.modelNavigationEnabled"
+        }
+      ],
       "editor/context": [
         {
           "command": "serverpod.goToModelDefinition",
-          "when": "editorLangId == dart",
+          "when": "serverpod.modelNavigationEnabled && editorLangId == dart",
           "group": "navigation"
         }
       ]
@@ -80,7 +86,7 @@
         "command": "serverpod.goToModelDefinition",
         "key": "ctrl+alt+f12",
         "mac": "cmd+alt+f12",
-        "when": "editorTextFocus && editorLangId == dart"
+        "when": "serverpod.modelNavigationEnabled && editorTextFocus && editorLangId == dart"
       }
     ]
   },

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -18,7 +18,8 @@
   ],
   "activationEvents": [
     "onLanguage:serverpod",
-    "onDebugResolve:dart"
+    "onDebugResolve:dart",
+    "workspaceContains:**/config/generator.yaml"
   ],
   "pricing": "Free",
   "homepage": "https://serverpod.dev",
@@ -56,6 +57,30 @@
         "language": "serverpod",
         "scopeName": "source.serverpod",
         "path": "./syntaxes/serverpod.tmLanguage.json"
+      }
+    ],
+    "commands": [
+      {
+        "command": "serverpod.goToModelDefinition",
+        "title": "Go to Model Definition",
+        "category": "Serverpod"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "serverpod.goToModelDefinition",
+          "when": "editorLangId == dart",
+          "group": "navigation"
+        }
+      ]
+    },
+    "keybindings": [
+      {
+        "command": "serverpod.goToModelDefinition",
+        "key": "ctrl+alt+f12",
+        "mac": "cmd+alt+f12",
+        "when": "editorTextFocus && editorLangId == dart"
       }
     ]
   },

--- a/tools/serverpod_vscode_extension/package.json
+++ b/tools/serverpod_vscode_extension/package.json
@@ -8,7 +8,7 @@
     "color": "#020E24",
     "theme": "dark"
   },
-  "version": "1.5.0",
+  "version": "1.6.0",
   "engines": {
     "vscode": "^1.75.0"
   },

--- a/tools/serverpod_vscode_extension/src/extension.ts
+++ b/tools/serverpod_vscode_extension/src/extension.ts
@@ -10,6 +10,7 @@ import {
 import { execSync } from 'child_process';
 import { satisfies, coerce } from 'semver';
 import { resolveServerpodFlutterAttach } from './flutter_device_selection';
+import { registerModelNavigation } from './model_navigation';
 
 let client: LanguageClient;
 
@@ -64,6 +65,8 @@ export function activate(context: ExtensionContext) {
 		serverOptions,
 		clientOptions
 	);
+
+	registerModelNavigation(context, client);
 
 	client.start();
 }

--- a/tools/serverpod_vscode_extension/src/model_navigation.ts
+++ b/tools/serverpod_vscode_extension/src/model_navigation.ts
@@ -2,6 +2,7 @@ import {
 	commands,
 	Definition,
 	DefinitionProvider,
+	Disposable,
 	ExtensionContext,
 	languages,
 	Location,
@@ -10,12 +11,12 @@ import {
 	TextDocument,
 	Uri,
 	window,
+	workspace,
 } from 'vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
 
 const modelDefinitionRequest = 'serverpod/modelDefinition';
-
-var navigationDisposables: { dispose(): void }[] = [];
+const modelFilePattern = '**/*.spy.yaml';
 
 interface ModelDefinitionResult {
 	uri: string;
@@ -25,35 +26,92 @@ interface ModelDefinitionResult {
 	};
 }
 
+let currentRegistration: Disposable | undefined;
+
 /// Wires Dart-to-model navigation: CTRL+Click on a model class name in Dart
 /// code surfaces the yaml model definition alongside the generated Dart
 /// class, and the `serverpod.goToModelDefinition` command jumps straight to
 /// the yaml model.
 export function registerModelNavigation(context: ExtensionContext, client: LanguageClient): void {
-	// Re-activation replaces previous registrations instead of conflicting
-	// with them.
-	for (const disposable of navigationDisposables) {
-		disposable.dispose();
-	}
-	navigationDisposables = [
+	// Commands are registered with the editor globally, so activating again
+	// without a deactivate in between would fail with "command already
+	// exists". Replace the previous registration instead.
+	currentRegistration?.dispose();
+
+	const resolver = new ModelLocationResolver(client);
+	const registration = Disposable.from(
+		resolver,
 		languages.registerDefinitionProvider(
 			{ language: 'dart', scheme: 'file' },
-			new ServerpodModelDefinitionProvider(client)
+			new ServerpodModelDefinitionProvider(resolver)
 		),
-		commands.registerCommand('serverpod.goToModelDefinition', () => goToModelDefinition(client)),
-	];
-	context.subscriptions.push(...navigationDisposables);
+		commands.registerCommand('serverpod.goToModelDefinition', () => goToModelDefinition(resolver))
+	);
+
+	currentRegistration = registration;
+	context.subscriptions.push(registration);
+}
+
+/// Resolves model class names to their yaml declaration.
+///
+/// The editor asks for a definition on every CTRL+hover, so resolutions are
+/// cached until a model file changes to keep those hovers off the wire.
+class ModelLocationResolver implements Disposable {
+	private readonly cache = new Map<string, Location | undefined>();
+	private readonly watcher = workspace.createFileSystemWatcher(modelFilePattern);
+
+	constructor(private client: LanguageClient) {
+		const clearCache = () => this.cache.clear();
+		this.watcher.onDidCreate(clearCache);
+		this.watcher.onDidChange(clearCache);
+		this.watcher.onDidDelete(clearCache);
+	}
+
+	async resolve(className: string): Promise<Location | undefined> {
+		if (this.cache.has(className)) {
+			return this.cache.get(className);
+		}
+
+		let result: ModelDefinitionResult | null;
+		try {
+			// Older CLI versions do not implement the request; treat failures as
+			// "no model" so navigation falls back to the Dart analyzer results.
+			// Failures are not cached, so recovering takes effect at once.
+			result = await this.client.sendRequest(modelDefinitionRequest, { className });
+		} catch (_) {
+			return undefined;
+		}
+
+		const location = result
+			? new Location(
+				Uri.parse(result.uri),
+				new Range(
+					result.range.start.line,
+					result.range.start.character,
+					result.range.end.line,
+					result.range.end.character
+				)
+			)
+			: undefined;
+		this.cache.set(className, location);
+		return location;
+	}
+
+	dispose(): void {
+		this.watcher.dispose();
+		this.cache.clear();
+	}
 }
 
 class ServerpodModelDefinitionProvider implements DefinitionProvider {
-	constructor(private client: LanguageClient) { }
+	constructor(private resolver: ModelLocationResolver) { }
 
 	async provideDefinition(document: TextDocument, position: Position): Promise<Definition | undefined> {
 		const className = modelClassNameAt(document, position);
 		if (!className) {
 			return undefined;
 		}
-		return resolveModelLocation(this.client, className);
+		return this.resolver.resolve(className);
 	}
 }
 
@@ -71,30 +129,7 @@ export function modelClassNameAt(document: TextDocument, position: Position): st
 	return word;
 }
 
-async function resolveModelLocation(client: LanguageClient, className: string): Promise<Location | undefined> {
-	let result: ModelDefinitionResult | null;
-	try {
-		// Older CLI versions do not implement the request; treat failures as
-		// "no model" so navigation falls back to the Dart analyzer results.
-		result = await client.sendRequest(modelDefinitionRequest, { className });
-	} catch (_) {
-		return undefined;
-	}
-	if (!result) {
-		return undefined;
-	}
-	return new Location(
-		Uri.parse(result.uri),
-		new Range(
-			result.range.start.line,
-			result.range.start.character,
-			result.range.end.line,
-			result.range.end.character
-		)
-	);
-}
-
-async function goToModelDefinition(client: LanguageClient): Promise<void> {
+async function goToModelDefinition(resolver: ModelLocationResolver): Promise<void> {
 	const editor = window.activeTextEditor;
 	if (!editor) {
 		return;
@@ -103,7 +138,7 @@ async function goToModelDefinition(client: LanguageClient): Promise<void> {
 	if (!className) {
 		return;
 	}
-	const location = await resolveModelLocation(client, className);
+	const location = await resolver.resolve(className);
 	if (!location) {
 		return;
 	}

--- a/tools/serverpod_vscode_extension/src/model_navigation.ts
+++ b/tools/serverpod_vscode_extension/src/model_navigation.ts
@@ -13,7 +13,7 @@ import {
 	window,
 	workspace,
 } from 'vscode';
-import { LanguageClient } from 'vscode-languageclient/node';
+import { ErrorCodes, LanguageClient, ResponseError, State } from 'vscode-languageclient/node';
 
 const modelDefinitionRequest = 'serverpod/modelDefinition';
 const modelFilePattern = '**/*.spy.yaml';
@@ -59,26 +59,43 @@ export function registerModelNavigation(context: ExtensionContext, client: Langu
 class ModelLocationResolver implements Disposable {
 	private readonly cache = new Map<string, Location | undefined>();
 	private readonly watcher = workspace.createFileSystemWatcher(modelFilePattern);
+	private readonly stateListener: Disposable;
+	private unsupported = false;
 
 	constructor(private client: LanguageClient) {
 		const clearCache = () => this.cache.clear();
 		this.watcher.onDidCreate(clearCache);
 		this.watcher.onDidChange(clearCache);
 		this.watcher.onDidDelete(clearCache);
+		this.stateListener = client.onDidChangeState((event) => {
+			// A restarted server may be running a different CLI version.
+			if (event.newState === State.Running) {
+				this.unsupported = false;
+				this.cache.clear();
+			}
+		});
 	}
 
 	async resolve(className: string): Promise<Location | undefined> {
+		if (this.unsupported) {
+			return undefined;
+		}
 		if (this.cache.has(className)) {
 			return this.cache.get(className);
 		}
 
 		let result: ModelDefinitionResult | null;
 		try {
-			// Older CLI versions do not implement the request; treat failures as
-			// "no model" so navigation falls back to the Dart analyzer results.
-			// Failures are not cached, so recovering takes effect at once.
 			result = await this.client.sendRequest(modelDefinitionRequest, { className });
-		} catch (_) {
+		} catch (error) {
+			// Older CLI versions do not implement the request. Treat failures as
+			// "no model" so navigation falls back to the Dart analyzer results,
+			// and stop asking a server that does not know the request at all.
+			// Transient failures are retried, and the flag is cleared whenever
+			// the server restarts, so upgrading the CLI takes effect.
+			if ((error as ResponseError<void>)?.code === ErrorCodes.MethodNotFound) {
+				this.unsupported = true;
+			}
 			return undefined;
 		}
 
@@ -98,6 +115,7 @@ class ModelLocationResolver implements Disposable {
 	}
 
 	dispose(): void {
+		this.stateListener.dispose();
 		this.watcher.dispose();
 		this.cache.clear();
 	}

--- a/tools/serverpod_vscode_extension/src/model_navigation.ts
+++ b/tools/serverpod_vscode_extension/src/model_navigation.ts
@@ -17,6 +17,8 @@ import { ErrorCodes, LanguageClient, ResponseError, State } from 'vscode-languag
 
 const modelDefinitionRequest = 'serverpod/modelDefinition';
 const modelFilePattern = '**/*.spy.yaml';
+const unsupportedByCliMessage =
+	'Go to Model Definition requires a newer Serverpod CLI. Please upgrade the Serverpod CLI to navigate from Dart code to model files.';
 
 interface ModelDefinitionResult {
 	uri: string;
@@ -74,6 +76,12 @@ class ModelLocationResolver implements Disposable {
 				this.cache.clear();
 			}
 		});
+	}
+
+	/// Whether the language server answered that it does not know the model
+	/// definition request, which an older Serverpod CLI does.
+	get isUnsupported(): boolean {
+		return this.unsupported;
 	}
 
 	async resolve(className: string): Promise<Location | undefined> {
@@ -158,6 +166,12 @@ async function goToModelDefinition(resolver: ModelLocationResolver): Promise<voi
 	}
 	const location = await resolver.resolve(className);
 	if (!location) {
+		// Only an outdated CLI is worth reporting. Invoking the command on a
+		// class that is not a model stays silent, since it is also bound to a
+		// keybinding.
+		if (resolver.isUnsupported) {
+			window.showWarningMessage(unsupportedByCliMessage);
+		}
 		return;
 	}
 	await window.showTextDocument(location.uri, { selection: location.range });

--- a/tools/serverpod_vscode_extension/src/model_navigation.ts
+++ b/tools/serverpod_vscode_extension/src/model_navigation.ts
@@ -16,6 +16,7 @@ import {
 import { ErrorCodes, LanguageClient, ResponseError, State } from 'vscode-languageclient/node';
 
 const modelDefinitionRequest = 'serverpod/modelDefinition';
+const modelNavigationEnabledContext = 'serverpod.modelNavigationEnabled';
 const modelFilePattern = '**/*.spy.yaml';
 const unsupportedByCliMessage =
 	'Go to Model Definition requires a newer Serverpod CLI. Please upgrade the Serverpod CLI to navigate from Dart code to model files.';
@@ -47,11 +48,22 @@ export function registerModelNavigation(context: ExtensionContext, client: Langu
 			{ language: 'dart', scheme: 'file' },
 			new ServerpodModelDefinitionProvider(resolver)
 		),
-		commands.registerCommand('serverpod.goToModelDefinition', () => goToModelDefinition(resolver))
+		commands.registerCommand('serverpod.goToModelDefinition', () => goToModelDefinition(resolver)),
+		new Disposable(() => setModelNavigationEnabled(false))
 	);
+
+	// The menu entry, the palette entry and the keybinding are contributed
+	// statically, while the command is only registered here. Without the
+	// context key they would still be offered when activation stopped at the
+	// CLI check, and invoking them would fail with "command not found".
+	setModelNavigationEnabled(true);
 
 	currentRegistration = registration;
 	context.subscriptions.push(registration);
+}
+
+function setModelNavigationEnabled(enabled: boolean): void {
+	commands.executeCommand('setContext', modelNavigationEnabledContext, enabled);
 }
 
 /// Resolves model class names to their yaml declaration.

--- a/tools/serverpod_vscode_extension/src/model_navigation.ts
+++ b/tools/serverpod_vscode_extension/src/model_navigation.ts
@@ -1,0 +1,111 @@
+import {
+	commands,
+	Definition,
+	DefinitionProvider,
+	ExtensionContext,
+	languages,
+	Location,
+	Position,
+	Range,
+	TextDocument,
+	Uri,
+	window,
+} from 'vscode';
+import { LanguageClient } from 'vscode-languageclient/node';
+
+const modelDefinitionRequest = 'serverpod/modelDefinition';
+
+var navigationDisposables: { dispose(): void }[] = [];
+
+interface ModelDefinitionResult {
+	uri: string;
+	range: {
+		start: { line: number; character: number };
+		end: { line: number; character: number };
+	};
+}
+
+/// Wires Dart-to-model navigation: CTRL+Click on a model class name in Dart
+/// code surfaces the yaml model definition alongside the generated Dart
+/// class, and the `serverpod.goToModelDefinition` command jumps straight to
+/// the yaml model.
+export function registerModelNavigation(context: ExtensionContext, client: LanguageClient): void {
+	// Re-activation replaces previous registrations instead of conflicting
+	// with them.
+	for (const disposable of navigationDisposables) {
+		disposable.dispose();
+	}
+	navigationDisposables = [
+		languages.registerDefinitionProvider(
+			{ language: 'dart', scheme: 'file' },
+			new ServerpodModelDefinitionProvider(client)
+		),
+		commands.registerCommand('serverpod.goToModelDefinition', () => goToModelDefinition(client)),
+	];
+	context.subscriptions.push(...navigationDisposables);
+}
+
+class ServerpodModelDefinitionProvider implements DefinitionProvider {
+	constructor(private client: LanguageClient) { }
+
+	async provideDefinition(document: TextDocument, position: Position): Promise<Definition | undefined> {
+		const className = modelClassNameAt(document, position);
+		if (!className) {
+			return undefined;
+		}
+		return resolveModelLocation(this.client, className);
+	}
+}
+
+/// Returns the identifier at [position] when it looks like a model class
+/// name (PascalCase), otherwise undefined.
+export function modelClassNameAt(document: TextDocument, position: Position): string | undefined {
+	const range = document.getWordRangeAtPosition(position);
+	if (!range) {
+		return undefined;
+	}
+	const word = document.getText(range);
+	if (!/^[A-Z][A-Za-z0-9_]*$/.test(word)) {
+		return undefined;
+	}
+	return word;
+}
+
+async function resolveModelLocation(client: LanguageClient, className: string): Promise<Location | undefined> {
+	let result: ModelDefinitionResult | null;
+	try {
+		// Older CLI versions do not implement the request; treat failures as
+		// "no model" so navigation falls back to the Dart analyzer results.
+		result = await client.sendRequest(modelDefinitionRequest, { className });
+	} catch (_) {
+		return undefined;
+	}
+	if (!result) {
+		return undefined;
+	}
+	return new Location(
+		Uri.parse(result.uri),
+		new Range(
+			result.range.start.line,
+			result.range.start.character,
+			result.range.end.line,
+			result.range.end.character
+		)
+	);
+}
+
+async function goToModelDefinition(client: LanguageClient): Promise<void> {
+	const editor = window.activeTextEditor;
+	if (!editor) {
+		return;
+	}
+	const className = modelClassNameAt(editor.document, editor.selection.active);
+	if (!className) {
+		return;
+	}
+	const location = await resolveModelLocation(client, className);
+	if (!location) {
+		return;
+	}
+	await window.showTextDocument(location.uri, { selection: location.range });
+}

--- a/tools/serverpod_vscode_extension/src/model_navigation.ts
+++ b/tools/serverpod_vscode_extension/src/model_navigation.ts
@@ -21,6 +21,13 @@ const modelFilePattern = '**/*.spy.yaml';
 const unsupportedByCliMessage =
 	'Go to Model Definition requires a newer Serverpod CLI. Please upgrade the Serverpod CLI to navigate from Dart code to model files.';
 
+/// A model class reference read out of Dart code, with the import prefix it
+/// was written under, if any.
+export interface ModelReference {
+	className: string;
+	moduleAlias?: string;
+}
+
 interface ModelDefinitionResult {
 	uri: string;
 	range: {
@@ -96,17 +103,20 @@ class ModelLocationResolver implements Disposable {
 		return this.unsupported;
 	}
 
-	async resolve(className: string): Promise<Location | undefined> {
+	async resolve(reference: ModelReference): Promise<Location | undefined> {
 		if (this.unsupported) {
 			return undefined;
 		}
-		if (this.cache.has(className)) {
-			return this.cache.get(className);
+		// References written under different import prefixes may resolve to
+		// different models, so the prefix is part of the key.
+		const key = `${reference.moduleAlias ?? ''}.${reference.className}`;
+		if (this.cache.has(key)) {
+			return this.cache.get(key);
 		}
 
 		let result: ModelDefinitionResult | null;
 		try {
-			result = await this.client.sendRequest(modelDefinitionRequest, { className });
+			result = await this.client.sendRequest(modelDefinitionRequest, reference);
 		} catch (error) {
 			// Older CLI versions do not implement the request. Treat failures as
 			// "no model" so navigation falls back to the Dart analyzer results,
@@ -130,7 +140,7 @@ class ModelLocationResolver implements Disposable {
 				)
 			)
 			: undefined;
-		this.cache.set(className, location);
+		this.cache.set(key, location);
 		return location;
 	}
 
@@ -145,26 +155,34 @@ class ServerpodModelDefinitionProvider implements DefinitionProvider {
 	constructor(private resolver: ModelLocationResolver) { }
 
 	async provideDefinition(document: TextDocument, position: Position): Promise<Definition | undefined> {
-		const className = modelClassNameAt(document, position);
-		if (!className) {
+		const reference = modelReferenceAt(document, position);
+		if (!reference) {
 			return undefined;
 		}
-		return this.resolver.resolve(className);
+		return this.resolver.resolve(reference);
 	}
 }
 
 /// Returns the identifier at [position] when it looks like a model class
-/// name (PascalCase), otherwise undefined.
-export function modelClassNameAt(document: TextDocument, position: Position): string | undefined {
+/// name (PascalCase), together with the import prefix it is written under,
+/// otherwise undefined.
+export function modelReferenceAt(document: TextDocument, position: Position): ModelReference | undefined {
 	const range = document.getWordRangeAtPosition(position);
 	if (!range) {
 		return undefined;
 	}
-	const word = document.getText(range);
-	if (!/^[A-Z][A-Za-z0-9_]*$/.test(word)) {
+	const className = document.getText(range);
+	if (!/^[A-Z][A-Za-z0-9_]*$/.test(className)) {
 		return undefined;
 	}
-	return word;
+
+	// The Dart word range stops at the dot, so `auth.UserInfo` reads as
+	// `UserInfo`. The prefix is picked at the import site and need not match
+	// the module alias, so the server treats it as a hint.
+	const beforeWord = document.getText(new Range(new Position(range.start.line, 0), range.start));
+	const moduleAlias = /([A-Za-z_$][A-Za-z0-9_$]*)\s*\.\s*$/.exec(beforeWord)?.[1];
+
+	return moduleAlias === undefined ? { className } : { className, moduleAlias };
 }
 
 async function goToModelDefinition(resolver: ModelLocationResolver): Promise<void> {
@@ -172,11 +190,11 @@ async function goToModelDefinition(resolver: ModelLocationResolver): Promise<voi
 	if (!editor) {
 		return;
 	}
-	const className = modelClassNameAt(editor.document, editor.selection.active);
-	if (!className) {
+	const reference = modelReferenceAt(editor.document, editor.selection.active);
+	if (!reference) {
 		return;
 	}
-	const location = await resolver.resolve(className);
+	const location = await resolver.resolve(reference);
 	if (!location) {
 		// Only an outdated CLI is worth reporting. Invoking the command on a
 		// class that is not a model stays silent, since it is also bound to a

--- a/tools/serverpod_vscode_extension/src/test/extension.test.ts
+++ b/tools/serverpod_vscode_extension/src/test/extension.test.ts
@@ -8,10 +8,12 @@ import { LanguageClient } from 'vscode-languageclient/node';
 suite('VS Code Extension', () => {
     let execSyncStub: sinon.SinonStub;
     let showErrorMessageStub: sinon.SinonStub;
+    let executeCommandStub: sinon.SinonStub;
 
     setup(() => {
         execSyncStub = sinon.stub(childProcess, 'execSync');
         showErrorMessageStub = sinon.stub(vscode.window, 'showErrorMessage');
+        executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
     });
 
     teardown(() => {
@@ -69,6 +71,30 @@ suite('VS Code Extension', () => {
             assert.strictEqual(
                 showErrorMessageStub.firstCall.args[0],
                 'The Serverpod CLI version is outdated. Please upgrade to the latest version (minimum required version is 1.2).'
+            );
+        });
+
+        test('Given serverpod CLI version is outdated when activate is called then the model navigation context key stays disabled.', () => {
+            execSyncStub.returns(Buffer.from('Version: 1.1.0'));
+            const mockContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+            activate(mockContext);
+
+            assert.strictEqual(
+                executeCommandStub.calledWith('setContext', 'serverpod.modelNavigationEnabled'),
+                false
+            );
+        });
+
+        test('Given serverpod CLI is not installed when activate is called then the model navigation context key stays disabled.', () => {
+            execSyncStub.throws(new Error('Command not found'));
+            const mockContext = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+            activate(mockContext);
+
+            assert.strictEqual(
+                executeCommandStub.calledWith('setContext', 'serverpod.modelNavigationEnabled'),
+                false
             );
         });
 

--- a/tools/serverpod_vscode_extension/src/test/extension.test.ts
+++ b/tools/serverpod_vscode_extension/src/test/extension.test.ts
@@ -100,7 +100,8 @@ suite('VS Code Extension', () => {
 
             let capturedClientOptions: any = null;
             const mockClient = {
-                start: sinon.stub()
+                start: sinon.stub(),
+                onDidChangeState: sinon.stub().returns({ dispose: () => { } })
             };
 
             const LanguageClientModule = require('vscode-languageclient/node');

--- a/tools/serverpod_vscode_extension/src/test/model_navigation.test.ts
+++ b/tools/serverpod_vscode_extension/src/test/model_navigation.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
-import { LanguageClient } from 'vscode-languageclient/node';
+import { ErrorCodes, LanguageClient, ResponseError, State } from 'vscode-languageclient/node';
 import { registerModelNavigation, modelClassNameAt } from '../model_navigation';
 
 suite('Model Navigation', () => {
@@ -12,6 +12,7 @@ suite('Model Navigation', () => {
 	let commandHandler: () => Promise<void>;
 	let modelFileChangeHandlers: (() => void)[];
 	let disposeStubs: sinon.SinonStub[];
+	let stateChangeHandlers: ((event: { oldState: State; newState: State }) => void)[];
 
 	const modelLocationResult = {
 		uri: 'file:///project/my_project_server/lib/src/models/user.spy.yaml',
@@ -31,7 +32,17 @@ suite('Model Navigation', () => {
 	}
 
 	function mockClient(sendRequest: sinon.SinonStub): LanguageClient {
-		return { sendRequest } as unknown as LanguageClient;
+		return {
+			sendRequest,
+			onDidChangeState: (handler: (event: { oldState: State; newState: State }) => void) => {
+				stateChangeHandlers.push(handler);
+				return { dispose: () => { } };
+			},
+		} as unknown as LanguageClient;
+	}
+
+	function methodNotFoundError(): ResponseError<void> {
+		return new ResponseError(ErrorCodes.MethodNotFound, 'Unknown method "serverpod/modelDefinition".');
 	}
 
 	setup(() => {
@@ -55,6 +66,7 @@ suite('Model Navigation', () => {
 			}) as never);
 		showTextDocumentStub = sinon.stub(vscode.window, 'showTextDocument');
 		modelFileChangeHandlers = [];
+		stateChangeHandlers = [];
 		sinon
 			.stub(vscode.workspace, 'createFileSystemWatcher')
 			.callsFake((() => {
@@ -217,7 +229,49 @@ suite('Model Navigation', () => {
 			assert.strictEqual(sendRequest.callCount, 2);
 		});
 
-		test('Given a failed model definition request when definition is requested again then the server is queried again.', async () => {
+		test('Given a CLI that does not implement the model definition request when definition is requested twice then the server is only queried once.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().rejects(methodNotFoundError());
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			await capturedProvider.provideDefinition(
+				mockDocument('User'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+			const result = await capturedProvider.provideDefinition(
+				mockDocument('Post'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+
+			assert.strictEqual(result, undefined);
+			assert.strictEqual(sendRequest.callCount, 1);
+		});
+
+		test('Given a CLI that does not implement the model definition request when the language server restarts then the request is tried again.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().rejects(methodNotFoundError());
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			await capturedProvider.provideDefinition(
+				mockDocument('User'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+			sendRequest.resolves(modelLocationResult);
+			stateChangeHandlers.forEach((handler) => handler({ oldState: State.Starting, newState: State.Running }));
+			const result = await capturedProvider.provideDefinition(
+				mockDocument('User'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+
+			assert.strictEqual(sendRequest.callCount, 2);
+			assert.strictEqual((result as vscode.Location).uri.toString(), modelLocationResult.uri);
+		});
+
+		test('Given a transient failure of the model definition request when definition is requested again then the server is queried again.', async () => {
 			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
 			const sendRequest = sinon.stub().rejects(new Error('Method not found: serverpod/modelDefinition'));
 			registerModelNavigation(context, mockClient(sendRequest));

--- a/tools/serverpod_vscode_extension/src/test/model_navigation.test.ts
+++ b/tools/serverpod_vscode_extension/src/test/model_navigation.test.ts
@@ -9,6 +9,7 @@ suite('Model Navigation', () => {
 	let registerCommandStub: sinon.SinonStub;
 	let showTextDocumentStub: sinon.SinonStub;
 	let showWarningMessageStub: sinon.SinonStub;
+	let executeCommandStub: sinon.SinonStub;
 	let capturedProvider: vscode.DefinitionProvider;
 	let commandHandler: () => Promise<void>;
 	let modelFileChangeHandlers: (() => void)[];
@@ -65,6 +66,7 @@ suite('Model Navigation', () => {
 				commandHandler = handler;
 				return trackedDisposable();
 			}) as never);
+		executeCommandStub = sinon.stub(vscode.commands, 'executeCommand');
 		showTextDocumentStub = sinon.stub(vscode.window, 'showTextDocument');
 		showWarningMessageStub = sinon.stub(vscode.window, 'showWarningMessage');
 		modelFileChangeHandlers = [];
@@ -99,6 +101,29 @@ suite('Model Navigation', () => {
 			assert.deepStrictEqual(registerDefinitionProviderStub.firstCall.args[0], { language: 'dart', scheme: 'file' });
 			assert.strictEqual(registerCommandStub.calledOnce, true);
 			assert.strictEqual(registerCommandStub.firstCall.args[0], 'serverpod.goToModelDefinition');
+		});
+
+		test('Given a running language client when navigation is registered then the model navigation context key is enabled.', () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+			registerModelNavigation(context, mockClient(sinon.stub()));
+
+			assert.strictEqual(
+				executeCommandStub.calledWithExactly('setContext', 'serverpod.modelNavigationEnabled', true),
+				true
+			);
+		});
+
+		test('Given navigation is registered when the registration is disposed then the model navigation context key is disabled.', () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			registerModelNavigation(context, mockClient(sinon.stub()));
+
+			(context.subscriptions[0] as vscode.Disposable).dispose();
+
+			assert.strictEqual(
+				executeCommandStub.calledWithExactly('setContext', 'serverpod.modelNavigationEnabled', false),
+				true
+			);
 		});
 
 		test('Given a dart document with a model class name when definition is requested then the provider returns the yaml model location.', async () => {

--- a/tools/serverpod_vscode_extension/src/test/model_navigation.test.ts
+++ b/tools/serverpod_vscode_extension/src/test/model_navigation.test.ts
@@ -1,0 +1,196 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as sinon from 'sinon';
+import { LanguageClient } from 'vscode-languageclient/node';
+import { registerModelNavigation, modelClassNameAt } from '../model_navigation';
+
+suite('Model Navigation', () => {
+	let registerDefinitionProviderStub: sinon.SinonStub;
+	let registerCommandStub: sinon.SinonStub;
+	let showTextDocumentStub: sinon.SinonStub;
+	let capturedProvider: vscode.DefinitionProvider;
+	let commandHandler: () => Promise<void>;
+
+	const modelLocationResult = {
+		uri: 'file:///project/my_project_server/lib/src/models/user.spy.yaml',
+		range: {
+			start: { line: 0, character: 7 },
+			end: { line: 0, character: 11 },
+		},
+	};
+
+	function mockDocument(word: string | undefined): vscode.TextDocument {
+		return {
+			getWordRangeAtPosition: sinon.stub().returns(
+				word === undefined ? undefined : new vscode.Range(0, 0, 0, word.length)
+			),
+			getText: sinon.stub().returns(word),
+		} as unknown as vscode.TextDocument;
+	}
+
+	function mockClient(sendRequest: sinon.SinonStub): LanguageClient {
+		return { sendRequest } as unknown as LanguageClient;
+	}
+
+	setup(() => {
+		registerDefinitionProviderStub = sinon
+			.stub(vscode.languages, 'registerDefinitionProvider')
+			.callsFake(((_selector: vscode.DocumentSelector, provider: vscode.DefinitionProvider) => {
+				capturedProvider = provider;
+				return { dispose: () => { } };
+			}) as never);
+		registerCommandStub = sinon
+			.stub(vscode.commands, 'registerCommand')
+			.callsFake(((_command: string, handler: () => Promise<void>) => {
+				commandHandler = handler;
+				return { dispose: () => { } };
+			}) as never);
+		showTextDocumentStub = sinon.stub(vscode.window, 'showTextDocument');
+	});
+
+	teardown(() => {
+		sinon.restore();
+	});
+
+	suite('registerModelNavigation', () => {
+		test('Given a running language client when navigation is registered then a definition provider for dart files and the go to command are registered.', () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+			registerModelNavigation(context, mockClient(sinon.stub()));
+
+			assert.strictEqual(registerDefinitionProviderStub.calledOnce, true);
+			assert.deepStrictEqual(registerDefinitionProviderStub.firstCall.args[0], { language: 'dart', scheme: 'file' });
+			assert.strictEqual(registerCommandStub.calledOnce, true);
+			assert.strictEqual(registerCommandStub.firstCall.args[0], 'serverpod.goToModelDefinition');
+		});
+
+		test('Given a dart document with a model class name when definition is requested then the provider returns the yaml model location.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().resolves(modelLocationResult);
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			const result = await capturedProvider.provideDefinition(
+				mockDocument('User'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+
+			assert.deepStrictEqual(sendRequest.firstCall.args, ['serverpod/modelDefinition', { className: 'User' }]);
+			const location = result as vscode.Location;
+			assert.strictEqual(location.uri.toString(), modelLocationResult.uri);
+			assert.strictEqual(location.range.start.line, 0);
+			assert.strictEqual(location.range.start.character, 7);
+		});
+
+		test('Given a dart document with a lowercase identifier when definition is requested then the provider returns undefined without querying the server.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().resolves(modelLocationResult);
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			const result = await capturedProvider.provideDefinition(
+				mockDocument('userId'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+
+			assert.strictEqual(result, undefined);
+			assert.strictEqual(sendRequest.called, false);
+		});
+
+		test('Given a dart document with no identifier at the position when definition is requested then the provider returns undefined.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().resolves(modelLocationResult);
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			const result = await capturedProvider.provideDefinition(
+				mockDocument(undefined),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+
+			assert.strictEqual(result, undefined);
+			assert.strictEqual(sendRequest.called, false);
+		});
+
+		test('Given a class name that is not a model when definition is requested then the provider returns undefined.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().resolves(null);
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			const result = await capturedProvider.provideDefinition(
+				mockDocument('String'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+
+			assert.strictEqual(result, undefined);
+		});
+
+		test('Given a CLI that does not implement the model definition request when definition is requested then the provider returns undefined.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().rejects(new Error('Method not found: serverpod/modelDefinition'));
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			const result = await capturedProvider.provideDefinition(
+				mockDocument('User'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+
+			assert.strictEqual(result, undefined);
+		});
+
+		test('Given a dart document with a model class name when the go to model definition command runs then the yaml model is opened at the declaration range.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().resolves(modelLocationResult);
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			sinon.stub(vscode.window, 'activeTextEditor').value({
+				document: mockDocument('User'),
+				selection: { active: new vscode.Position(0, 2) },
+			});
+
+			await commandHandler();
+
+			assert.strictEqual(showTextDocumentStub.calledOnce, true);
+			const [uri, options] = showTextDocumentStub.firstCall.args;
+			assert.strictEqual(uri.toString(), modelLocationResult.uri);
+			assert.strictEqual((options.selection as vscode.Range).start.line, 0);
+		});
+
+		test('Given a class name that is not a model when the go to model definition command runs then no document is opened.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().resolves(null);
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			sinon.stub(vscode.window, 'activeTextEditor').value({
+				document: mockDocument('String'),
+				selection: { active: new vscode.Position(0, 2) },
+			});
+
+			await commandHandler();
+
+			assert.strictEqual(showTextDocumentStub.called, false);
+		});
+	});
+
+	suite('modelClassNameAt', () => {
+		test('Given a PascalCase identifier at the position when the class name is extracted then the identifier is returned.', () => {
+			const result = modelClassNameAt(mockDocument('UserInfo'), new vscode.Position(0, 2));
+
+			assert.strictEqual(result, 'UserInfo');
+		});
+
+		test('Given a camelCase identifier at the position when the class name is extracted then undefined is returned.', () => {
+			const result = modelClassNameAt(mockDocument('userInfo'), new vscode.Position(0, 2));
+
+			assert.strictEqual(result, undefined);
+		});
+
+		test('Given no identifier at the position when the class name is extracted then undefined is returned.', () => {
+			const result = modelClassNameAt(mockDocument(undefined), new vscode.Position(0, 0));
+
+			assert.strictEqual(result, undefined);
+		});
+	});
+});

--- a/tools/serverpod_vscode_extension/src/test/model_navigation.test.ts
+++ b/tools/serverpod_vscode_extension/src/test/model_navigation.test.ts
@@ -10,6 +10,8 @@ suite('Model Navigation', () => {
 	let showTextDocumentStub: sinon.SinonStub;
 	let capturedProvider: vscode.DefinitionProvider;
 	let commandHandler: () => Promise<void>;
+	let modelFileChangeHandlers: (() => void)[];
+	let disposeStubs: sinon.SinonStub[];
 
 	const modelLocationResult = {
 		uri: 'file:///project/my_project_server/lib/src/models/user.spy.yaml',
@@ -33,19 +35,40 @@ suite('Model Navigation', () => {
 	}
 
 	setup(() => {
+		disposeStubs = [];
+		const trackedDisposable = () => {
+			const dispose = sinon.stub();
+			disposeStubs.push(dispose);
+			return { dispose };
+		};
 		registerDefinitionProviderStub = sinon
 			.stub(vscode.languages, 'registerDefinitionProvider')
 			.callsFake(((_selector: vscode.DocumentSelector, provider: vscode.DefinitionProvider) => {
 				capturedProvider = provider;
-				return { dispose: () => { } };
+				return trackedDisposable();
 			}) as never);
 		registerCommandStub = sinon
 			.stub(vscode.commands, 'registerCommand')
 			.callsFake(((_command: string, handler: () => Promise<void>) => {
 				commandHandler = handler;
-				return { dispose: () => { } };
+				return trackedDisposable();
 			}) as never);
 		showTextDocumentStub = sinon.stub(vscode.window, 'showTextDocument');
+		modelFileChangeHandlers = [];
+		sinon
+			.stub(vscode.workspace, 'createFileSystemWatcher')
+			.callsFake((() => {
+				const register = (handler: () => void) => {
+					modelFileChangeHandlers.push(handler);
+					return { dispose: () => { } };
+				};
+				return {
+					onDidCreate: register,
+					onDidChange: register,
+					onDidDelete: register,
+					dispose: () => { },
+				};
+			}) as never);
 	});
 
 	teardown(() => {
@@ -138,6 +161,79 @@ suite('Model Navigation', () => {
 			);
 
 			assert.strictEqual(result, undefined);
+		});
+
+		test('Given navigation is already registered when it is registered again then the previous registrations are disposed.', () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			registerModelNavigation(context, mockClient(sinon.stub()));
+			const firstRegistrationDisposals = [...disposeStubs];
+
+			registerModelNavigation(context, mockClient(sinon.stub()));
+
+			assert.strictEqual(
+				firstRegistrationDisposals.every((dispose) => dispose.calledOnce),
+				true
+			);
+			assert.strictEqual(registerCommandStub.callCount, 2);
+		});
+
+		test('Given a model class name already resolved when definition is requested again then the cached location is returned without querying the server.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().resolves(modelLocationResult);
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			await capturedProvider.provideDefinition(
+				mockDocument('User'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+			const result = await capturedProvider.provideDefinition(
+				mockDocument('User'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+
+			assert.strictEqual(sendRequest.callCount, 1);
+			assert.strictEqual((result as vscode.Location).uri.toString(), modelLocationResult.uri);
+		});
+
+		test('Given a model class name already resolved when a model file changes then the next definition request queries the server again.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().resolves(modelLocationResult);
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			await capturedProvider.provideDefinition(
+				mockDocument('User'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+			modelFileChangeHandlers.forEach((handler) => handler());
+			await capturedProvider.provideDefinition(
+				mockDocument('User'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+
+			assert.strictEqual(sendRequest.callCount, 2);
+		});
+
+		test('Given a failed model definition request when definition is requested again then the server is queried again.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().rejects(new Error('Method not found: serverpod/modelDefinition'));
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			await capturedProvider.provideDefinition(
+				mockDocument('User'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+			await capturedProvider.provideDefinition(
+				mockDocument('User'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+
+			assert.strictEqual(sendRequest.callCount, 2);
 		});
 
 		test('Given a dart document with a model class name when the go to model definition command runs then the yaml model is opened at the declaration range.', async () => {

--- a/tools/serverpod_vscode_extension/src/test/model_navigation.test.ts
+++ b/tools/serverpod_vscode_extension/src/test/model_navigation.test.ts
@@ -8,6 +8,7 @@ suite('Model Navigation', () => {
 	let registerDefinitionProviderStub: sinon.SinonStub;
 	let registerCommandStub: sinon.SinonStub;
 	let showTextDocumentStub: sinon.SinonStub;
+	let showWarningMessageStub: sinon.SinonStub;
 	let capturedProvider: vscode.DefinitionProvider;
 	let commandHandler: () => Promise<void>;
 	let modelFileChangeHandlers: (() => void)[];
@@ -65,6 +66,7 @@ suite('Model Navigation', () => {
 				return trackedDisposable();
 			}) as never);
 		showTextDocumentStub = sinon.stub(vscode.window, 'showTextDocument');
+		showWarningMessageStub = sinon.stub(vscode.window, 'showWarningMessage');
 		modelFileChangeHandlers = [];
 		stateChangeHandlers = [];
 		sinon
@@ -306,6 +308,38 @@ suite('Model Navigation', () => {
 			const [uri, options] = showTextDocumentStub.firstCall.args;
 			assert.strictEqual(uri.toString(), modelLocationResult.uri);
 			assert.strictEqual((options.selection as vscode.Range).start.line, 0);
+		});
+
+		test('Given a CLI that does not implement the model definition request when the go to model definition command runs then an upgrade message is shown.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().rejects(methodNotFoundError());
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			sinon.stub(vscode.window, 'activeTextEditor').value({
+				document: mockDocument('User'),
+				selection: { active: new vscode.Position(0, 2) },
+			});
+
+			await commandHandler();
+
+			assert.strictEqual(showWarningMessageStub.calledOnce, true);
+			assert.match(showWarningMessageStub.firstCall.args[0], /newer Serverpod CLI/);
+			assert.strictEqual(showTextDocumentStub.called, false);
+		});
+
+		test('Given a class name that is not a model when the go to model definition command runs then no message is shown.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().resolves(null);
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			sinon.stub(vscode.window, 'activeTextEditor').value({
+				document: mockDocument('String'),
+				selection: { active: new vscode.Position(0, 2) },
+			});
+
+			await commandHandler();
+
+			assert.strictEqual(showWarningMessageStub.called, false);
 		});
 
 		test('Given a class name that is not a model when the go to model definition command runs then no document is opened.', async () => {

--- a/tools/serverpod_vscode_extension/src/test/model_navigation.test.ts
+++ b/tools/serverpod_vscode_extension/src/test/model_navigation.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 import { ErrorCodes, LanguageClient, ResponseError, State } from 'vscode-languageclient/node';
-import { registerModelNavigation, modelClassNameAt } from '../model_navigation';
+import { registerModelNavigation, modelReferenceAt } from '../model_navigation';
 
 suite('Model Navigation', () => {
 	let registerDefinitionProviderStub: sinon.SinonStub;
@@ -24,12 +24,17 @@ suite('Model Navigation', () => {
 		},
 	};
 
-	function mockDocument(word: string | undefined): vscode.TextDocument {
+	/// Builds a document holding `<prefix><word>` on its first line, where the
+	/// prefix stands for an import prefix such as `auth.`.
+	function mockDocument(word: string | undefined, prefix = ''): vscode.TextDocument {
+		const start = prefix.length;
 		return {
 			getWordRangeAtPosition: sinon.stub().returns(
-				word === undefined ? undefined : new vscode.Range(0, 0, 0, word.length)
+				word === undefined ? undefined : new vscode.Range(0, start, 0, start + word.length)
 			),
-			getText: sinon.stub().returns(word),
+			getText: sinon.stub().callsFake((range?: vscode.Range) =>
+				range !== undefined && range.end.character === start ? prefix : word
+			),
 		} as unknown as vscode.TextDocument;
 	}
 
@@ -236,6 +241,42 @@ suite('Model Navigation', () => {
 			assert.strictEqual((result as vscode.Location).uri.toString(), modelLocationResult.uri);
 		});
 
+		test('Given a prefixed model class name when definition is requested then the import prefix is sent as the module alias.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().resolves(modelLocationResult);
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			await capturedProvider.provideDefinition(
+				mockDocument('UserInfo', 'auth.'),
+				new vscode.Position(0, 7),
+				{} as vscode.CancellationToken
+			);
+
+			assert.deepStrictEqual(
+				sendRequest.firstCall.args,
+				['serverpod/modelDefinition', { className: 'UserInfo', moduleAlias: 'auth' }]
+			);
+		});
+
+		test('Given a model class name resolved under one import prefix when definition is requested under another then the server is queried again.', async () => {
+			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+			const sendRequest = sinon.stub().resolves(modelLocationResult);
+			registerModelNavigation(context, mockClient(sendRequest));
+
+			await capturedProvider.provideDefinition(
+				mockDocument('UserInfo', 'auth.'),
+				new vscode.Position(0, 7),
+				{} as vscode.CancellationToken
+			);
+			await capturedProvider.provideDefinition(
+				mockDocument('UserInfo'),
+				new vscode.Position(0, 2),
+				{} as vscode.CancellationToken
+			);
+
+			assert.strictEqual(sendRequest.callCount, 2);
+		});
+
 		test('Given a model class name already resolved when a model file changes then the next definition request queries the server again.', async () => {
 			const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
 			const sendRequest = sinon.stub().resolves(modelLocationResult);
@@ -383,21 +424,33 @@ suite('Model Navigation', () => {
 		});
 	});
 
-	suite('modelClassNameAt', () => {
-		test('Given a PascalCase identifier at the position when the class name is extracted then the identifier is returned.', () => {
-			const result = modelClassNameAt(mockDocument('UserInfo'), new vscode.Position(0, 2));
+	suite('modelReferenceAt', () => {
+		test('Given a PascalCase identifier at the position when the reference is extracted then the identifier is returned.', () => {
+			const result = modelReferenceAt(mockDocument('UserInfo'), new vscode.Position(0, 2));
 
-			assert.strictEqual(result, 'UserInfo');
+			assert.deepStrictEqual(result, { className: 'UserInfo' });
 		});
 
-		test('Given a camelCase identifier at the position when the class name is extracted then undefined is returned.', () => {
-			const result = modelClassNameAt(mockDocument('userInfo'), new vscode.Position(0, 2));
+		test('Given a prefixed identifier at the position when the reference is extracted then the import prefix is returned as the module alias.', () => {
+			const result = modelReferenceAt(mockDocument('UserInfo', 'auth.'), new vscode.Position(0, 7));
+
+			assert.deepStrictEqual(result, { className: 'UserInfo', moduleAlias: 'auth' });
+		});
+
+		test('Given an identifier after an unrelated expression when the reference is extracted then no module alias is returned.', () => {
+			const result = modelReferenceAt(mockDocument('UserInfo', 'var user = '), new vscode.Position(0, 13));
+
+			assert.deepStrictEqual(result, { className: 'UserInfo' });
+		});
+
+		test('Given a camelCase identifier at the position when the reference is extracted then undefined is returned.', () => {
+			const result = modelReferenceAt(mockDocument('userInfo'), new vscode.Position(0, 2));
 
 			assert.strictEqual(result, undefined);
 		});
 
-		test('Given no identifier at the position when the class name is extracted then undefined is returned.', () => {
-			const result = modelClassNameAt(mockDocument(undefined), new vscode.Position(0, 0));
+		test('Given no identifier at the position when the reference is extracted then undefined is returned.', () => {
+			const result = modelReferenceAt(mockDocument(undefined), new vscode.Position(0, 0));
 
 			assert.strictEqual(result, undefined);
 		});


### PR DESCRIPTION
Closes: #5679

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None. The extension accepts an older version of the language server and prints a warning message if trying to navigate to a model definition with a version that does not support this feature.