### PR TITLE
fix: Wait for Redis subscription confirmation before publishing

### DIFF
--- a/packages/serverpod/lib/src/redis/controller.dart
+++ b/packages/serverpod/lib/src/redis/controller.dart
@@ -44,6 +44,17 @@ class RedisController {
 
   final Map<String, RedisSubscriptionCallback> _subscriptions = {};
 
+  /// `SUBSCRIBE` commands that Redis has not confirmed yet, keyed by channel.
+  final Map<String, List<_PendingConfirmation>> _pendingSubscribes = {};
+
+  /// `UNSUBSCRIBE` commands that Redis has not confirmed yet, keyed by channel.
+  final Map<String, List<_PendingConfirmation>> _pendingUnsubscribes = {};
+
+  /// Backstop for how long to wait for Redis to confirm a subscription change.
+  /// A broken connection resolves the pending commands through
+  /// [_invalidatePubSub] well before this elapses.
+  static const _subscriptionConfirmationTimeout = Duration(seconds: 10);
+
   Command? _command;
   bool _connecting = false;
 
@@ -72,6 +83,9 @@ class RedisController {
     bool Function(Exception e)? handleError,
     Duration? connectTimeout,
   }) async {
+    // Reset so a controller that was previously stopped can be started again.
+    _running = true;
+
     final connected = await _connect(handleError, connectTimeout);
     if (!connected && handleError != null) {
       return;
@@ -84,8 +98,21 @@ class RedisController {
   /// Stops the controller and closes all open connections.
   Future<void> stop() async {
     _running = false;
-    await _command?.get_connection().close();
-    await _pubSubCommand?.get_connection().close();
+
+    var command = _command;
+    var pubSubCommand = _pubSubCommand;
+
+    // Cleared alongside closing, so a later [start] reconnects instead of
+    // handing out the closed connections.
+    _command = null;
+    _pubSub = null;
+    _pubSubCommand = null;
+
+    _failAllPending(_pendingSubscribes);
+    _failAllPending(_pendingUnsubscribes);
+
+    await command?.get_connection().close();
+    await pubSubCommand?.get_connection().close();
   }
 
   Future<Socket> _openRedisSocket([Duration? connectTimeoutOverride]) async {
@@ -206,17 +233,26 @@ class RedisController {
   Future<void> _listenToSubscriptions(Stream stream) async {
     try {
       await for (var message in stream) {
-        if (message is List && message.length == 3) {
-          if (message[0] == 'message') {
+        if (message is! List || message.length != 3) continue;
+
+        var channel = message[1];
+        if (channel is! String) continue;
+
+        switch (message[0]) {
+          case 'message':
             // We got a message (can also be confirmation on publish)
-            String channel = message[1];
             String data = message[2];
 
             var callback = _subscriptions[channel];
             if (callback != null) {
               callback(channel, data);
             }
-          }
+          case 'subscribe':
+            // The channel is now active on the server, so anyone waiting for
+            // this subscription can safely start publishing to it.
+            _resolvePending(_pendingSubscribes, channel, true);
+          case 'unsubscribe':
+            _resolvePending(_pendingUnsubscribes, channel, true);
         }
       }
     } catch (e) {
@@ -224,6 +260,29 @@ class RedisController {
       return;
     }
     _invalidatePubSub();
+  }
+
+  /// Resolves every command outstanding for [channel]. One confirmation
+  /// satisfies all of them, since they all describe the same server side
+  /// state.
+  void _resolvePending(
+    Map<String, List<_PendingConfirmation>> register,
+    String channel,
+    bool result,
+  ) {
+    for (var pending in List.of(
+      register[channel] ?? const <_PendingConfirmation>[],
+    )) {
+      pending.complete(result);
+    }
+  }
+
+  /// Fails every outstanding command, used when the connection carrying the
+  /// confirmations goes away.
+  void _failAllPending(Map<String, List<_PendingConfirmation>> register) {
+    for (var channel in register.keys.toList()) {
+      _resolvePending(register, channel, false);
+    }
   }
 
   void _invalidateCommand() {
@@ -243,6 +302,9 @@ class RedisController {
     }
     _pubSub = null;
     _pubSubCommand = null;
+
+    _failAllPending(_pendingSubscribes);
+    _failAllPending(_pendingUnsubscribes);
   }
 
   /// Sets a [String] in the Redis cache, which optionally expires.
@@ -307,33 +369,60 @@ class RedisController {
   /// Subscribes to a Redis channel. When a message is published on the channel
   /// the [listener] callback is called. Only one subscription call should be
   /// made per channel.
+  ///
+  /// The returned future does not complete until Redis has confirmed the
+  /// subscription. Awaiting it is optional: [publish] waits for an in-flight
+  /// subscription to the same channel on its own, so a message published
+  /// straight after this call is not delivered before the server is ready to
+  /// route it.
   Future<bool> subscribe(
     String channel,
     RedisSubscriptionCallback listener,
   ) async {
+    // Registered before the first await, so a publish issued immediately after
+    // this call already observes the subscription as in flight.
+    var pending = _PendingConfirmation(_pendingSubscribes, channel);
+
     try {
-      await _connectPubSub();
-      _pubSub!.subscribe([channel]);
+      if (!await _connectPubSub()) return pending.complete(false);
+
+      // In place before the command is sent, so the listener is ready by the
+      // time the server starts delivering messages for the channel.
       _subscriptions[channel] = listener;
-      return true;
+      _pubSub!.subscribe([channel]);
+
+      return await pending.confirmed.timeout(
+        _subscriptionConfirmationTimeout,
+        onTimeout: () => pending.complete(false),
+      );
     } catch (e) {
       _invalidatePubSub();
-      return false;
+      return pending.complete(false);
     }
   }
 
   /// Unsubscribes from a Redis channel.
+  ///
+  /// The returned future does not complete until Redis has confirmed that the
+  /// subscription is gone.
   Future<bool> unsubscribe(
     String channel,
   ) async {
+    var pending = _PendingConfirmation(_pendingUnsubscribes, channel);
+
     try {
-      await _connectPubSub();
-      _pubSub!.unsubscribe([channel]);
+      if (!await _connectPubSub()) return pending.complete(false);
+
       _subscriptions.remove(channel);
-      return true;
+      _pubSub!.unsubscribe([channel]);
+
+      return await pending.confirmed.timeout(
+        _subscriptionConfirmationTimeout,
+        onTimeout: () => pending.complete(false),
+      );
     } catch (e) {
       _invalidatePubSub();
-      return false;
+      return pending.complete(false);
     }
   }
 
@@ -342,6 +431,8 @@ class RedisController {
   ///
   /// Returns true if the message was successfully published.
   Future<bool> publish(String channel, String message) async {
+    await _awaitPendingSubscribe(channel);
+
     try {
       if (!await _connect()) {
         return false;
@@ -355,6 +446,26 @@ class RedisController {
       _invalidateCommand();
       return false;
     }
+  }
+
+  /// Waits for an in-flight [subscribe] on [channel] to be confirmed.
+  ///
+  /// Subscriptions are usually started without being awaited - [MessageCentral]
+  /// registers listeners synchronously - and the `SUBSCRIBE` travels on the
+  /// pub/sub connection while `PUBLISH` travels on the command connection.
+  /// Without this wait the publish can reach the server first, and Redis drops
+  /// a message that has no subscriber yet.
+  ///
+  /// Only subscriptions started through this controller are covered. A
+  /// subscriber on another server in the cluster cannot be waited for, which
+  /// is inherent to pub/sub rather than something this can solve.
+  Future<void> _awaitPendingSubscribe(String channel) async {
+    var pending = _pendingSubscribes[channel];
+    if (pending == null || pending.isEmpty) return;
+
+    await Future.wait([
+      for (var confirmation in List.of(pending)) confirmation.confirmed,
+    ]);
   }
 
   /// Returns the underlying Redis [Command] connection.
@@ -390,4 +501,36 @@ class RedisController {
 
   /// Returns a list of subscribed channels.
   List<String> get subscribedChannels => _subscriptions.keys.toList();
+}
+
+/// A subscription command that has been handed to Redis and is waiting for the
+/// server's confirmation frame.
+///
+/// It registers itself on construction and unregisters itself on [complete], so
+/// a command that fails, times out, or loses its connection can never leave a
+/// publisher waiting on a confirmation that will never arrive.
+class _PendingConfirmation {
+  final Map<String, List<_PendingConfirmation>> _register;
+  final String _channel;
+  final Completer<bool> _completer = Completer<bool>();
+
+  _PendingConfirmation(this._register, this._channel) {
+    _register.putIfAbsent(_channel, () => []).add(this);
+  }
+
+  /// Completes once the server has answered, or the command was given up on.
+  Future<bool> get confirmed => _completer.future;
+
+  /// Settles this command with [result], which is also returned so callers can
+  /// `return pending.complete(false)` on their failure paths.
+  bool complete(bool result) {
+    var pending = _register[_channel];
+    if (pending != null) {
+      pending.remove(this);
+      if (pending.isEmpty) _register.remove(_channel);
+    }
+
+    if (!_completer.isCompleted) _completer.complete(result);
+    return result;
+  }
 }

--- a/packages/serverpod/test/redis/fake_redis_server.dart
+++ b/packages/serverpod/test/redis/fake_redis_server.dart
@@ -1,0 +1,198 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// A minimal stand-in for a Redis server, speaking just enough RESP to drive
+/// [RedisController] in tests.
+///
+/// Its purpose is control over *when* a subscription is confirmed. A real Redis
+/// confirms so fast that a controller which never waits for the confirmation
+/// still passes, which makes the wait itself untestable against a real server.
+class FakeRedisServer {
+  final ServerSocket _socketServer;
+  final List<Socket> _connections = [];
+  final List<_HeldConfirmation> _held = [];
+  final Map<String, Set<Socket>> _subscribers = {};
+
+  /// Every command received so far, in arrival order.
+  final List<List<String>> receivedCommands = [];
+  final StreamController<List<String>> _commands =
+      StreamController<List<String>>.broadcast();
+
+  /// When true, `SUBSCRIBE` and `UNSUBSCRIBE` are received and acknowledged in
+  /// the test's own time via [releaseHeldConfirmations], rather than at once.
+  bool holdConfirmations = false;
+
+  FakeRedisServer._(this._socketServer) {
+    _socketServer.listen(_handleConnection);
+  }
+
+  static Future<FakeRedisServer> start() async {
+    var socketServer = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    return FakeRedisServer._(socketServer);
+  }
+
+  int get port => _socketServer.port;
+
+  /// Every command the server has received, as its RESP arguments.
+  Stream<List<String>> get commands => _commands.stream;
+
+  /// Completes once a command named [name] has been received.
+  Future<List<String>> nextCommand(String name) => commands.firstWhere(
+    (command) => command.first.toUpperCase() == name.toUpperCase(),
+  );
+
+  /// Acknowledges everything withheld while [holdConfirmations] was set.
+  void releaseHeldConfirmations() {
+    for (var confirmation in _held) {
+      _writeConfirmation(
+        confirmation.socket,
+        confirmation.kind,
+        confirmation.channel,
+      );
+    }
+    _held.clear();
+  }
+
+  /// Pushes a message to everyone subscribed to [channel], the way a real
+  /// server does when another client publishes.
+  void deliverMessage(String channel, String data) {
+    for (var socket in _subscribers[channel] ?? <Socket>{}) {
+      socket.add(
+        utf8.encode(
+          '*3\r\n'
+          '\$7\r\nmessage\r\n'
+          '\$${channel.length}\r\n$channel\r\n'
+          '\$${data.length}\r\n$data\r\n',
+        ),
+      );
+    }
+  }
+
+  /// Drops every open connection, as an unresponsive server or a network
+  /// failure would.
+  Future<void> dropConnections() async {
+    var connections = List.of(_connections);
+    _connections.clear();
+    _held.clear();
+    _subscribers.clear();
+    for (var connection in connections) {
+      await connection.close();
+    }
+  }
+
+  Future<void> close() async {
+    await dropConnections();
+    await _socketServer.close();
+    await _commands.close();
+  }
+
+  void _handleConnection(Socket socket) {
+    _connections.add(socket);
+
+    var buffer = <int>[];
+    socket.listen(
+      (data) {
+        buffer.addAll(data);
+
+        for (
+          var command = _takeCommand(buffer);
+          command != null;
+          command = _takeCommand(buffer)
+        ) {
+          _handleCommand(socket, command);
+        }
+      },
+      onDone: () => _connections.remove(socket),
+      onError: (_) => _connections.remove(socket),
+      cancelOnError: true,
+    );
+  }
+
+  void _handleCommand(Socket socket, List<String> command) {
+    receivedCommands.add(command);
+    _commands.add(command);
+
+    var name = command.first.toUpperCase();
+    switch (name) {
+      case 'SUBSCRIBE':
+      case 'UNSUBSCRIBE':
+        var kind = name.toLowerCase();
+        var channel = command[1];
+        if (name == 'SUBSCRIBE') {
+          _subscribers.putIfAbsent(channel, () => {}).add(socket);
+        } else {
+          _subscribers[channel]?.remove(socket);
+        }
+        if (holdConfirmations) {
+          _held.add(_HeldConfirmation(socket, kind, channel));
+        } else {
+          _writeConfirmation(socket, kind, channel);
+        }
+      case 'PING':
+        socket.add(utf8.encode('+PONG\r\n'));
+      case 'PUBLISH':
+        // Reply shape of a real PUBLISH: the number of clients that got it.
+        socket.add(utf8.encode(':0\r\n'));
+      default:
+        socket.add(utf8.encode('+OK\r\n'));
+    }
+  }
+
+  void _writeConfirmation(Socket socket, String kind, String channel) {
+    socket.add(
+      utf8.encode(
+        '*3\r\n'
+        '\$${kind.length}\r\n$kind\r\n'
+        '\$${channel.length}\r\n$channel\r\n'
+        ':1\r\n',
+      ),
+    );
+  }
+
+  /// Removes and returns the next complete RESP command in [buffer], or null
+  /// while it still holds only a partial one.
+  List<String>? _takeCommand(List<int> buffer) {
+    if (buffer.isEmpty || buffer.first != 0x2a /* '*' */ ) return null;
+
+    var position = 0;
+
+    String? takeLine() {
+      for (var i = position; i + 1 < buffer.length; i++) {
+        if (buffer[i] == 0x0d /* CR */ && buffer[i + 1] == 0x0a /* LF */ ) {
+          var line = utf8.decode(buffer.sublist(position, i));
+          position = i + 2;
+          return line;
+        }
+      }
+      return null;
+    }
+
+    var header = takeLine();
+    if (header == null) return null;
+
+    var argumentCount = int.parse(header.substring(1));
+    var arguments = <String>[];
+    for (var i = 0; i < argumentCount; i++) {
+      var lengthLine = takeLine();
+      if (lengthLine == null) return null;
+
+      var length = int.parse(lengthLine.substring(1));
+      if (buffer.length < position + length + 2) return null;
+
+      arguments.add(utf8.decode(buffer.sublist(position, position + length)));
+      position += length + 2;
+    }
+
+    buffer.removeRange(0, position);
+    return arguments;
+  }
+}
+
+class _HeldConfirmation {
+  final Socket socket;
+  final String kind;
+  final String channel;
+
+  _HeldConfirmation(this.socket, this.kind, this.channel);
+}

--- a/packages/serverpod/test/redis/redis_controller_subscription_test.dart
+++ b/packages/serverpod/test/redis/redis_controller_subscription_test.dart
@@ -1,0 +1,161 @@
+import 'dart:async';
+
+import 'package:serverpod/src/redis/controller.dart';
+import 'package:test/test.dart';
+
+import 'fake_redis_server.dart';
+
+void main() {
+  late FakeRedisServer redis;
+  late RedisController controller;
+
+  setUp(() async {
+    redis = await FakeRedisServer.start();
+    controller = RedisController(
+      host: '127.0.0.1',
+      port: redis.port,
+      requireSsl: false,
+    );
+    await controller.start();
+  });
+
+  tearDown(() async {
+    await controller.stop();
+    await redis.close();
+  });
+
+  group('Given a Redis server that has not confirmed a subscription', () {
+    test('when subscribing '
+        'then the returned future does not complete', () async {
+      redis.holdConfirmations = true;
+
+      var completed = false;
+      var subscribing = controller.subscribe('channel', (_, _) {});
+      unawaited(subscribing.then((_) => completed = true));
+
+      await redis.nextCommand('SUBSCRIBE');
+      await pumpEventQueue();
+
+      expect(
+        completed,
+        isFalse,
+        reason:
+            'subscribe must not complete before Redis confirms the '
+            'subscription, otherwise a publish right after it can be dropped',
+      );
+
+      redis.releaseHeldConfirmations();
+      await expectLater(subscribing, completion(isTrue));
+    });
+
+    test('when unsubscribing '
+        'then the returned future does not complete', () async {
+      await controller.subscribe('channel', (_, _) {});
+      redis.holdConfirmations = true;
+
+      var completed = false;
+      var unsubscribing = controller.unsubscribe('channel');
+      unawaited(unsubscribing.then((_) => completed = true));
+
+      await redis.nextCommand('UNSUBSCRIBE');
+      await pumpEventQueue();
+
+      expect(completed, isFalse);
+
+      redis.releaseHeldConfirmations();
+      await expectLater(unsubscribing, completion(isTrue));
+    });
+
+    test('when the connection drops while waiting '
+        'then subscribing reports failure', () async {
+      redis.holdConfirmations = true;
+
+      var subscribing = controller.subscribe('channel', (_, _) {});
+      await redis.nextCommand('SUBSCRIBE');
+
+      await redis.dropConnections();
+
+      await expectLater(subscribing, completion(isFalse));
+    });
+  });
+
+  group('Given a subscription that Redis has not confirmed yet', () {
+    setUp(() => redis.holdConfirmations = true);
+
+    test('when a message is published to the same channel '
+        'then the publish waits for the confirmation', () async {
+      // Deliberately not awaited: this is how MessageCentral registers
+      // listeners, and the reason the wait cannot live at the call site.
+      unawaited(controller.subscribe('channel', (_, _) {}));
+
+      var published = false;
+      var publishing = controller.publish('channel', 'a-message');
+      unawaited(publishing.then((_) => published = true));
+
+      await redis.nextCommand('SUBSCRIBE');
+      await pumpEventQueue();
+
+      expect(
+        published,
+        isFalse,
+        reason:
+            'the publish must not reach Redis before the subscription, '
+            'or the server drops the message',
+      );
+      expect(
+        redis.receivedCommands.map((command) => command.first),
+        isNot(contains('PUBLISH')),
+      );
+
+      redis.releaseHeldConfirmations();
+      await expectLater(publishing, completion(isTrue));
+      expect(
+        redis.receivedCommands.map((command) => command.first),
+        contains('PUBLISH'),
+      );
+    });
+
+    test('when a message is published to a different channel '
+        'then the publish is not held up', () async {
+      unawaited(controller.subscribe('channel', (_, _) {}));
+      await redis.nextCommand('SUBSCRIBE');
+
+      await expectLater(
+        controller.publish('other-channel', 'a-message'),
+        completion(isTrue),
+      );
+    });
+
+    test('when the subscription never completes '
+        'then the publish is released rather than deadlocked', () async {
+      unawaited(controller.subscribe('channel', (_, _) {}));
+      await redis.nextCommand('SUBSCRIBE');
+
+      var publishing = controller.publish('channel', 'a-message');
+      await redis.dropConnections();
+
+      await expectLater(publishing, completes);
+    });
+  });
+
+  group('Given a Redis server that confirms subscriptions', () {
+    test('when subscribing '
+        'then the confirmation is awaited before completing', () async {
+      var subscribed = await controller.subscribe('channel', (_, _) {});
+
+      expect(subscribed, isTrue);
+    });
+
+    test('when a message is delivered on the channel '
+        'then the listener is notified', () async {
+      var received = Completer<String>();
+      await controller.subscribe('channel', (_, message) {
+        received.complete(message);
+      });
+
+      redis.deliverMessage('channel', 'hello');
+
+      await expectLater(received.future, completion('hello'));
+    });
+  });
+}

--- a/tests/serverpod_test_server/lib/src/endpoints/redis.dart
+++ b/tests/serverpod_test_server/lib/src/endpoints/redis.dart
@@ -46,7 +46,11 @@ class RedisEndpoint extends Endpoint {
     String channel,
     SimpleData data,
   ) async {
-    session.messages.postMessage(channel, data, scope: MessageScope.global);
+    await session.messages.postMessage(
+      channel,
+      data,
+      scope: MessageScope.global,
+    );
   }
 
   Future<int> countSubscribedChannels(Session session) async {

--- a/tests/serverpod_test_server/test_integration/redis_cache_test.dart
+++ b/tests/serverpod_test_server/test_integration/redis_cache_test.dart
@@ -413,8 +413,8 @@ void main() {
       };
 
       setUp(() async {
-        session.messages.addListener(uniqueChannelName, uniqueChannelListener);
         uniqueChannelMessageCompleter = Completer();
+        session.messages.addListener(uniqueChannelName, uniqueChannelListener);
       });
 
       tearDown(() async {
@@ -437,9 +437,15 @@ void main() {
               Duration(seconds: 10),
               onTimeout: () => null,
             );
+
+        // Both channels were subscribed on the same Redis connection, and
+        // [channelName] first, so Redis had applied that subscription by the
+        // time this message came back. The listener on [channelName] was
+        // therefore live and would have been notified if the channels were
+        // not isolated.
         expect(uniqueChannelMessageReceived, isNotNull);
 
-        expectLater(
+        await expectLater(
           messageCompleter.future.timeout(
             Duration(milliseconds: 100),
           ),

--- a/tests/serverpod_test_server/test_integration/redis_controller_test.dart
+++ b/tests/serverpod_test_server/test_integration/redis_controller_test.dart
@@ -1,0 +1,181 @@
+@Tags(['redis'])
+library;
+
+import 'dart:async';
+
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_test_server/test_util/test_serverpod.dart';
+import 'package:test/test.dart';
+
+/// Asks Redis which of its channels currently have subscribers, over the
+/// regular command connection rather than the pub/sub one.
+///
+/// This is the server's own view of the subscription, so it is the ground
+/// truth for whether [RedisController.subscribe] waited long enough.
+Future<List<String>> _serverSideSubscribers(
+  RedisController controller,
+  String channel,
+) async {
+  var connection = await controller.getConnection();
+  var result = await connection?.send_object(['PUBSUB', 'CHANNELS', channel]);
+  return (result as List?)?.cast<String>() ?? [];
+}
+
+void main() {
+  late Session session;
+  late RedisController controller;
+  late String channel;
+
+  setUpAll(() async {
+    session = await IntegrationTestServer(withRedis: true).session();
+    var redisController = session.serverpod.redisController;
+    if (redisController == null) {
+      throw StateError('Expected the test server to have a Redis controller');
+    }
+
+    controller = redisController;
+    await controller.start();
+  });
+
+  setUp(() {
+    channel = Uuid().v4();
+  });
+
+  group('Given a running Redis controller,', () {
+    group('when subscribing to a channel,', () {
+      late bool subscribed;
+
+      setUp(() async {
+        subscribed = await controller.subscribe(channel, (_, _) {});
+      });
+
+      tearDown(() async {
+        await controller.unsubscribe(channel);
+      });
+
+      test('then the subscription is confirmed.', () {
+        expect(subscribed, isTrue);
+      });
+
+      test('then Redis reports the channel as subscribed.', () async {
+        expect(await _serverSideSubscribers(controller, channel), [channel]);
+      });
+    });
+
+    group('when subscribing to the same channel twice,', () {
+      late List<bool> subscribed;
+
+      setUp(() async {
+        subscribed = await Future.wait([
+          controller.subscribe(channel, (_, _) {}),
+          controller.subscribe(channel, (_, _) {}),
+        ]).timeout(Duration(seconds: 10));
+      });
+
+      tearDown(() async {
+        await controller.unsubscribe(channel);
+      });
+
+      test('then both subscriptions are confirmed.', () {
+        expect(subscribed, [true, true]);
+      });
+    });
+  });
+
+  group('Given a channel subscribed on a running Redis controller,', () {
+    late Completer<String> received;
+
+    setUp(() async {
+      received = Completer<String>();
+      await controller.subscribe(channel, (_, message) {
+        received.complete(message);
+      });
+    });
+
+    tearDown(() async {
+      await controller.unsubscribe(channel);
+    });
+
+    group('when a message is published to the channel,', () {
+      setUp(() async {
+        await controller.publish(channel, 'a-message');
+      });
+
+      test('then the message is delivered to the listener.', () async {
+        await expectLater(
+          received.future.timeout(Duration(seconds: 10)),
+          completion('a-message'),
+        );
+      });
+    });
+
+    group('when unsubscribing from the channel,', () {
+      late bool unsubscribed;
+
+      setUp(() async {
+        unsubscribed = await controller.unsubscribe(channel);
+      });
+
+      test('then the unsubscription is confirmed.', () {
+        expect(unsubscribed, isTrue);
+      });
+
+      test('then Redis no longer reports the channel as subscribed.', () async {
+        expect(await _serverSideSubscribers(controller, channel), isEmpty);
+      });
+    });
+  });
+
+  group('Given a stopped Redis controller,', () {
+    setUp(() async {
+      await controller.stop();
+    });
+
+    tearDown(() async {
+      await controller.start();
+    });
+
+    group('when subscribing to a channel,', () {
+      late bool subscribed;
+
+      // The timeout turns a hanging subscription into a failure rather than a
+      // suite that never finishes.
+      setUp(() async {
+        subscribed = await controller
+            .subscribe(channel, (_, _) {})
+            .timeout(Duration(seconds: 5));
+      });
+
+      test('then the subscription reports failure.', () {
+        expect(subscribed, isFalse);
+      });
+    });
+  });
+
+  group('Given a Redis controller that was stopped and started again,', () {
+    setUp(() async {
+      await controller.stop();
+      await controller.start();
+    });
+
+    group('when subscribing to a channel,', () {
+      late bool subscribed;
+
+      setUp(() async {
+        subscribed = await controller.subscribe(channel, (_, _) {});
+      });
+
+      tearDown(() async {
+        await controller.unsubscribe(channel);
+      });
+
+      test('then the subscription is confirmed.', () {
+        expect(subscribed, isTrue);
+      });
+
+      test('then Redis reports the channel as subscribed.', () async {
+        expect(await _serverSideSubscribers(controller, channel), [channel]);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Messages published immediately after registering a listener could be silently dropped. `RedisController.subscribe` wrote `SUBSCRIBE` to the pub/sub socket without waiting for the server to acknowledge it, while `PUBLISH` went out on a separate connection, so the publish could reach Redis first and be discarded for having no subscriber. Usually the subscribe won the race, which is why this surfaced as a flaky test rather than a consistent failure.

### Changes

- `subscribe`/`unsubscribe` now wait for Redis's confirmation frame. These were already arriving on the pub/sub stream and being discarded.
- `publish` waits for an in-flight subscribe on the same channel. This keeps the fix invisible to callers: `MessageCentral.addListener` stays synchronous, and `createStream` is covered too, with no API change anywhere.
- `stop()` followed by `start()` left the controller permanently unusable (`_running` was never reset and `_command` kept pointing at a closed socket).

A `_PendingConfirmation` unregisters itself whenever it completes, so a command that fails, times out, or loses its connection releases waiting publishers instead of deadlocking them.

Subscribers on *other* servers still can't be waited for as that's inherent to pub/sub.


## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

None.