### PR TITLE
fix: Acquire single watcher per signal on pod start

### DIFF
--- a/packages/serverpod/lib/src/server/serverpod.dart
+++ b/packages/serverpod/lib/src/server/serverpod.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:serverpod/serverpod.dart' hide LogLevel;
 import 'package:serverpod_database/embedded.dart';
@@ -870,9 +871,15 @@ class Serverpod {
         config.role == ServerpodRole.serverless) {
       var serversStarted = true;
 
-      ProcessSignal.sigint.watch().listen(_onInterruptSignal);
+      // Guard against registering duplicate watchers if start() is called
+      // again on the same instance.
+      _sigintSubscription ??= _signalStreamFactory(
+        ProcessSignal.sigint,
+      ).listen(_onInterruptSignal);
       if (!Platform.isWindows) {
-        ProcessSignal.sigterm.watch().listen(_onShutdownSignal);
+        _sigtermSubscription ??= _signalStreamFactory(
+          ProcessSignal.sigterm,
+        ).listen(_onShutdownSignal);
       }
 
       // Serverpod Insights.
@@ -1085,6 +1092,28 @@ class Serverpod {
     shutdown(exitProcess: true, signalNumber: signal.signalNumber);
   }
 
+  StreamSubscription<ProcessSignal>? _sigintSubscription;
+  StreamSubscription<ProcessSignal>? _sigtermSubscription;
+
+  Stream<ProcessSignal> Function(ProcessSignal signal) _signalStreamFactory =
+      (signal) => signal.watch();
+
+  /// Cancels the SIGINT/SIGTERM watchers registered by [start].
+  ///
+  /// The signal socket pairs that back them stay open for as long as a
+  /// subscription is alive, so leaving them behind leaks file descriptors and
+  /// keeps a shut down Serverpod handling signals on behalf of the process.
+  Future<void> _cancelSignalWatchers() async {
+    var sigintSubscription = _sigintSubscription;
+    var sigtermSubscription = _sigtermSubscription;
+    _sigintSubscription = null;
+    _sigtermSubscription = null;
+    _interruptSignalSent = false;
+
+    await sigintSubscription?.cancel();
+    await sigtermSubscription?.cancel();
+  }
+
   bool _interruptSignalSent = false;
 
   void _onInterruptSignal(ProcessSignal signal) {
@@ -1242,64 +1271,83 @@ class Serverpod {
 
     Object? shutdownError;
 
-    await _requestReceivingShutdownTasks.executeTasks(
-      onTaskError: (error, stack, id) {
-        shutdownError = error;
-        _reportException(
-          error,
-          stack,
-          message: 'Error in request receiving shutdown "$id"',
-        );
-      },
-    );
-
-    await experimental._shutdownTasks.executeTasks(
-      onTaskError: (error, stack, id) {
-        shutdownError = error;
-        _reportException(error, stack, message: 'Error in shutdown task "$id"');
-      },
-    );
-
-    await _internalServicesShutdownTasks.executeTasks(
-      onTaskError: (error, stack, id) {
-        shutdownError = error;
-        _reportException(
-          error,
-          stack,
-          message: 'Error in service shutdown "$id"',
-        );
-      },
-    );
-
-    // Drain the database log writer before tearing the pool down so its
-    // in-flight close rows reach the database instead of racing pool.stop().
-    // Dispose is idempotent; if the caller owns the log setup and later
-    // closes it, the duplicate dispose is a no-op.
     try {
-      final dbWriter = _loggingSetup.databaseWriter;
-      if (dbWriter != null) {
-        sessionLogWriter.remove(dbWriter);
-        await dbWriter.dispose();
+      await _requestReceivingShutdownTasks.executeTasks(
+        onTaskError: (error, stack, id) {
+          shutdownError = error;
+          _reportException(
+            error,
+            stack,
+            message: 'Error in request receiving shutdown "$id"',
+          );
+        },
+      );
+
+      await experimental._shutdownTasks.executeTasks(
+        onTaskError: (error, stack, id) {
+          shutdownError = error;
+          _reportException(
+            error,
+            stack,
+            message: 'Error in shutdown task "$id"',
+          );
+        },
+      );
+
+      await _internalServicesShutdownTasks.executeTasks(
+        onTaskError: (error, stack, id) {
+          shutdownError = error;
+          _reportException(
+            error,
+            stack,
+            message: 'Error in service shutdown "$id"',
+          );
+        },
+      );
+
+      // Drain the database log writer before tearing the pool down so its
+      // in-flight close rows reach the database instead of racing pool.stop().
+      // Dispose is idempotent; if the caller owns the log setup and later
+      // closes it, the duplicate dispose is a no-op.
+      try {
+        final dbWriter = _loggingSetup.databaseWriter;
+        if (dbWriter != null) {
+          sessionLogWriter.remove(dbWriter);
+          await dbWriter.dispose();
+        }
+      } catch (e, stackTrace) {
+        shutdownError = e;
+        _reportException(
+          e,
+          stackTrace,
+          message: 'Error draining database log writer',
+        );
       }
-    } catch (e, stackTrace) {
-      shutdownError = e;
-      _reportException(
-        e,
-        stackTrace,
-        message: 'Error draining database log writer',
-      );
-    }
 
-    // This needs to be closed last as it is used by the other services.
-    try {
-      await _databasePoolManager?.stop();
-    } catch (e, stackTrace) {
-      shutdownError = e;
-      _reportException(
-        e,
-        stackTrace,
-        message: 'Error in database pool manager shutdown',
-      );
+      // This needs to be closed last as it is used by the other services.
+      try {
+        await _databasePoolManager?.stop();
+      } catch (e, stackTrace) {
+        shutdownError = e;
+        _reportException(
+          e,
+          stackTrace,
+          message: 'Error in database pool manager shutdown',
+        );
+      }
+    } finally {
+      // Released last so that a second SIGINT during the shutdown above still
+      // reaches [_onInterruptSignal] and forces an immediate exit.
+      try {
+        await _cancelSignalWatchers();
+      } catch (e, stackTrace) {
+        shutdownError = e;
+        _reportException(
+          e,
+          stackTrace,
+          message: 'Error cancelling signal watchers',
+        );
+      }
     }
 
     _writeLifecycleMessage(
@@ -1562,5 +1610,19 @@ extension ServerpodInternalMethods on Serverpod {
       space: space,
       context: context,
     );
+  }
+
+  /// Overrides how the SIGINT/SIGTERM streams watched by [Serverpod.start] are
+  /// created.
+  ///
+  /// This allows tests to observe the signal subscription lifecycle without
+  /// installing handlers for real process signals, which would be shared with
+  /// every other test running in the same process. Must be called before
+  /// [Serverpod.start].
+  @visibleForTesting
+  void setSignalStreamFactoryForTesting(
+    Stream<ProcessSignal> Function(ProcessSignal signal) signalStreamFactory,
+  ) {
+    _signalStreamFactory = signalStreamFactory;
   }
 }

--- a/packages/serverpod/test/server/signal_watcher_shutdown_test.dart
+++ b/packages/serverpod/test/server/signal_watcher_shutdown_test.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod/src/generated/protocol.dart' as internal;
+import 'package:serverpod/src/server/serverpod.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers/empty_endpoints.dart';
+
+/// Stands in for the process-wide `ProcessSignal.watch()` streams.
+///
+/// Real signal streams cannot be used here: `dart test` runs every test file
+/// in the same process, so a subscription taken out by one test is observable
+/// by all the others. Handing [Serverpod] its own streams keeps the assertions
+/// below independent of everything else running in the process.
+class _FakeProcessSignals {
+  final _controllers = <ProcessSignal, List<StreamController<ProcessSignal>>>{};
+
+  Stream<ProcessSignal> watch(ProcessSignal signal) {
+    var controller = StreamController<ProcessSignal>();
+    (_controllers[signal] ??= []).add(controller);
+    return controller.stream;
+  }
+
+  /// The number of streams for [signal] that currently have a subscription.
+  int watcherCount(ProcessSignal signal) =>
+      _controllers[signal]?.where((c) => c.hasListener).length ?? 0;
+
+  /// The number of streams handed out for [signal], subscribed or not.
+  int streamCount(ProcessSignal signal) => _controllers[signal]?.length ?? 0;
+}
+
+void main() {
+  var portZeroConfig = ServerConfig(
+    port: 0,
+    publicScheme: 'http',
+    publicHost: 'localhost',
+    publicPort: 0,
+  );
+
+  var watchedSignals = [
+    ProcessSignal.sigint,
+    if (!Platform.isWindows) ProcessSignal.sigterm,
+  ];
+
+  late _FakeProcessSignals signals;
+  late Serverpod pod;
+
+  setUp(() {
+    signals = _FakeProcessSignals();
+    pod = Serverpod(
+      [],
+      internal.Protocol(),
+      EmptyEndpoints(),
+      config: ServerpodConfig(
+        apiServer: portZeroConfig,
+        webServer: portZeroConfig,
+      ),
+    );
+    pod.setSignalStreamFactoryForTesting(signals.watch);
+  });
+
+  group('Given a started Serverpod', () {
+    setUp(() async {
+      await pod.start();
+    });
+
+    tearDown(() async {
+      await pod.shutdown(exitProcess: false);
+    });
+
+    test(
+      'when inspecting the watched process signals, '
+      'then each of them has exactly one watcher.',
+      () {
+        for (var signal in watchedSignals) {
+          expect(
+            signals.watcherCount(signal),
+            1,
+            reason: '${signal.name} should be watched while running',
+          );
+        }
+      },
+    );
+  });
+
+  group('Given a started Serverpod that has been shut down', () {
+    setUp(() async {
+      await pod.start();
+      await pod.shutdown(exitProcess: false);
+    });
+
+    test(
+      'when inspecting the watched process signals, '
+      'then none of them has a watcher left.',
+      () {
+        for (var signal in watchedSignals) {
+          expect(
+            signals.watcherCount(signal),
+            0,
+            reason:
+                '${signal.name} watcher should be cancelled by the shutdown',
+          );
+        }
+      },
+    );
+  });
+
+  group('Given a Serverpod that is started and shut down repeatedly', () {
+    setUp(() async {
+      for (var i = 0; i < 3; i++) {
+        await pod.start();
+        await pod.shutdown(exitProcess: false);
+      }
+    });
+
+    test(
+      'when inspecting the watched process signals, '
+      'then no watcher is left behind.',
+      () {
+        for (var signal in watchedSignals) {
+          expect(
+            signals.watcherCount(signal),
+            0,
+            reason: '${signal.name} watchers should not accumulate',
+          );
+        }
+      },
+    );
+
+    test(
+      'when inspecting the streams handed to the Serverpod, '
+      'then each start took out a new watcher.',
+      () {
+        for (var signal in watchedSignals) {
+          expect(
+            signals.streamCount(signal),
+            3,
+            reason: '${signal.name} should be watched again by every start',
+          );
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #5672 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None