### PR TITLE
feat: Add support for FVM

### DIFF
--- a/docs/design/sdk_resolution.md
+++ b/docs/design/sdk_resolution.md
@@ -1,0 +1,184 @@
+# Design: Dart and Flutter SDK resolution
+
+This document describes how the Serverpod CLI decides which Dart and Flutter
+SDK to use when it runs `pub get`, `flutter create`, `flutter run`, and when it
+compiles and runs the server. Today that decision is made independently at
+different call sites using two different and sometimes conflicting strategies.
+This proposes a single resolution chain — **`SdkResolver`** — that every call
+site consults, and which understands project-pinned SDKs (fvm) without any
+configuration from the user.
+
+The user-visible goal: a developer who pins Flutter with fvm should be able to
+run `serverpod create` and `serverpod start` and have them work, with the
+project's pinned SDK, without setting anything up.
+
+## Current state
+
+The CLI resolves Dart and Flutter in two unrelated ways.
+
+**By PATH lookup** — the bare names `dart` and `flutter`, resolved by the OS
+against `$PATH`:
+
+- `tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart` —
+  `_preCommandEnvironmentChecks` runs `dart --version` and `flutter --version`
+  before *every* command and aborts the CLI if either is missing. The Flutter
+  check is skipped when `ci.isCI`.
+- `tools/serverpod_cli/lib/src/util/command_line_tools.dart` — the
+  `existsCommand('flutter')` probe that chooses between `flutter pub get` and
+  `dart pub get`, plus `dartPubGet`, `flutterPubGet`, and `flutterCreate`.
+- `tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart` passes
+  the literal `'flutter'` to `FlutterProcess`.
+
+**By the CLI's own SDK** — `getSdkPath()` from `cli_util`, which is just
+`dirname(dirname(Platform.resolvedExecutable))`, i.e. the SDK of the Dart VM
+that is running the CLI:
+
+- `tools/serverpod_cli/lib/src/commands/start/kernel_compiler.dart` — the
+  Frontend Server `sdkRoot`, the `vm_platform_strong.dill` it compiles against,
+  and the `dart` binary handed to `ServerProcess`.
+- `tools/serverpod_cli/lib/src/commands/start/server_process.dart` — the default
+  `dart` used to run the pod.
+- `tools/serverpod_cli/lib/src/util/analysis_helpers.dart` — the analyzer's
+  `sdkPath`.
+- `tools/serverpod_cli/lib/src/commands/cloud.dart`.
+
+### What breaks
+
+**fvm projects cannot be created or started.** fvm does not install PATH shims.
+It pins a version per project via `.fvmrc` and a `.fvm/flutter_sdk` symlink, and
+expects tools to invoke `fvm flutter` or follow the symlink. A developer who
+uses fvm exclusively has no `flutter` on `$PATH` at all, so
+`_preCommandEnvironmentChecks` aborts every Serverpod command, even though a
+perfectly good Flutter SDK is sitting behind the project's pin.
+
+**The server is compiled by the wrong SDK, silently.** `serverpod_cli` is typically activated
+with the system Dart, so `getSdkPath()` returns the system SDK. A project that
+pins Flutter 3.32 via fvm still gets its server compiled and run by whatever
+Dart happens to be running the CLI. There is no error — just a version skew
+between the SDK the project declares and the SDK that builds it, surfacing later
+as confusing analyzer or runtime errors.
+
+## Overview
+
+The CLI resolves a **Flutter SDK root** and a **Dart SDK root** once per
+invocation, as early as possible, and every subprocess launch and SDK-path
+consumer reads from that result. Resolution walks a fixed chain and stops at the
+first tier that yields an SDK that actually exists on disk:
+
+| # | Tier | Flutter | Dart |
+| --- | ------ | --------- | ------ |
+| 1 | Project pin | `.fvm/flutter_sdk`, found by walking up | derived from the Flutter root |
+| 2 | PATH | `flutter` | `dart` |
+| 3 | Running SDK | — | `getSdkPath()` |
+
+Tier 1 is the one that makes fvm work with no user action. Tier 3 exists only for
+Dart as a last resort, it is what the CLI does today.
+
+**Dart is derived from Flutter, not resolved separately.** Whenever a Flutter
+root is resolved at tier 1 or 2, the Dart SDK is taken from
+`<flutterRoot>/bin/cache/dart-sdk` rather than resolved independently. A project
+pinned to Flutter 3.32 gets Dart 3.8, which is what `pub` in that project
+expects.
+
+### Resolution scope
+
+The project pin is a property of a directory, not of the machine, so tier 1 is
+resolved relative to a **base directory** that depends on the command:
+
+- `serverpod create <name>` — the directory the project is being created into,
+  before the project exists. A developer who has run `fvm use` in the parent directory gets that
+  pinned SDK for the new project's `flutter create` and `pub get`.
+- Every other command — the resolved server directory, falling back to the
+  current working directory.
+
+The upward walk stops at the same repository boundaries
+`ServerpodDirectoryFinder` already uses (`.git`, `melos.yaml`, a workspace
+`pubspec.yaml`, the home directory), so it never escapes the project and never
+picks up an unrelated `.fvm` from a parent checkout.
+
+For a multi-app workspace, the walk starts at each Flutter app's own directory,
+so apps pinned to different Flutter versions each get their own SDK.
+
+### Behaviour of the environment checks
+
+`_preCommandEnvironmentChecks` requires both SDKs up front and aborts when
+either is missing. That requirement is kept. What changes is what it
+consults.
+
+**The check asks the resolver, not `$PATH`.** A project with a
+`.fvm/flutter_sdk` pin satisfies the Flutter requirement with no `flutter` on
+`$PATH` at all.
+
+The pre-command check runs before command-specific project discovery, using
+the resolver's initial current-directory scope. After `start` and `generate`
+select their server package, they rescope the resolver for the SDK consumers
+that perform analysis, compilation, and process launches.
+
+**Commands still report Flutter problems at the point of use**, because the
+up-front check cannot stand in for them. It resolves against the server
+directory, while `serverpod start` resolves a Flutter SDK **per app** — a
+workspace can pin different versions per app, so an individual app's pin can be
+broken or absent even when the check passed. The SDK can also disappear between
+the check and the launch, or its `bin/flutter` can fail to spawn on a cold
+cache. `FlutterAppManager` therefore still reports a per-app failure and
+releases the app's TUI tab.
+
+### Diagnostics
+
+Resolution is traceable. `serverpod version --verbose` reports what was resolved
+and which tier it came from:
+
+The same two lines are logged at debug level on every command, so a bug report
+that includes `--verbose` output answers "which SDK built this?" without a
+follow-up question.
+
+## Behaviour by command
+
+**`serverpod create`** resolves against the target directory before writing
+anything, so `flutter create` and the workspace `pub get` both run under the
+project's pinned SDK. If no Flutter SDK is found and the template includes a
+Flutter app, creation fails at the `flutter create` step with a message naming
+the chain that was tried.
+
+**`serverpod start`** resolves once at startup. The resolved Dart SDK becomes the
+Frontend Server's `sdkRoot` and the source of `vm_platform_strong.dill`, and the
+`dart` that runs the pod. The resolved Flutter SDK is what `FlutterProcess`
+launches.
+
+**`serverpod generate` and the analyzer-backed commands** use the resolved Dart
+SDK for `analysis_helpers`, so analysis matches the SDK the project is compiled
+with.
+
+**`serverpod upgrade`** keeps using the CLI's own SDK. It updates the globally
+activated CLI, which has nothing to do with the project's pin, and using a
+project SDK here would install the CLI into the wrong place.
+
+## Backwards compatibility
+
+For a developer with a single system Flutter on `$PATH` and no fvm, resolution
+lands on tier 2 and behaviour is unchanged.
+
+Two behaviour changes are deliberate and affect existing users:
+
+**Commands work in a project pinned with fvm.** Previously-failing invocations
+now succeed: the up-front check resolves the pin instead of requiring `flutter`
+on `$PATH`.
+
+**The server may be compiled by a different SDK than before.** On a machine where
+`flutter` on `$PATH` embeds a different Dart than the one running the CLI, tier 2
+now wins over tier 3 and the server is built by the Flutter-embedded Dart.
+
+## Design decisions
+
+### Why the Dart SDK is derived from Flutter
+
+Resolving the two independently is how the current split arose, and it lets the
+server and the Flutter app be built by different SDKs on the same machine without
+anyone noticing. Deriving Dart from the Flutter root leaves no supported way to introduce skew.
+
+### Why resolve once per invocation rather than per call site
+
+Per-call-site resolution is what produces the current inconsistency. Resolving
+once means the diagnostics can state a single answer, the subprocess environment
+can be constructed once, and it is impossible for the compiler and the pod to
+disagree about which SDK they are using.

--- a/tools/serverpod_cli/lib/src/commands/generate.dart
+++ b/tools/serverpod_cli/lib/src/commands/generate.dart
@@ -20,6 +20,7 @@ import 'package:serverpod_cli/src/serverpod_packages_version_check/serverpod_pac
 import 'package:serverpod_cli/src/util/legacy_model_files.dart';
 import 'package:serverpod_cli/src/util/pubspec_lock_parser.dart';
 import 'package:serverpod_cli/src/util/pubspec_plus.dart';
+import 'package:serverpod_cli/src/util/sdk_resolver.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/util/shutdown_signal.dart';
 import 'package:stream_transform/stream_transform.dart';
@@ -94,6 +95,12 @@ class GenerateCommand extends ServerpodCommand<GenerateOption> {
       log.error('$e');
       throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
+
+    // GeneratorConfig has now resolved `--directory` or any interactive
+    // selection to the actual server package.
+    rescopeSdkResolver(
+      Directory(path.joinAll(config.serverPackageDirectoryPathParts)),
+    );
 
     if (await LegacyModelFiles.report(config)) {
       throw ExitException.error();
@@ -227,7 +234,10 @@ Future<bool> performOneShotGenerate({
 }) async {
   final result = await generateIfStale(
     config: config,
-    createAnalyzers: () => Analyzers.create(config),
+    createAnalyzers: () async => Analyzers.create(
+      config,
+      dartSdkPath: (await sdkResolver.dartSdk).root,
+    ),
     force: force,
   );
   if (result.upToDate) {
@@ -336,7 +346,10 @@ Future<bool> _performGenerateWatch({
       // keepPrimedWhenFresh: the incremental loop only updates changed files, so
       // the analyzer must be primed up front even when nothing needs regenerating.
       // In-process is fine here; only start's TUI needs the isolate offload.
-      final activeAnalyzers = await Analyzers.create(config);
+      final activeAnalyzers = await Analyzers.create(
+        config,
+        dartSdkPath: (await sdkResolver.dartSdk).root,
+      );
       analyzers = activeAnalyzers;
       final initialResult = await generateIfStale(
         config: config,

--- a/tools/serverpod_cli/lib/src/commands/start.dart
+++ b/tools/serverpod_cli/lib/src/commands/start.dart
@@ -41,6 +41,7 @@ import 'package:serverpod_cli/src/runner/serverpod_command.dart';
 import 'package:serverpod_cli/src/runner/serverpod_command_runner.dart';
 import 'package:serverpod_cli/src/util/internal_error.dart';
 import 'package:serverpod_cli/src/util/legacy_model_files.dart';
+import 'package:serverpod_cli/src/util/sdk_resolver.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/util/shutdown_signal.dart';
 import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
@@ -160,6 +161,10 @@ class StartCommand extends ServerpodCommand<StartOption> {
         ),
       );
 
+      rescopeSdkResolver(
+        Directory(p.joinAll(config.serverPackageDirectoryPathParts)),
+      );
+
       // Bail before the TUI takes over the terminal
       if (await _detectExistingInstance(config)) return;
       if (await LegacyModelFiles.report(config)) throw ExitException.error();
@@ -206,6 +211,10 @@ class StartCommand extends ServerpodCommand<StartOption> {
       log.error('$e');
       throw ExitException(ServerpodCommand.commandInvokedCannotExecute);
     }
+
+    rescopeSdkResolver(
+      Directory(p.joinAll(config.serverPackageDirectoryPathParts)),
+    );
 
     if (await _detectExistingInstance(config)) return;
     if (await LegacyModelFiles.report(config)) throw ExitException.error();
@@ -564,9 +573,15 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
     rethrow;
   }
 
+  final resolvedDartSdk = await sdkResolver.dartSdk;
+
   // prime: false - the single full prime happens inside generateIfStale; here
   // we only spawn the isolate eagerly so it overlaps the staleness check.
-  final analyzersFuture = IsolatedAnalyzers.create(config, prime: false);
+  final analyzersFuture = IsolatedAnalyzers.create(
+    config,
+    prime: false,
+    dartSdkPath: resolvedDartSdk.root,
+  );
   Future<void> closeAnalyzers() async => (await analyzersFuture).close();
 
   // Tear down everything provisioned so far: the analyzer isolate and any
@@ -619,7 +634,10 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
   // FES setup (watch mode only).
   KernelCompiler? compiler;
   NativeAssetsBuilder? nativeAssetsBuilder;
-  String? dartExecutable;
+  // Seeded for `--no-watch`, where there is no compiler to take it from.
+  // Watch mode overwrites it with the compiler's, which resolves to the same
+  // SDK root.
+  String? dartExecutable = dartExecutableIn(resolvedDartSdk.root);
   // The resolution's `.dart_tool` whose package_config.json the FES reads;
   // watched below so a dependency change is picked up in place.
   String? serverDartToolDir;
@@ -641,6 +659,7 @@ Future<WatchLoopSetupResult> _setupWatchLoop({
       entryPoint: entryPoint,
       outputDill: initialDill,
       packagesPath: packageConfigPath,
+      sdkRoot: resolvedDartSdk.root,
     );
 
     final localBuilder = _createNativeAssetsBuilder(

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -11,6 +11,7 @@ import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
 import 'package:serverpod_cli/src/commands/start/package_dependency_tracker.dart';
 import 'package:serverpod_cli/src/config/flutter_app_config.dart';
 import 'package:serverpod_cli/src/util/pubspec_helpers.dart';
+import 'package:serverpod_cli/src/util/sdk_resolver.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
@@ -261,13 +262,36 @@ class FlutterAppManager {
     final device =
         runtime.app.device ?? ideDevice() ?? flutterDeviceWebServerWithBrowser;
 
+    final appDir = p.joinAll(runtime.app.pathParts);
+
+    // Resolved per app: a workspace can hold apps pinned to different Flutter
+    // versions, and the pin is a property of the app's own directory.
+    String? sdkRoot;
+    if (flutterExecutableForTesting == null) {
+      final appResolver = SdkResolver(baseDirectory: Directory(appDir));
+      final resolved = await appResolver.flutterSdk;
+      if (resolved == null) {
+        log.warning(
+          'No Flutter SDK found for ${runtime.app.name}; skipping launch. '
+          'Make sure `flutter` is on your PATH.',
+        );
+        // onEnsureAppTab above already put the tab into its launching
+        // state, so bailing out silently would leave it neither ready nor
+        // stopped.
+        _abandonLaunch(runtime);
+        return;
+      }
+      sdkRoot = resolved.root;
+    }
+
     late final FlutterProcess process;
     process = FlutterProcess(
-      flutterPackageDir: p.joinAll(runtime.app.pathParts),
+      flutterPackageDir: appDir,
       device: device,
       extraArgs: runtime.app.extraRunArgs,
       flutterProxy: runtime.proxy,
       flutterExecutable: flutterExecutableForTesting ?? 'flutter',
+      flutterSdkRoot: sdkRoot,
       machineArgsOverride: argsOverrideForTesting?.call(runtime.app),
       stdoutSink: stdoutSinkFor(runtime.app),
       stderrSink: stderrSinkFor(runtime.app),
@@ -286,10 +310,10 @@ class FlutterAppManager {
       await process.start();
     } on FlutterNotInstalledException catch (e) {
       log.warning(e.message);
-      runtime.spawnInFlight = false;
+      _abandonLaunch(runtime);
       return;
     } catch (_) {
-      runtime.spawnInFlight = false;
+      _abandonLaunch(runtime);
       rethrow;
     }
 
@@ -563,6 +587,17 @@ class FlutterAppManager {
     if (runtime.stopSignaled) return;
     runtime.stopSignaled = true;
     onStop(runtime.app);
+  }
+
+  /// Releases a launch that never reached a running process.
+  ///
+  /// The tab has already been created and reset by [onEnsureAppTab], so it
+  /// has to be told the launch is over; otherwise it sits in its launching
+  /// state for the rest of the session, with its "Stop App" action having
+  /// nothing to act on.
+  void _abandonLaunch(_AppRuntime runtime) {
+    runtime.spawnInFlight = false;
+    onLaunchFailed(runtime.app);
   }
 
   Future<void> _connectAfterLaunch(

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_app_manager.dart
@@ -269,19 +269,7 @@ class FlutterAppManager {
     String? sdkRoot;
     if (flutterExecutableForTesting == null) {
       final appResolver = SdkResolver(baseDirectory: Directory(appDir));
-      final resolved = await appResolver.flutterSdk;
-      if (resolved == null) {
-        log.warning(
-          'No Flutter SDK found for ${runtime.app.name}; skipping launch. '
-          'Make sure `flutter` is on your PATH.',
-        );
-        // onEnsureAppTab above already put the tab into its launching
-        // state, so bailing out silently would leave it neither ready nor
-        // stopped.
-        _abandonLaunch(runtime);
-        return;
-      }
-      sdkRoot = resolved.root;
+      sdkRoot = (await appResolver.flutterSdk)?.root;
     }
 
     late final FlutterProcess process;

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -38,6 +38,10 @@ class FlutterNotInstalledException implements Exception {
   String toString() => 'FlutterNotInstalledException: $message';
 }
 
+/// Invocation for spawning the Flutter tool: the executable, and the
+/// arguments that precede the `flutter` command itself.
+typedef FlutterInvocation = ({String executable, List<String> baseArgs});
+
 /// Manages a `flutter run --machine` subprocess. Mirrors [ServerProcess].
 /// IDE attach flows through [flutterProxy] (which owns the stable
 /// vm-service URI and the per-app `flutter-vm-service-info-<appId>.json`
@@ -48,6 +52,10 @@ class FlutterProcess {
 
   final String _flutterPackageDir;
   final String _flutterExecutable;
+
+  /// Resolved Flutter SDK root. When set, the invocation is built from it
+  /// directly.
+  final String? _flutterSdkRoot;
   final String _device;
   final List<String> _extraArgs;
   final IOSink _stdout;
@@ -119,6 +127,7 @@ class FlutterProcess {
     required String flutterPackageDir,
     required String device,
     String flutterExecutable = 'flutter',
+    String? flutterSdkRoot,
     List<String> extraArgs = const [],
     VmServiceProxy? flutterProxy,
     void Function(String stage)? onProgress,
@@ -131,6 +140,7 @@ class FlutterProcess {
     @visibleForTesting Future<bool> Function(Uri url)? openBrowserForTesting,
   }) : _flutterPackageDir = flutterPackageDir,
        _flutterExecutable = flutterExecutable,
+       _flutterSdkRoot = flutterSdkRoot,
        _device = device,
        _extraArgs = extraArgs,
        _flutterProxy = flutterProxy,
@@ -173,7 +183,8 @@ class FlutterProcess {
   /// Exit code of the `flutter run` subprocess.
   Future<int> get exitCode => _exitCodeCompleter.future;
 
-  /// Throws [FlutterNotInstalledException] when `flutter` isn't on PATH.
+  /// Throws [FlutterNotInstalledException] when the Flutter tool cannot be
+  /// located or cannot be spawned.
   Future<void> start() async {
     if (_process != null) {
       throw StateError('FlutterProcess is already running.');
@@ -185,18 +196,34 @@ class FlutterProcess {
         _machineArgsOverride ??
         <String>['run', '--machine', '-d', device, ..._extraArgs];
 
-    final invocation = await _resolveFlutterInvocation(_flutterExecutable);
+    final root = _flutterSdkRoot;
+    final invocation = root != null
+        ? invocationForSdkRoot(root)
+        : await resolveFlutterInvocation(_flutterExecutable);
+
+    // A missing absolute executable is checked rather than left to the spawn:
+    // a Windows batch wrapper goes through `cmd.exe`, which starts whether or
+    // not the command exists, so a missing Flutter would otherwise surface as
+    // a daemon that dies immediately instead of as this exception.
+    final executable = invocation.executable;
+    if (p.isAbsolute(executable) && !File(executable).existsSync()) {
+      throw FlutterNotInstalledException(
+        'Failed to launch `$executable`: not found. '
+        'Install Flutter (https://flutter.dev) or pass `--no-flutter`.',
+      );
+    }
 
     Process process;
     try {
       process = await Process.start(
-        invocation.executable,
+        executable,
         [...invocation.baseArgs, ...args],
         workingDirectory: _flutterPackageDir,
+        runInShell: needsShell(executable),
       );
     } on ProcessException catch (e) {
       throw FlutterNotInstalledException(
-        'Failed to launch `${invocation.executable}`: ${e.message}. '
+        'Failed to launch `$executable`: ${e.message}. '
         'Install Flutter (https://flutter.dev) or pass `--no-flutter`.',
         e,
       );
@@ -968,15 +995,97 @@ class FlutterProcess {
     }
   }
 
-  static ({String executable, List<String> baseArgs})? _cachedInvocation;
+  /// Whether [executable] has to be launched through a shell.
+  /// Only Windows batch wrappers do.
+  @visibleForTesting
+  static bool needsShell(String executable) {
+    if (!Platform.isWindows) return false;
+    final lower = executable.toLowerCase();
+    return lower.endsWith('.bat') || lower.endsWith('.cmd');
+  }
+
+  /// Fast-path invocations, keyed by the SDK root they were derived from.
+  ///
+  /// Keyed rather than a single slot: a workspace can hold apps pinned to
+  /// different Flutter versions, and one shared slot would hand the first
+  /// app's SDK to all of them.
+  static final Map<String, FlutterInvocation> _cachedInvocationsByRoot = {};
+
+  /// Fast-path invocations from the probe, keyed by the command probed. The
+  /// prefix is part of the key so two probes of the same executable through
+  /// different test shims cannot be confused for one another.
+  static final Map<String, FlutterInvocation> _cachedInvocationsByProbe = {};
+
+  /// Builds the invocation for an already-resolved Flutter SDK [root].
+  ///
+  /// Prefers `flutter_tools.dart` on the SDK's embedded Dart so `kill` reaches
+  /// the daemon rather than a wrapper script. Falls back to the SDK's own
+  /// `bin/flutter` when `bin/cache` is cold or partially populated.
+  @visibleForTesting
+  static FlutterInvocation invocationForSdkRoot(String root) {
+    final cached = _cachedInvocationsByRoot[root];
+    if (cached != null) return cached;
+
+    final fallback = (
+      executable: p.join(
+        root,
+        'bin',
+        Platform.isWindows ? 'flutter.bat' : 'flutter',
+      ),
+      baseArgs: <String>[],
+    );
+
+    final dartBin = p.join(
+      root,
+      'bin',
+      'cache',
+      'dart-sdk',
+      'bin',
+      Platform.isWindows ? 'dart.exe' : 'dart',
+    );
+    final packages = p.join(
+      root,
+      'packages',
+      'flutter_tools',
+      '.dart_tool',
+      'package_config.json',
+    );
+    final entry = p.join(
+      root,
+      'packages',
+      'flutter_tools',
+      'bin',
+      'flutter_tools.dart',
+    );
+    if (!File(dartBin).existsSync() ||
+        !File(packages).existsSync() ||
+        !File(entry).existsSync()) {
+      // Deliberately not cached. The fallback is the answer for a cold or
+      // partially populated `bin/cache`; caching it would pin the app to the
+      // wrapper for the rest of the session even once the cache filled in.
+      return fallback;
+    }
+
+    return _cachedInvocationsByRoot[root] = (
+      executable: dartBin,
+      baseArgs: ['--disable-dart-dev', '--packages=$packages', entry],
+    );
+  }
 
   /// Probe `flutter --version --machine` for `flutterRoot`, then return
   /// `dart <flutterRoot>/.../flutter_tools.dart` so signals bypass
   /// puro/fvm/asdf wrappers and reach the daemon. Falls back to
   /// invoking [flutterExecutable] verbatim if the SDK paths are missing.
-  static Future<({String executable, List<String> baseArgs})>
-  _resolveFlutterInvocation(String flutterExecutable) async {
-    final cached = _cachedInvocation;
+  @visibleForTesting
+  static Future<FlutterInvocation> resolveFlutterInvocation(
+    String flutterExecutable, {
+    @visibleForTesting List<String> probeArgsPrefixForTesting = const [],
+  }) async {
+    final probeKey = [
+      flutterExecutable,
+      ...probeArgsPrefixForTesting,
+    ].join('\u0000');
+    final cached = _cachedInvocationsByProbe[probeKey];
     if (cached != null) return cached;
 
     // Don't cache the fallback: a fake-executable test probe would
@@ -985,7 +1094,7 @@ class FlutterProcess {
     try {
       final result = await Process.run(
         flutterExecutable,
-        ['--version', '--machine'],
+        [...probeArgsPrefixForTesting, '--version', '--machine'],
         runInShell: Platform.isWindows,
       );
       if (result.exitCode != 0) return fallback;
@@ -1021,7 +1130,7 @@ class FlutterProcess {
           !File(entry).existsSync()) {
         return fallback;
       }
-      return _cachedInvocation = (
+      return _cachedInvocationsByProbe[probeKey] = (
         executable: dartBin,
         baseArgs: ['--disable-dart-dev', '--packages=$packages', entry],
       );

--- a/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/flutter_process.dart
@@ -198,7 +198,7 @@ class FlutterProcess {
 
     final root = _flutterSdkRoot;
     final invocation = root != null
-        ? invocationForSdkRoot(root)
+        ? _invocationForSdkRoot(root)
         : await resolveFlutterInvocation(_flutterExecutable);
 
     // A missing absolute executable is checked rather than left to the spawn:
@@ -219,7 +219,7 @@ class FlutterProcess {
         executable,
         [...invocation.baseArgs, ...args],
         workingDirectory: _flutterPackageDir,
-        runInShell: needsShell(executable),
+        runInShell: _needsShell(executable),
       );
     } on ProcessException catch (e) {
       throw FlutterNotInstalledException(
@@ -997,8 +997,7 @@ class FlutterProcess {
 
   /// Whether [executable] has to be launched through a shell.
   /// Only Windows batch wrappers do.
-  @visibleForTesting
-  static bool needsShell(String executable) {
+  static bool _needsShell(String executable) {
     if (!Platform.isWindows) return false;
     final lower = executable.toLowerCase();
     return lower.endsWith('.bat') || lower.endsWith('.cmd');
@@ -1021,8 +1020,7 @@ class FlutterProcess {
   /// Prefers `flutter_tools.dart` on the SDK's embedded Dart so `kill` reaches
   /// the daemon rather than a wrapper script. Falls back to the SDK's own
   /// `bin/flutter` when `bin/cache` is cold or partially populated.
-  @visibleForTesting
-  static FlutterInvocation invocationForSdkRoot(String root) {
+  static FlutterInvocation _invocationForSdkRoot(String root) {
     final cached = _cachedInvocationsByRoot[root];
     if (cached != null) return cached;
 

--- a/tools/serverpod_cli/lib/src/commands/start/kernel_compiler.dart
+++ b/tools/serverpod_cli/lib/src/commands/start/kernel_compiler.dart
@@ -27,7 +27,12 @@ class KernelCompiler {
   /// so changes require a [restart] to take effect.
   String? nativeAssetsPath;
 
-  late final String _sdkRoot = getSdkPath();
+  /// Explicit Dart SDK root, or `null` to use the SDK running this CLI.
+  final String? sdkRoot;
+
+  /// SDK the Frontend Server compiles against.
+  /// Defaults to the SDK running this CLI.
+  late final String _sdkRoot = sdkRoot ?? getSdkPath();
   late final String _platformDill = p.join(
     _sdkRoot,
     'lib',
@@ -41,6 +46,7 @@ class KernelCompiler {
 
   KernelCompiler({
     required this.entryPoint,
+    this.sdkRoot,
     this.outputDill = '.dart_tool/serverpod/server.dill',
     this.packagesPath,
     this.nativeAssetsPath,

--- a/tools/serverpod_cli/lib/src/create/create.dart
+++ b/tools/serverpod_cli/lib/src/create/create.dart
@@ -23,6 +23,7 @@ import 'package:serverpod_cli/src/util/directory.dart';
 import 'package:serverpod_cli/src/util/entitlements_modifier.dart';
 import 'package:serverpod_cli/src/util/project_name.dart';
 import 'package:serverpod_cli/src/util/pubspec_helpers.dart';
+import 'package:serverpod_cli/src/util/sdk_resolver.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 import 'package:serverpod_cli/src/util/string_validators.dart';
 import 'package:serverpod_shared/serverpod_shared.dart';
@@ -176,6 +177,11 @@ Future<CreateResult> performCreate(
     projectDir: Directory(p.join(projectRoot.path, name)),
     name: name,
   );
+
+  // Resolved against the directory being created into, so a pin
+  // applies to the new project's `flutter create` and `pub get`.
+  rescopeSdkResolver(serverpodDirs.projectDir);
+
   var pubspecFile = File(p.join(serverpodDirs.projectDir.path, 'pubspec.yaml'));
   if (pubspecFile.existsSync()) {
     _logError('Project $name already exists.');
@@ -1454,6 +1460,7 @@ Future<bool> _runGenerate(
     return await GenerateFiles.generateFiles(
       Directory(serverDirPath),
       interactive: interactive,
+      dartSdkPath: (await sdkResolver.dartSdk).root,
     );
   });
 }

--- a/tools/serverpod_cli/lib/src/create/generate_files.dart
+++ b/tools/serverpod_cli/lib/src/create/generate_files.dart
@@ -12,6 +12,7 @@ class GenerateFiles {
   static Future<bool> generateFiles(
     Directory serverDir, {
     required bool? interactive,
+    required String dartSdkPath,
   }) async {
     GeneratorConfig config;
     try {
@@ -24,7 +25,10 @@ class GenerateFiles {
       return false;
     }
 
-    final isolated = await IsolatedAnalyzers.create(config);
+    final isolated = await IsolatedAnalyzers.create(
+      config,
+      dartSdkPath: dartSdkPath,
+    );
     try {
       final result = await isolated.performGenerate(config: config);
       return result.success;

--- a/tools/serverpod_cli/lib/src/generator/analyzers.dart
+++ b/tools/serverpod_cli/lib/src/generator/analyzers.dart
@@ -56,7 +56,12 @@ class Analyzers {
   Future<void> close() async {}
 
   /// Creates the analyzers needed for code generation from [config].
-  static Future<Analyzers> create(GeneratorConfig config) async {
+  ///
+  /// [dartSdkPath] is the resolved Dart SDK to analyse against.
+  static Future<Analyzers> create(
+    GeneratorConfig config, {
+    String? dartSdkPath,
+  }) async {
     final libDirectory = Directory(p.joinAll(config.libSourcePathParts));
     // Overlay-backed so generation can shadow protocol.dart with a temporary
     // stub in memory instead of writing it to disk (see [performGenerate]).
@@ -64,6 +69,7 @@ class Analyzers {
     final collection = createAnalysisContextCollection(
       libDirectory,
       resourceProvider: overlay,
+      sdkPath: dartSdkPath,
     );
     final endpointsAnalyzer = EndpointsAnalyzer(
       libDirectory,
@@ -91,9 +97,10 @@ class Analyzers {
 
   /// Creates and primes the analyzers for code generation.
   static Future<Analyzers> createAndUpdate(
-    GeneratorConfig config,
-  ) async {
-    final analyzers = await Analyzers.create(config);
+    GeneratorConfig config, {
+    String? dartSdkPath,
+  }) async {
+    final analyzers = await Analyzers.create(config, dartSdkPath: dartSdkPath);
     await analyzers.update(
       config: config,
       affectedPaths: (await enumerateSourceFiles(config)).keys.toSet(),

--- a/tools/serverpod_cli/lib/src/generator/isolated_analyzers.dart
+++ b/tools/serverpod_cli/lib/src/generator/isolated_analyzers.dart
@@ -58,11 +58,15 @@ final class IsolatedAnalyzers extends IsolatedObject<Analyzers>
   /// sources before returning. Pass `false` to only spawn the isolate and defer
   /// priming to the first [update] call.
   ///
+  /// [dartSdkPath] is the resolved Dart SDK the worker should analyse
+  /// against.
+  ///
   /// Log messages from the worker are forwarded to the main isolate's
   /// [log] singleton via a [SendPort].
   static Future<IsolatedAnalyzers> create(
     GeneratorConfig config, {
     bool prime = true,
+    required String dartSdkPath,
   }) async {
     final logPort = ReceivePort();
     logPort.listen((message) {
@@ -86,8 +90,8 @@ final class IsolatedAnalyzers extends IsolatedObject<Analyzers>
         // Install a logger on the worker isolate that forwards to main.
         initializeLoggerWith(_PortForwardingLogger(logSendPort));
         return prime
-            ? Analyzers.createAndUpdate(config)
-            : Analyzers.create(config);
+            ? Analyzers.createAndUpdate(config, dartSdkPath: dartSdkPath)
+            : Analyzers.create(config, dartSdkPath: dartSdkPath);
       },
       logPort,
     );

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -27,7 +27,7 @@ Future<void> _preCommandEnvironmentChecks() async {
     );
     throw ExitException.error();
   }
-  if (!ci.isCI && await sdkResolver.flutterSdk == null) {
+  if (!ci.isCI && !await sdkResolver.isFlutterInstalled) {
     log.error(
       'Failed to run serverpod. You need to have flutter installed and in your \$PATH',
     );

--- a/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
+++ b/tools/serverpod_cli/lib/src/runner/serverpod_command_runner.dart
@@ -10,8 +10,8 @@ import 'package:serverpod_cli/src/analytics/cli_analytics.dart';
 import 'package:serverpod_cli/src/commands/language_server.dart';
 import 'package:serverpod_cli/src/config/experimental_feature.dart';
 import 'package:serverpod_cli/src/update_prompt/prompt_to_update.dart';
-import 'package:serverpod_cli/src/util/command_line_tools.dart';
 import 'package:serverpod_cli/src/util/directory.dart';
+import 'package:serverpod_cli/src/util/sdk_resolver.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
 import '../commands/upgrade.dart' show UpgradeCommand;
@@ -19,19 +19,23 @@ import '../commands/version.dart' show VersionCommand;
 import '../generated/completion_script_carapace.dart';
 
 Future<void> _preCommandEnvironmentChecks() async {
-  // Check that required tools are installed
-  if (!await CommandLineTools.existsCommand('dart', ['--version'])) {
+  try {
+    await sdkResolver.dartSdk;
+  } on SdkResolutionException {
     log.error(
       'Failed to run serverpod. You need to have dart installed and in your \$PATH',
     );
     throw ExitException.error();
   }
-  if (!ci.isCI &&
-      !await CommandLineTools.existsCommand('flutter', ['--version'])) {
+  if (!ci.isCI && await sdkResolver.flutterSdk == null) {
     log.error(
       'Failed to run serverpod. You need to have flutter installed and in your \$PATH',
     );
     throw ExitException.error();
+  }
+
+  if (log.logLevel == LogLevel.debug) {
+    log.debug(await sdkResolver.describeResolution());
   }
 }
 
@@ -78,6 +82,11 @@ class ServerpodCommandRunner extends BetterCommandRunner<GlobalOption, void> {
     // call site reads it from the singleton instead of taking a flag. Set
     // before the `--version` early return so the state is never stale.
     cliAnalytics.enabled = analyticsEnabled();
+
+    // Installed before any command runs so every call site reads one answer.
+    // Resolution itself is lazy, so a command that never touches an SDK never
+    // pays for looking one up.
+    initializeSdkResolver();
 
     if (globalConfiguration.value(GlobalOption.version)) {
       await commands['version']?.run();

--- a/tools/serverpod_cli/lib/src/util/analysis_helpers.dart
+++ b/tools/serverpod_cli/lib/src/util/analysis_helpers.dart
@@ -24,13 +24,18 @@ Future<void> refreshAnalysisContext(
 /// Pass [resourceProvider] to back the collection with something other than
 /// the physical file system (e.g. an overlay provider that shadows files
 /// with in-memory content).
+///
+/// Pass [sdkPath] to analyse against a specific Dart SDK; defaults to the SDK
+/// running this CLI. Callers that also compile the project must pass the
+/// resolved SDK so analysis and compilation agree.
 AnalysisContextCollection createAnalysisContextCollection(
   Directory directory, {
   ResourceProvider? resourceProvider,
+  String? sdkPath,
 }) {
   return AnalysisContextCollection(
     includedPaths: [directory.absolute.path],
     resourceProvider: resourceProvider ?? PhysicalResourceProvider.INSTANCE,
-    sdkPath: getSdkPath(),
+    sdkPath: sdkPath ?? getSdkPath(),
   );
 }

--- a/tools/serverpod_cli/lib/src/util/command_line_tools.dart
+++ b/tools/serverpod_cli/lib/src/util/command_line_tools.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:cli_tools/cli_tools.dart';
+import 'package:serverpod_cli/src/util/sdk_resolver.dart';
 import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
 
 class CommandLineTools {
@@ -23,25 +24,24 @@ class CommandLineTools {
     _errorBuffer.clear();
   }
 
-  static bool? _flutterAvailable;
-
-  /// Resolves [dir] with `flutter pub get` whenever Flutter is available,
-  /// falling back to `dart pub get`. Generated workspaces can require the
-  /// Flutter SDK even without a Flutter app (development-mode
+  /// Resolves [dir] with `flutter pub get` whenever a Flutter SDK is
+  /// available, falling back to `dart pub get`. Generated workspaces can
+  /// require the Flutter SDK even without a Flutter app (development-mode
   /// dependency_overrides pull in serverpod_flutter), and plain `dart pub`
   /// only finds the SDK when dart itself is the Flutter-embedded binary -
   /// not the case with a standalone Dart install or version managers like
   /// puro.
   static Future<bool> pubGet(Directory dir) async {
-    _flutterAvailable ??= await existsCommand('flutter', ['--version']);
-    return _flutterAvailable! ? flutterPubGet(dir) : dartPubGet(dir);
+    final flutter = await sdkResolver.flutterSdk;
+    return flutter != null ? flutterPubGet(dir) : dartPubGet(dir);
   }
 
   static Future<bool> dartPubGet(Directory dir) async {
     log.debug('Running `dart pub get` in ${dir.path}', newParagraph: true);
 
+    final dart = await sdkResolver.dartSdk;
     var exitCode = await _runProcessWithDefaultLogger(
-      executable: 'dart',
+      executable: dartExecutableIn(dart.root),
       arguments: ['pub', 'get'],
       workingDirectory: dir.path,
     );
@@ -57,8 +57,11 @@ class CommandLineTools {
   static Future<bool> flutterPubGet(Directory dir) async {
     log.debug('Running `flutter pub get` in ${dir.path}', newParagraph: true);
 
+    final executable = await _flutterExecutableOrReport('pub get');
+    if (executable == null) return false;
+
     var exitCode = await _runProcessWithDefaultLogger(
-      executable: 'flutter',
+      executable: executable,
       arguments: ['pub', 'get'],
       workingDirectory: dir.path,
     );
@@ -74,8 +77,11 @@ class CommandLineTools {
   static Future<bool> flutterCreate(Directory dir) async {
     log.debug('Running `flutter create .` in ${dir.path}', newParagraph: true);
 
+    final executable = await _flutterExecutableOrReport('create');
+    if (executable == null) return false;
+
     var exitCode = await _runProcessWithDefaultLogger(
-      executable: 'flutter',
+      executable: executable,
       arguments: ['create', '.'],
       workingDirectory: dir.path,
     );
@@ -88,15 +94,16 @@ class CommandLineTools {
     return true;
   }
 
-  static Future<bool> existsCommand(
-    String command, [
-    List<String> arguments = const [],
-  ]) async {
-    var exitCode = await _runProcessWithDefaultLogger(
-      executable: command,
-      arguments: arguments,
+  /// The resolved `flutter` executable, or `null` after reporting that no
+  /// Flutter SDK could be found.
+  static Future<String?> _flutterExecutableOrReport(String step) async {
+    final flutter = await sdkResolver.flutterSdk;
+    if (flutter != null) return flutterExecutableIn(flutter.root);
+
+    _logError(
+      'Cannot run `flutter $step`: no Flutter SDK found.',
     );
-    return exitCode == 0;
+    return null;
   }
 }
 

--- a/tools/serverpod_cli/lib/src/util/sdk_resolver.dart
+++ b/tools/serverpod_cli/lib/src/util/sdk_resolver.dart
@@ -211,6 +211,21 @@ class SdkResolver {
     }
   }
 
+  /// Whether `flutter` is installed.
+  Future<bool> get isFlutterInstalled async {
+    if (await flutterSdk != null) return true;
+    try {
+      final result = await Process.run(
+        'flutter',
+        ['--version'],
+        runInShell: Platform.isWindows,
+      );
+      return result.exitCode == 0;
+    } catch (_) {
+      return false;
+    }
+  }
+
   /// Asks the `flutter` on `$PATH` for its own root.
   static Future<String?> _probeFlutterRootOnPath() async {
     try {

--- a/tools/serverpod_cli/lib/src/util/sdk_resolver.dart
+++ b/tools/serverpod_cli/lib/src/util/sdk_resolver.dart
@@ -1,0 +1,246 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/util/server_directory_finder.dart';
+import 'package:serverpod_cli/src/util/serverpod_cli_logger.dart';
+import 'package:serverpod_shared/process_io.dart';
+
+// ---------------------------------------------------------------------------
+// Singleton resolver
+// ---------------------------------------------------------------------------
+
+SdkResolver? _resolver;
+
+/// Installs the resolver every call site reads from.
+///
+/// Called once per invocation, before any command runs. Commands that know a
+/// better base directory than the working directory call [rescopeSdkResolver]
+/// once they have resolved it.
+void initializeSdkResolver() {
+  _resolver = SdkResolver(baseDirectory: Directory.current);
+}
+
+/// Re-points the singleton at [baseDirectory]. Discards anything already
+/// resolved.
+void rescopeSdkResolver(Directory baseDirectory) {
+  _resolver = SdkResolver(baseDirectory: baseDirectory);
+}
+
+/// The resolver for this invocation.
+///
+/// Self-initializes against the working directory, so entry points
+/// that never called [initializeSdkResolver] still get the documented chain
+/// rather than a crash.
+SdkResolver get sdkResolver =>
+    _resolver ??= SdkResolver(baseDirectory: Directory.current);
+
+/// An SDK root, and where it was resolved from.
+class ResolvedSdk {
+  /// Absolute path to the SDK root - the directory holding `bin/`.
+  final String root;
+
+  /// Human-readable account of where [root] came from, for diagnostics.
+  /// Names the specific file the chain followed rather than just the tier.
+  final String origin;
+
+  const ResolvedSdk({required this.root, required this.origin});
+}
+
+/// Thrown when the Dart chain is exhausted - no Flutter SDK to derive from,
+/// and the SDK running this CLI cannot be located either.
+class SdkResolutionException implements Exception {
+  final String message;
+
+  const SdkResolutionException(this.message);
+
+  @override
+  String toString() => message;
+}
+
+/// The `flutter` executable inside [root].
+String flutterExecutableIn(String root) =>
+    p.join(root, 'bin', Platform.isWindows ? 'flutter.bat' : 'flutter');
+
+/// The `dart` executable inside a Dart SDK [root].
+String dartExecutableIn(String root) =>
+    p.join(root, 'bin', Platform.isWindows ? 'dart.exe' : 'dart');
+
+/// The Dart SDK a Flutter SDK at [flutterRoot] embeds.
+String embeddedDartSdkIn(String flutterRoot) =>
+    p.join(flutterRoot, 'bin', 'cache', 'dart-sdk');
+
+/// Whether [root] is a Flutter SDK.
+bool isFlutterSdk(String root) => File(flutterExecutableIn(root)).existsSync();
+
+/// Whether [root] is a Dart SDK.
+bool isDartSdk(String root) => File(dartExecutableIn(root)).existsSync();
+
+/// Resolves which Dart and Flutter SDK the CLI should use, and where every
+/// subprocess it spawns should find them.
+///
+/// Resolution is lazy and memoized: a command that never touches Flutter never
+/// pays for looking for one.
+///
+/// The resolution chain:
+/// project pin (`.fvm/flutter_sdk`), `$PATH`, and - for Dart only - the SDK
+/// running this CLI. Dart is derived from the resolved Flutter SDK whenever one
+/// was found, so the server and the Flutter app are built by matching SDKs.
+class SdkResolver {
+  /// Directory the project is resolved relative to.
+  final Directory baseDirectory;
+
+  /// Overrides the `flutter --version --machine` probe used for the
+  /// PATH tier.
+  final Future<String?> Function()? _probePathFlutterRoot;
+
+  /// Overrides the last-resort lookup of the SDK running this CLI.
+  final String Function()? _runningSdkRoot;
+
+  SdkResolver({
+    required this.baseDirectory,
+    @visibleForTesting Future<String?> Function()? probePathFlutterRoot,
+    @visibleForTesting String Function()? runningSdkRoot,
+  }) : _probePathFlutterRoot = probePathFlutterRoot,
+       _runningSdkRoot = runningSdkRoot;
+
+  Future<ResolvedSdk?>? _flutter;
+  Future<ResolvedSdk>? _dart;
+
+  /// The Flutter SDK to use, or `null` when none could be found.
+  Future<ResolvedSdk?> get flutterSdk => _flutter ??= _resolveFlutter();
+
+  /// The Dart SDK to use.
+  /// Throws [SdkResolutionException] when the chain is exhausted.
+  Future<ResolvedSdk> get dartSdk => _dart ??= _resolveDart();
+
+  Future<ResolvedSdk?> _resolveFlutter() async {
+    final pinned = _findFvmProjectPin();
+    if (pinned != null) return pinned;
+
+    // Ask the `flutter` on PATH where it lives. This is the only tier that
+    // costs a subprocess, so it runs after the pin lookup rather than before.
+    // Going through the executable rather than reading $PATH directly is what
+    // makes shim-based managers (asdf, mise, puro) report their real root.
+    final probed = await (_probePathFlutterRoot ?? _probeFlutterRootOnPath)();
+    if (probed != null && isFlutterSdk(probed)) {
+      return ResolvedSdk(
+        root: p.normalize(probed),
+        origin: '`flutter` on PATH',
+      );
+    }
+
+    log.debug('No Flutter SDK found.');
+    return null;
+  }
+
+  Future<ResolvedSdk> _resolveDart() async {
+    // Derived from Flutter whenever one was found, so `pub` resolves against
+    // the Dart the project's Flutter actually embeds.
+    final flutter = await flutterSdk;
+    if (flutter != null) {
+      final embedded = embeddedDartSdkIn(flutter.root);
+      if (isDartSdk(embedded)) {
+        return ResolvedSdk(
+          root: embedded,
+          origin: 'the resolved Flutter SDK',
+        );
+      }
+      // A cold `bin/cache` has no embedded Dart yet.
+      log.warning(
+        'The Flutter SDK at ${flutter.root} has no populated bin/cache, so '
+        'this project will build against the Dart SDK running this CLI '
+        'instead of the one it pins. Run `flutter --version` (or `fvm '
+        'install`) against it once to set it up.',
+      );
+    }
+
+    // Last resort: the SDK running this CLI.
+    try {
+      return ResolvedSdk(
+        root: (_runningSdkRoot ?? getSdkPath)(),
+        origin: 'the Dart SDK running this CLI',
+      );
+    } catch (e) {
+      throw SdkResolutionException(
+        'Could not locate a Dart SDK. You need to have dart installed '
+        'and in your \$PATH. ($e)',
+      );
+    }
+  }
+
+  /// Walks up from [baseDirectory] looking for `.fvm/flutter_sdk`.
+  ///
+  /// The walk stops after the first repository boundary so it never escapes
+  /// the project and picks up an unrelated pin from a parent checkout.
+  ResolvedSdk? _findFvmProjectPin() {
+    var dir = baseDirectory.absolute;
+    while (true) {
+      final link = p.join(dir.path, '.fvm', 'flutter_sdk');
+      if (Directory(link).existsSync() || Link(link).existsSync()) {
+        // Resolve through the symlink so the recorded root is the real cache
+        // directory. That keeps diagnostics honest about which version is in
+        // play, and survives `fvm use` pointing the link somewhere else.
+        String resolved;
+        try {
+          resolved = Directory(link).resolveSymbolicLinksSync();
+        } on FileSystemException catch (e) {
+          log.debug('Ignoring unusable Flutter pin at $link: ${e.message}');
+          return null;
+        }
+
+        if (!isFlutterSdk(resolved)) {
+          log.debug(
+            'Ignoring Flutter pin at $link: $resolved is not a Flutter SDK.',
+          );
+          return null;
+        }
+
+        return ResolvedSdk(
+          root: resolved,
+          origin: '.fvm/flutter_sdk in ${dir.path}',
+        );
+      }
+
+      if (ServerDirectoryFinder.isRepositoryBoundary(dir)) return null;
+
+      final parent = dir.parent;
+      if (parent.path == dir.path) return null;
+      dir = parent;
+    }
+  }
+
+  /// Asks the `flutter` on `$PATH` for its own root.
+  static Future<String?> _probeFlutterRootOnPath() async {
+    try {
+      final result = await Process.run(
+        'flutter',
+        ['--version', '--machine'],
+        runInShell: Platform.isWindows,
+      );
+      if (result.exitCode != 0) return null;
+      final decoded = jsonDecode(result.stdout as String);
+      if (decoded is! Map || decoded['flutterRoot'] is! String) return null;
+      return decoded['flutterRoot'] as String;
+    } catch (_) {
+      // No `flutter` to spawn, or it answered with something unparseable.
+      return null;
+    }
+  }
+
+  /// Describes the resolved SDKs and their resolution origin.
+  Future<String> describeResolution() async {
+    final flutter = await flutterSdk;
+    final dart = await dartSdk;
+
+    final buffer = StringBuffer();
+    if (flutter == null) {
+      buffer.writeln('Flutter SDK  not found');
+    } else {
+      buffer.writeln('Flutter SDK ${flutter.root} from ${flutter.origin}');
+    }
+    buffer.writeln('Dart SDK ${dart.root} from ${dart.origin}');
+    return buffer.toString();
+  }
+}

--- a/tools/serverpod_cli/lib/src/util/server_directory_finder.dart
+++ b/tools/serverpod_cli/lib/src/util/server_directory_finder.dart
@@ -81,7 +81,7 @@ DirectoryFinder<T> serverpodDirectoryFinder<T>({
     }
 
     // Determine if we should search upward/outward
-    var atBoundary = ServerDirectoryFinder._isRepositoryBoundary(start);
+    var atBoundary = ServerDirectoryFinder.isRepositoryBoundary(start);
 
     if (!atBoundary) {
       // 3. Check for standard naming pattern siblings
@@ -103,7 +103,7 @@ DirectoryFinder<T> serverpodDirectoryFinder<T>({
           candidates.add(current);
         }
 
-        var isAtBoundary = ServerDirectoryFinder._isRepositoryBoundary(current);
+        var isAtBoundary = ServerDirectoryFinder.isRepositoryBoundary(current);
 
         // At boundaries (like .git), search deeper to find nested servers
         var searchDepth = isAtBoundary ? 2 : 1;
@@ -302,10 +302,16 @@ class ServerDirectoryFinder {
   ///
   /// This prevents the search from escaping the project and accessing
   /// system directories that may trigger permission prompts.
-  static bool _isRepositoryBoundary(Directory dir) {
+  static bool isRepositoryBoundary(Directory dir) {
     try {
-      var gitDir = Directory(p.join(dir.path, '.git'));
-      if (gitDir.existsSync()) return true;
+      final gitEntry = p.join(dir.path, '.git');
+      // Linked worktrees and submodules use a `.git` file containing a
+      // `gitdir:` pointer, while ordinary checkouts use a directory.
+      if (Directory(gitEntry).existsSync() ||
+          File(gitEntry).existsSync() ||
+          Link(gitEntry).existsSync()) {
+        return true;
+      }
 
       var pubspecFile = File(p.join(dir.path, 'pubspec.yaml'));
       if (pubspecFile.existsSync()) {

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -24,6 +24,24 @@ String _dartExecutable() {
   return Platform.resolvedExecutable;
 }
 
+/// [cachePopulated] controls whether `bin/cache/dart-sdk` is present, which is
+/// what distinguishes a warm SDK from a cold `bin/cache`.
+String _fakeFlutterSdkRoot({required bool cachePopulated}) {
+  final dir = Directory.systemTemp.createTempSync('serverpod_fake_flutter');
+  addTearDown(() => dir.deleteSync(recursive: true));
+
+  final root = p.join(dir.path, 'sdk');
+  for (final relative in [
+    ['packages', 'flutter_tools', '.dart_tool', 'package_config.json'],
+    ['packages', 'flutter_tools', 'bin', 'flutter_tools.dart'],
+    if (cachePopulated) ['bin', 'cache', 'dart-sdk', 'bin', 'dart'],
+  ]) {
+    File(p.joinAll([root, ...relative])).createSync(recursive: true);
+  }
+
+  return root;
+}
+
 /// Minimal WebSocket server that accepts a connect and ignores any RPC.
 /// Enough to populate `vmServiceUri`; do not use for getVM-style calls.
 Future<({HttpServer server, String wsUri})> _startFakeVmService() async {
@@ -150,6 +168,80 @@ Future<({HttpServer server, String wsUri})> _startFakeLoggingVmService({
 }
 
 void main() {
+  group('Given a Windows batch wrapper', () {
+    test(
+      'when asked whether it needs a shell then it does, on Windows only',
+      () {
+        // CreateProcess cannot execute a `.bat` however it is spelled, so this
+        // is the one case that has to go through cmd.exe.
+        expect(
+          FlutterProcess.needsShell(r'C:\flutter\bin\flutter.bat'),
+          Platform.isWindows,
+        );
+        expect(
+          FlutterProcess.needsShell(r'C:\flutter\bin\flutter.CMD'),
+          Platform.isWindows,
+        );
+      },
+    );
+  });
+
+  group('Given an executable that is not a batch wrapper', () {
+    test('when asked whether it needs a shell then it does not', () {
+      // A shell here would swallow the signals `kill` sends the daemon.
+      expect(
+        FlutterProcess.needsShell('/flutter/bin/cache/dart-sdk/bin/dart'),
+        isFalse,
+      );
+      expect(FlutterProcess.needsShell('/flutter/bin/flutter'), isFalse);
+      expect(FlutterProcess.needsShell(r'C:\dart-sdk\bin\dart.exe'), isFalse);
+    });
+  });
+
+  group('Given a FlutterProcess whose executable is a name not on PATH', () {
+    late FlutterProcess fp;
+
+    setUp(() {
+      fp = FlutterProcess(
+        flutterPackageDir: Directory.systemTemp.path,
+        device: 'web-server',
+        // A bare name rather than a path, so the spawn is what fails.
+        // Deliberately not `flutter`: the probe runs against the ambient
+        // environment, so a real install would resolve and this would never
+        // reach the fallback.
+        flutterExecutable: 'definitely-not-a-real-flutter',
+      );
+    });
+
+    group('when calling start', () {
+      late Object? failure;
+
+      setUp(() async {
+        try {
+          await fp.start();
+          failure = null;
+        } catch (e) {
+          failure = e;
+        }
+      });
+
+      test(
+        'then FlutterNotInstalledException is thrown so the caller can keep '
+        'going',
+        () {
+          expect(failure, isA<FlutterNotInstalledException>());
+        },
+      );
+
+      test('then the message names the executable it looked for', () {
+        expect(
+          (failure as FlutterNotInstalledException).message,
+          contains('definitely-not-a-real-flutter'),
+        );
+      });
+    });
+  });
+
   group('Given a FlutterProcess missing the executable', () {
     late FlutterProcess fp;
 
@@ -171,6 +263,112 @@ void main() {
         );
       },
     );
+  });
+
+  group(
+    'Given a probe that answers with plain text instead of machine JSON',
+    () {
+      group('when the flutter invocation is resolved', () {
+        late FlutterInvocation invocation;
+
+        setUp(() async {
+          invocation = await FlutterProcess.resolveFlutterInvocation(
+            _dartExecutable(),
+            probeArgsPrefixForTesting: [
+              _shimPath('emits_no_machine_json.dart'),
+            ],
+          );
+        });
+
+        test('then it falls back to running the executable verbatim', () {
+          expect(invocation.executable, _dartExecutable());
+        });
+
+        test('then it passes no leading arguments', () {
+          expect(invocation.baseArgs, isEmpty);
+        });
+      });
+    },
+  );
+
+  group(
+    'Given a probe reporting a flutterRoot whose bin/cache is incomplete',
+    () {
+      late String root;
+
+      setUp(() {
+        root = _fakeFlutterSdkRoot(cachePopulated: false);
+      });
+
+      group('when the flutter invocation is resolved', () {
+        late FlutterInvocation invocation;
+
+        setUp(() async {
+          invocation = await FlutterProcess.resolveFlutterInvocation(
+            _dartExecutable(),
+            probeArgsPrefixForTesting: [
+              _shimPath('reports_flutter_root.dart'),
+              '--root=$root',
+            ],
+          );
+        });
+
+        test(
+          'then it falls back instead of launching a dart that is not there',
+          () {
+            expect(invocation.executable, _dartExecutable());
+          },
+        );
+
+        test('then it passes no leading arguments', () {
+          expect(invocation.baseArgs, isEmpty);
+        });
+      });
+    },
+  );
+
+  group('Given a probe reporting a complete flutterRoot', () {
+    late String root;
+
+    setUp(() {
+      root = _fakeFlutterSdkRoot(cachePopulated: true);
+    });
+
+    group('when the flutter invocation is resolved', () {
+      late FlutterInvocation invocation;
+
+      setUp(() async {
+        invocation = await FlutterProcess.resolveFlutterInvocation(
+          _dartExecutable(),
+          probeArgsPrefixForTesting: [
+            _shimPath('reports_flutter_root.dart'),
+            '--root=$root',
+          ],
+        );
+      });
+
+      test("then it runs on the SDK's embedded dart", () {
+        expect(
+          invocation.executable,
+          p.join(root, 'bin', 'cache', 'dart-sdk', 'bin', 'dart'),
+        );
+      });
+
+      test('then it passes the flutter_tools entrypoint', () {
+        expect(
+          invocation.baseArgs,
+          contains(
+            p.join(
+              root,
+              'packages',
+              'flutter_tools',
+              'bin',
+              'flutter_tools.dart',
+            ),
+          ),
+        );
+      });
+    });
   });
 
   group('Given a FlutterProcess running', () {

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as p;
 import 'package:serverpod_cli/src/commands/messages.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_log_event.dart';
 import 'package:serverpod_cli/src/commands/start/flutter_process.dart';
+import 'package:serverpod_cli/src/util/sdk_resolver.dart';
 import 'package:serverpod_cli/src/vm_proxy/proxy.dart';
 import 'package:serverpod_shared/log.dart' show LogLevel;
 import 'package:test/test.dart';
@@ -31,12 +32,27 @@ String _fakeFlutterSdkRoot({required bool cachePopulated}) {
   addTearDown(() => dir.deleteSync(recursive: true));
 
   final root = p.join(dir.path, 'sdk');
-  for (final relative in [
-    ['packages', 'flutter_tools', '.dart_tool', 'package_config.json'],
-    ['packages', 'flutter_tools', 'bin', 'flutter_tools.dart'],
-    if (cachePopulated) ['bin', 'cache', 'dart-sdk', 'bin', 'dart'],
+  for (final path in [
+    p.joinAll([
+      root,
+      'packages',
+      'flutter_tools',
+      '.dart_tool',
+      'package_config.json',
+    ]),
+    p.joinAll([
+      root,
+      'packages',
+      'flutter_tools',
+      'bin',
+      'flutter_tools.dart',
+    ]),
+    // Named through the shared helper rather than spelled out: the embedded
+    // binary is `dart.exe` on Windows, and hardcoding `dart` here made the
+    // fast-path guard miss and silently fall back.
+    if (cachePopulated) dartExecutableIn(embeddedDartSdkIn(root)),
   ]) {
-    File(p.joinAll([root, ...relative])).createSync(recursive: true);
+    File(path).createSync(recursive: true);
   }
 
   return root;
@@ -350,7 +366,7 @@ void main() {
       test("then it runs on the SDK's embedded dart", () {
         expect(
           invocation.executable,
-          p.join(root, 'bin', 'cache', 'dart-sdk', 'bin', 'dart'),
+          dartExecutableIn(embeddedDartSdkIn(root)),
         );
       });
 

--- a/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_process_test.dart
@@ -184,36 +184,6 @@ Future<({HttpServer server, String wsUri})> _startFakeLoggingVmService({
 }
 
 void main() {
-  group('Given a Windows batch wrapper', () {
-    test(
-      'when asked whether it needs a shell then it does, on Windows only',
-      () {
-        // CreateProcess cannot execute a `.bat` however it is spelled, so this
-        // is the one case that has to go through cmd.exe.
-        expect(
-          FlutterProcess.needsShell(r'C:\flutter\bin\flutter.bat'),
-          Platform.isWindows,
-        );
-        expect(
-          FlutterProcess.needsShell(r'C:\flutter\bin\flutter.CMD'),
-          Platform.isWindows,
-        );
-      },
-    );
-  });
-
-  group('Given an executable that is not a batch wrapper', () {
-    test('when asked whether it needs a shell then it does not', () {
-      // A shell here would swallow the signals `kill` sends the daemon.
-      expect(
-        FlutterProcess.needsShell('/flutter/bin/cache/dart-sdk/bin/dart'),
-        isFalse,
-      );
-      expect(FlutterProcess.needsShell('/flutter/bin/flutter'), isFalse);
-      expect(FlutterProcess.needsShell(r'C:\dart-sdk\bin\dart.exe'), isFalse);
-    });
-  });
-
   group('Given a FlutterProcess whose executable is a name not on PATH', () {
     late FlutterProcess fp;
 
@@ -229,36 +199,19 @@ void main() {
       );
     });
 
-    group('when calling start', () {
-      late Object? failure;
-
-      setUp(() async {
-        try {
-          await fp.start();
-          failure = null;
-        } catch (e) {
-          failure = e;
-        }
-      });
-
-      test(
-        'then FlutterNotInstalledException is thrown so the caller can keep '
-        'going',
-        () {
-          expect(failure, isA<FlutterNotInstalledException>());
-        },
-      );
-
-      test('then the message names the executable it looked for', () {
-        expect(
-          (failure as FlutterNotInstalledException).message,
-          contains('definitely-not-a-real-flutter'),
+    test(
+      'when calling start, '
+      'then FlutterNotInstalledException is thrown',
+      () async {
+        await expectLater(
+          fp.start,
+          throwsA(isA<FlutterNotInstalledException>()),
         );
-      });
-    });
+      },
+    );
   });
 
-  group('Given a FlutterProcess missing the executable', () {
+  group('Given a FlutterProcess with a missing executable', () {
     late FlutterProcess fp;
 
     setUp(() {
@@ -271,7 +224,7 @@ void main() {
 
     test(
       'when calling start '
-      'then FlutterNotInstalledException is thrown so the caller can keep going',
+      'then FlutterNotInstalledException is thrown',
       () async {
         await expectLater(
           fp.start,

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/emits_no_machine_json.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/emits_no_machine_json.dart
@@ -1,0 +1,5 @@
+// Test shim: succeeds but answers `--version --machine` with plain text
+// instead of JSON, the way a `flutter` that ignores `--machine` would.
+void main() {
+  print('Flutter 3.32.0 • channel stable');
+}

--- a/tools/serverpod_cli/test/commands/start/flutter_shims/reports_flutter_root.dart
+++ b/tools/serverpod_cli/test/commands/start/flutter_shims/reports_flutter_root.dart
@@ -1,0 +1,13 @@
+// Test shim: answers `--version --machine` with a `flutterRoot` pointing at
+// the directory given by `--root=<path>`. Stands in for a `flutter` on PATH
+// during invocation resolution.
+import 'dart:convert';
+
+void main(List<String> args) {
+  final root = args
+      .where((a) => a.startsWith('--root='))
+      .map((a) => a.substring('--root='.length))
+      .first;
+
+  print(jsonEncode({'flutterRoot': root}));
+}

--- a/tools/serverpod_cli/test/integration/analytics/generate_isolate_analytics_test.dart
+++ b/tools/serverpod_cli/test/integration/analytics/generate_isolate_analytics_test.dart
@@ -1,5 +1,6 @@
 import 'package:serverpod_cli/src/generator/analyzers.dart';
 import 'package:serverpod_cli/src/generator/isolated_analyzers.dart';
+import 'package:serverpod_shared/process_io.dart';
 import 'package:test/test.dart';
 
 import '../../test_util/analytics_helpers.dart';
@@ -14,7 +15,10 @@ void main() {
 
       setUpAll(() async {
         fixture = await GenerateAnalyticsFixture.create();
-        analyzers = await IsolatedAnalyzers.create(fixture.config);
+        analyzers = await IsolatedAnalyzers.create(
+          fixture.config,
+          dartSdkPath: getSdkPath(),
+        );
         result = await analyzers.performGenerate(config: fixture.config);
       });
 

--- a/tools/serverpod_cli/test/runner/serverpod_command_runner_test.dart
+++ b/tools/serverpod_cli/test/runner/serverpod_command_runner_test.dart
@@ -55,6 +55,10 @@ class MockLogger extends VoidLogger {
 
   @override
   void debug(String message, {bool newParagraph = false, LogType? type}) {
+    // The real logger drops messages below the active level before they reach
+    // any output; mirror that here so a debug-level diagnostic does not show
+    // up in assertions about what a command actually printed.
+    if (logLevel.index > LogLevel.debug.index) return;
     output.debug(message);
   }
 

--- a/tools/serverpod_cli/test/util/sdk_resolver_test.dart
+++ b/tools/serverpod_cli/test/util/sdk_resolver_test.dart
@@ -1,0 +1,466 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:serverpod_cli/src/util/sdk_resolver.dart';
+import 'package:serverpod_shared/process_io.dart';
+import 'package:test/test.dart';
+
+/// A throwaway directory, removed when the test finishes.
+Directory _tempDir() {
+  final dir = Directory.systemTemp.createTempSync('serverpod_sdk_resolver');
+  addTearDown(() {
+    if (dir.existsSync()) dir.deleteSync(recursive: true);
+  });
+  // Resolve now: on macOS the system temp dir is itself a symlink, and the
+  // resolver reports pins through `resolveSymbolicLinksSync`.
+  return Directory(dir.resolveSymbolicLinksSync());
+}
+
+/// Creates a directory that passes [isFlutterSdk].
+///
+/// [withEmbeddedDart] populates `bin/cache/dart-sdk`, which is what
+/// distinguishes a warm SDK from a cold `bin/cache`.
+String _fakeFlutterSdk(
+  Directory parent, {
+  String name = 'flutter',
+  bool withEmbeddedDart = true,
+}) {
+  final root = p.join(parent.path, name);
+  File(flutterExecutableIn(root)).createSync(recursive: true);
+  if (withEmbeddedDart) {
+    File(
+      dartExecutableIn(embeddedDartSdkIn(root)),
+    ).createSync(recursive: true);
+  }
+  return root;
+}
+
+/// Points `<project>/.fvm/flutter_sdk` at [sdkRoot], the way `fvm use` does.
+void _pinFvmFlutter(Directory project, String sdkRoot) {
+  final fvmDir = Directory(p.join(project.path, '.fvm'))
+    ..createSync(recursive: true);
+  Link(p.join(fvmDir.path, 'flutter_sdk')).createSync(sdkRoot);
+}
+
+/// A resolver that never falls through to a real `flutter` on PATH, so the
+/// host machine's own install cannot influence the result.
+SdkResolver _resolver(
+  Directory baseDirectory, {
+  String? pathFlutterRoot,
+  String Function()? runningSdkRoot,
+}) {
+  return SdkResolver(
+    baseDirectory: baseDirectory,
+    probePathFlutterRoot: () async => pathFlutterRoot,
+    runningSdkRoot: runningSdkRoot,
+  );
+}
+
+void main() {
+  group('Given a project pinned with fvm', () {
+    late Directory temp;
+    late String cachedSdk;
+    late Directory project;
+
+    setUp(() {
+      temp = _tempDir();
+      cachedSdk = _fakeFlutterSdk(temp, name: 'cached-3.32.0');
+      project = Directory(p.join(temp.path, 'project'))..createSync();
+      _pinFvmFlutter(project, cachedSdk);
+    });
+
+    group('when the Flutter SDK is resolved from the pinned directory', () {
+      late ResolvedSdk? resolved;
+
+      setUp(() async {
+        resolved = await _resolver(project).flutterSdk;
+      });
+
+      test('then it resolves through the symlink to the cached SDK', () {
+        expect(resolved?.root, cachedSdk);
+      });
+
+      test('then it names the pin it followed as the origin', () {
+        expect(resolved?.origin, contains('.fvm/flutter_sdk'));
+      });
+    });
+
+    group('when the Flutter SDK is resolved from a nested subdirectory', () {
+      late ResolvedSdk? resolved;
+
+      setUp(() async {
+        final nested = Directory(p.join(project.path, 'apps', 'admin'))
+          ..createSync(recursive: true);
+        resolved = await _resolver(nested).flutterSdk;
+      });
+
+      test('then it finds the same pinned SDK', () {
+        expect(resolved?.root, cachedSdk);
+      });
+
+      test('then it names the pin it followed as the origin', () {
+        expect(resolved?.origin, contains('.fvm/flutter_sdk'));
+      });
+    });
+
+    group('when the resolution is described', () {
+      late String description;
+
+      setUp(() async {
+        description = await _resolver(project).describeResolution();
+      });
+
+      test('then it names the resolved Flutter SDK', () {
+        expect(description, contains(cachedSdk));
+      });
+
+      test('then it names the pin the Flutter SDK came from', () {
+        expect(description, contains('.fvm/flutter_sdk'));
+      });
+
+      test('then it names the Dart SDK derived from it', () {
+        expect(description, contains(embeddedDartSdkIn(cachedSdk)));
+      });
+
+      test('then it says the Dart SDK came from the Flutter SDK', () {
+        expect(description, contains('the resolved Flutter SDK'));
+      });
+    });
+  });
+
+  group(
+    'Given a project with fvm pin that sits above a repository boundary',
+    () {
+      late Directory insideRepository;
+
+      setUp(() {
+        final temp = _tempDir();
+        final outer = Directory(p.join(temp.path, 'outer'))..createSync();
+        _pinFvmFlutter(outer, _fakeFlutterSdk(temp, name: 'outer-cached'));
+        // An unrelated repository checked out inside the pinned directory.
+        insideRepository = Directory(p.join(outer.path, 'inner'))..createSync();
+        Directory(p.join(insideRepository.path, '.git')).createSync();
+      });
+
+      group('when the Flutter SDK is resolved from inside the repository', () {
+        late ResolvedSdk? resolved;
+
+        setUp(() async {
+          resolved = await _resolver(insideRepository).flutterSdk;
+        });
+
+        test('then it returns null', () {
+          expect(resolved, isNull);
+        });
+      });
+    },
+  );
+
+  group(
+    'Given a project with fvm pin above a linked-worktree boundary',
+    () {
+      late Directory insideRepository;
+
+      setUp(() {
+        final temp = _tempDir();
+        final outer = Directory(p.join(temp.path, 'outer'))..createSync();
+        _pinFvmFlutter(outer, _fakeFlutterSdk(temp, name: 'outer-cached'));
+        insideRepository = Directory(p.join(outer.path, 'worktree'))
+          ..createSync();
+        File(
+          p.join(insideRepository.path, '.git'),
+        ).writeAsStringSync('gitdir: ../.git/worktrees/example\n');
+      });
+
+      test(
+        'when resolving Flutter then it does not escape the worktree',
+        () async {
+          final resolved = await _resolver(insideRepository).flutterSdk;
+
+          expect(resolved, isNull);
+        },
+      );
+    },
+  );
+
+  group('Given a project whose fvm pin is a dangling symlink', () {
+    late Directory project;
+    late String sdkOnPath;
+
+    setUp(() {
+      final temp = _tempDir();
+      project = Directory(p.join(temp.path, 'project'))..createSync();
+      _pinFvmFlutter(project, p.join(temp.path, 'was-removed'));
+      sdkOnPath = _fakeFlutterSdk(temp, name: 'on-path');
+    });
+
+    group('when the Flutter SDK is resolved', () {
+      late ResolvedSdk? resolved;
+
+      setUp(() async {
+        resolved = await _resolver(
+          project,
+          pathFlutterRoot: sdkOnPath,
+        ).flutterSdk;
+      });
+
+      test('then it falls through to PATH instead of failing', () {
+        expect(resolved?.root, sdkOnPath);
+      });
+
+      test('then it names PATH as the origin', () {
+        expect(resolved?.origin, contains('PATH'));
+      });
+    });
+  });
+
+  group(
+    'Given a base directory that does not exist yet, pinned by its parent',
+    () {
+      // `serverpod create` resolves against the directory it is about to
+      // create, so the pin has to be found from a path with nothing at it.
+      late Directory notYetCreated;
+      late String cachedSdk;
+
+      setUp(() {
+        final temp = _tempDir();
+        cachedSdk = _fakeFlutterSdk(temp, name: 'cached');
+        final parent = Directory(p.join(temp.path, 'workspace'))..createSync();
+        _pinFvmFlutter(parent, cachedSdk);
+        notYetCreated = Directory(p.join(parent.path, 'my_new_app'));
+      });
+
+      group('when the Flutter SDK is resolved', () {
+        late ResolvedSdk? resolved;
+
+        setUp(() async {
+          resolved = await _resolver(notYetCreated).flutterSdk;
+        });
+
+        test('then it finds the pinned SDK', () {
+          expect(resolved?.root, cachedSdk);
+        });
+
+        test('then it names the pin it followed as the origin', () {
+          expect(resolved?.origin, contains('.fvm/flutter_sdk'));
+        });
+
+        test('then the base directory was never created to make that work', () {
+          expect(notYetCreated.existsSync(), isFalse);
+        });
+      });
+    },
+  );
+
+  group(
+    'Given a base directory that does not exist yet pinned further up',
+    () {
+      late Directory notYetCreated;
+      late String cachedSdk;
+
+      setUp(() {
+        final temp = _tempDir();
+        cachedSdk = _fakeFlutterSdk(temp, name: 'cached');
+        final root = Directory(p.join(temp.path, 'workspace'))..createSync();
+        _pinFvmFlutter(root, cachedSdk);
+        final nested = Directory(p.join(root.path, 'apps'))..createSync();
+        notYetCreated = Directory(p.join(nested.path, 'my_new_app'));
+      });
+
+      group('when the Flutter SDK is resolved', () {
+        late ResolvedSdk? resolved;
+
+        setUp(() async {
+          resolved = await _resolver(notYetCreated).flutterSdk;
+        });
+
+        test('then it finds the pinned SDK', () {
+          expect(resolved?.root, cachedSdk);
+        });
+      });
+    },
+  );
+
+  group('Given a base directory whose parent does not exist either', () {
+    late Directory deeplyMissing;
+
+    setUp(() {
+      final temp = _tempDir();
+      _pinFvmFlutter(temp, _fakeFlutterSdk(temp, name: 'cached'));
+      deeplyMissing = Directory(p.join(temp.path, 'missing', 'my_new_app'));
+    });
+
+    group('when the Flutter SDK is resolved', () {
+      late ResolvedSdk? resolved;
+
+      setUp(() async {
+        resolved = await _resolver(deeplyMissing).flutterSdk;
+      });
+
+      test('then it returns null', () {
+        expect(resolved, isNull);
+      });
+    });
+  });
+
+  group('Given a project without fvm pin and a Flutter SDK on PATH', () {
+    late Directory workingDirectory;
+    late String sdkOnPath;
+
+    setUp(() {
+      workingDirectory = _tempDir();
+      sdkOnPath = _fakeFlutterSdk(workingDirectory, name: 'on-path');
+    });
+
+    group('when the Flutter SDK is resolved', () {
+      late ResolvedSdk? resolved;
+
+      setUp(() async {
+        resolved = await _resolver(
+          workingDirectory,
+          pathFlutterRoot: sdkOnPath,
+        ).flutterSdk;
+      });
+
+      test('then it resolves to the SDK that PATH reported', () {
+        expect(resolved?.root, sdkOnPath);
+      });
+
+      test('then it names PATH as the origin', () {
+        expect(resolved?.origin, contains('PATH'));
+      });
+    });
+
+    group('when the Dart SDK is resolved', () {
+      late ResolvedSdk resolved;
+
+      setUp(() async {
+        resolved = await _resolver(
+          workingDirectory,
+          pathFlutterRoot: sdkOnPath,
+        ).dartSdk;
+      });
+
+      test('then it comes from the SDK the Flutter SDK embeds', () {
+        expect(resolved.root, embeddedDartSdkIn(sdkOnPath));
+      });
+
+      test('then it names the Flutter SDK as the origin', () {
+        expect(resolved.origin, contains('the resolved Flutter SDK'));
+      });
+    });
+  });
+
+  group('Given a Flutter SDK on PATH whose bin/cache is cold', () {
+    late Directory workingDirectory;
+    late String coldSdk;
+
+    setUp(() {
+      workingDirectory = _tempDir();
+      coldSdk = _fakeFlutterSdk(workingDirectory, withEmbeddedDart: false);
+    });
+
+    group('when the Dart SDK is resolved', () {
+      late ResolvedSdk resolved;
+
+      setUp(() async {
+        resolved = await _resolver(
+          workingDirectory,
+          pathFlutterRoot: coldSdk,
+        ).dartSdk;
+      });
+
+      test('then it falls back to the SDK running the CLI', () {
+        expect(resolved.root, getSdkPath());
+      });
+
+      test('then it names the running SDK as the origin', () {
+        expect(resolved.origin, contains('running this CLI'));
+      });
+    });
+  });
+
+  group('Given an environment with no Flutter SDK', () {
+    late Directory workingDirectory;
+
+    setUp(() {
+      workingDirectory = _tempDir();
+    });
+
+    group('when the Flutter SDK is resolved', () {
+      late ResolvedSdk? resolved;
+
+      setUp(() async {
+        resolved = await _resolver(workingDirectory).flutterSdk;
+      });
+
+      test('then no Flutter SDK is reported', () {
+        expect(resolved, isNull);
+      });
+    });
+
+    group('when the Dart SDK is resolved', () {
+      late ResolvedSdk resolved;
+
+      setUp(() async {
+        resolved = await _resolver(workingDirectory).dartSdk;
+      });
+
+      test('then it falls back to the SDK running the CLI', () {
+        expect(resolved.root, getSdkPath());
+      });
+
+      test('then it names the running SDK as the origin', () {
+        expect(resolved.origin, contains('running this CLI'));
+      });
+    });
+
+    group('when the resolution is described', () {
+      late String description;
+
+      setUp(() async {
+        description = await _resolver(workingDirectory).describeResolution();
+      });
+
+      test(
+        'then it says no Flutter SDK was found',
+        () {
+          expect(description, contains('Flutter SDK  not found'));
+        },
+      );
+    });
+  });
+
+  group('Given no Flutter SDK and no locatable running SDK', () {
+    // Reachable in released builds: those are AOT-compiled, so the last resort
+    // locates `dart` by spawning it rather than by reading
+    // Platform.resolvedExecutable, and there may be none to spawn.
+    late SdkResolver resolver;
+    final exception = StateError('no dart on PATH');
+
+    setUp(() {
+      resolver = _resolver(
+        _tempDir(),
+        runningSdkRoot: () => throw exception,
+      );
+    });
+
+    test(
+      'when the Dart SDK is resolved, '
+      'then it throws a SdkResolutionException',
+      () async {
+        await expectLater(
+          () => resolver.dartSdk,
+          throwsA(
+            isA<SdkResolutionException>().having(
+              (e) => e.message,
+              'message',
+              'Could not locate a Dart SDK. You need to have dart installed '
+                  'and in your \$PATH. ($exception)',
+            ),
+          ),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
Introduces `SdkResolver` to consolidate flutter and dart sdk resolution efforts in one place. Resolution follows a chain that looks for fvm config first and then probes the PATH. This is the key part that enables FVM support. Other shim-based version managers already work and are unaffected by this PR.

This also enables multiple Flutter apps in a Serverpod workspace to pin different Flutter versions for use. `FlutterAppManager` resolves the SDK per app on launch.

Closes #5608 

## Pre-launch Checklist

- [x] I read the [Contribute](https://docs.serverpod.dev/contribute) page and followed the process outlined there for submitting PRs.
- [x] This update contains only one single feature or bug fix and nothing else. (If you are submitting multiple fixes, please make multiple PRs.)
- [x] I read and followed the [Dart Style Guide](https://dart.dev/guides/language/effective-dart/style) and formatted the code with [dart format](https://dart.dev/tools/dart-format).
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`), and made sure that the documentation follows the same style as other Serverpod documentation. I checked spelling and grammar.
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.
- [x] Any breaking changes are documented below.

If you need help, consider asking for advice on the [discussion board](https://github.com/serverpod/serverpod/discussions).

## Breaking changes

